### PR TITLE
fix: lorebook token counting and tokenizer visualization

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -672,7 +672,7 @@ Active branch: `fast-fixes`
       - **Encryption is now optional**: Sync works without encryption key. Data stored as plain `.json` instead of `.enc`. If key exists — encrypts as before.
       - **Redirect URI fix**: Both Dropbox and Google Drive adapters now use configurable redirect URIs via env vars (`VITE_DROPBOX_REDIRECT_NATIVE`, `VITE_DROPBOX_REDIRECT_WEB`, `VITE_GDRIVE_REDIRECT_NATIVE`, `VITE_GDRIVE_REDIRECT_WEB`). Web defaults to `window.location.origin` instead of hardcoded `localhost:5173`.
       - **Electron OAuth**: Added Electron-specific OAuth flow for Dropbox (loopback server pattern, same as gdrive already had).
-      - **Error 400 root cause**: `redirect_uri` must exactly match what's registered in the OAuth console (Dropbox App Console / Google Cloud Console). Hardcoded `localhost:5173` only works in dev.
+      - **Error 400 root cause**: `redirect_uri` must exactly match what's registered in the OAuth console (Dropbox App Console / Google Cloud Console). Hardcoded `localhost:5173` only works in dev. Fixed: now uses `window.location.origin` as default.
       - **Backward compatibility**: `readCloudEntityByEntry` tries both `.enc` and `.json` extensions. `decryptEntity` auto-detects encrypted vs plain payload.
       - **SyncSheet UI**: Push/Pull/Auto-sync available without encryption. Encryption shown as optional section. `doWipe` no longer forces new key generation.
     - Files modified:
@@ -698,6 +698,123 @@ Active branch: `fast-fixes`
       - Sync endpoint configuration guide (PC/Linux/iOS/Android)
       - Error 400/402 troubleshooting runbook
       - OAuth/app token setup instructions per platform
