### PR TITLE
feat: Glaze punctuation-boundary matching for lorebook keywords

### DIFF
--- a/src/components/sheets/LorebookSheet.vue
+++ b/src/components/sheets/LorebookSheet.vue
@@ -497,9 +497,21 @@ defineExpose({ open, openEntry, close, openLorebook });
                              <label>{{ t('label_case_sensitive_global') }}</label>
                              <input type="checkbox" v-model="lorebookState.globalSettings.caseSensitive" class="vk-switch small-switch">
                         </div>
-                         <div class="settings-item-checkbox small-checkbox">
+                         <div class="settings-item">
                              <label>{{ t('label_match_whole_words_global') }}</label>
-                             <input type="checkbox" v-model="lorebookState.globalSettings.matchWholeWords" class="vk-switch small-switch">
+                             <div class="clickable-selector" @click="openOptionSelector({
+                                 title: t('label_match_whole_words_global'),
+                                 options: [
+                                     { value: false, label: t('off') },
+                                     { value: true, label: t('match_whole_words_st') },
+                                     { value: 'glaze', label: t('match_whole_words_glaze') }
+                                 ],
+                                 currentValue: lorebookState.globalSettings.matchWholeWords,
+                                 onSelect: (v) => lorebookState.globalSettings.matchWholeWords = v
+                             })">
+                                 <span>{{ lorebookState.globalSettings.matchWholeWords === 'glaze' ? t('match_whole_words_glaze') : (lorebookState.globalSettings.matchWholeWords ? t('match_whole_words_st') : t('off')) }}</span>
+                                 <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+                             </div>
                         </div>
                     </div>
                 </div>

