### PR TITLE
feat: chat context UI - token breakdown and tokenizer sheet

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -391,6 +391,7 @@ const characterEditorConfig = [
         title: 'section_basic_info',
         fields: [
             { key: 'name', label: 'label_name', type: 'text' },
+            { key: 'macro_name', label: 'label_char_macro_name', type: 'text', placeholder: 'placeholder_char_macro_name' },
             { key: 'description', label: 'label_description', type: 'textarea', rows: 3, expandable: true },
             { key: 'creator_notes', label: 'label_creator_notes', type: 'textarea', rows: 2 },
             { key: 'tags', label: 'label_tags', type: 'tags' }

--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -25,7 +25,7 @@ const props = defineProps({
 
 const emit = defineEmits([
     'update:modelValue', 'send', 'scroll-to-bottom', 
-    'magic-regenerate', 'magic-impersonate', 'magic-notes', 'magic-stats', 'magic-sessions', 'magic-summary', 'magic-api', 'magic-presets', 'magic-char-card', 'magic-lorebooks', 'magic-regex', 'magic-image-gen', 'magic-glossary',
+    'magic-regenerate', 'magic-impersonate', 'magic-notes', 'magic-context', 'magic-stats', 'magic-sessions', 'magic-summary', 'magic-api', 'magic-presets', 'magic-char-card', 'magic-lorebooks', 'magic-regex', 'magic-image-gen', 'magic-glossary',
     'search-next', 'search-prev', 'delete-selected', 'hide-selected', 'cancel-selection'
 ]);
 
@@ -536,6 +536,7 @@ defineExpose({
                 :active-char="activeChar"
                 @close="isMagicMenuVisible = false"
                 @magic-notes="emit('magic-notes')"
+                @magic-context="emit('magic-context')"
                 @magic-summary="emit('magic-summary')"
                 @magic-sessions="emit('magic-sessions')"
                 @magic-stats="emit('magic-stats')"

--- a/src/components/chat/MagicDrawer.vue
+++ b/src/components/chat/MagicDrawer.vue
@@ -25,6 +25,7 @@ const props = defineProps({
 const emit = defineEmits([
     'close',
     'magic-notes',
+    'magic-context',
     'magic-summary',
     'magic-sessions',
     'magic-stats',
@@ -48,6 +49,7 @@ let longPressTimer = null;
 
 const allAvailableItems = [
     { id: 'notes', i18n: 'magic_authors_notes', icon: 'M3 10h11v2H3v-2zm0-2h11V6H3v2zm0 8h7v-2H3v2zm15.01-3.13l.71-.71c.39-.39 1.02-.39 1.41 0l.71.71c.39.39.39 1.02 0 1.41l-.71.71-2.12-2.12zm-.71.71l-5.3 5.3V21h2.12l5.3-5.3-2.12-2.12z', event: 'magic-notes' },
+    { id: 'context', i18n: 'label_tokenizer', fallback: 'Tokenizer', icon: 'M4 11h16v2H4zm0-6h16v2H4zm0 12h10v2H4z', event: 'magic-context' },
     { id: 'summary', i18n: 'magic_summary', icon: 'M14 17H4v2h10v-2zm6-8H4v2h16V9zM4 15h16v-2H4v2zM4 5v2h16V5H4z', event: 'magic-summary' },
     { id: 'sessions', i18n: 'history_title', fallback: 'Sessions', icon: 'M13 3a9 9 0 0 0-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z', event: 'magic-sessions' },
     { id: 'stats', i18n: 'action_chat_stats', icon: 'M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z', event: 'magic-stats' },

--- a/src/components/chat/MagicDrawer.vue
+++ b/src/components/chat/MagicDrawer.vue
@@ -12,6 +12,7 @@ import { db } from '@/utils/db.js';
 import { getLastPrompt } from '@/core/services/generationService.js';
 import { getImageGenSettings } from '@/core/services/imageGenService.js';
 import { replaceMacros } from '@/utils/macroEngine.js';
+import { normalizeBlockId } from '@/utils/presetBlockIds.js';
 import { getApiPresets } from '@/core/config/APISettings.js';
 import PersonasSheet from '@/views/PersonasView.vue';
 
@@ -310,18 +311,19 @@ const effectivePersonaName = computed(() => {
 
 const resolveBlockContent = (block, preset, activeChar, persona, history) => {
     if (!block) return '';
-    if (block.id === 'chat_history') {
+    const blockId = normalizeBlockId(block.id);
+    if (blockId === 'chat_history') {
         if (!history || history.length === 0) return '';
         return history.map(m => `${m.role === 'user' ? (persona?.name || 'User') : (activeChar?.name || 'Char')}: ${m.text}`).join('\n');
     }
-    if (block.id === 'authors_note') return activeChar?.authors_note || '';
-    if (block.id === 'summary') return activeChar?.summary || '';
-    if (block.id === 'user_persona') return persona?.prompt || '';
-    if (block.id === 'char_card') return activeChar?.description || activeChar?.desc || '';
-    if (block.id === 'char_personality' || block.id === 'char_persona') return activeChar?.personality || '';
-    if (block.id === 'scenario') return activeChar?.scenario || '';
-    if (block.id === 'example_dialogue') return activeChar?.mes_example || '';
-    if (block.id === 'first_message') return activeChar?.first_mes || '';
+    if (blockId === 'authors_note') return activeChar?.authors_note || '';
+    if (blockId === 'summary') return activeChar?.summary || '';
+    if (blockId === 'user_persona') return persona?.prompt || '';
+    if (blockId === 'char_card') return activeChar?.description || activeChar?.desc || '';
+    if (blockId === 'char_personality' || blockId === 'char_persona') return activeChar?.personality || '';
+    if (blockId === 'scenario') return activeChar?.scenario || '';
+    if (blockId === 'example_dialogue') return activeChar?.mes_example || '';
+    if (blockId === 'first_message') return activeChar?.first_mes || '';
     return block.content || '';
 };
 

--- a/src/components/chat/MagicDrawer.vue
+++ b/src/components/chat/MagicDrawer.vue
@@ -387,7 +387,20 @@ const activeRegexCount = computed(() => {
 
 const notesTokens = computed(() => estimateTokens(props.activeChar?.authors_note));
 const summaryTokens = computed(() => estimateTokens(props.activeChar?.summary));
-const cardTokens = computed(() => estimateTokens((props.activeChar?.name || '') + '\n' + (props.activeChar?.description || props.activeChar?.desc || '')));
+const cardTokens = computed(() => {
+    const char = props.activeChar;
+    if (!char) return 0;
+
+    const parts = [
+        char.name,
+        char.description || char.desc,
+        char.personality,
+        char.scenario,
+        char.mes_example
+    ].filter(Boolean);
+
+    return estimateTokens(parts.join('\n\n'));
+});
 
 const personaTokens = computed(() => {
     const persona = getEffectivePersona(props.activeChar?.id, props.activeChar?.sessionId ? `${props.activeChar.id}_${props.activeChar.sessionId}` : null);

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -134,6 +134,12 @@ function setupChatHeader(char, currentSessionId, callbacks, sessionName) {
     state.chat.callbacks = callbacks;
     
     state.actions = [{
+        id: 'chat-context-action',
+        icon: `<svg viewBox="0 0 24 24" fill="currentColor" style="width:24px;height:24px;"><path d="M4 11h16v2H4zm0-6h16v2H4zm0 12h10v2H4z"/></svg>`,
+        onClick: () => {
+            if (state.chat.callbacks?.onContextClick) state.chat.callbacks.onContextClick();
+        }
+    }, {
         id: 'chat-search-action',
         icon: `<svg viewBox="0 0 24 24" fill="currentColor" style="width:24px;height:24px;"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>`,
         onClick: () => {

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -134,12 +134,6 @@ function setupChatHeader(char, currentSessionId, callbacks, sessionName) {
     state.chat.callbacks = callbacks;
     
     state.actions = [{
-        id: 'chat-context-action',
-        icon: `<svg viewBox="0 0 24 24" fill="currentColor" style="width:24px;height:24px;"><path d="M4 11h16v2H4zm0-6h16v2H4zm0 12h10v2H4z"/></svg>`,
-        onClick: () => {
-            if (state.chat.callbacks?.onContextClick) state.chat.callbacks.onContextClick();
-        }
-    }, {
         id: 'chat-search-action',
         icon: `<svg viewBox="0 0 24 24" fill="currentColor" style="width:24px;height:24px;"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>`,
         onClick: () => {

--- a/src/components/sheets/CharacterCardSheet.vue
+++ b/src/components/sheets/CharacterCardSheet.vue
@@ -17,6 +17,7 @@ const config = computed(() => [
         title: 'section_basic_info',
         fields: [
             { key: 'name', label: 'label_name', type: 'text', placeholder: 'placeholder_enter_name' },
+            { key: 'macro_name', label: 'label_char_macro_name', type: 'text', placeholder: 'placeholder_char_macro_name' },
             { key: 'description', label: 'label_description', type: 'textarea', rows: 4, placeholder: 'placeholder_char_desc', expandable: true },
             { key: 'first_mes', label: 'label_first_mes', type: 'greeting_list', rows: 4, placeholder: 'placeholder_greeting' }
         ]

--- a/src/components/sheets/LorebookSheet.vue
+++ b/src/components/sheets/LorebookSheet.vue
@@ -228,6 +228,12 @@ function openOptionSelector({ title, options, currentValue, onSelect }) {
     showBottomSheet({ title, items });
 }
 
+function getReserveModeLabel() {
+    return lorebookState.globalSettings.reserveMode === 'tokens'
+        ? (t('label_budget_cap') || 'Exact tokens')
+        : (t('label_context_percent') || 'Percent');
+}
+
 // activation now managed via LorebookConnectionsSheet
 
 // --- Lifecycle ---
@@ -444,14 +450,25 @@ defineExpose({ open, openEntry, close, openLorebook });
                                 <input type="number" v-model="lorebookState.globalSettings.scanDepth">
                             </div>
                              <div class="settings-col">
-                                <label>{{ t('label_context_percent') }}</label>
-                                <input type="number" v-model="lorebookState.globalSettings.contextPercent">
+                                <label>Lorebook reserve mode</label>
+                                <div class="clickable-selector" @click="openOptionSelector({
+                                    title: 'Lorebook reserve mode',
+                                    options: [
+                                        { value: 'percent', label: t('label_context_percent') || 'Percent' },
+                                        { value: 'tokens', label: t('label_budget_cap') || 'Exact tokens' }
+                                    ],
+                                    currentValue: lorebookState.globalSettings.reserveMode,
+                                    onSelect: (v) => lorebookState.globalSettings.reserveMode = v
+                                })">
+                                    <span>{{ getReserveModeLabel() }}</span>
+                                    <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+                                </div>
                             </div>
                         </div>
                          <div class="settings-row">
                             <div class="settings-col">
-                                <label>{{ t('label_budget_cap') }}</label>
-                                <input type="number" v-model="lorebookState.globalSettings.budgetCap">
+                                <label>{{ lorebookState.globalSettings.reserveMode === 'tokens' ? (t('label_budget_cap') || 'Exact tokens') : (t('label_context_percent') || 'Reserve percent') }}</label>
+                                <input type="number" v-model="lorebookState.globalSettings.reserveValue" :min="lorebookState.globalSettings.reserveMode === 'tokens' ? 0 : 1" :max="lorebookState.globalSettings.reserveMode === 'tokens' ? undefined : 100">
                             </div>
                              <div class="settings-col">
                                 <label>{{ t('label_min_activations') }}</label>

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -368,13 +368,20 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             apiConfig
         }));
 
-        const result = await processPromptAsync(payload);
-        return result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
+        const resolvedCutoff = result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
             ? result.cutoffOriginalIndex
             : result.cutoffIndex;
+
+        return {
+            cutoffIndex: resolvedCutoff,
+            contextBreakdown: result.contextBreakdown || null
+        };
     } catch (e) {
         console.error("Calculate context worker error", e);
-        return 0;
+        return {
+            cutoffIndex: 0,
+            contextBreakdown: null
+        };
     }
 }
 

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -224,7 +224,10 @@ export async function generateChatResponse({
     }
 
     if (callbacks.onPromptReady) {
-        callbacks.onPromptReady({ loreEntries: result.loreEntries });
+        callbacks.onPromptReady({
+            loreEntries: result.loreEntries,
+            contextBreakdown: result.contextBreakdown || null
+        });
     }
 
     let messages = result.messages;
@@ -368,6 +371,8 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             apiConfig
         }));
 
+        const result = await processPromptAsync(payload);
+
         const resolvedCutoff = result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
             ? result.cutoffOriginalIndex
             : result.cutoffIndex;
@@ -385,8 +390,12 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
     }
 }
 
-export async function generateSummary({ history, prompt, controller }) {
-    const { apiKey, apiUrl, model, temp } = getEffectiveApiConfig();
+export async function generateSummary({ history, prompt, controller, apiConfigOverride = null }) {
+    const effectiveConfig = {
+        ...getEffectiveApiConfig(),
+        ...(apiConfigOverride || {})
+    };
+    const { apiKey, apiUrl, model, temp } = effectiveConfig;
 
     if (!apiUrl || !model) {
         throw new Error("API Not Configured");

--- a/src/core/states/lorebookState.js
+++ b/src/core/states/lorebookState.js
@@ -12,6 +12,8 @@ export const lorebookState = reactive({
         scanDepth: 1000,
         contextPercent: 100,
         budgetCap: 0,
+        reserveMode: 'tokens',
+        reserveValue: 0,
         minActivations: 0,
         maxDepth: 0,
         maxRecursionSteps: 0,
@@ -43,6 +45,17 @@ export async function initLorebookState() {
                 // New format with settings
                 lorebookState.lorebooks = data.lorebooks;
                 if (data.settings) {
+                    if (data.settings.reserveMode === undefined) {
+                        data.settings.reserveMode = 'tokens';
+                    }
+                    if (data.settings.reserveValue === undefined) {
+                        const legacyBudget = Number(data.settings.budgetCap || 0);
+                        const legacyPercent = Number(data.settings.contextPercent || 0);
+                        data.settings.reserveValue = legacyBudget > 0 ? legacyBudget : Math.max(legacyPercent, 0);
+                        if (legacyBudget <= 0 && legacyPercent > 0) {
+                            data.settings.reserveMode = 'percent';
+                        }
+                    }
                     Object.assign(lorebookState.globalSettings, data.settings);
                 }
                 if (data.activations) {

--- a/src/core/states/lorebookState.js
+++ b/src/core/states/lorebookState.js
@@ -12,8 +12,8 @@ export const lorebookState = reactive({
         scanDepth: 1000,
         contextPercent: 100,
         budgetCap: 0,
-        reserveMode: 'tokens',
-        reserveValue: 0,
+        reserveMode: 'percent',
+        reserveValue: 10,
         minActivations: 0,
         maxDepth: 0,
         maxRecursionSteps: 0,
@@ -46,12 +46,12 @@ export async function initLorebookState() {
                 lorebookState.lorebooks = data.lorebooks;
                 if (data.settings) {
                     if (data.settings.reserveMode === undefined) {
-                        data.settings.reserveMode = 'tokens';
+                        data.settings.reserveMode = 'percent';
                     }
                     if (data.settings.reserveValue === undefined) {
                         const legacyBudget = Number(data.settings.budgetCap || 0);
                         const legacyPercent = Number(data.settings.contextPercent || 0);
-                        data.settings.reserveValue = legacyBudget > 0 ? legacyBudget : Math.max(legacyPercent, 0);
+                        data.settings.reserveValue = legacyBudget > 0 ? legacyBudget : Math.max(legacyPercent, 10);
                         if (legacyBudget <= 0 && legacyPercent > 0) {
                             data.settings.reserveMode = 'percent';
                         }

--- a/src/locales/en/index.json
+++ b/src/locales/en/index.json
@@ -249,6 +249,8 @@
     "stat_gen_time": "Generation Time",
     "notification_generating": "Generating response...",
     "magic_authors_notes": "Author's Notes",
+    "label_tokenizer": "Tokenizer",
+    "label_hide_top_messages": "Hide top messages",
     "magic_summary": "Chat Summary",
     "summary_title": "Current Summary",
     "unique_for_chat": "Content is unique for each chat",

--- a/src/locales/en/index.json
+++ b/src/locales/en/index.json
@@ -132,6 +132,8 @@
     "placeholder_enter_name": "Enter name",
     "label_char_prompt": "Character Prompt",
     "label_description": "Description",
+    "label_char_macro_name": "Macro Name",
+    "placeholder_char_macro_name": "Optional {{char}} override, e.g. Narrator",
     "label_creator_notes": "Creator Notes",
     "label_tags": "Tags",
     "label_personality": "Personality",

--- a/src/locales/ru/index.json
+++ b/src/locales/ru/index.json
@@ -249,6 +249,8 @@
     "stat_gen_time": "Время генерации",
     "notification_generating": "Генерация ответа...",
     "magic_authors_notes": "Заметки автора",
+    "label_tokenizer": "Токенайзер",
+    "label_hide_top_messages": "Скрыть верхние сообщения",
     "magic_summary": "Саммари чата",
     "summary_title": "Текущее саммари",
     "unique_for_chat": "Содержимое уникально для каждого чата",

--- a/src/locales/ru/index.json
+++ b/src/locales/ru/index.json
@@ -131,6 +131,8 @@
     "placeholder_enter_name": "Введите имя",
     "label_char_prompt": "Промпт персонажа",
     "label_description": "Описание",
+    "label_char_macro_name": "Имя для макроса",
+    "placeholder_char_macro_name": "Необязательно: подмена {{char}}, например Narrator",
     "label_creator_notes": "Заметки автора",
     "label_tags": "Теги",
     "label_personality": "Личность",

--- a/src/utils/macroEngine.js
+++ b/src/utils/macroEngine.js
@@ -7,7 +7,7 @@ export function replaceMacros(text, char, persona, sessionVarsIn = null, notifyO
     // Single-line: {{// comment}}
     result = result.replace(/\{\{\/\/[^}]*\}\}/g, '');
 
-    const charName = char ? char.name : "Character";
+    const charName = char ? (char.macro_name || char.name) : "Character";
     const charDesc = char ? (char.description || char.desc || "") : "";
     const charScenario = char ? (char.scenario || "") : "";
     const charPersonality = char ? (char.personality || "") : "";

--- a/src/utils/presetBlockIds.js
+++ b/src/utils/presetBlockIds.js
@@ -1,0 +1,11 @@
+const ST_TO_INTERNAL_BLOCK_ID = {
+    personaDescription: 'user_persona',
+    charDescription: 'char_card',
+    charPersonality: 'char_personality',
+    dialogueExamples: 'example_dialogue',
+    chatHistory: 'chat_history'
+};
+
+export function normalizeBlockId(blockId) {
+    return ST_TO_INTERNAL_BLOCK_ID[blockId] || blockId;
+}

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -79,6 +79,11 @@ const regexSheet = ref(null);
 const activeChar = ref(null);
 const regexRevision = ref(0);
 const onRegexChanged = () => { regexRevision.value++; };
+const contextBreakdown = ref(null);
+const HISTORY_FILL_THRESHOLD_KEY = 'gz_history_fill_threshold';
+const HISTORY_HIDE_PERCENT_KEY = 'gz_history_hide_percent';
+const historyFillThreshold = ref(parseInt(localStorage.getItem(HISTORY_FILL_THRESHOLD_KEY) || '85', 10));
+const historyHidePercent = ref(parseInt(localStorage.getItem(HISTORY_HIDE_PERCENT_KEY) || '30', 10));
 let isCalculatingCutoff = false;
 let pendingCutoffRecalc = false;
 let isOpeningChat = false;
@@ -217,6 +222,77 @@ window.forceScrollToBottom = () => { vsScrollToBottom('auto') };
 
 // Helper to access translations
 const t = (key) => translations[currentLang.value]?.[key] || key;
+
+const contextSegments = computed(() => {
+    const breakdown = contextBreakdown.value;
+    if (!breakdown || !breakdown.safeContext) return [];
+
+    const total = breakdown.safeContext;
+    const toPercent = (value) => Math.max(0, Math.min(100, (value / total) * 100));
+    const segments = [];
+
+    const fixedTokens = breakdown.character + breakdown.preset + breakdown.authorsNote;
+    if (fixedTokens > 0) {
+        segments.push({ key: 'fixed', value: fixedTokens, percent: toPercent(fixedTokens), className: 'segment-fixed' });
+    }
+    if (breakdown.summary > 0) {
+        segments.push({ key: 'summary', value: breakdown.summary, percent: toPercent(breakdown.summary), className: 'segment-summary' });
+    }
+    if (breakdown.history > 0) {
+        segments.push({ key: 'history', value: breakdown.history, percent: toPercent(breakdown.history), className: 'segment-history' });
+    }
+    if (breakdown.lorebookReserve > 0) {
+        segments.push({ key: 'lorebookReserve', value: breakdown.lorebookReserve, percent: toPercent(breakdown.lorebookReserve), className: 'segment-lorebook-reserve' });
+    }
+
+    return segments;
+});
+
+const contextBreakdownItems = computed(() => {
+    const breakdown = contextBreakdown.value;
+    if (!breakdown) return [];
+
+    return [
+        { key: 'character', label: 'Character', value: breakdown.character || 0 },
+        { key: 'preset', label: 'Preset', value: (breakdown.preset || 0) + (breakdown.authorsNote || 0) },
+        { key: 'summary', label: 'Summary', value: breakdown.summary || 0 },
+        { key: 'lorebookReserve', label: 'Lorebook Reserve', value: breakdown.lorebookReserve || 0 },
+        { key: 'history', label: 'History', value: breakdown.history || 0 }
+    ];
+});
+
+const visibleHistoryMessages = computed(() => {
+    return currentMessages.value.filter(m => m && !m.isTyping && !m.isHidden);
+});
+
+const historyUsagePercent = computed(() => {
+    const breakdown = contextBreakdown.value;
+    if (!breakdown) return 0;
+    const available = breakdown.availableForHistory || 0;
+    if (available <= 0) return breakdown.history > 0 ? 100 : 0;
+    return Math.max(0, Math.min(100, Math.round(((breakdown.history || 0) / available) * 100)));
+});
+
+const historyHidePreview = computed(() => {
+    const messages = visibleHistoryMessages.value;
+    const percent = Math.max(1, Math.min(95, historyHidePercent.value || 30));
+    if (!messages.length) return { count: 0, tokens: 0 };
+
+    const count = Math.max(1, Math.min(messages.length, Math.ceil(messages.length * percent / 100)));
+    const tokens = messages
+        .slice(0, count)
+        .reduce((sum, msg) => sum + estimateTokens(msg.text || ''), 0);
+
+    return { count, tokens };
+});
+
+const shouldRecommendHide = computed(() => {
+    const breakdown = contextBreakdown.value;
+    if (!breakdown || !breakdown.history) return false;
+    const threshold = Math.max(1, Math.min(100, historyFillThreshold.value || 85));
+    return historyUsagePercent.value >= threshold;
+});
+
 
 // --- Search Logic ---
 watch(searchQuery, (newVal) => {
@@ -393,7 +469,7 @@ async function updateContextCutoff() {
     }
 
     try {
-        const newCutoff = await calculateContext({
+        const result = await calculateContext({
             char: activeChatChar,
             history,
             authorsNote,
@@ -401,7 +477,8 @@ async function updateContextCutoff() {
         });
         
         if (activeChatChar && activeChatChar.id === currentCharId) {
-            cutoffIndex.value = newCutoff;
+            cutoffIndex.value = result?.cutoffIndex ?? 0;
+            contextBreakdown.value = result?.contextBreakdown || null;
         }
     } finally {
         isCalculatingCutoff = false;
@@ -423,6 +500,211 @@ async function updateSessionMessage(char, msgIndex, newMsgData) {
     }
 }
 
+function clampHistoryFillThreshold(value) {
+    const parsed = parseInt(value, 10);
+    if (Number.isNaN(parsed)) return 85;
+    return Math.max(1, Math.min(100, parsed));
+}
+
+function clampHistoryHidePercent(value) {
+    const parsed = parseInt(value, 10);
+    if (Number.isNaN(parsed)) return 30;
+    return Math.max(1, Math.min(95, parsed));
+}
+
+function persistHistoryContextSettings(fillThreshold, hidePercent) {
+    historyFillThreshold.value = clampHistoryFillThreshold(fillThreshold);
+    historyHidePercent.value = clampHistoryHidePercent(hidePercent);
+    localStorage.setItem(HISTORY_FILL_THRESHOLD_KEY, String(historyFillThreshold.value));
+    localStorage.setItem(HISTORY_HIDE_PERCENT_KEY, String(historyHidePercent.value));
+}
+
+async function saveCurrentMessages() {
+    if (!activeChatChar) return;
+    const data = await getChatData(activeChatChar.id);
+    if (!data) return;
+    const sessionId = activeChatChar.sessionId || data.currentId;
+    data.sessions[sessionId] = currentMessages.value;
+    await db.saveChat(activeChatChar.id, data);
+}
+
+function openHistoryContextSettings() {
+    const content = document.createElement('div');
+    content.className = 'context-sheet';
+    content.innerHTML = `
+        <div class="settings-item">
+            <label>History fill threshold (%)</label>
+            <input id="history-fill-threshold" type="number" min="1" max="100" value="${historyFillThreshold.value}">
+        </div>
+        <div class="settings-item">
+            <label>Hide top messages (%)</label>
+            <input id="history-hide-percent" type="number" min="1" max="95" value="${historyHidePercent.value}">
+        </div>
+        <div class="context-sheet-note">Hide top messages recommendation appears when visible history reaches the configured threshold.</div>
+        <div class="context-sheet-actions">
+            <button type="button" class="context-sheet-btn context-sheet-btn-secondary" id="history-context-cancel">Cancel</button>
+            <button type="button" class="context-sheet-btn context-sheet-btn-primary" id="history-context-save">Save</button>
+        </div>
+    `;
+
+    const fillInput = content.querySelector('#history-fill-threshold');
+    const hideInput = content.querySelector('#history-hide-percent');
+    const saveBtn = content.querySelector('#history-context-save');
+    const cancelBtn = content.querySelector('#history-context-cancel');
+
+    cancelBtn.addEventListener('click', () => closeBottomSheet());
+    saveBtn.addEventListener('click', () => {
+        persistHistoryContextSettings(fillInput?.value, hideInput?.value);
+        closeBottomSheet();
+        setTimeout(() => openContextSheet(), 250);
+    });
+
+    showBottomSheet({
+        title: 'History Context Settings',
+        content,
+        isSolid: true
+    });
+}
+
+async function hideTopMessagesNow() {
+    const count = historyHidePreview.value.count;
+    if (!count || !activeChatChar) return;
+
+    let hidden = 0;
+    for (const msg of currentMessages.value) {
+        if (!msg || msg.isTyping || msg.isHidden) continue;
+        msg.isHidden = true;
+        hidden += 1;
+        if (hidden >= count) break;
+    }
+
+    if (!hidden) return;
+
+    await saveCurrentMessages();
+    await updateContextCutoff();
+    closeBottomSheet();
+    showToast(`Hidden ${hidden} top message${hidden === 1 ? '' : 's'}`);
+}
+
+function confirmHideTopMessages() {
+    const preview = historyHidePreview.value;
+    if (!preview.count) return;
+
+    showBottomSheet({
+        title: 'Hide Top Messages',
+        items: [
+            {
+                label: 'Open Summary',
+                hint: 'Review or generate a summary first',
+                icon: '<svg viewBox="0 0 24 24"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 14H7v-2h10v2zm0-4H7v-2h10v2zm0-4H7V7h10v2z"/></svg>',
+                onClick: () => {
+                    closeBottomSheet();
+                    setTimeout(() => presetView.value?.openSummarySheet(), 250);
+                }
+            },
+            {
+                label: `Hide ${preview.count} message${preview.count === 1 ? '' : 's'} now`,
+                hint: `Free about ${preview.tokens} tokens`,
+                icon: '<svg viewBox="0 0 24 24"><path d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46C3.08 8.3 1.78 10.02 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27z"/></svg>',
+                onClick: () => {
+                    hideTopMessagesNow();
+                }
+            },
+            {
+                label: 'Cancel',
+                onClick: () => closeBottomSheet()
+            }
+        ]
+    });
+}
+
+async function openContextSheet() {
+    if (!contextBreakdown.value && activeChatChar) {
+        await updateContextCutoff();
+    }
+
+    const breakdown = contextBreakdown.value;
+    if (!breakdown) {
+        showBottomSheet({
+            title: 'Context',
+            bigInfo: {
+                icon: '<svg viewBox="0 0 24 24" style="fill:currentColor;width:100%;height:100%;"><path d="M11 17h2v-6h-2v6zm0-8h2V7h-2v2zm1-7C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"/></svg>',
+                description: 'Context breakdown is not ready yet. Try again in a moment.',
+                buttonText: 'Close',
+                onButtonClick: () => closeBottomSheet()
+            }
+        });
+        return;
+    }
+
+    const used = breakdown.totalUsed || 0;
+    const safeContext = breakdown.safeContext || 0;
+    const remaining = Math.max(0, breakdown.remaining || 0);
+    const preview = historyHidePreview.value;
+    const content = document.createElement('div');
+    content.className = 'context-sheet';
+
+    const segmentHtml = contextSegments.value.map(segment => `
+        <div class="chat-context-segment ${segment.className}" style="width:${segment.percent}%"></div>
+    `).join('');
+
+    const breakdownHtml = contextBreakdownItems.value.map(item => `
+        <div class="context-breakdown-row">
+            <span>${item.label}</span>
+            <strong>${item.value}</strong>
+        </div>
+    `).join('');
+
+    const recommendationHtml = shouldRecommendHide.value ? `
+        <div class="context-recommendation">
+            <div class="context-recommendation-title">History is near its limit</div>
+            <div class="context-recommendation-text">Hide about ${preview.count} top message${preview.count === 1 ? '' : 's'} to free about ${preview.tokens} tokens.</div>
+        </div>
+    ` : '';
+
+    const hideButtonHtml = shouldRecommendHide.value ? `
+        <button type="button" class="context-sheet-btn context-sheet-btn-primary" id="context-hide-btn">Hide top ${preview.count}</button>
+    ` : '';
+
+    content.innerHTML = `
+        <div class="context-sheet-summary">
+            <div class="context-sheet-kpi">
+                <strong>${used}</strong>
+                <span>used / ${safeContext}</span>
+            </div>
+            <div class="context-sheet-kpi">
+                <strong>${remaining}</strong>
+                <span>remaining</span>
+            </div>
+            <div class="context-sheet-kpi">
+                <strong>${historyUsagePercent.value}%</strong>
+                <span>history fill</span>
+            </div>
+        </div>
+        <div class="chat-context-bar context-sheet-bar">${segmentHtml}</div>
+        <div class="context-breakdown">${breakdownHtml}</div>
+        ${recommendationHtml}
+        <div class="context-sheet-actions">
+            <button type="button" class="context-sheet-btn context-sheet-btn-secondary" id="context-settings-btn">Settings</button>
+            ${hideButtonHtml}
+        </div>
+    `;
+
+    content.querySelector('#context-settings-btn')?.addEventListener('click', () => {
+        openHistoryContextSettings();
+    });
+
+    content.querySelector('#context-hide-btn')?.addEventListener('click', () => {
+        confirmHideTopMessages();
+    });
+
+    showBottomSheet({
+        title: 'Context',
+        content,
+        isSolid: true
+    });
+}
+
 async function setupHeader(char = activeChatChar) {
     if (!char) return;
     const data = await getChatData(char.id);
@@ -436,6 +718,7 @@ async function setupHeader(char = activeChatChar) {
             sessionName,
             callbacks: {
                 onActionsClick: () => openSessionsSheet(char),
+                onContextClick: () => openContextSheet(),
                 onBackClick: () => {
                     closeChat();
                     if (currentOnBack) currentOnBack();
@@ -2854,7 +3137,6 @@ onUnmounted(() => {
 
         <div class="chat-status-gradient"></div>
 
-
         <div class="chat-input-wrapper" ref="chatInputContainer" :style="isAndroid ? { bottom: keyboardOverlap + 'px' } : {}">
             <ChatInput 
                 ref="chatInputRef"
@@ -3018,6 +3300,150 @@ onUnmounted(() => {
     flex-direction: column;
     overflow: visible !important;
     flex-shrink: 0;
+}
+
+.chat-context-bar {
+    display: flex;
+    width: 100%;
+    height: 10px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.chat-context-segment {
+    height: 100%;
+}
+
+.segment-fixed {
+    background: #8f8f95;
+}
+
+.segment-history {
+    background: #d8b84a;
+}
+
+.segment-summary {
+    background: #8f6bff;
+}
+
+.segment-lorebook-reserve {
+    background: #43b56f;
+}
+
+.context-sheet {
+    padding: 0 16px 16px;
+}
+
+.context-sheet-summary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    margin-bottom: 14px;
+}
+
+.context-sheet-kpi {
+    padding: 12px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, var(--element-opacity, 0.72));
+    backdrop-filter: blur(var(--element-blur, 20px));
+    text-align: center;
+}
+
+.context-sheet-kpi strong {
+    display: block;
+    font-size: 18px;
+    line-height: 1.2;
+}
+
+.context-sheet-kpi span {
+    display: block;
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--text-gray);
+}
+
+.context-sheet-bar {
+    margin-bottom: 14px;
+}
+
+.context-breakdown {
+    display: grid;
+    gap: 8px;
+}
+
+.context-breakdown-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.context-breakdown-row span {
+    color: var(--text-gray);
+}
+
+.context-breakdown-row strong {
+    font-weight: 600;
+}
+
+.context-recommendation {
+    margin-top: 14px;
+    padding: 12px;
+    border-radius: 14px;
+    background: rgba(216, 184, 74, 0.14);
+    border: 1px solid rgba(216, 184, 74, 0.35);
+}
+
+.context-recommendation-title {
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.context-recommendation-text,
+.context-sheet-note {
+    font-size: 13px;
+    color: var(--text-gray);
+    line-height: 1.45;
+}
+
+.context-sheet-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 16px;
+}
+
+.context-sheet-btn {
+    flex: 1;
+    min-height: 42px;
+    border: none;
+    border-radius: 12px;
+    padding: 0 14px;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.context-sheet-btn-primary {
+    color: #fff;
+    background: var(--vk-blue);
+}
+
+.context-sheet-btn-secondary {
+    color: var(--text-black);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 480px) {
+    .context-sheet-summary {
+        grid-template-columns: 1fr;
+    }
+
+    .context-sheet-actions {
+        flex-direction: column;
+    }
 }
 
 

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -225,27 +225,37 @@ const t = (key) => translations[currentLang.value]?.[key] || key;
 
 const contextSegments = computed(() => {
     const breakdown = contextBreakdown.value;
-    if (!breakdown || !breakdown.safeContext) return [];
+    if (!breakdown || !breakdown.safeContext) return { used: [], reserve: null };
 
     const total = breakdown.safeContext;
     const toPercent = (value) => Math.max(0, Math.min(100, (value / total) * 100));
-    const segments = [];
+    const used = [];
 
-    const fixedTokens = breakdown.character + breakdown.preset + breakdown.authorsNote;
-    if (fixedTokens > 0) {
-        segments.push({ key: 'fixed', value: fixedTokens, percent: toPercent(fixedTokens), className: 'segment-fixed' });
+    if (breakdown.character > 0) {
+        used.push({ key: 'character', value: breakdown.character, percent: toPercent(breakdown.character), className: 'segment-character' });
+    }
+    if (breakdown.preset > 0) {
+        used.push({ key: 'preset', value: breakdown.preset, percent: toPercent(breakdown.preset), className: 'segment-fixed' });
+    }
+    if (breakdown.authorsNote > 0) {
+        used.push({ key: 'authorsNote', value: breakdown.authorsNote, percent: toPercent(breakdown.authorsNote), className: 'segment-authors-note' });
     }
     if (breakdown.summary > 0) {
-        segments.push({ key: 'summary', value: breakdown.summary, percent: toPercent(breakdown.summary), className: 'segment-summary' });
+        used.push({ key: 'summary', value: breakdown.summary, percent: toPercent(breakdown.summary), className: 'segment-summary' });
+    }
+    if (breakdown.lorebook > 0) {
+        used.push({ key: 'lorebook', value: breakdown.lorebook, percent: toPercent(breakdown.lorebook), className: 'segment-lorebook' });
     }
     if (breakdown.history > 0) {
-        segments.push({ key: 'history', value: breakdown.history, percent: toPercent(breakdown.history), className: 'segment-history' });
-    }
-    if (breakdown.lorebookReserve > 0) {
-        segments.push({ key: 'lorebookReserve', value: breakdown.lorebookReserve, percent: toPercent(breakdown.lorebookReserve), className: 'segment-lorebook-reserve' });
+        used.push({ key: 'history', value: breakdown.history, percent: toPercent(breakdown.history), className: 'segment-history' });
     }
 
-    return segments;
+    return {
+        used,
+        reserve: breakdown.lorebookReserve > 0
+            ? { key: 'lorebookReserve', value: breakdown.lorebookReserve, percent: toPercent(breakdown.lorebookReserve), className: 'segment-lorebook-reserve' }
+            : null
+    };
 });
 
 const contextBreakdownItems = computed(() => {
@@ -254,12 +264,24 @@ const contextBreakdownItems = computed(() => {
 
     return [
         { key: 'character', label: 'Character', value: breakdown.character || 0 },
-        { key: 'preset', label: 'Preset', value: (breakdown.preset || 0) + (breakdown.authorsNote || 0) },
+        { key: 'preset', label: 'Preset', value: breakdown.preset || 0 },
+        { key: 'authorsNote', label: 'Author\'s Note', value: breakdown.authorsNote || 0 },
         { key: 'summary', label: 'Summary', value: breakdown.summary || 0 },
+        { key: 'lorebook', label: 'Lorebook Used', value: breakdown.lorebook || 0 },
         { key: 'lorebookReserve', label: 'Lorebook Reserve', value: breakdown.lorebookReserve || 0 },
         { key: 'history', label: 'History', value: breakdown.history || 0 }
     ];
 });
+
+const contextLegendItems = computed(() => [
+    { key: 'character', label: 'Character', className: 'segment-character' },
+    { key: 'preset', label: 'Preset', className: 'segment-fixed' },
+    { key: 'authorsNote', label: 'Author\'s Note', className: 'segment-authors-note' },
+    { key: 'summary', label: 'Summary', className: 'segment-summary' },
+    { key: 'lorebook', label: 'Lorebook Used', className: 'segment-lorebook' },
+    { key: 'history', label: 'History', className: 'segment-history' },
+    { key: 'lorebookReserve', label: 'Lorebook Reserve', className: 'segment-lorebook-reserve' }
+]);
 
 const visibleHistoryMessages = computed(() => {
     return currentMessages.value.filter(m => m && !m.isTyping && !m.isHidden);
@@ -542,7 +564,7 @@ function openHistoryContextSettings() {
         </div>
         <div class="context-sheet-note">Hide top messages recommendation appears when visible history reaches the configured threshold.</div>
         <div class="context-sheet-actions">
-            <button type="button" class="context-sheet-btn context-sheet-btn-secondary" id="history-context-cancel">Cancel</button>
+            <button type="button" class="context-sheet-btn context-sheet-btn-secondary" id="history-context-back">Back</button>
             <button type="button" class="context-sheet-btn context-sheet-btn-primary" id="history-context-save">Save</button>
         </div>
     `;
@@ -550,9 +572,12 @@ function openHistoryContextSettings() {
     const fillInput = content.querySelector('#history-fill-threshold');
     const hideInput = content.querySelector('#history-hide-percent');
     const saveBtn = content.querySelector('#history-context-save');
-    const cancelBtn = content.querySelector('#history-context-cancel');
+    const backBtn = content.querySelector('#history-context-back');
 
-    cancelBtn.addEventListener('click', () => closeBottomSheet());
+    backBtn.addEventListener('click', () => {
+        closeBottomSheet();
+        setTimeout(() => openContextSheet(), 250);
+    });
     saveBtn.addEventListener('click', () => {
         persistHistoryContextSettings(fillInput?.value, hideInput?.value);
         closeBottomSheet();
@@ -644,8 +669,20 @@ async function openContextSheet() {
     const content = document.createElement('div');
     content.className = 'context-sheet';
 
-    const segmentHtml = contextSegments.value.map(segment => `
+    const usedWidth = Math.max(0, 100 - (contextSegments.value.reserve?.percent || 0));
+    const segmentHtml = contextSegments.value.used.map(segment => `
         <div class="chat-context-segment ${segment.className}" style="width:${segment.percent}%"></div>
+    `).join('');
+
+    const reserveHtml = contextSegments.value.reserve
+        ? `<div class="chat-context-reserve ${contextSegments.value.reserve.className}" style="width:${contextSegments.value.reserve.percent}%"></div>`
+        : '';
+
+    const legendHtml = contextLegendItems.value.map(segment => `
+        <div class="context-legend-item">
+            <span class="context-legend-swatch ${segment.className}"></span>
+            <span>${segment.label}</span>
+        </div>
     `).join('');
 
     const breakdownHtml = contextBreakdownItems.value.map(item => `
@@ -662,15 +699,15 @@ async function openContextSheet() {
         </div>
     ` : '';
 
-    const hideButtonHtml = shouldRecommendHide.value ? `
-        <button type="button" class="context-sheet-btn context-sheet-btn-primary" id="context-hide-btn">Hide top ${preview.count}</button>
-    ` : '';
+    const hideButtonLabel = preview.count
+        ? `Hide top ${preview.count}`
+        : 'Hide top messages';
 
     content.innerHTML = `
         <div class="context-sheet-summary">
             <div class="context-sheet-kpi">
                 <strong>${used}</strong>
-                <span>used / ${safeContext}</span>
+                <span>used / ${breakdown.contextSize || safeContext}</span>
             </div>
             <div class="context-sheet-kpi">
                 <strong>${remaining}</strong>
@@ -681,12 +718,16 @@ async function openContextSheet() {
                 <span>history fill</span>
             </div>
         </div>
-        <div class="chat-context-bar context-sheet-bar">${segmentHtml}</div>
+        <div class="chat-context-bar context-sheet-bar">
+            <div class="chat-context-used" style="width:${usedWidth}%">${segmentHtml}</div>
+            ${reserveHtml}
+        </div>
+        <div class="context-legend">${legendHtml}</div>
         <div class="context-breakdown">${breakdownHtml}</div>
         ${recommendationHtml}
         <div class="context-sheet-actions">
+            <button type="button" class="context-sheet-btn context-sheet-btn-primary" id="context-hide-btn">${hideButtonLabel}</button>
             <button type="button" class="context-sheet-btn context-sheet-btn-secondary" id="context-settings-btn">Settings</button>
-            ${hideButtonHtml}
         </div>
     `;
 
@@ -718,7 +759,6 @@ async function setupHeader(char = activeChatChar) {
             sessionName,
             callbacks: {
                 onActionsClick: () => openSessionsSheet(char),
-                onContextClick: () => openContextSheet(),
                 onBackClick: () => {
                     closeChat();
                     if (currentOnBack) currentOnBack();
@@ -3156,6 +3196,7 @@ onUnmounted(() => {
                 @search-prev="prevSearchResult"
                 @magic-impersonate="startImpersonation"
                 @magic-notes="presetView.openAuthorsNoteSheet()"
+                @magic-context="openContextSheet()"
                 @magic-stats="openChatStatsSheet()"
                 @magic-summary="presetView.openSummarySheet()"
                 @magic-sessions="openSessionsSheet(activeChatChar)"
@@ -3303,12 +3344,28 @@ onUnmounted(() => {
 }
 
 .chat-context-bar {
+    position: relative;
     display: flex;
     width: 100%;
     height: 10px;
     overflow: hidden;
     border-radius: 999px;
-    background: rgba(0, 0, 0, 0.08);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.chat-context-used {
+    display: flex;
+    height: 100%;
+    min-width: 0;
+    flex: 0 0 auto;
+}
+
+.chat-context-reserve {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    box-shadow: inset 2px 0 0 rgba(0, 0, 0, 0.35);
 }
 
 .chat-context-segment {
@@ -3319,12 +3376,24 @@ onUnmounted(() => {
     background: #8f8f95;
 }
 
+.segment-character {
+    background: #4f8cff;
+}
+
 .segment-history {
     background: #d8b84a;
 }
 
 .segment-summary {
-    background: #8f6bff;
+    background: #1ec8ff;
+}
+
+.segment-authors-note {
+    background: #7a6cff;
+}
+
+.segment-lorebook {
+    background: #ff8c42;
 }
 
 .segment-lorebook-reserve {
@@ -3345,15 +3414,18 @@ onUnmounted(() => {
 .context-sheet-kpi {
     padding: 12px;
     border-radius: 14px;
-    background: rgba(255, 255, 255, var(--element-opacity, 0.72));
+    background: rgba(255, 255, 255, 0.08);
     backdrop-filter: blur(var(--element-blur, 20px));
     text-align: center;
+    color: var(--text-black);
+    border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .context-sheet-kpi strong {
     display: block;
     font-size: 18px;
     line-height: 1.2;
+    color: var(--text-black);
 }
 
 .context-sheet-kpi span {
@@ -3365,6 +3437,28 @@ onUnmounted(() => {
 
 .context-sheet-bar {
     margin-bottom: 14px;
+}
+
+.context-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    margin-bottom: 14px;
+}
+
+.context-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-gray);
+}
+
+.context-legend-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    flex-shrink: 0;
 }
 
 .context-breakdown {
@@ -3379,7 +3473,8 @@ onUnmounted(() => {
     gap: 12px;
     padding: 10px 12px;
     border-radius: 12px;
-    background: rgba(255, 255, 255, 0.05);
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .context-breakdown-row span {
@@ -3388,6 +3483,7 @@ onUnmounted(() => {
 
 .context-breakdown-row strong {
     font-weight: 600;
+    color: var(--text-black);
 }
 
 .context-recommendation {

--- a/src/views/DialogList.vue
+++ b/src/views/DialogList.vue
@@ -48,11 +48,12 @@ const loadData = async () => {
             const sessions = charData.sessions || (Array.isArray(charData) ? { 1: charData } : {});
             const currentId = charData.currentId || 1;
 
-            Object.keys(sessions).forEach(sid => {
-                const sessionId = parseInt(sid);
-                const msgs = sessions[sid];
-                const lastMsg = msgs[msgs.length - 1];
-                const timestamp = lastMsg ? (lastMsg.timestamp || 0) : 0;
+        Object.keys(sessions).forEach(sid => {
+            const sessionId = parseInt(sid);
+            const msgs = sessions[sid];
+            if (!Array.isArray(msgs)) return;
+            const lastMsg = msgs[msgs.length - 1];
+            const timestamp = lastMsg ? (lastMsg.timestamp || 0) : 0;
                 
                 // Check generation status from localStorage
                 if (localStorage.getItem(`gz_generating_${charId}_${sessionId}`)) generating.value[`${charId}_${sessionId}`] = true;

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -6,6 +6,7 @@ import Editor from '@/components/editors/GenericEditor.vue';
 import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetState.js';
 import { estimateTokens } from '@/utils/tokenizer.js';
 import { replaceMacros } from '@/utils/macroEngine.js';
+import { normalizeBlockId } from '@/utils/presetBlockIds.js';
 import { getEffectivePersona } from '@/core/states/personaState.js';
 import { convertSTPreset, convertLatexPreset, exportSTPreset, detectPresetFormat, finalizeImportedPreset, mandatoryBlocks } from '@/core/services/presetImportService.js';
 import { generateSummary } from '@/core/services/generationService.js';
@@ -374,22 +375,23 @@ const activeEditBlock = computed(() => {
 
 const resolveBlockContent = (block) => {
     if (!block) return '';
+    const blockId = normalizeBlockId(block.id);
     
-    if (block.id === 'chat_history') {
+    if (blockId === 'chat_history') {
         if (!props.chatHistory || props.chatHistory.length === 0) return '';
         return props.chatHistory.map(m => `${m.role === 'user' ? (m.persona?.name || 'User') : (props.activeChatChar?.name || 'Char')}: ${m.text}`).join('\n');
     }
     
-    if (block.id === 'guided_generation') return block.content || '[System Note: {{guidance}}]';
-    if (block.id === 'authors_note') return props.activeChatChar?.authors_note || '';
-    if (block.id === 'summary') return props.activeChatChar?.summary || '';
+    if (blockId === 'guided_generation') return block.content || '[System Note: {{guidance}}]';
+    if (blockId === 'authors_note') return props.activeChatChar?.authors_note || '';
+    if (blockId === 'summary') return props.activeChatChar?.summary || '';
     
-    if (block.id === 'user_persona') return effectivePersona.value?.prompt || '';
-    if (block.id === 'char_card') return props.activeChatChar?.description || '';
-    if (block.id === 'char_personality' || block.id === 'char_persona') return props.activeChatChar?.personality || '';
-    if (block.id === 'scenario') return props.activeChatChar?.scenario || '';
-    if (block.id === 'example_dialogue') return props.activeChatChar?.mes_example || '';
-    if (block.id === 'first_message') return props.activeChatChar?.first_mes || '';
+    if (blockId === 'user_persona') return effectivePersona.value?.prompt || '';
+    if (blockId === 'char_card') return props.activeChatChar?.description || props.activeChatChar?.desc || '';
+    if (blockId === 'char_personality' || blockId === 'char_persona') return props.activeChatChar?.personality || '';
+    if (blockId === 'scenario') return props.activeChatChar?.scenario || '';
+    if (blockId === 'example_dialogue') return props.activeChatChar?.mes_example || '';
+    if (blockId === 'first_message') return props.activeChatChar?.first_mes || '';
 
     return block.content || '';
 };
@@ -1651,7 +1653,7 @@ const editorProxy = computed({
 });
 
 function getBlockIcon(block) {
-    if (block.id === 'chat_history') {
+    if (normalizeBlockId(block.id) === 'chat_history') {
         return '<path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>';
     }
     return getRoleIcon(block.role);

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -1797,14 +1797,22 @@ function openSummarySheet() {
     const char = props.activeChatChar;
     const block = currentPreset.value.blocks.find(b => b.id === 'summary');
     if (!block) return;
+
+    const SUMMARY_CUSTOM_MODEL_ENABLED_KEY = 'gz_summary_custom_model_enabled';
+    const SUMMARY_CUSTOM_MODEL_KEY = 'gz_summary_custom_model';
     
     const data = {
         role: block.role || 'system',
         insertion_mode: block.insertion_mode || 'relative',
         depth: block.depth !== undefined ? block.depth : 4,
-        content: char.summary || '',
+        savedContent: char.summary || '',
+        draftContent: char.summary || '',
         prefix: block.prefix || 'Summary: '
     };
+    let isGenerating = false;
+    let debounceTimer = null;
+    let useCustomModel = localStorage.getItem(SUMMARY_CUSTOM_MODEL_ENABLED_KEY) === 'true';
+    let customModel = localStorage.getItem(SUMMARY_CUSTOM_MODEL_KEY) || '';
     
     const helpTipHtml = (term) => `
         <button class="help-tip" data-term="${term}" type="button" tabindex="-1" style="width:20px;height:20px;padding:0;border:none;background:none;cursor:pointer;display:inline-flex;align-items:center;justify-content:center;flex-shrink:0;opacity:0.4;color:var(--text-gray);vertical-align:middle;margin-left:4px;">
@@ -1813,13 +1821,27 @@ function openSummarySheet() {
     `;
 
     const content = document.createElement('div');
+    content.className = 'summary-sheet';
     content.innerHTML = `
         <div class="settings-item"><label>${t('label_role')}${helpTipHtml('preset-role')}</label><select id="summary-role" class="settings-select"><option value="system" ${data.role === 'system' ? 'selected' : ''}>${t('role_system') || 'System'}</option><option value="user" ${data.role === 'user' ? 'selected' : ''}>${t('role_user') || 'User'}</option><option value="assistant" ${data.role === 'assistant' ? 'selected' : ''}>${t('role_assistant') || 'Assistant'}</option></select></div>
         <div class="settings-item"><label>${t('label_injection_point')}${helpTipHtml('preset-injection')}</label><select id="summary-mode" class="settings-select"><option value="relative" ${data.insertion_mode === 'relative' ? 'selected' : ''}>${t('injection_relative')}</option><option value="depth" ${data.insertion_mode === 'depth' ? 'selected' : ''}>${t('injection_depth')}</option></select></div>
         <div class="settings-item" id="summary-depth-container" style="${data.insertion_mode === 'depth' ? '' : 'display:none'}"><label>${t('label_depth')}</label><input type="number" id="summary-depth" value="${data.depth}" placeholder="${t('placeholder_depth')}"></div>
         <div class="settings-item"><label>${t('label_prefix') || 'Prefix'}</label><input type="text" id="summary-prefix" value="${data.prefix}" placeholder="Summary: "></div>
-        <div class="settings-item"><label>${t('label_content')}</label><textarea id="summary-content" rows="8" placeholder="${t('summary_placeholder')}">${data.content}</textarea></div>
-        <div class="settings-item"><button id="btn-auto-summary" class="btn-save" style="width: 100%; display: flex; align-items: center; justify-content: center; gap: 8px;"><svg viewBox="0 0 24 24" style="width:20px;height:20px;fill:currentColor"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 14l-5-5 1.41-1.41L10 12.17l7.59-7.59L19 6l-9 11z"/></svg>${t('btn_auto_summary')}</button></div>
+        <div class="settings-item-checkbox">
+            <label>${t('label_custom_model') || 'Custom summary model'}</label>
+            <input type="checkbox" id="summary-custom-model-enabled" class="vk-switch" ${useCustomModel ? 'checked' : ''}>
+        </div>
+        <div class="settings-item" id="summary-custom-model-row" style="${useCustomModel ? '' : 'display:none'}"><label>${t('label_model') || 'Model'}</label><input type="text" id="summary-custom-model" value="${customModel}" placeholder="${t('label_model') || 'Model'}"></div>
+        <div class="summary-status-row">
+            <div class="summary-status-badge" id="summary-status-badge">${data.savedContent ? 'Saved summary present' : 'No saved summary yet'}</div>
+            <div class="summary-status-text" id="summary-status-text">Draft editing is separate until you press Save.</div>
+        </div>
+        <div class="settings-item"><label>${t('label_content')}</label><textarea id="summary-content" rows="8" placeholder="${t('summary_placeholder')}">${data.draftContent}</textarea></div>
+        <div class="summary-action-grid">
+            <button id="btn-summary-generate" class="btn-save summary-action-btn summary-action-secondary">Generate Draft</button>
+            <button id="btn-summary-update" class="btn-save summary-action-btn summary-action-secondary">Update Draft</button>
+            <button id="btn-summary-save" class="btn-save summary-action-btn">Save</button>
+        </div>
     `;
 
     content.querySelectorAll('.help-tip').forEach(btn => {
@@ -1829,14 +1851,36 @@ function openSummarySheet() {
         };
     });
 
-    let debounceTimer = null;
     const save = () => {
         block.role = content.querySelector('#summary-role').value;
         block.insertion_mode = content.querySelector('#summary-mode').value;
         let parsedDepth = parseInt(content.querySelector('#summary-depth').value);
         block.depth = isNaN(parsedDepth) ? 0 : parsedDepth;
         block.prefix = content.querySelector('#summary-prefix').value;
-        char.summary = content.querySelector('#summary-content').value;
+    };
+
+    const persistSummaryModelSettings = () => {
+        useCustomModel = !!content.querySelector('#summary-custom-model-enabled')?.checked;
+        customModel = content.querySelector('#summary-custom-model')?.value?.trim() || '';
+        localStorage.setItem(SUMMARY_CUSTOM_MODEL_ENABLED_KEY, String(useCustomModel));
+        localStorage.setItem(SUMMARY_CUSTOM_MODEL_KEY, customModel);
+    };
+
+    const updateDraftState = (text) => {
+        data.draftContent = text;
+        const isDirty = data.draftContent !== data.savedContent;
+        const statusBadge = content.querySelector('#summary-status-badge');
+        const statusText = content.querySelector('#summary-status-text');
+        if (statusBadge) {
+            statusBadge.textContent = isDirty
+                ? 'Draft has unsaved changes'
+                : (data.savedContent ? 'Draft matches saved summary' : 'No saved summary yet');
+        }
+        if (statusText) {
+            statusText.textContent = isDirty
+                ? 'Press Save to apply this summary to the chat.'
+                : 'Draft editing is separate until you press Save.';
+        }
     };
 
     const debouncedSave = () => {
@@ -1851,26 +1895,72 @@ function openSummarySheet() {
     });
     content.querySelector('#summary-depth').addEventListener('input', save);
     content.querySelector('#summary-prefix').addEventListener('input', save);
-    content.querySelector('#summary-content').addEventListener('input', debouncedSave);
+    content.querySelector('#summary-content').addEventListener('input', (e) => {
+        updateDraftState(e.target.value);
+        debouncedSave();
+    });
+    content.querySelector('#summary-custom-model-enabled').addEventListener('change', (e) => {
+        content.querySelector('#summary-custom-model-row').style.display = e.target.checked ? 'block' : 'none';
+        persistSummaryModelSettings();
+    });
+    content.querySelector('#summary-custom-model').addEventListener('input', persistSummaryModelSettings);
 
-    content.querySelector('#btn-auto-summary').addEventListener('click', async (e) => {
-        const btn = e.currentTarget;
-        btn.disabled = true;
-        const originalHtml = btn.innerHTML;
-        btn.innerHTML = `<div class="app-loader-spinner" style="width:20px;height:20px;border-width:2px;"></div>`;
+    const runSummaryGeneration = async (mode) => {
+        if (isGenerating) return;
+        isGenerating = true;
+        const generateBtn = content.querySelector('#btn-summary-generate');
+        const updateBtn = content.querySelector('#btn-summary-update');
+        const saveBtn = content.querySelector('#btn-summary-save');
+        const originalGenerateHtml = generateBtn.innerHTML;
+        const originalUpdateHtml = updateBtn.innerHTML;
+        generateBtn.disabled = true;
+        updateBtn.disabled = true;
+        saveBtn.disabled = true;
+        if (mode === 'generate') {
+            generateBtn.innerHTML = `<div class="app-loader-spinner" style="width:20px;height:20px;border-width:2px;"></div>`;
+        } else {
+            updateBtn.innerHTML = `<div class="app-loader-spinner" style="width:20px;height:20px;border-width:2px;"></div>`;
+        }
         try {
             const historyText = props.chatHistory.filter(m => !m.isHidden && !m.isTyping).slice(-50).map(m => `${m.role === 'user' ? (m.persona?.name || 'User') : char.name}: ${m.text}`).join('\n');
+            const currentDraft = content.querySelector('#summary-content').value.trim();
+            const promptBase = currentPreset.value.summaryPrompt;
+            const prompt = mode === 'update' && currentDraft
+                ? `${promptBase}\n\nCurrent summary draft:\n${currentDraft}\n\nUpdate the draft summary to reflect the conversation more accurately.`
+                : promptBase;
             const summary = await generateSummary({
                 history: historyText,
-                prompt: currentPreset.value.summaryPrompt
+                prompt,
+                apiConfigOverride: useCustomModel && customModel ? { model: customModel } : null
             });
             content.querySelector('#summary-content').value = summary;
-            save();
-        } catch (e) { console.error(e); } finally {
-            btn.disabled = false;
-            btn.innerHTML = originalHtml;
+            updateDraftState(summary);
+        } catch (e) {
+            console.error(e);
+        } finally {
+            isGenerating = false;
+            generateBtn.disabled = false;
+            updateBtn.disabled = false;
+            saveBtn.disabled = false;
+            generateBtn.innerHTML = originalGenerateHtml;
+            updateBtn.innerHTML = originalUpdateHtml;
         }
+    };
+
+    content.querySelector('#btn-summary-generate').addEventListener('click', () => {
+        runSummaryGeneration('generate');
     });
+    content.querySelector('#btn-summary-update').addEventListener('click', () => {
+        runSummaryGeneration('update');
+    });
+    content.querySelector('#btn-summary-save').addEventListener('click', () => {
+        save();
+        data.savedContent = content.querySelector('#summary-content').value;
+        char.summary = data.savedContent;
+        updateDraftState(data.savedContent);
+        closeBottomSheet();
+    });
+    updateDraftState(data.draftContent);
 
     showBottomSheet({ 
         title: t('magic_summary'), 
@@ -2604,6 +2694,51 @@ onBeforeUnmount(() => {
     height: 20px;
     fill: var(--text-gray);
     opacity: 0.5;
+}
+
+.summary-sheet {
+    padding-bottom: 4px;
+}
+
+.summary-status-row {
+    margin: 4px 16px 12px;
+    padding: 12px;
+    border-radius: 14px;
+    background: rgba(var(--vk-blue-rgb), 0.06);
+    border: 1px solid var(--border-color);
+}
+
+.summary-status-badge {
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+
+.summary-status-text {
+    font-size: 13px;
+    color: var(--text-gray);
+    line-height: 1.45;
+}
+
+.summary-action-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+    padding: 0 16px 16px;
+}
+
+.summary-action-btn {
+    margin-top: 0;
+}
+
+.summary-action-secondary {
+    background: rgba(var(--vk-blue-rgb), 0.1);
+    color: var(--vk-blue);
+}
+
+@media (max-width: 520px) {
+    .summary-action-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 .preset-overview-block {

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -41,6 +41,18 @@ function estimateTokens(text) {
     return Math.ceil(cleaned.length / 3.35);
 }
 
+function getLorebookReserve(globalSettings, safeContext) {
+    const mode = globalSettings?.reserveMode || 'tokens';
+    const rawValue = Number(globalSettings?.reserveValue || 0);
+    if (!Number.isFinite(rawValue) || rawValue <= 0) return 0;
+
+    if (mode === 'percent') {
+        return Math.max(0, Math.floor((safeContext * rawValue) / 100));
+    }
+
+    return Math.max(0, Math.floor(rawValue));
+}
+
 function escapeRegex(string) {
     return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }
@@ -577,24 +589,59 @@ self.onmessage = async function (e) {
             const safeContext = contextSize - maxTokens;
 
             const staticMessages = messages.filter(m => !m.isHistory);
+            const historyMessages = messages.filter(m => m.isHistory);
+            const loreReserveTokens = getLorebookReserve(payload.globalSettings, safeContext);
+            const breakdown = {
+                safeContext,
+                maxTokens,
+                contextSize,
+                character: 0,
+                preset: 0,
+                summary: 0,
+                authorsNote: 0,
+                lorebook: 0,
+                lorebookReserve: loreReserveTokens,
+                history: 0,
+                fixedBase: 0,
+                fixedTotal: 0,
+                availableForHistory: 0,
+                totalUsed: 0,
+                remaining: 0,
+                historyMessagesTotal: historyMessages.length,
+                historyMessagesIncluded: 0,
+                historyMessagesHiddenByContext: 0
+            };
+
             let staticTokens = 0;
             for (const m of staticMessages) {
-                staticTokens += estimateTokens(m.content);
+                const tokens = estimateTokens(m.content);
+                staticTokens += tokens;
+
+                if (m.isLorebook) breakdown.lorebook += tokens;
+                else if (m.blockName === 'Summary') breakdown.summary += tokens;
+                else if (m.blockName === 'authors_note') breakdown.authorsNote += tokens;
+                else if (m.blockName === 'char_card' || m.blockName === 'Character' || /Character Name:/i.test(m.content || '')) breakdown.character += tokens;
+                else breakdown.preset += tokens;
             }
 
-            let availableForHistory = safeContext - staticTokens;
+            breakdown.fixedBase = breakdown.character + breakdown.preset + breakdown.summary + breakdown.authorsNote;
+            breakdown.fixedTotal = breakdown.fixedBase + breakdown.lorebookReserve;
+
+            let availableForHistory = safeContext - breakdown.fixedTotal;
+            breakdown.availableForHistory = Math.max(0, availableForHistory);
             let finalMessages = [];
             let cutoffIndex = -1;
 
             let cutoffOriginalIndex = -1;
 
-            if (staticTokens >= safeContext) {
+            if (breakdown.fixedTotal >= safeContext) {
                 // Out of context entirely just based on prompt
                 finalMessages = staticMessages;
-                cutoffIndex = payload.history?.length || 0;
+                cutoffIndex = historyMessages.length;
                 cutoffOriginalIndex = Number.MAX_SAFE_INTEGER;
+                breakdown.historyMessagesIncluded = 0;
+                breakdown.historyMessagesHiddenByContext = historyMessages.length;
             } else {
-                const historyMessages = messages.filter(m => m.isHistory);
                 let currentHistoryTokens = 0;
                 let includedCount = 0;
 
@@ -611,6 +658,9 @@ self.onmessage = async function (e) {
                 cutoffIndex = historyMessages.length - includedCount;
                 const cutoffMessage = historyMessages[cutoffIndex];
                 cutoffOriginalIndex = cutoffMessage !== undefined ? cutoffMessage.chatId : -1;
+                breakdown.history = currentHistoryTokens;
+                breakdown.historyMessagesIncluded = includedCount;
+                breakdown.historyMessagesHiddenByContext = historyMessages.length - includedCount;
 
                 const keptHistoryMessages = historyMessages.slice(cutoffIndex);
 
@@ -622,6 +672,9 @@ self.onmessage = async function (e) {
                 }
             }
 
+            breakdown.totalUsed = breakdown.fixedBase + breakdown.lorebookReserve + breakdown.history;
+            breakdown.remaining = Math.max(0, safeContext - breakdown.totalUsed);
+
             self.postMessage({
                 id,
                 success: true,
@@ -631,6 +684,7 @@ self.onmessage = async function (e) {
                     cutoffOriginalIndex,
                     loreEntries,
                     staticTokens,
+                    contextBreakdown: breakdown,
                     needsVarsSave: notifyObj.varsChanged,
                     sessionVars: payload.sessionVars
                 }

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -1,4 +1,5 @@
 import { replaceMacros } from '../utils/macroEngine.js';
+import { normalizeBlockId } from '../utils/presetBlockIds.js';
 
 let GPTTokenizer = null;
 const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent);
@@ -428,10 +429,14 @@ function buildPromptMessagesWorker(args) {
 
         activePreset.blocks.forEach(block => {
             if (!block.enabled || block.isStashed) return;
-            if (block.insertion_mode === 'depth' && block.id !== 'chat_history') {
-                depthBlocks.push(block);
+            const normalizedId = normalizeBlockId(block.id);
+            const normalizedBlock = normalizedId === block.id
+                ? block
+                : { ...block, id: normalizedId, originalId: block.id };
+            if (normalizedBlock.insertion_mode === 'depth' && normalizedBlock.id !== 'chat_history') {
+                depthBlocks.push(normalizedBlock);
             } else {
-                relativeBlocks.push(block);
+                relativeBlocks.push(normalizedBlock);
             }
         });
 

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -316,12 +316,24 @@ function buildNoAssistantHistory(historyMsgs, userPrefix, charPrefix, squashRole
     return lines.join('\n');
 }
 
+function buildBlockSourceReplacements(char, personaObj, sessionVars, notifyObj, summaryRawContent, getLorebookContent) {
+    return [
+        { macro: '{{description}}', replacement: char?.description || char?.desc || '', source: 'character' },
+        { macro: '{{scenario}}', replacement: char?.scenario || '', source: 'character' },
+        { macro: '{{personality}}', replacement: char?.personality || '', source: 'character' },
+        { macro: '{{mesExamples}}', replacement: char?.mes_example || '', source: 'character' },
+        { macro: '{{summary}}', replacement: summaryRawContent || '', source: 'summary' },
+        { macro: '{{lorebooks}}', replacement: getLorebookContent(), source: 'lorebook' }
+    ];
+}
+
 function buildPromptMessagesWorker(args) {
     let { char, history, summary, activePreset, mergePrompts, mergeRole, noAssistant, userPrefix, charPrefix, squashRole, personaObj, authorsNote, guidanceText, guidanceType, lorebooks, globalSettings, activations, globalRegexes, sessionVars } = args;
     if (noAssistant) mergePrompts = true;
 
     const messages = [];
-    let mergeBuffer = [];
+    let mergeSourcesBuffer = [];
+    let mergeContentBuffer = [];
     let allLoreEntries = [];
     let notifyObj = { varsChanged: false };
 
@@ -329,14 +341,27 @@ function buildPromptMessagesWorker(args) {
     const sessionId = char?.sessionId || "current";
     const chatId = char?.id && char?.sessionId ? `${char.id}_${char.sessionId}` : null;
 
-    // Combine regexes
     const presetRegexes = activePreset?.regexes || [];
     const allScripts = [...presetRegexes, ...globalRegexes];
 
     const flushMergeBuffer = () => {
-        if (mergeBuffer.length > 0) {
-            messages.push({ role: mergeRole || 'system', content: mergeBuffer.join('\n'), blockName: 'merged prompt' });
-            mergeBuffer = [];
+        if (mergeContentBuffer.length > 0) {
+            const content = mergeContentBuffer.join('\n');
+            const sources = [];
+            for (const s of mergeSourcesBuffer) {
+                const existing = sources.find(x => x.source === s.source);
+                if (existing) existing.tokens += s.tokens;
+                else sources.push({ ...s });
+            }
+            messages.push({
+                role: mergeRole || 'system',
+                content,
+                blockName: 'merged prompt',
+                sources,
+                _allSources: mergeSourcesBuffer.slice()
+            });
+            mergeContentBuffer = [];
+            mergeSourcesBuffer = [];
         }
     };
 
@@ -347,11 +372,15 @@ function buildPromptMessagesWorker(args) {
 
         loreEntries.forEach(entry => {
             const pos = entry.position ?? 0;
+            const content = replaceMacros(entry.content || "", char, personaObj, sessionVars, notifyObj);
+            const tokens = estimateTokens(content);
             const msg = {
                 role: 'system',
-                content: replaceMacros(entry.content || "", char, personaObj, sessionVars, notifyObj),
+                content,
                 blockName: `Lorebook: ${entry.comment || entry.keys?.[0] || 'Entry'}`,
-                isLorebook: true
+                isLorebook: true,
+                sources: tokens > 0 ? [{ source: 'lorebook', tokens }] : [],
+                _allSources: tokens > 0 ? [{ source: 'lorebook', tokens }] : []
             };
             if (loreByPosition[pos]) loreByPosition[pos].push(msg);
             else loreByPosition[0].push(msg);
@@ -371,8 +400,10 @@ function buildPromptMessagesWorker(args) {
         if (hasLorebookMacro) return;
         if (loreByPosition[pos] && loreByPosition[pos].length > 0) {
             loreByPosition[pos].forEach(msg => {
-                if (mergePrompts) mergeBuffer.push(msg.content);
-                else {
+                if (mergePrompts) {
+                    mergeContentBuffer.push(msg.content);
+                    if (msg._allSources) mergeSourcesBuffer.push(...msg._allSources);
+                } else {
                     flushMergeBuffer();
                     messages.push(msg);
                 }
@@ -419,6 +450,7 @@ function buildPromptMessagesWorker(args) {
         const resolveBlockContent = (block) => {
             let content = "";
             let role = block.role || "system";
+            let primarySource = 'preset';
 
             if (block.id === 'guided_generation') {
                 const isImpersonation = guidanceType === 'impersonation';
@@ -428,21 +460,38 @@ function buildPromptMessagesWorker(args) {
                     : (activePreset?.guidedGenerationPrompt || '[Generate your next reply according to these instructions: {{guidance}}]');
                 content = template.replace(/\{\{guidance\}\}/gi, guidanceText || '');
             }
-            else if (block.id === 'user_persona') content = `User Name: ${personaObj.name}\nUser Description: ${personaObj.prompt || ""}`;
-            else if (block.id === 'char_card') content = `Character Name: ${char.name}\nDescription: ${char.description || char.desc}`;
-            else if (block.id === 'char_personality') content = `Personality: ${char.personality}`;
-            else if (block.id === 'scenario') content = `Scenario: ${char.scenario}`;
-            else if (block.id === 'example_dialogue') content = char.mes_example || "";
+            else if (block.id === 'user_persona') {
+                content = `User Name: ${personaObj.name}\nUser Description: ${personaObj.prompt || ""}`;
+                primarySource = 'preset';
+            }
+            else if (block.id === 'char_card') {
+                content = `Character Name: ${char.name}\nDescription: ${char.description || char.desc}`;
+                primarySource = 'character';
+            }
+            else if (block.id === 'char_personality') {
+                content = `Personality: ${char.personality}`;
+                primarySource = 'character';
+            }
+            else if (block.id === 'scenario') {
+                content = `Scenario: ${char.scenario}`;
+                primarySource = 'character';
+            }
+            else if (block.id === 'example_dialogue') {
+                content = char.mes_example || "";
+                primarySource = 'character';
+            }
             else if (block.id === 'authors_note') {
                 if (authorsNote && authorsNote.content) {
                     content = authorsNote.content;
                     if (authorsNote.role) role = authorsNote.role;
+                    primarySource = 'authorsNote';
                 } else return null;
             }
             else if (block.id === 'summary') {
                 if (summaryText) {
                     content = summaryText;
                     if (typeof summary === 'object' && summary.role) role = summary.role;
+                    primarySource = 'summary';
                 } else return null;
             } else {
                 content = block.content;
@@ -450,10 +499,47 @@ function buildPromptMessagesWorker(args) {
 
             if (!content) return null;
 
-            content = replaceMacros(content, char, personaObj, sessionVars, notifyObj);
-            content = resolveDynamicMacros(content);
+            const sourceMacros = [
+                { regex: /\{\{description\}\}/gi, value: char?.description || char?.desc || '', source: 'character' },
+                { regex: /\{\{scenario\}\}/gi, value: char?.scenario || '', source: 'character' },
+                { regex: /\{\{personality\}\}/gi, value: char?.personality || '', source: 'character' },
+                { regex: /\{\{mesExamples\}\}/gi, value: char?.mes_example || '', source: 'character' },
+                { regex: /\{\{summary\}\}/gi, value: summaryRawContent || '', source: 'summary' },
+                { regex: /\{\{lorebooks\}\}/gi, value: getLorebookContent(), source: 'lorebook' }
+            ];
 
-            return { content, role };
+            const sources = [];
+            let literalTemplate = content;
+            for (const sm of sourceMacros) {
+                const matches = content.match(sm.regex);
+                if (matches && matches.length > 0) {
+                    const tokens = estimateTokens(sm.value) * matches.length;
+                    if (tokens > 0) sources.push({ source: sm.source, tokens });
+                    literalTemplate = literalTemplate.replace(sm.regex, '');
+                }
+            }
+
+            content = replaceMacros(content, char, personaObj, sessionVars, notifyObj);
+            literalTemplate = replaceMacros(literalTemplate, char, personaObj, sessionVars, notifyObj);
+
+            if (content.includes('{{lorebooks}}')) {
+                content = content.split('{{lorebooks}}').join(getLorebookContent());
+            }
+            if (content.includes('{{summary}}')) {
+                content = content.split('{{summary}}').join(summaryRawContent || '');
+            }
+
+            const literalTokens = estimateTokens(literalTemplate);
+            if (literalTokens > 0) {
+                sources.push({ source: primarySource, tokens: literalTokens });
+            } else if (sources.length === 0) {
+                const totalTokens = estimateTokens(content);
+                if (totalTokens > 0) {
+                    sources.push({ source: primarySource, tokens: totalTokens });
+                }
+            }
+
+            return { content, role, sources, primarySource };
         };
 
         const resolvedDepthBlocks = depthBlocks.map(block => {
@@ -464,12 +550,26 @@ function buildPromptMessagesWorker(args) {
             if (resolved.role === 'user') placement = 1;
             else if (resolved.role === 'assistant') placement = 2;
 
+            const preRegexTokens = estimateTokens(resolved.content);
             resolved.content = applyRegexes(resolved.content, placement, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj });
+            const postRegexTokens = estimateTokens(resolved.content);
+
+            if (preRegexTokens > 0 && postRegexTokens > 0 && resolved.sources.length > 0) {
+                const scale = postRegexTokens / preRegexTokens;
+                resolved.sources = resolved.sources.map(s => ({ source: s.source, tokens: Math.max(0, Math.round(s.tokens * scale)) }));
+            } else if (postRegexTokens > 0) {
+                resolved.sources = [{ source: resolved.primarySource, tokens: postRegexTokens }];
+            } else {
+                resolved.sources = [];
+            }
 
             return {
                 role: resolved.role,
                 content: resolved.content,
                 blockName: block.name,
+                blockId: block.id,
+                sources: resolved.sources,
+                _allSources: resolved.sources,
                 depth: block.depth || 0,
                 isDepth: true
             };
@@ -485,17 +585,19 @@ function buildPromptMessagesWorker(args) {
                     historyMsgs = history.map((m, i) => {
                         let content = m.content !== undefined ? m.content : (m.text || m.mes || "");
 
-                        // Macros and Regex
                         content = replaceMacros(content, char, personaObj, sessionVars, notifyObj);
                         const placement = m.role === 'user' ? 1 : 2;
                         content = applyRegexes(content, placement, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj });
 
+                        const tokens = estimateTokens(content);
                         return {
                             role: m.role || (m.isUser ? 'user' : 'assistant'),
                             content: content,
                             image: m.image,
                             isHistory: true,
-                            chatId: m.chatId !== undefined ? m.chatId : (m.originalIndex !== undefined ? m.originalIndex : i)
+                            chatId: m.chatId !== undefined ? m.chatId : (m.originalIndex !== undefined ? m.originalIndex : i),
+                            sources: tokens > 0 ? [{ source: 'history', tokens }] : [],
+                            _allSources: tokens > 0 ? [{ source: 'history', tokens }] : []
                         };
                     });
                 }
@@ -503,7 +605,15 @@ function buildPromptMessagesWorker(args) {
                 if (noAssistant) {
                     const combinedContent = buildNoAssistantHistory(historyMsgs, userPrefix, charPrefix, squashRole);
                     if (combinedContent) {
-                        messages.push({ role: 'assistant', content: combinedContent, blockName: 'chat_history', isHistory: true });
+                        const tokens = estimateTokens(combinedContent);
+                        messages.push({
+                            role: 'assistant',
+                            content: combinedContent,
+                            blockName: 'chat_history',
+                            isHistory: true,
+                            sources: tokens > 0 ? [{ source: 'history', tokens }] : [],
+                            _allSources: tokens > 0 ? [{ source: 'history', tokens }] : []
+                        });
                     }
                     return;
                 }
@@ -536,10 +646,13 @@ function buildPromptMessagesWorker(args) {
                 return;
             }
 
-            let { content, role } = resolved;
+            let { content, role, sources, primarySource } = resolved;
 
             if (mergePrompts && role !== 'assistant') {
-                if (content) mergeBuffer.push(content);
+                if (content) {
+                    mergeContentBuffer.push(content);
+                    if (sources) mergeSourcesBuffer.push(...sources);
+                }
             } else {
                 if (mergePrompts) flushMergeBuffer();
 
@@ -547,9 +660,27 @@ function buildPromptMessagesWorker(args) {
                 if (role === 'user') placement = 1;
                 else if (role === 'assistant') placement = 2;
 
+                const preRegexTokens = estimateTokens(content);
                 content = applyRegexes(content, placement, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj });
+                const postRegexTokens = estimateTokens(content);
 
-                const msg = { role: role, content: content, blockName: block.name };
+                if (preRegexTokens > 0 && postRegexTokens > 0 && sources.length > 0) {
+                    const scale = postRegexTokens / preRegexTokens;
+                    sources = sources.map(s => ({ source: s.source, tokens: Math.max(0, Math.round(s.tokens * scale)) }));
+                } else if (postRegexTokens > 0) {
+                    sources = [{ source: primarySource, tokens: postRegexTokens }];
+                } else {
+                    sources = [];
+                }
+
+                const msg = {
+                    role: role,
+                    content: content,
+                    blockName: block.name,
+                    blockId: block.id,
+                    sources,
+                    _allSources: sources
+                };
                 messages.push(msg);
             }
 
@@ -558,16 +689,37 @@ function buildPromptMessagesWorker(args) {
         });
         if (mergePrompts) flushMergeBuffer();
     } else {
-        messages.push({ role: "system", content: "You are a helpful assistant." });
-        if (summaryText) messages.push({ role: "system", content: summaryText });
+        const fallbackTokens = estimateTokens("You are a helpful assistant.");
+        messages.push({
+            role: "system",
+            content: "You are a helpful assistant.",
+            sources: fallbackTokens > 0 ? [{ source: 'preset', tokens: fallbackTokens }] : [],
+            _allSources: fallbackTokens > 0 ? [{ source: 'preset', tokens: fallbackTokens }] : []
+        });
+        if (summaryText) {
+            const sTokens = estimateTokens(summaryText);
+            messages.push({
+                role: "system",
+                content: summaryText,
+                sources: sTokens > 0 ? [{ source: 'summary', tokens: sTokens }] : [],
+                _allSources: sTokens > 0 ? [{ source: 'summary', tokens: sTokens }] : []
+            });
+        }
         if (history) {
             for (const m of history) {
-                messages.push({ ...m, isHistory: true });
+                const content = m.content !== undefined ? m.content : (m.text || m.mes || "");
+                const tokens = estimateTokens(content);
+                messages.push({
+                    ...m,
+                    content,
+                    isHistory: true,
+                    sources: tokens > 0 ? [{ source: 'history', tokens }] : [],
+                    _allSources: tokens > 0 ? [{ source: 'history', tokens }] : []
+                });
             }
         }
     }
 
-    // Remove prompt blocks that ended up empty after macro/regex processing
     const filteredMessages = messages.filter(m => {
         if (m.isHistory) return true;
         return m.content && m.content.trim().length > 0;
@@ -591,15 +743,33 @@ self.onmessage = async function (e) {
             const staticMessages = messages.filter(m => !m.isHistory);
             const historyMessages = messages.filter(m => m.isHistory);
             const loreReserveTokens = getLorebookReserve(payload.globalSettings, safeContext);
+
+            const sourceKeys = ['character', 'preset', 'summary', 'authorsNote', 'lorebook', 'history'];
+            const sourceTotals = {};
+            for (const k of sourceKeys) sourceTotals[k] = 0;
+
+            let staticTokens = 0;
+            for (const m of staticMessages) {
+                const msgTokens = estimateTokens(m.content);
+                staticTokens += msgTokens;
+
+                const msgSources = m._allSources || m.sources || [];
+                for (const s of msgSources) {
+                    if (sourceKeys.includes(s.source)) {
+                        sourceTotals[s.source] += s.tokens;
+                    }
+                }
+            }
+
             const breakdown = {
                 safeContext,
                 maxTokens,
                 contextSize,
-                character: 0,
-                preset: 0,
-                summary: 0,
-                authorsNote: 0,
-                lorebook: 0,
+                character: sourceTotals.character,
+                preset: sourceTotals.preset,
+                summary: sourceTotals.summary,
+                authorsNote: sourceTotals.authorsNote,
+                lorebook: sourceTotals.lorebook,
                 lorebookReserve: loreReserveTokens,
                 history: 0,
                 fixedBase: 0,
@@ -612,30 +782,16 @@ self.onmessage = async function (e) {
                 historyMessagesHiddenByContext: 0
             };
 
-            let staticTokens = 0;
-            for (const m of staticMessages) {
-                const tokens = estimateTokens(m.content);
-                staticTokens += tokens;
-
-                if (m.isLorebook) breakdown.lorebook += tokens;
-                else if (m.blockName === 'Summary') breakdown.summary += tokens;
-                else if (m.blockName === 'authors_note') breakdown.authorsNote += tokens;
-                else if (m.blockName === 'char_card' || m.blockName === 'Character' || /Character Name:/i.test(m.content || '')) breakdown.character += tokens;
-                else breakdown.preset += tokens;
-            }
-
-            breakdown.fixedBase = breakdown.character + breakdown.preset + breakdown.summary + breakdown.authorsNote;
+            breakdown.fixedBase = breakdown.character + breakdown.preset + breakdown.summary + breakdown.authorsNote + breakdown.lorebook;
             breakdown.fixedTotal = breakdown.fixedBase + breakdown.lorebookReserve;
 
             let availableForHistory = safeContext - breakdown.fixedTotal;
             breakdown.availableForHistory = Math.max(0, availableForHistory);
             let finalMessages = [];
             let cutoffIndex = -1;
-
             let cutoffOriginalIndex = -1;
 
             if (breakdown.fixedTotal >= safeContext) {
-                // Out of context entirely just based on prompt
                 finalMessages = staticMessages;
                 cutoffIndex = historyMessages.length;
                 cutoffOriginalIndex = Number.MAX_SAFE_INTEGER;
@@ -664,7 +820,6 @@ self.onmessage = async function (e) {
 
                 const keptHistoryMessages = historyMessages.slice(cutoffIndex);
 
-                // Reconstruct final messages array keeping the order
                 for (const m of messages) {
                     if (!m.isHistory || keptHistoryMessages.includes(m)) {
                         finalMessages.push(m);


### PR DESCRIPTION
## Summary

- **Tokenizer sheet in MagicDrawer** — visual context bar showing token breakdown by source (Character, Preset, Summary, Lorebook Reserve, History) with real-time updates
- **Source-based token attribution in worker** — rewrites breakdown from heuristics to tracking actual sources per block; fixes lorebook tokens bleeding into preset/character when using ` macro
- **Lorebook reserve mode** — new selector: Percent (legacy) or Exact Tokens, with adaptive input field
- **History context controls** — fill threshold warning, hide-top-messages with preview (count + tokens), persisted settings
- **Per-character ` macro override** — custom char name in MagicDrawer
- **Normalize legacy preset block IDs** for accurate token counting

## Test plan
- [x] Build passes (
pm run build)
- [x] Unit tests pass (
pm test — 36/36)
- [ ] Manual: open Tokenizer in MagicDrawer, verify breakdown segments render
- [ ] Manual: toggle Lorebook reserve mode between Percent/Exact, confirm behavior
- [ ] Manual: set history fill threshold, verify recommendation appears when exceeded