### PR TITLE
refactor: extract app entry point to src/main.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist-ssr/
 *.sln
 *.sw?
 *.iml
+.prettierrc
 
 # OS specific
 .DS_Store

--- a/index.html
+++ b/index.html
@@ -35,25 +35,7 @@
 
 <body class="preload">
     <div id="app"></div>
-    <script type="module">
-        import { initGlobalErrorHandling } from './src/utils/errors.js';
-        initGlobalErrorHandling();
-    </script>
-    <script type="module">
-        import { createApp } from 'vue';
-        import App from './src/App.vue';
-        import './src/assets/styles.css';
-
-        const app = createApp(App);
-
-        // Vue-specific error handling
-        app.config.errorHandler = (err, vm, info) => {
-            console.error('[Vue Error]', err, info);
-            window.dispatchEvent(new CustomEvent('vue-error', { detail: { err, info } }));
-        };
-
-        app.mount('#app');
-    </script>
+    <script type="module" src="./src/main.js"></script>
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glaze",
-  "version": "alpha 0.4.0",
+  "version": "0.4.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glaze",
-      "version": "alpha 0.4.0",
+      "version": "0.4.0-alpha",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anuradev/capacitor-background-mode": "^7.2.1",

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,17 @@
+import { initGlobalErrorHandling } from './utils/errors.js';
+import { createApp } from 'vue';
+import App from './App.vue';
+import './assets/styles.css';
+
+initGlobalErrorHandling();
+
+const app = createApp(App);
+
+app.config.errorHandler = (err, vm, info) => {
+    console.error('[Vue Error]', err, info);
+    window.dispatchEvent(
+        new CustomEvent('vue-error', { detail: { err, info } })
+    );
+};
+
+app.mount('#app');


### PR DESCRIPTION
Moves app initialization logic from inline `<script>` tags in `index.html` into a dedicated `src/main.js` entry point.

## Changes

- `src/main.js` — new file with Vue app creation, mounting, and error handler
- `index.html` — replaced inline scripts with `<script type="module" src="./src/main.js">`
- `.gitignore` — added `.prettierrc`
- `package-lock.json` — version string normalized to `0.4.0-alpha`