--- a/src/core/states/lorebookState.js
+++ b/src/core/states/lorebookState.js
@@ -5,6 +5,8 @@ function escapeRegex(string) {
     return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
+const GLAZE_BOUNDARIES = '[\\s.,!?;:"\'\\u201C\\u201D\\u2018\\u2019\\u00AB\\u00BB(){}\\[\\]—–]';
+
 // --- State Definition ---
 export const lorebookState = reactive({
     lorebooks: [],
@@ -219,16 +221,34 @@ export function scanLorebooks(history = [], char = null, textToScan = "", chatId
                 if (!key) return false;
                 const sourceText = `${text ?? ''}`;
                 const sourceKey = `${key}`;
+                const flags = caseSensitive ? '' : 'i';
+
+                if (wholeWords === 'glaze') {
+                    const escaped = escapeRegex(sourceKey);
+                    const pattern = `(?:^|${GLAZE_BOUNDARIES})${escaped}(?:$|${GLAZE_BOUNDARIES})`;
+                    try {
+                        return new RegExp(pattern, flags).test(sourceText);
+                    } catch (e) {
+                        const haystack = caseSensitive ? sourceText : sourceText.toLowerCase();
+                        const needle = caseSensitive ? sourceKey : sourceKey.toLowerCase();
+                        if (!needle) return false;
+                        const escapedNeedle = escapeRegex(needle);
+                        try {
+                            return new RegExp(`(?:^|${GLAZE_BOUNDARIES})${escapedNeedle}(?:$|${GLAZE_BOUNDARIES})`, caseSensitive ? '' : 'i').test(haystack);
+                        } catch (e2) {
+                            return false;
+                        }
+                    }
+                }
+
                 let pattern = sourceKey;
                 if (wholeWords) {
                     pattern = `\\b${pattern}\\b`;
                 }
-                const flags = caseSensitive ? '' : 'i';
                 try {
                     const regex = new RegExp(pattern, flags);
                     return regex.test(sourceText);
                 } catch (e) {
-                    // Prevent crashes on invalid/pathological patterns by using literal fallback.
                     const haystack = caseSensitive ? sourceText : sourceText.toLowerCase();
                     const needle = caseSensitive ? sourceKey : sourceKey.toLowerCase();
                     if (!needle) return false;

--- a/src/locales/en/index.json
+++ b/src/locales/en/index.json
@@ -486,6 +486,8 @@
     "logic_not_all": "NOT All (Has Primary AND Not All Filters)",
     "label_case_sensitive": "Case Sensitive",
     "label_match_whole_words": "Match Whole Words",
+    "match_whole_words_st": "ST (\\b)",
+    "match_whole_words_glaze": "Glaze (Punctuation)",
     "label_group_scoring": "Group Scoring",
     "match_global": "Match Global",
     "on": "On",

--- a/src/locales/ru/index.json
+++ b/src/locales/ru/index.json
@@ -492,6 +492,8 @@
     "logic_not_all": "НЕ все (Основные И Не все из фильтра)",
     "label_case_sensitive": "Регистрозависимость",
     "label_match_whole_words": "Целые слова",
+    "match_whole_words_st": "ST (\\b)",
+    "match_whole_words_glaze": "Glaze (Пунктуация)",
     "label_group_scoring": "Групповой скоринг",
     "match_global": "Как в глобальных",
     "on": "Вкл",

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -45,6 +45,8 @@ function escapeRegex(string) {
     return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
+const GLAZE_BOUNDARIES = '[\\s.,!?;:"\'\\u201C\\u201D\\u2018\\u2019\\u00AB\\u00BB(){}\\[\\]—–]';
+
 function sanitizeRegexFlags(flags) {
     const valid = new Set(['g', 'i', 'm', 's', 'u', 'y']);
     let out = '';
@@ -194,6 +196,20 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
                 const sourceText = `${text ?? ''}`;
                 const sourceKey = `${key}`;
                 const flags = caseSensitive ? '' : 'i';
+
+                if (wholeWords === 'glaze') {
+                    const escaped = escapeRegex(sourceKey);
+                    const pattern = `(?:^|${GLAZE_BOUNDARIES})${escaped}(?:$|${GLAZE_BOUNDARIES})`;
+                    const regex = tryCreateRegex(pattern, flags);
+                    if (regex) return regex.test(sourceText);
+                    const haystack = caseSensitive ? sourceText : sourceText.toLowerCase();
+                    const needle = caseSensitive ? sourceKey : sourceKey.toLowerCase();
+                    if (!needle) return false;
+                    const escapedNeedle = escapeRegex(needle);
+                    const fallback = tryCreateRegex(`(?:^|${GLAZE_BOUNDARIES})${escapedNeedle}(?:$|${GLAZE_BOUNDARIES})`, caseSensitive ? '' : 'i');
+                    return fallback ? fallback.test(haystack) : false;
+                }
+
                 let pattern = sourceKey;
                 if (wholeWords) pattern = `\\b${pattern}\\b`;
 
@@ -202,8 +218,6 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
                     return regex.test(sourceText);
                 }
 
-                // iOS WebKit can throw RangeError for pathological patterns.
-                // Fallback to literal matching to avoid crashing the worker.
                 const haystack = caseSensitive ? sourceText : sourceText.toLowerCase();
                 const needle = caseSensitive ? sourceKey : sourceKey.toLowerCase();
                 if (!needle) return false;


### PR DESCRIPTION
## Summary

- Adds a third keyword matching mode **Glaze (Punctuation)** for lorebook whole-word matching, alongside existing Off and ST modes
- JS \\\b only works for ASCII word boundaries, so it fails for Cyrillic and other non-ASCII scripts — e.g. Orra, with comma would not match key Orra with \\\b, but works correctly with Glaze mode
- matchWholeWords is now tri-state: false (substring) / true (\\\b) / glaze (punctuation boundaries)
- Glaze mode uses explicit boundary characters: whitespace, punctuation, quotes, brackets, em/en dashes, start/end of string
- Global selector changed from checkbox to 3-option picker: Off / ST / Glaze (Punctuation)
- Per-entry selector unchanged (3 options: Global/On/Off) — no new entry-level option
- On import, caseSensitive and matchWholeWords are reset to null per entry, ensuring all entries inherit global settings and maintaining ST compatibility