+
+14. **Fix: Tokenizer lorebook display and reserve visualization**
+    - Status: `done | tested`
+    - Complexity: medium
+    - Branch: `bug-fixes`
+    - Issue: Lorebook tokens not counted or displayed incorrectly in tokenizer breakdown
+    - Root causes:
+      - Vector lorebooks marked as `source: 'lorebook'` instead of `source: 'vectorLore'`
+      - Worker didn't recognize `vectorLore` as valid source (not in `sourceKeys` array)
+      - `calculateContext()` didn't run vector search, so tokenizer showed 0 for vector lorebooks
+      - Lorebooks displayed in main bar instead of inside reserve zone
+    - Fixes applied:
+      - Changed vector lorebook source from `'lorebook'` to `'vectorLore'` in `generationService.js`
+      - Added `'vectorLore'` to `sourceKeys` array in `generationWorker.js`
+      - Added `vectorLore` field to breakdown structure in worker
+      - Updated `fixedBase` calculation to include `vectorLore`
+      - Added vector search to `calculateContext()` for accurate tokenizer display
+      - Modified UI to show lorebooks **inside** reserve zone, not in main bar
+      - Created nested reserve visualization: reserve contains keyword + vector lorebooks + unused space
+      - Updated labels: "Keyword Lorebook", "Vector Lorebook", "Lorebook Total"
+      - Added `.chat-context-reserve-container` CSS for nested segment display
+    - Files modified:
+      - `src/workers/generationWorker.js` — add vectorLore to sourceKeys, breakdown, fixedBase calculation
+      - `src/core/services/generationService.js` — change source to vectorLore, add vector search to calculateContext
+      - `src/views/ChatView.vue` — nested reserve visualization, updated labels, CSS changes
+    - Testing:
+      - Tokenizer now correctly shows keyword lorebook (0 tokens) + vector lorebook (~8657 tokens)
+      - Visual bar: lorebooks display inside green reserve zone on the right
+      - Reserve shows: [Vector Lorebook (purple)] [Unused Reserve (green)]
+      - Main bar shows: Character, Preset, Summary, Memory, History (no lorebooks)
+    - PR: pending
+
+15. **Image Generation Improvements — Info Blocks & Dynamic Character State**
+    - Status: `not started`
+    - Complexity: hard
+    - Branch: `img-gen-improve` (from `dev`)
+    - Goal: Implement comprehensive image generation system with dynamic character state tracking, dual API endpoints, and quick generation workflow
+    
+    **Phase 1: Info Blocks — Dynamic State Tracking**
+    - Problem: User persona describes "favorite outfit: tweed", but user wrote "wearing hoodie today" 20 messages ago. Current system uses static persona, not dynamic session state.
+    - Proposed Solution: **Info Blocks** — dedicated structured data blocks that track current session state
+    - Info Block Structure:
+      - `current_outfit_user`: What {{user}} is wearing right now
+      - `current_outfit_char`: What {{char}} is wearing
+      - `current_location`: Current scene location  
+      - `time_of_day`: Morning/afternoon/evening/night
+      - `lighting`: Scene lighting conditions
+      - `weather`: If outdoors
+      - `current_pose`: Action/position of characters
+    - Implementation:
+      - Create new Memory Book type: `info_blocks` (high priority, always included)
+      - Auto-extract from chat: Pattern matching for outfit/location/time changes (keywords: "wearing", "dressed in", "changed into", "now in")
+      - Manual edit: UI for quick state updates (floating button or context menu)
+      - Image gen integration: Use info_blocks as primary source, persona as fallback
+    - Alternative Approaches Considered:
+      - Parsing last N messages: Too slow, unreliable with complex descriptions
+      - Static Memory Books: Requires manual updates, not automatic
+    
+    **Phase 2: Dual API Setup (SFW/NSFW)**
+    - Support two separate image generation endpoints:
+      - SFW endpoint: Standard generation (OpenAI/Gemini/Naistera)
+      - NSFW endpoint: Uncensored generation (NovelAI/Naistera specialized)
+    - Settings:
+      - Two sets of credentials: `sfw_endpoint`, `sfw_key`, `nsfw_endpoint`, `nsfw_key`
+      - Default toggle: Auto-detect content type or manual selection
+      - Style presets per endpoint
+    - Use case: Different models for different content types without switching settings manually
+    
+    **Phase 3: Quick Image Generation Button**
+    - Location: Bottom-left button group in ChatInput (4th button or replace existing image-gen)
+    - Workflow:
+      1. Long-press or context menu: Choose SFW/NSFW/Settings
+      2. Click: Quick menu with options:
+         - "Generate scene" (uses current info_blocks + last 3 messages)
+         - "Generate portrait - {{char}}" (character focus)
+         - "Generate portrait - {{user}}" (user focus)
+         - "Custom prompt..." (manual override)
+      3. Auto-prompt building from:
+         - Info blocks (primary)
+         - Current macros: {{char}}, {{user}}, {{scenario}}, {{persona}}
+         - Last 3-5 chat messages for context
+      4. Direct generation without waiting for model response
+      5. Insert as new message or inline in chat
+    
+    **Phase 4: Multi-Character Support**
+    - Problem: Character cards can define multiple characters (main + NPCs)
+    - Solution: Parse character definitions from card and lorebooks
+    - Auto-detect speaking characters from recent messages
+    - Generate composite prompts with all present characters
+    - Per-character outfit tracking in info_blocks
+    
+    **Pre-Generation Preview (Optional Enhancement)**
+    - Show detected state before generation:
+      - Detected: "You in hoodie and jeans, {{char}} in dress, location: cafe, evening"
+      - Editable fields for quick correction
+      - Generate button
+    - Benefits: User can fix misdetected state before wasting API call
+    
+    **Technical Notes:**
+    - Prerequisite for reliable automated image generation
+    - Without accurate state tracking, generated images mismatch actual scene
+    - Info blocks solve the "static vs dynamic" state problem
+    - Dual API enables content-appropriate generation without manual switching
+    
+    **Files to Modify (Future):**
+    - `src/core/services/imageGenService.js` — dual API support, auto-prompt builder
+    - `src/components/sheets/ImageGenSheet.vue` — dual endpoint settings UI
+    - `src/components/chat/ChatInput.vue` — quick gen button
+    - `src/core/services/infoBlockService.js` — new service for state tracking
+    - `src/core/services/characterExtractor.js` — multi-char parsing
+    - `src/components/sheets/InfoBlockEditor.vue` — manual state editor
+    
+    **Deferred for Later:**
+    - Advanced pattern matching for outfit changes
+    - Automatic pose detection from action verbs
+    - Scene mood extraction from dialogue tone
+    - Background/location detail enrichment from lorebooks
 
 ### Branch Strategy (updated)
 - Current: `feat/sync-infrastructure-fixes` (from `feat/multi-vector-retrieval`)

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -723,11 +723,18 @@ Active branch: `fast-fixes`
       - `src/workers/generationWorker.js` — add vectorLore to sourceKeys, breakdown, fixedBase calculation
       - `src/core/services/generationService.js` — change source to vectorLore, add vector search to calculateContext
       - `src/views/ChatView.vue` — nested reserve visualization, updated labels, CSS changes
