### PR TITLE
refactor: universal macro resolution + fix native block disabling on LaTeX import

### DIFF
--- a/src/components/ui/DragDropOverlay.vue
+++ b/src/components/ui/DragDropOverlay.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue';
-import { parseCharacterCard } from '@/utils/characterIO.js';
+import { parseCharacterCard, extractCharacterBook } from '@/utils/characterIO.js';
 import { db } from '@/utils/db.js';
 import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetState.js';
 import { translations } from '@/utils/i18n.js';
@@ -61,6 +61,7 @@ const onDrop = async (e) => {
                 if (!charData.id) {
                     charData.id = Date.now().toString();
                 }
+                await extractCharacterBook(charData);
                 await db.saveCharacter(charData, -1);
                 
                 // Notify UI to update

--- a/src/core/services/presetImportService.js
+++ b/src/core/services/presetImportService.js
@@ -185,27 +185,21 @@ export function convertSTPreset(data, fileName) {
     };
 }
 
-export const LATEX_MACRO_MAP = {
-    '{personality}': 'char_personality',
-    '{bot_description}': 'char_card',
-    '{user_persona}': 'user_persona',
-    '{scenario}': 'scenario',
-    '{example_dialogs}': 'example_dialogue',
-    '{example_dialogue}': 'example_dialogue',
-    '{lorebooks}': 'worldInfoBefore',
-    '{summary}': 'summary'
+export const LATEX_MACRO_DISABLE_MAP = {
+    '{bot_persona}': ['char_personality', 'char_card'],
+    '{user_persona}': ['user_persona'],
+    '{scenario}': ['scenario'],
+    '{example_dialogs}': ['example_dialogue'],
+    '{lorebooks}': ['worldInfoBefore', 'worldInfoAfter'],
+    '{summary}': ['summary', 'authors_note']
 };
 
-export const LATEX_MACRO_TO_BLOCK = Object.fromEntries(
-    Object.entries(LATEX_MACRO_MAP).map(([macro, blockId]) => [macro, blockId])
-);
-
-export function getLatexMacroBlockIds(content) {
+export function getLatexMacroDisabledBlockIds(content) {
     if (!content) return [];
     const ids = new Set();
-    for (const macro of Object.keys(LATEX_MACRO_MAP)) {
+    for (const [macro, blockIds] of Object.entries(LATEX_MACRO_DISABLE_MAP)) {
         if (content.includes(macro)) {
-            ids.add(LATEX_MACRO_MAP[macro]);
+            blockIds.forEach(id => ids.add(id));
         }
     }
     return [...ids];
@@ -243,54 +237,47 @@ export function convertLatexPreset(data, fileName) {
 
     const tabs = data.tabs || [];
 
-    const LATEX_MACRO_ALIASES = {
-        '{bot_persona}': '{personality}'
+    const LATEX_TO_GLAZE_MACRO = {
+        '{bot_persona}': '{{personality}}',
+        '{user_persona}': '{{persona}}',
+        '{scenario}': '{{scenario}}',
+        '{example_dialogs}': '{{mesExamples}}',
+        '{lorebooks}': '{{lorebooks}}',
+        '{summary}': '{{summary}}'
     };
 
-    const normalizeTabContent = (content) => {
+    const convertLatexMacrosToGlaze = (content) => {
         if (!content) return content;
         let result = content;
-        for (const [alias, canonical] of Object.entries(LATEX_MACRO_ALIASES)) {
-            result = result.split(alias).join(canonical);
+        for (const [latex, glaze] of Object.entries(LATEX_TO_GLAZE_MACRO)) {
+            result = result.split(latex).join(glaze);
         }
         return result;
     };
 
-    const allTabContent = tabs.map(t => normalizeTabContent(t.content || '')).join('\n');
-    const macroReferencedBlockIds = getLatexMacroBlockIds(allTabContent);
+    const allTabContent = tabs.map(t => t.content || '').join('\n');
+    const macroReferencedBlockIds = getLatexMacroDisabledBlockIds(allTabContent);
 
     tabs.forEach((tab) => {
         const tabId = tab.id || generateId();
         const tabTitle = tab.title || '';
-        const tabContent = normalizeTabContent(tab.content || '');
+        const tabContent = convertLatexMacrosToGlaze(tab.content || '');
         const tabRole = tab.role || 'system';
         const tabEnabled = tab.enabled !== undefined ? tab.enabled : true;
         const tabDepth = tab.injectionDepth || 0;
-        const isPinned = tab.isPinned || false;
 
         const mandatoryMatch = normalizeTitle(tabTitle);
+
+        if (mandatoryMatch === 'chat_history') {
+            usedMandatory.add('chat_history');
+            const mb = mandatoryBlocks.find(b => b.id === 'chat_history');
+            if (mb) orderedBlocks.push({ ...mb });
+            return;
+        }
+
         if (mandatoryMatch && !usedMandatory.has(mandatoryMatch)) {
-            const mb = mandatoryBlocks.find(b => b.id === mandatoryMatch);
-            if (mb) {
-                if (macroReferencedBlockIds.includes(mandatoryMatch)) {
-                    disabledNativeIds.add(mandatoryMatch);
-                    orderedBlocks.push({
-                        ...mb,
-                        enabled: false,
-                        isStashed: false,
-                        content: mandatoryMatch === 'guided_generation' ? mb.content : tabContent
-                    });
-                } else {
-                    orderedBlocks.push({
-                        ...mb,
-                        enabled: tabEnabled,
-                        isStashed: false,
-                        content: mandatoryMatch === 'guided_generation' ? mb.content : tabContent
-                    });
-                }
-                usedMandatory.add(mandatoryMatch);
-                return;
-            }
+            disabledNativeIds.add(mandatoryMatch);
+            usedMandatory.add(mandatoryMatch);
         }
 
         let insertion_mode = 'relative';
@@ -313,21 +300,30 @@ export function convertLatexPreset(data, fileName) {
     });
 
     macroReferencedBlockIds.forEach(blockId => {
+        if (blockId === 'chat_history') return;
         if (!usedMandatory.has(blockId)) {
-            const mb = mandatoryBlocks.find(b => b.id === blockId);
-            if (mb) {
-                disabledNativeIds.add(blockId);
-                orderedBlocks.push({ ...mb, enabled: false, isStashed: false });
-                usedMandatory.add(blockId);
-            }
+            disabledNativeIds.add(blockId);
+            usedMandatory.add(blockId);
         }
     });
 
     mandatoryBlocks.forEach(mb => {
-        if (!usedMandatory.has(mb.id)) {
+        if (disabledNativeIds.has(mb.id)) {
+            orderedBlocks.push({ ...mb, enabled: false, isStashed: false });
+        } else if (!usedMandatory.has(mb.id)) {
             orderedBlocks.push({ ...mb });
         }
     });
+
+    const EXTRA_DISABLED_BLOCKS = {
+        'authors_note': { id: 'authors_note', name: "Author's Note", role: 'system', content: '', isStatic: true, i18n: 'magic_authors_notes', enabled: false, isStashed: false, insertion_mode: 'relative' },
+        'summary': { id: 'summary', name: 'Summary', role: 'system', content: '', isStatic: true, i18n: 'magic_summary', enabled: false, isStashed: false, depth: 4, insertion_mode: 'relative', prefix: 'Summary: ' }
+    };
+    for (const [blockId, blockDef] of Object.entries(EXTRA_DISABLED_BLOCKS)) {
+        if (disabledNativeIds.has(blockId)) {
+            orderedBlocks.push({ ...blockDef });
+        }
+    }
 
     return {
         name: data.name || fileName || "Imported Preset",
@@ -339,7 +335,6 @@ export function convertLatexPreset(data, fileName) {
         mergeRole: 'system',
         blocks: orderedBlocks,
         regexes: [],
-        latexMode: true,
         disabledNativeIds: [...disabledNativeIds]
     };
 }

--- a/src/core/services/presetImportService.js
+++ b/src/core/services/presetImportService.js
@@ -1,3 +1,52 @@
+export function generateId(length = 6) {
+    return Date.now().toString(36) + Math.random().toString(36).substr(2, length);
+}
+
+export function detectPresetFormat(data) {
+    if (data.tabs && Array.isArray(data.tabs)) return 'latex';
+    if (data.prompts && Array.isArray(data.prompts)) return 'sillytavern';
+    if (data.blocks && Array.isArray(data.blocks)) return 'glaze';
+    return null;
+}
+
+export function finalizeImportedPreset(preset) {
+    if (!preset.blocks) preset.blocks = [];
+
+    preset.blocks.forEach(b => {
+        if (b.id !== 'authors_note' && b.id !== 'summary' && !b.insertion_mode) {
+            b.insertion_mode = 'relative';
+        }
+    });
+
+    if (!preset.blocks.find(b => b.id === 'summary')) {
+        const historyIdx = preset.blocks.findIndex(b => b.id === 'chat_history');
+        const insertIdx = historyIdx !== -1 ? historyIdx : preset.blocks.length;
+        preset.blocks.splice(insertIdx, 0, { id: 'summary', name: 'Summary', role: 'system', content: '', enabled: true, isStatic: true, i18n: 'magic_summary', depth: 4, insertion_mode: 'relative', prefix: 'Summary: ' });
+    }
+    if (!preset.blocks.find(b => b.id === 'authors_note')) {
+        const historyIdx = preset.blocks.findIndex(b => b.id === 'chat_history');
+        const insertIdx = historyIdx !== -1 ? historyIdx + 1 : preset.blocks.length;
+        preset.blocks.splice(insertIdx, 0, { id: 'authors_note', name: "Author's Note", role: 'system', content: '', enabled: true, isStatic: true, i18n: 'magic_authors_notes', insertion_mode: 'relative' });
+    }
+    if (!preset.blocks.find(b => b.id === 'guided_generation')) {
+        const authorsIdx = preset.blocks.findIndex(b => b.id === 'authors_note');
+        const historyIdx = preset.blocks.findIndex(b => b.id === 'chat_history');
+        const insertIdx = authorsIdx !== -1 ? authorsIdx + 1 : (historyIdx !== -1 ? historyIdx + 1 : preset.blocks.length);
+        preset.blocks.splice(insertIdx, 0, { id: 'guided_generation', name: 'Guided Generation', role: 'system', content: '[System Note: {{guidance}}]', enabled: true, isStatic: true, i18n: 'block_guided_generation', insertion_mode: 'relative' });
+    }
+
+    if (!preset.guidedGenerationPrompt) preset.guidedGenerationPrompt = '[Generate your next reply according to these instructions: {{guidance}}]';
+    if (!preset.guidedImpersonationPrompt) preset.guidedImpersonationPrompt = '[Instead of replying for {{char}}, impersonate {{user}} according to these instructions: {{guidance}}]';
+    if (!preset.summaryPrompt) {
+        preset.summaryPrompt = 'Summarize the following roleplay conversation concisely, focusing on the current situation and key events:\n\n{{history}}\n\nSummary:';
+    }
+
+    const newId = Date.now().toString();
+    preset.id = newId;
+    if (preset.createdAt === undefined) preset.createdAt = Date.now();
+    return preset;
+}
+
 export const mandatoryBlocks = [
     { id: "worldInfoBefore", i18n: "block_wi_before", name: "World Info Before", role: "system", content: "", isStatic: true, enabled: true },
     { id: "user_persona", i18n: "block_user_persona", name: "User Persona", role: "system", content: "", isStatic: true, enabled: true },
@@ -133,6 +182,165 @@ export function convertSTPreset(data, fileName) {
         mergeRole: 'system',
         blocks: orderedBlocks,
         regexes: regexes
+    };
+}
+
+export const LATEX_MACRO_MAP = {
+    '{personality}': 'char_personality',
+    '{bot_description}': 'char_card',
+    '{user_persona}': 'user_persona',
+    '{scenario}': 'scenario',
+    '{example_dialogs}': 'example_dialogue',
+    '{example_dialogue}': 'example_dialogue',
+    '{lorebooks}': 'worldInfoBefore',
+    '{summary}': 'summary'
+};
+
+export const LATEX_MACRO_TO_BLOCK = Object.fromEntries(
+    Object.entries(LATEX_MACRO_MAP).map(([macro, blockId]) => [macro, blockId])
+);
+
+export function getLatexMacroBlockIds(content) {
+    if (!content) return [];
+    const ids = new Set();
+    for (const macro of Object.keys(LATEX_MACRO_MAP)) {
+        if (content.includes(macro)) {
+            ids.add(LATEX_MACRO_MAP[macro]);
+        }
+    }
+    return [...ids];
+}
+
+export function convertLatexPreset(data, fileName) {
+    const orderedBlocks = [];
+    const usedMandatory = new Set();
+    const disabledNativeIds = new Set();
+
+    const LATEX_TITLE_TO_BLOCK = {
+        'persona': 'user_persona',
+        'char description': 'char_card',
+        'character card': 'char_card',
+        'char personality': 'char_personality',
+        'character personality': 'char_personality',
+        'scenario': 'scenario',
+        'world info before': 'worldInfoBefore',
+        'world info after': 'worldInfoAfter',
+        'chat history': 'chat_history',
+        'dialogue examples': 'example_dialogue',
+        'example dialogue': 'example_dialogue',
+        'author\'s note': 'authors_note',
+        'summary': 'summary',
+        'guided generation': 'guided_generation'
+    };
+
+    const normalizeTitle = (title) => {
+        const lower = (title || '').toLowerCase().replace(/[━─🏳️✏️🛑🧑‍🔧🧠🧍📜]/gu, '').trim();
+        for (const [key, blockId] of Object.entries(LATEX_TITLE_TO_BLOCK)) {
+            if (lower.includes(key)) return blockId;
+        }
+        return null;
+    };
+
+    const tabs = data.tabs || [];
+
+    const LATEX_MACRO_ALIASES = {
+        '{bot_persona}': '{personality}'
+    };
+
+    const normalizeTabContent = (content) => {
+        if (!content) return content;
+        let result = content;
+        for (const [alias, canonical] of Object.entries(LATEX_MACRO_ALIASES)) {
+            result = result.split(alias).join(canonical);
+        }
+        return result;
+    };
+
+    const allTabContent = tabs.map(t => normalizeTabContent(t.content || '')).join('\n');
+    const macroReferencedBlockIds = getLatexMacroBlockIds(allTabContent);
+
+    tabs.forEach((tab) => {
+        const tabId = tab.id || generateId();
+        const tabTitle = tab.title || '';
+        const tabContent = normalizeTabContent(tab.content || '');
+        const tabRole = tab.role || 'system';
+        const tabEnabled = tab.enabled !== undefined ? tab.enabled : true;
+        const tabDepth = tab.injectionDepth || 0;
+        const isPinned = tab.isPinned || false;
+
+        const mandatoryMatch = normalizeTitle(tabTitle);
+        if (mandatoryMatch && !usedMandatory.has(mandatoryMatch)) {
+            const mb = mandatoryBlocks.find(b => b.id === mandatoryMatch);
+            if (mb) {
+                if (macroReferencedBlockIds.includes(mandatoryMatch)) {
+                    disabledNativeIds.add(mandatoryMatch);
+                    orderedBlocks.push({
+                        ...mb,
+                        enabled: false,
+                        isStashed: false,
+                        content: mandatoryMatch === 'guided_generation' ? mb.content : tabContent
+                    });
+                } else {
+                    orderedBlocks.push({
+                        ...mb,
+                        enabled: tabEnabled,
+                        isStashed: false,
+                        content: mandatoryMatch === 'guided_generation' ? mb.content : tabContent
+                    });
+                }
+                usedMandatory.add(mandatoryMatch);
+                return;
+            }
+        }
+
+        let insertion_mode = 'relative';
+        let depth = 4;
+        if (tabDepth > 0) {
+            insertion_mode = 'depth';
+            depth = tabDepth;
+        }
+
+        orderedBlocks.push({
+            id: tabId,
+            name: tabTitle,
+            content: tabContent,
+            enabled: tabEnabled,
+            isStashed: false,
+            role: tabRole,
+            insertion_mode,
+            depth
+        });
+    });
+
+    macroReferencedBlockIds.forEach(blockId => {
+        if (!usedMandatory.has(blockId)) {
+            const mb = mandatoryBlocks.find(b => b.id === blockId);
+            if (mb) {
+                disabledNativeIds.add(blockId);
+                orderedBlocks.push({ ...mb, enabled: false, isStashed: false });
+                usedMandatory.add(blockId);
+            }
+        }
+    });
+
+    mandatoryBlocks.forEach(mb => {
+        if (!usedMandatory.has(mb.id)) {
+            orderedBlocks.push({ ...mb });
+        }
+    });
+
+    return {
+        name: data.name || fileName || "Imported Preset",
+        reasoningEnabled: false,
+        impersonationPrompt: "",
+        reasoningStart: "",
+        reasoningEnd: "",
+        mergePrompts: !!data.mergeConsecutiveRoles,
+        mergeRole: 'system',
+        blocks: orderedBlocks,
+        regexes: [],
+        latexMode: true,
+        disabledNativeIds: [...disabledNativeIds]
     };
 }
 

--- a/src/core/states/lorebookState.js
+++ b/src/core/states/lorebookState.js
@@ -353,32 +353,36 @@ export async function importSTLorebook(json, fileName = 'Imported') {
             id: Date.now().toString(36) + Math.random().toString(36).substr(2, 5),
             name: json.name || fileName.replace('.json', ''),
             enabled: true,
-            entries: normalizedEntries.map(entry => ({
-                id: entry.uid?.toString() || (Date.now() + Math.random()).toString(36),
-                keys: Array.isArray(entry.key) ? entry.key : (entry.key || '').split(',').map(k => k.trim()).filter(k => k),
-                content: entry.content || '',
-                enabled: entry.enabled !== false && entry.disable !== true,
-                secondary_keys: Array.isArray(entry.keysecondary) ? entry.keysecondary : (entry.keysecondary || '').split(',').map(k => k.trim()).filter(k => k),
-                comment: entry.comment || '',
-                order: entry.order !== undefined ? entry.order : 100,
-                probability: entry.probability !== undefined ? entry.probability : 100,
-                constant: entry.constant || false,
-                selectiveLogic: entry.selectiveLogic ?? 0,
-                matchWholeWords: entry.matchWholeWords ?? null,
-                caseSensitive: entry.caseSensitive ?? null,
-                useGroupScoring: entry.useGroupScoring ?? null,
-                scanDepth: entry.scanDepth,
-                position: (entry.position === 0) ? 'worldInfoBefore' : (entry.position === 1) ? 'worldInfoAfter' : (entry.position ?? 'worldInfoBefore'),
-                characterFilter: entry.characterFilter,
-                preventRecursion: entry.preventRecursion || false,
-                delayUntilRecursion: entry.delayUntilRecursion || false,
-                sticky: entry.sticky || 0,
-                cooldown: entry.cooldown || 0,
-                delay: entry.delay || 0,
-                group: entry.group || '',
-                groupProminence: entry.groupProminence || 100,
-                ignoreBudget: entry.ignoreBudget || false
-            }))
+            entries: normalizedEntries.map(entry => {
+                const rawKeys = entry.keys || entry.key || [];
+                const rawSecondary = entry.secondary_keys || entry.keysecondary || [];
+                return {
+                    id: entry.uid?.toString() || (Date.now() + Math.random()).toString(36),
+                    keys: Array.isArray(rawKeys) ? rawKeys : String(rawKeys || '').split(',').map(k => k.trim()).filter(k => k),
+                    content: entry.content || '',
+                    enabled: entry.enabled !== false && entry.disable !== true,
+                    secondary_keys: Array.isArray(rawSecondary) ? rawSecondary : String(rawSecondary || '').split(',').map(k => k.trim()).filter(k => k),
+                    comment: entry.comment || '',
+                    order: entry.order !== undefined ? entry.order : 100,
+                    probability: entry.probability !== undefined ? entry.probability : 100,
+                    constant: entry.constant || false,
+                    selectiveLogic: entry.selectiveLogic ?? 0,
+                    matchWholeWords: entry.matchWholeWords ?? null,
+                    caseSensitive: entry.caseSensitive ?? null,
+                    useGroupScoring: entry.useGroupScoring ?? null,
+                    scanDepth: entry.scanDepth,
+                    position: (entry.position === 0) ? 'worldInfoBefore' : (entry.position === 1) ? 'worldInfoAfter' : (entry.position ?? 'worldInfoBefore'),
+                    characterFilter: entry.characterFilter,
+                    preventRecursion: entry.preventRecursion || false,
+                    delayUntilRecursion: entry.delayUntilRecursion || false,
+                    sticky: entry.sticky || 0,
+                    cooldown: entry.cooldown || 0,
+                    delay: entry.delay || 0,
+                    group: entry.group || '',
+                    groupProminence: entry.groupProminence || 100,
+                    ignoreBudget: entry.ignoreBudget || false
+                };
+            })
         };
 
         lorebookState.lorebooks.push(newLb);

--- a/src/utils/characterIO.js
+++ b/src/utils/characterIO.js
@@ -7,6 +7,7 @@ import { currentLang } from '@/core/config/APPSettings.js';
 import { db } from '@/utils/db.js';
 import { logger } from './logger.js';
 import { saveFile } from '../core/services/fileSaver.js';
+import { importSTLorebook } from '@/core/states/lorebookState.js';
 
 // ─── Import ──────────────────────────────────────────────────────────────────
 
@@ -144,6 +145,18 @@ function normalizeCharacterData(json) {
         data.avatar = null;
     }
     return data;
+}
+
+export async function extractCharacterBook(charData) {
+    const cb = charData.character_book;
+    if (!cb || (!cb.entries && !cb.name)) return null;
+
+    const lbName = cb.name || `${charData.name || 'Character'} Lorebook`;
+    const lorebook = await importSTLorebook({ ...cb, name: lbName }, lbName);
+
+    delete charData.character_book;
+
+    return lorebook;
 }
 
 function fileToBase64(file) {

--- a/src/views/CharacterList.vue
+++ b/src/views/CharacterList.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue';
-import { triggerCharacterImport } from '@/utils/characterIO.js';
+import { triggerCharacterImport, extractCharacterBook } from '@/utils/characterIO.js';
 import { exportCharacterAsV2Json, exportCharacterAsV2Png } from '@/utils/characterIO.js';
 import { triggerChatImport } from '@/core/services/chatImporter.js';
 import { db } from '@/utils/db.js';
@@ -87,9 +87,8 @@ const onAddCharacter = () => {
                                 if (!charData.id) {
                                     charData.id = Date.now().toString();
                                 }
-                                // Save to IndexedDB
+                                await extractCharacterBook(charData);
                                 await db.saveCharacter(charData, -1);
-                                // Reload the list
                                 await loadCharacters();
                             } catch (e) {
                                 console.error("Failed to save character", e);

--- a/src/views/OnboardingView.vue
+++ b/src/views/OnboardingView.vue
@@ -7,7 +7,7 @@ import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetStat
 import BackupSheet from '@/components/sheets/BackupSheet.vue';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
-import { convertSTPreset } from '@/core/services/presetImportService.js';
+import { convertSTPreset, convertLatexPreset, detectPresetFormat, finalizeImportedPreset } from '@/core/services/presetImportService.js';
 import { requestNotificationPermission } from '@/core/services/notificationService.js';
 import { presetState, initPresetState, savePresets, setPresetConnection } from '@/core/states/presetState.js';
 import { isKeyboardOpen as globalKeyboardOpen } from '@/core/services/keyboardHandler.js';
@@ -293,28 +293,34 @@ function triggerPresetImport() {
             
             initPresetState();
 
-            // Logic to handle ST format or internal format
-            if (data.prompts && Array.isArray(data.prompts)) {
-                // ST Format conversion
-                const preset = convertSTPreset(data, file.name.replace(/\.json$/i, ''));
-                const newId = Date.now().toString();
-                presetState.presets[newId] = preset;
-                setPresetConnection('global', null, newId);
-            } else {
-                // Assume internal format (dictionary or single object)
+            const format = detectPresetFormat(data);
+            let preset;
+
+            if (format === 'latex') {
+                preset = convertLatexPreset(data, file.name.replace(/\.json$/i, ''));
+            } else if (format === 'sillytavern') {
+                preset = convertSTPreset(data, file.name.replace(/\.json$/i, ''));
+            } else if (format === 'glaze') {
                 if (data.blocks) {
-                     const id = Date.now().toString();
-                     presetState.presets[id] = data;
-                     setPresetConnection('global', null, id);
+                    preset = data;
                 } else {
-                     Object.assign(presetState.presets, data);
+                    Object.assign(presetState.presets, data);
+                    savePresets();
+                    next();
+                    return;
                 }
+            } else {
+                alert(translations[currentLang.value]?.onboarding_import_error || 'Unknown preset format');
+                return;
             }
-            
+
+            preset = finalizeImportedPreset(preset);
+            presetState.presets[preset.id] = preset;
+            setPresetConnection('global', null, preset.id);
             savePresets();
             next();
         } catch (err) {
-            alert(t('onboarding_import_error') + err.message);
+            alert(translations[currentLang.value]?.onboarding_import_error + err.message);
         }
     };
     input.click();

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -7,7 +7,7 @@ import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetStat
 import { estimateTokens } from '@/utils/tokenizer.js';
 import { replaceMacros } from '@/utils/macroEngine.js';
 import { getEffectivePersona } from '@/core/states/personaState.js';
-import { convertSTPreset, exportSTPreset, mandatoryBlocks } from '@/core/services/presetImportService.js';
+import { convertSTPreset, convertLatexPreset, exportSTPreset, detectPresetFormat, finalizeImportedPreset, mandatoryBlocks } from '@/core/services/presetImportService.js';
 import { generateSummary } from '@/core/services/generationService.js';
 import { presetState, initPresetState, setPresetConnection, getEffectivePresetId, DEFAULT_PRESETS, flushPresetSave } from '@/core/states/presetState.js';
 import { Browser } from '@capacitor/browser';
@@ -1419,48 +1419,23 @@ function onFileSelected(event) {
 }
 
 function processImportedPreset(data, defaultName) {
-    if (!data.prompts || !Array.isArray(data.prompts)) {
-        alert("Invalid ST format: 'prompts' array missing.");
+    const format = detectPresetFormat(data);
+    let preset;
+
+    if (format === 'latex') {
+        preset = convertLatexPreset(data, defaultName);
+    } else if (format === 'sillytavern') {
+        preset = convertSTPreset(data, defaultName);
+    } else if (format === 'glaze') {
+        preset = data;
+    } else {
+        alert("Unknown preset format. Expected SillyTavern, LaTeX, or Glaze JSON.");
         return;
     }
 
-    const preset = convertSTPreset(data, defaultName);
-    
-    // Ensure insertion_mode for all blocks
-    preset.blocks.forEach(b => {
-        if (b.id !== 'authors_note' && b.id !== 'summary' && !b.insertion_mode) {
-            b.insertion_mode = 'relative';
-        }
-    });
-    
-    // Ensure static blocks
-    if (!preset.blocks.find(b => b.id === 'summary')) {
-         const historyIdx = preset.blocks.findIndex(b => b.id === 'chat_history');
-         const insertIdx = historyIdx !== -1 ? historyIdx : preset.blocks.length;
-         preset.blocks.splice(insertIdx, 0, { id: 'summary', name: 'Summary', role: 'system', content: '', enabled: true, isStatic: true, i18n: 'magic_summary', depth: 4, insertion_mode: 'relative', prefix: 'Summary: ' });
-    }
-    if (!preset.blocks.find(b => b.id === 'authors_note')) {
-         const historyIdx = preset.blocks.findIndex(b => b.id === 'chat_history');
-         const insertIdx = historyIdx !== -1 ? historyIdx + 1 : preset.blocks.length;
-         preset.blocks.splice(insertIdx, 0, { id: 'authors_note', name: "Author's Note", role: 'system', content: '', enabled: true, isStatic: true, i18n: 'magic_authors_notes', insertion_mode: 'relative' });
-    }
-    if (!preset.blocks.find(b => b.id === 'guided_generation')) {
-         const authorsIdx = preset.blocks.findIndex(b => b.id === 'authors_note');
-         const historyIdx = preset.blocks.findIndex(b => b.id === 'chat_history');
-         const insertIdx = authorsIdx !== -1 ? authorsIdx + 1 : (historyIdx !== -1 ? historyIdx + 1 : preset.blocks.length);
-         preset.blocks.splice(insertIdx, 0, { id: 'guided_generation', name: 'Guided Generation', role: 'system', content: '[System Note: {{guidance}}]', enabled: true, isStatic: true, i18n: 'block_guided_generation', insertion_mode: 'relative' });
-    }
-    if (!preset.guidedGenerationPrompt) preset.guidedGenerationPrompt = '[Generate your next reply according to these instructions: {{guidance}}]';
-    if (!preset.guidedImpersonationPrompt) preset.guidedImpersonationPrompt = '[Instead of replying for {{char}}, impersonate {{user}} according to these instructions: {{guidance}}]';
-    if (!preset.summaryPrompt) {
-        preset.summaryPrompt = 'Summarize the following roleplay conversation concisely, focusing on the current situation and key events:\n\n{{history}}\n\nSummary:';
-    }
-
-    const newId = Date.now().toString();
-    preset.id = newId;
-    if (preset.createdAt === undefined) preset.createdAt = Date.now();
-    presetState.presets[newId] = preset;
-    editingPresetId.value = newId;
+    preset = finalizeImportedPreset(preset);
+    presetState.presets[preset.id] = preset;
+    editingPresetId.value = preset.id;
     updateHeaderState();
 }
 

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -346,7 +346,17 @@ function buildPromptMessagesWorker(args) {
         });
     }
 
+    const isLatexMode = activePreset?.latexMode === true;
+    const hasLorebookMacro = isLatexMode && activePreset.blocks?.some(b => b.content?.includes('{lorebooks}'));
+
+    const getAllLoreContent = () => {
+        const allEntries = [];
+        Object.values(loreByPosition).forEach(entries => allEntries.push(...entries));
+        return allEntries.map(e => e.content).filter(Boolean).join('\n');
+    };
+
     const injectLore = (pos) => {
+        if (hasLorebookMacro) return;
         if (loreByPosition[pos] && loreByPosition[pos].length > 0) {
             loreByPosition[pos].forEach(msg => {
                 if (mergePrompts) mergeBuffer.push(msg.content);
@@ -359,7 +369,7 @@ function buildPromptMessagesWorker(args) {
         }
     };
 
-    injectLore(4);
+    if (!hasLorebookMacro) injectLore(4);
 
     let summaryText = null;
     if (summary) {
@@ -380,6 +390,28 @@ function buildPromptMessagesWorker(args) {
                 relativeBlocks.push(block);
             }
         });
+
+        const LATEX_BLOCK_CONTENT = {
+            '{personality}': () => char ? `Personality: ${char.personality || ''}` : '',
+            '{bot_description}': () => char ? `Character Name: ${char.name || 'Character'}\nDescription: ${char.description || char.desc || ''}` : '',
+            '{user_persona}': () => personaObj ? `User Name: ${personaObj.name || 'User'}\nUser Description: ${personaObj.prompt || ''}` : '',
+            '{scenario}': () => char ? `Scenario: ${char.scenario || ''}` : '',
+            '{example_dialogs}': () => char ? (char.mes_example || '') : '',
+            '{example_dialogue}': () => char ? (char.mes_example || '') : '',
+            '{lorebooks}': () => getAllLoreContent(),
+            '{summary}': () => summaryText || ''
+        };
+
+        const resolveLatexMacros = (text) => {
+            if (!text) return text;
+            let result = text;
+            for (const [macro, resolver] of Object.entries(LATEX_BLOCK_CONTENT)) {
+                if (result.includes(macro)) {
+                    result = result.split(macro).join(resolver());
+                }
+            }
+            return result;
+        };
 
         const resolveBlockContent = (block) => {
             let content = "";
@@ -415,7 +447,8 @@ function buildPromptMessagesWorker(args) {
 
             if (!content) return null;
 
-            // Execute macros on the final block content to catch embedded setvar/getvar
+            content = resolveLatexMacros(content);
+
             content = replaceMacros(content, char, personaObj, sessionVars, notifyObj);
 
             return { content, role };
@@ -443,7 +476,7 @@ function buildPromptMessagesWorker(args) {
         relativeBlocks.forEach(block => {
             if (block.id === 'chat_history') {
                 if (mergePrompts) flushMergeBuffer();
-                Object.keys(loreByPosition).forEach(pos => injectLore(pos));
+                if (!hasLorebookMacro) Object.keys(loreByPosition).forEach(pos => injectLore(pos));
 
                 let historyMsgs = [];
                 if (history) {

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -346,13 +346,13 @@ function buildPromptMessagesWorker(args) {
         });
     }
 
-    const isLatexMode = activePreset?.latexMode === true;
-    const hasLorebookMacro = isLatexMode && activePreset.blocks?.some(b => b.content?.includes('{lorebooks}'));
+    const hasLorebookMacro = activePreset?.blocks?.some(b => b.enabled !== false && !b.isStashed && b.content?.includes('{{lorebooks}}'));
 
-    const getAllLoreContent = () => {
-        const allEntries = [];
-        Object.values(loreByPosition).forEach(entries => allEntries.push(...entries));
-        return allEntries.map(e => e.content).filter(Boolean).join('\n');
+    const getLorebookContent = () => {
+        return allLoreEntries
+            .map(entry => replaceMacros(entry.content || "", char, personaObj, sessionVars, notifyObj))
+            .filter(Boolean)
+            .join('\n\n');
     };
 
     const injectLore = (pos) => {
@@ -371,11 +371,12 @@ function buildPromptMessagesWorker(args) {
 
     if (!hasLorebookMacro) injectLore(4);
 
+    let summaryRawContent = null;
     let summaryText = null;
     if (summary) {
-        const content = typeof summary === 'object' ? summary.content : summary;
+        summaryRawContent = typeof summary === 'object' ? summary.content : summary;
         const prefix = (typeof summary === 'object' && summary.prefix) ? summary.prefix : 'Summary: ';
-        if (content) summaryText = `[${prefix}${content}]`;
+        if (summaryRawContent) summaryText = `[${prefix}${summaryRawContent}]`;
     }
 
     if (activePreset && activePreset.blocks) {
@@ -391,24 +392,14 @@ function buildPromptMessagesWorker(args) {
             }
         });
 
-        const LATEX_BLOCK_CONTENT = {
-            '{personality}': () => char ? `Personality: ${char.personality || ''}` : '',
-            '{bot_description}': () => char ? `Character Name: ${char.name || 'Character'}\nDescription: ${char.description || char.desc || ''}` : '',
-            '{user_persona}': () => personaObj ? `User Name: ${personaObj.name || 'User'}\nUser Description: ${personaObj.prompt || ''}` : '',
-            '{scenario}': () => char ? `Scenario: ${char.scenario || ''}` : '',
-            '{example_dialogs}': () => char ? (char.mes_example || '') : '',
-            '{example_dialogue}': () => char ? (char.mes_example || '') : '',
-            '{lorebooks}': () => getAllLoreContent(),
-            '{summary}': () => summaryText || ''
-        };
-
-        const resolveLatexMacros = (text) => {
+        const resolveDynamicMacros = (text) => {
             if (!text) return text;
             let result = text;
-            for (const [macro, resolver] of Object.entries(LATEX_BLOCK_CONTENT)) {
-                if (result.includes(macro)) {
-                    result = result.split(macro).join(resolver());
-                }
+            if (result.includes('{{lorebooks}}')) {
+                result = result.split('{{lorebooks}}').join(getLorebookContent());
+            }
+            if (result.includes('{{summary}}')) {
+                result = result.split('{{summary}}').join(summaryRawContent || '');
             }
             return result;
         };
@@ -447,9 +438,8 @@ function buildPromptMessagesWorker(args) {
 
             if (!content) return null;
 
-            content = resolveLatexMacros(content);
-
             content = replaceMacros(content, char, personaObj, sessionVars, notifyObj);
+            content = resolveDynamicMacros(content);
 
             return { content, role };
         };


### PR DESCRIPTION
## Summary

- Convert LaTeX single-brace macros to Glaze double-brace format during import
- Add universal resolveDynamicMacros in generationWorker for any preset
- {{lorebooks}} resolves triggered entries by order, suppresses injectLore
- {{summary}} resolves raw summary content
- Disable native blocks when referenced by LaTeX macros: bot_persona -> char_personality+char_card, lorebooks -> worldInfoBefore+worldInfoAfter, summary -> summary+authors_note
- Chat History tab becomes native chat_history block at tab position
- Add EXTRA_DISABLED_BLOCKS for authors_note/summary
- Remove isLatexMode, LATEX_BLOCK_CONTENT, resolveLatexMacros, latexMode flag