+    - Additional fixes (second commit):
+      - Fixed `remaining` calculation: changed from `safeContext - totalUsed` to `contextSize - totalUsed`
+      - Excluded lorebook/vectorLore from `fixedBase` (they're inside reserve, not in base)
+      - Now `fixedBase = character + preset + summary + authorsNote` (without lorebooks)
+      - Result: `remaining` now shows correct value relative to full context (80000)
     - Testing:
       - Tokenizer now correctly shows keyword lorebook (0 tokens) + vector lorebook (~8657 tokens)
       - Visual bar: lorebooks display inside green reserve zone on the right
       - Reserve shows: [Vector Lorebook (purple)] [Unused Reserve (green)]
       - Main bar shows: Character, Preset, Summary, Memory, History (no lorebooks)
+      - Remaining calculation: 80000 - totalUsed (instead of 72000 - totalUsed)
+    - Commits: `f33a9d3`, `915dbf3`
     - PR: pending
 
 15. **Image Generation Improvements — Info Blocks & Dynamic Character State**

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -342,20 +342,30 @@ export async function generateChatResponse({
 
     if (callbacks.onPromptReady) {
         const contextBreakdown = result.contextBreakdown
-            ? {
-                ...result.contextBreakdown,
-                memory: memoryInjection.tokens || 0,
-                vectorLore: (result.contextBreakdown.vectorLore || 0) + vectorLoreTokens,
-                summaryBase: result.contextBreakdown.summary || 0,
-                summary: (result.contextBreakdown.summary || 0) + (memoryInjection.tokens || 0),
-                // Keep lorebook and vectorLore separate for UI display
-                // lorebook = keyword-matched entries only (from generationWorker)
-                // vectorLore = vector-retrieved entries only (from this service)
-                fixedBase: (result.contextBreakdown.fixedBase || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
-                fixedTotal: (result.contextBreakdown.fixedTotal || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
-                totalUsed: (result.contextBreakdown.totalUsed || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
-                remaining: Math.max(0, (result.contextBreakdown.remaining || 0) - (memoryInjection.tokens || 0) - vectorLoreTokens)
-            }
+            ? (() => {
+                const totalLoreTokens = (result.contextBreakdown.lorebook || 0) + vectorLoreTokens;
+                const reserveTokens = result.contextBreakdown.lorebookReserve || 0;
+                
+                // All lorebooks (keyword + vector) must fit within the reserve
+                // Reserve remains unchanged, lorebooks are displayed within it
+                const effectiveReserve = reserveTokens - totalLoreTokens;
+                
+                return {
+                    ...result.contextBreakdown,
+                    memory: memoryInjection.tokens || 0,
+                    vectorLore: (result.contextBreakdown.vectorLore || 0) + vectorLoreTokens,
+                    summaryBase: result.contextBreakdown.summary || 0,
+                    summary: (result.contextBreakdown.summary || 0) + (memoryInjection.tokens || 0),
+                    // Keep lorebook and vectorLore separate for UI display
+                    // lorebook = keyword-matched entries only (from generationWorker)
+                    // vectorLore = vector-retrieved entries only (from this service)
+                    // lorebookReserve stays the same - lorebooks are shown within it
+                    fixedBase: (result.contextBreakdown.fixedBase || 0) + (memoryInjection.tokens || 0),
+                    fixedTotal: (result.contextBreakdown.fixedTotal || 0) + (memoryInjection.tokens || 0),
+                    totalUsed: (result.contextBreakdown.totalUsed || 0) + (memoryInjection.tokens || 0),
+                    remaining: Math.max(0, (result.contextBreakdown.remaining || 0) - (memoryInjection.tokens || 0))
+                };
+            })()
             : null;
 
         callbacks.onPromptReady({
@@ -517,17 +527,27 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             : result.cutoffIndex;
 
         const contextBreakdown = result.contextBreakdown
-            ? {
-                ...result.contextBreakdown,
-                memory: memoryInjection.tokens || 0,
-                vectorLore: (result.contextBreakdown.vectorLore || 0) + vectorLoreTokens,
-                summaryBase: result.contextBreakdown.summary || 0,
-                summary: (result.contextBreakdown.summary || 0) + (memoryInjection.tokens || 0),
-                fixedBase: (result.contextBreakdown.fixedBase || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
-                fixedTotal: (result.contextBreakdown.fixedTotal || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
-                totalUsed: (result.contextBreakdown.totalUsed || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
-                remaining: Math.max(0, (result.contextBreakdown.remaining || 0) - (memoryInjection.tokens || 0) - vectorLoreTokens)
-            }
+            ? (() => {
+                const totalLoreTokens = (result.contextBreakdown.lorebook || 0) + vectorLoreTokens;
+                const reserveTokens = result.contextBreakdown.lorebookReserve || 0;
+                
+                // All lorebooks (keyword + vector) must fit within the reserve
+                // Reserve remains unchanged, lorebooks are displayed within it
+                const effectiveReserve = reserveTokens - totalLoreTokens;
+                
+                return {
+                    ...result.contextBreakdown,
+                    memory: memoryInjection.tokens || 0,
+                    vectorLore: (result.contextBreakdown.vectorLore || 0) + vectorLoreTokens,
+                    summaryBase: result.contextBreakdown.summary || 0,
+                    summary: (result.contextBreakdown.summary || 0) + (memoryInjection.tokens || 0),
+                    // All lorebooks must fit within reserve - don't add to fixedBase
+                    fixedBase: (result.contextBreakdown.fixedBase || 0) + (memoryInjection.tokens || 0),
+                    fixedTotal: (result.contextBreakdown.fixedTotal || 0) + (memoryInjection.tokens || 0),
+                    totalUsed: (result.contextBreakdown.totalUsed || 0) + (memoryInjection.tokens || 0),
+                    remaining: Math.max(0, (result.contextBreakdown.remaining || 0) - (memoryInjection.tokens || 0))
+                };
+            })()
             : null;
 
         return {

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -280,8 +280,8 @@ export async function generateChatResponse({
                     content,
                     blockName: `Lorebook: ${entry.comment || entry.keys?.[0] || 'Entry'}`,
                     isLorebook: true,
-                    sources: tokens > 0 ? [{ source: 'lorebook', tokens }] : [],
-                    _allSources: tokens > 0 ? [{ source: 'lorebook', tokens }] : []
+                    sources: tokens > 0 ? [{ source: 'vectorLore', tokens }] : [],
+                    _allSources: tokens > 0 ? [{ source: 'vectorLore', tokens }] : []
                 };
             })
             .filter(msg => msg.content && msg.content.trim().length > 0);
@@ -345,16 +345,19 @@ export async function generateChatResponse({
             ? {
                 ...result.contextBreakdown,
                 memory: memoryInjection.tokens || 0,
-                vectorLore: vectorLoreTokens,
+                vectorLore: (result.contextBreakdown.vectorLore || 0) + vectorLoreTokens,
                 summaryBase: result.contextBreakdown.summary || 0,
                 summary: (result.contextBreakdown.summary || 0) + (memoryInjection.tokens || 0),
-                lorebook: (result.contextBreakdown.lorebook || 0) + vectorLoreTokens,
+                // Keep lorebook and vectorLore separate for UI display
+                // lorebook = keyword-matched entries only (from generationWorker)
+                // vectorLore = vector-retrieved entries only (from this service)
                 fixedBase: (result.contextBreakdown.fixedBase || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
                 fixedTotal: (result.contextBreakdown.fixedTotal || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
                 totalUsed: (result.contextBreakdown.totalUsed || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
                 remaining: Math.max(0, (result.contextBreakdown.remaining || 0) - (memoryInjection.tokens || 0) - vectorLoreTokens)
             }
             : null;
+
         callbacks.onPromptReady({
             loreEntries: result.loreEntries,
             memoryEntries: memoryInjection.entries,
@@ -492,6 +495,23 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             safeContext: safeContextLimit
         });
 
+        // Calculate vector lorebook tokens for accurate breakdown display
+        let vectorLoreTokens = 0;
+        try {
+            const vectorResults = await vectorSearchLorebooks(safeHistory || history, '', char, char?.sessionId);
+            if (vectorResults.length > 0) {
+                const keywordIds = result.loreEntries ? new Set(result.loreEntries.map(e => e.id)) : new Set();
+                const newVectorEntries = vectorResults.filter(e => !keywordIds.has(e.id));
+                vectorLoreTokens = newVectorEntries.reduce((sum, entry) => {
+                    const content = entry.content || '';
+                    const tokens = estimateTokens(content);
+                    return sum + tokens;
+                }, 0);
+            }
+        } catch (e) {
+            console.warn('[calculateContext] Vector search failed:', e);
+        }
+
         const resolvedCutoff = result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
             ? result.cutoffOriginalIndex
             : result.cutoffIndex;
@@ -500,12 +520,13 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             ? {
                 ...result.contextBreakdown,
                 memory: memoryInjection.tokens || 0,
+                vectorLore: (result.contextBreakdown.vectorLore || 0) + vectorLoreTokens,
                 summaryBase: result.contextBreakdown.summary || 0,
                 summary: (result.contextBreakdown.summary || 0) + (memoryInjection.tokens || 0),
-                fixedBase: (result.contextBreakdown.fixedBase || 0) + (memoryInjection.tokens || 0),
-                fixedTotal: (result.contextBreakdown.fixedTotal || 0) + (memoryInjection.tokens || 0),
-                totalUsed: (result.contextBreakdown.totalUsed || 0) + (memoryInjection.tokens || 0),
-                remaining: Math.max(0, (result.contextBreakdown.remaining || 0) - (memoryInjection.tokens || 0))
+                fixedBase: (result.contextBreakdown.fixedBase || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
+                fixedTotal: (result.contextBreakdown.fixedTotal || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
+                totalUsed: (result.contextBreakdown.totalUsed || 0) + (memoryInjection.tokens || 0) + vectorLoreTokens,
+                remaining: Math.max(0, (result.contextBreakdown.remaining || 0) - (memoryInjection.tokens || 0) - vectorLoreTokens)
             }
             : null;
 

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -2193,22 +2193,35 @@ const contextSegments = computed(() => {
     if (breakdown.memory > 0) {
         used.push({ key: 'memory', value: breakdown.memory, percent: toPercent(breakdown.memory), className: 'segment-memory' });
     }
-    if (breakdown.lorebook > 0) {
-        used.push({ key: 'lorebook', value: breakdown.lorebook, percent: toPercent(breakdown.lorebook), className: 'segment-lorebook' });
-    }
-    if (breakdown.vectorLore > 0) {
-        used.push({ key: 'vectorLore', value: breakdown.vectorLore, percent: toPercent(breakdown.vectorLore), className: 'segment-vector-lore' });
-    }
+    // Don't add lorebook/vectorLore to used - they go inside reserve
     if (breakdown.history > 0) {
         used.push({ key: 'history', value: breakdown.history, percent: toPercent(breakdown.history), className: 'segment-history' });
     }
 
-    return {
-        used,
-        reserve: breakdown.lorebookReserve > 0
-            ? { key: 'lorebookReserve', value: breakdown.lorebookReserve, percent: toPercent(breakdown.lorebookReserve), className: 'segment-lorebook-reserve' }
-            : null
-    };
+    // Build reserve with lorebooks inside
+    let reserve = null;
+    if (breakdown.lorebookReserve > 0) {
+        const reserveUsed = [];
+        if (breakdown.lorebook > 0) {
+            reserveUsed.push({ key: 'lorebook', value: breakdown.lorebook, percent: toPercent(breakdown.lorebook), className: 'segment-lorebook' });
+        }
+        if (breakdown.vectorLore > 0) {
+            reserveUsed.push({ key: 'vectorLore', value: breakdown.vectorLore, percent: toPercent(breakdown.vectorLore), className: 'segment-vector-lore' });
+        }
+        const totalLoreUsed = (breakdown.lorebook || 0) + (breakdown.vectorLore || 0);
+        const reserveRemaining = breakdown.lorebookReserve - totalLoreUsed;
+        
+        reserve = {
+            key: 'lorebookReserve',
+            value: breakdown.lorebookReserve,
+            percent: toPercent(breakdown.lorebookReserve),
+            className: 'segment-lorebook-reserve',
+            used: reserveUsed,
+            remaining: reserveRemaining > 0 ? reserveRemaining : 0
+        };
+    }
+
+    return { used, reserve };
 });
 
 const contextBreakdownItems = computed(() => {
@@ -2618,7 +2631,8 @@ function confirmHideTopMessages() {
 }
 
 async function openContextSheet() {
-    if (!contextBreakdown.value && activeChatChar) {
+    // Always recalculate to ensure vector lorebooks are included
+    if (activeChatChar) {
         await updateContextCutoff();
     }
 
@@ -2649,7 +2663,17 @@ async function openContextSheet() {
     `).join('');
 
     const reserveHtml = contextSegments.value.reserve
-        ? `<div class="chat-context-reserve ${contextSegments.value.reserve.className}" style="width:${contextSegments.value.reserve.percent}%"></div>`
+        ? (() => {
+            const reserve = contextSegments.value.reserve;
+            const innerSegments = reserve.used?.map(seg => 
+                `<div class="chat-context-segment ${seg.className}" style="width:${(seg.value / reserve.value * 100).toFixed(2)}%"></div>`
+            ).join('') || '';
+            const remainingPercent = reserve.remaining > 0 ? ((reserve.remaining / reserve.value) * 100).toFixed(2) : 0;
+            const remainingHtml = reserve.remaining > 0 
+                ? `<div class="chat-context-segment ${reserve.className}" style="width:${remainingPercent}%"></div>`
+                : '';
+            return `<div class="chat-context-reserve-container" style="width:${reserve.percent}%">${innerSegments}${remainingHtml}</div>`;
+        })()
         : '';
 
     const legendHtml = contextLegendItems.value.map(segment => `
@@ -5499,12 +5523,17 @@ onUnmounted(() => {
     flex: 0 0 auto;
 }
 
-.chat-context-reserve {
+.chat-context-reserve-container {
     position: absolute;
     top: 0;
     right: 0;
     height: 100%;
+    display: flex;
     box-shadow: inset 2px 0 0 rgba(0, 0, 0, 0.35);
+}
+
+.chat-context-reserve {
+    height: 100%;
 }
 
 .chat-context-segment {

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -2222,8 +2222,9 @@ const contextBreakdownItems = computed(() => {
         { key: 'summary', label: 'Summary Base', value: breakdown.summaryBase ?? breakdown.summary ?? 0 },
         { key: 'memory', label: 'Memory', value: breakdown.memory || 0 },
         { key: 'summaryCombined', label: 'Summary Total', value: breakdown.summary || 0 },
-        { key: 'lorebook', label: 'Lorebook Used', value: breakdown.lorebook || 0 },
+        { key: 'lorebook', label: 'Keyword Lorebook', value: breakdown.lorebook || 0 },
         { key: 'vectorLore', label: 'Vector Lorebook', value: breakdown.vectorLore || 0 },
+        { key: 'lorebookTotal', label: 'Lorebook Total', value: (breakdown.lorebook || 0) + (breakdown.vectorLore || 0) },
         { key: 'lorebookReserve', label: 'Lorebook Reserve', value: breakdown.lorebookReserve || 0 },
         { key: 'history', label: 'History', value: breakdown.history || 0 }
     ];
@@ -2235,7 +2236,7 @@ const contextLegendItems = computed(() => [
     { key: 'authorsNote', label: 'Author\'s Note', className: 'segment-authors-note' },
     { key: 'summary', label: 'Summary', className: 'segment-summary' },
     { key: 'memory', label: 'Memory', className: 'segment-memory' },
-    { key: 'lorebook', label: 'Lorebook Used', className: 'segment-lorebook' },
+    { key: 'lorebook', label: 'Keyword Lorebook', className: 'segment-lorebook' },
     { key: 'vectorLore', label: 'Vector Lorebook', className: 'segment-vector-lore' },
     { key: 'history', label: 'History', className: 'segment-history' },
     { key: 'lorebookReserve', label: 'Lorebook Reserve', className: 'segment-lorebook-reserve' }

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -827,7 +827,8 @@ self.onmessage = async function (e) {
                 historyMessagesHiddenByContext: 0
             };
 
-            breakdown.fixedBase = breakdown.character + breakdown.preset + breakdown.summary + breakdown.authorsNote + breakdown.lorebook + breakdown.vectorLore;
+            // Lorebook and vectorLore are inside reserve, not in fixedBase
+            breakdown.fixedBase = breakdown.character + breakdown.preset + breakdown.summary + breakdown.authorsNote;
             breakdown.fixedTotal = breakdown.fixedBase + breakdown.lorebookReserve;
 
             let availableForHistory = safeContext - breakdown.fixedTotal;
@@ -873,7 +874,7 @@ self.onmessage = async function (e) {
             }
 
             breakdown.totalUsed = breakdown.fixedBase + breakdown.lorebookReserve + breakdown.history;
-            breakdown.remaining = Math.max(0, safeContext - breakdown.totalUsed);
+            breakdown.remaining = Math.max(0, contextSize - breakdown.totalUsed);
 
             self.postMessage({
                 id,

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -788,7 +788,7 @@ self.onmessage = async function (e) {
             const historyMessages = messages.filter(m => m.isHistory);
             const loreReserveTokens = getLorebookReserve(payload.globalSettings, safeContext);
 
-            const sourceKeys = ['character', 'preset', 'summary', 'authorsNote', 'lorebook', 'history'];
+            const sourceKeys = ['character', 'preset', 'summary', 'authorsNote', 'lorebook', 'vectorLore', 'history'];
             const sourceTotals = {};
             for (const k of sourceKeys) sourceTotals[k] = 0;
 
@@ -814,6 +814,7 @@ self.onmessage = async function (e) {
                 summary: sourceTotals.summary,
                 authorsNote: sourceTotals.authorsNote,
                 lorebook: sourceTotals.lorebook,
+                vectorLore: sourceTotals.vectorLore,
                 lorebookReserve: loreReserveTokens,
                 history: 0,
                 fixedBase: 0,
@@ -826,7 +827,7 @@ self.onmessage = async function (e) {
                 historyMessagesHiddenByContext: 0
             };
 
-            breakdown.fixedBase = breakdown.character + breakdown.preset + breakdown.summary + breakdown.authorsNote + breakdown.lorebook;
+            breakdown.fixedBase = breakdown.character + breakdown.preset + breakdown.summary + breakdown.authorsNote + breakdown.lorebook + breakdown.vectorLore;
             breakdown.fixedTotal = breakdown.fixedBase + breakdown.lorebookReserve;
 
             let availableForHistory = safeContext - breakdown.fixedTotal;


### PR DESCRIPTION
## Summary
Fixes lorebook token counting and visualization in the tokenizer UI.

### Changes
- **Token counting**: Added vector lorebook support to worker's sourceKeys and breakdown structure
- **Source labels**: Changed vector lorebook source from 'lorebook' to 'vectorLore' for proper distinction
- **Tokenizer accuracy**: Added vector search to calculateContext() so tokenizer shows actual vector lorebook tokens
- **UI visualization**: Moved lorebooks inside the reserve zone (green area) instead of main context bar
- **Calculation fixes**: 
  - emaining now calculated from full contextSize instead of safeContext
  - ixedBase excludes lorebooks (they're only in reserve)

### Testing
- Tokenizer now correctly shows keyword and vector lorebook tokens separately
- All lorebooks display inside reserve zone
- Remaining tokens calculated correctly from full context size