### PR TITLE
fix: dual-channel lorebook retrieval - keyword scan for vectorSearch entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,8 +88,6 @@ captures/
 !README.md
 !CLAUDE.md
 !CONTRIBUTING.md
-!AGENTS.md
-!Roadmap.md
 /.claude
 docs/index.html
 /tavo-backup

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -231,14 +231,55 @@ export async function generateChatResponse({
     let vectorLoreTokens = 0;
     try {
         const vectorResults = await vectorSearchLorebooks(safeHistory || history, text, char, char?.sessionId);
+        
+        console.info('[generateChatResponse] Dual-channel lorebook merge', {
+            keywordMatches: result.loreEntries?.length || 0,
+            vectorMatches: vectorResults.length,
+            keywordEntries: result.loreEntries?.map(e => ({
+                id: e.id,
+                comment: e.comment,
+                keys: e.keys
+            })) || [],
+            vectorEntries: vectorResults.map(e => ({
+                id: e.id,
+                comment: e.comment,
+                keys: e.keys,
+                score: e.vectorScore
+            }))
+        });
+        
         if (vectorResults.length > 0 && result.loreEntries) {
             const keywordIds = new Set(result.loreEntries.map(e => e.id));
             newVectorEntries = vectorResults.filter(e => !keywordIds.has(e.id));
+            
+            const duplicates = vectorResults.filter(e => keywordIds.has(e.id));
+            console.info('[generateChatResponse] Dual-channel deduplication', {
+                keywordMatchedIds: Array.from(keywordIds),
+                vectorOnlyCount: newVectorEntries.length,
+                duplicatesRemoved: duplicates.length,
+                duplicateEntries: duplicates.map(e => ({
+                    id: e.id,
+                    comment: e.comment,
+                    vectorScore: e.vectorScore
+                }))
+            });
+            
             newVectorEntries.forEach(e => { e._source = 'vector'; });
             result.loreEntries.forEach(e => { if (!e._source) e._source = 'keyword'; });
             const keywordEntries = result.loreEntries.filter(e => e._source === 'keyword');
             const vectorOnly = newVectorEntries.sort((a, b) => (b.vectorScore || 0) - (a.vectorScore || 0));
             result.loreEntries = [...keywordEntries, ...vectorOnly];
+            
+            console.info('[generateChatResponse] Final lorebook order', {
+                total: result.loreEntries.length,
+                keywordFirst: keywordEntries.length,
+                vectorLast: vectorOnly.length,
+                finalOrder: result.loreEntries.map(e => ({
+                    id: e.id,
+                    comment: e.comment,
+                    source: e._source
+                }))
+            });
         }
     } catch (e) {
         console.warn('[generateChatResponse] Vector search failed:', e);
@@ -509,9 +550,39 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
         let vectorLoreTokens = 0;
         try {
             const vectorResults = await vectorSearchLorebooks(safeHistory || history, '', char, char?.sessionId);
+            
+            console.info('[calculateContext] Dual-channel lorebook merge', {
+                keywordMatches: result.loreEntries?.length || 0,
+                vectorMatches: vectorResults.length,
+                keywordEntries: result.loreEntries?.map(e => ({
+                    id: e.id,
+                    comment: e.comment,
+                    keys: e.keys
+                })) || [],
+                vectorEntries: vectorResults.map(e => ({
+                    id: e.id,
+                    comment: e.comment,
+                    keys: e.keys,
+                    score: e.vectorScore
+                }))
+            });
+            
             if (vectorResults.length > 0) {
                 const keywordIds = result.loreEntries ? new Set(result.loreEntries.map(e => e.id)) : new Set();
                 const newVectorEntries = vectorResults.filter(e => !keywordIds.has(e.id));
+                
+                const duplicates = vectorResults.filter(e => keywordIds.has(e.id));
+                console.info('[calculateContext] Dual-channel deduplication', {
+                    keywordMatchedIds: Array.from(keywordIds),
+                    vectorOnlyCount: newVectorEntries.length,
+                    duplicatesRemoved: duplicates.length,
+                    duplicateEntries: duplicates.map(e => ({
+                        id: e.id,
+                        comment: e.comment,
+                        vectorScore: e.vectorScore
+                    }))
+                });
+                
                 vectorLoreTokens = newVectorEntries.reduce((sum, entry) => {
                     const content = entry.content || '';
                     const tokens = estimateTokens(content);

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -231,55 +231,14 @@ export async function generateChatResponse({
     let vectorLoreTokens = 0;
     try {
         const vectorResults = await vectorSearchLorebooks(safeHistory || history, text, char, char?.sessionId);
-        
-        console.info('[generateChatResponse] Dual-channel lorebook merge', {
-            keywordMatches: result.loreEntries?.length || 0,
-            vectorMatches: vectorResults.length,
-            keywordEntries: result.loreEntries?.map(e => ({
-                id: e.id,
-                comment: e.comment,
-                keys: e.keys
-            })) || [],
-            vectorEntries: vectorResults.map(e => ({
-                id: e.id,
-                comment: e.comment,
-                keys: e.keys,
-                score: e.vectorScore
-            }))
-        });
-        
         if (vectorResults.length > 0 && result.loreEntries) {
             const keywordIds = new Set(result.loreEntries.map(e => e.id));
             newVectorEntries = vectorResults.filter(e => !keywordIds.has(e.id));
-            
-            const duplicates = vectorResults.filter(e => keywordIds.has(e.id));
-            console.info('[generateChatResponse] Dual-channel deduplication', {
-                keywordMatchedIds: Array.from(keywordIds),
-                vectorOnlyCount: newVectorEntries.length,
-                duplicatesRemoved: duplicates.length,
-                duplicateEntries: duplicates.map(e => ({
-                    id: e.id,
-                    comment: e.comment,
-                    vectorScore: e.vectorScore
-                }))
-            });
-            
             newVectorEntries.forEach(e => { e._source = 'vector'; });
             result.loreEntries.forEach(e => { if (!e._source) e._source = 'keyword'; });
             const keywordEntries = result.loreEntries.filter(e => e._source === 'keyword');
             const vectorOnly = newVectorEntries.sort((a, b) => (b.vectorScore || 0) - (a.vectorScore || 0));
             result.loreEntries = [...keywordEntries, ...vectorOnly];
-            
-            console.info('[generateChatResponse] Final lorebook order', {
-                total: result.loreEntries.length,
-                keywordFirst: keywordEntries.length,
-                vectorLast: vectorOnly.length,
-                finalOrder: result.loreEntries.map(e => ({
-                    id: e.id,
-                    comment: e.comment,
-                    source: e._source
-                }))
-            });
         }
     } catch (e) {
         console.warn('[generateChatResponse] Vector search failed:', e);
@@ -550,39 +509,9 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
         let vectorLoreTokens = 0;
         try {
             const vectorResults = await vectorSearchLorebooks(safeHistory || history, '', char, char?.sessionId);
-            
-            console.info('[calculateContext] Dual-channel lorebook merge', {
-                keywordMatches: result.loreEntries?.length || 0,
-                vectorMatches: vectorResults.length,
-                keywordEntries: result.loreEntries?.map(e => ({
-                    id: e.id,
-                    comment: e.comment,
-                    keys: e.keys
-                })) || [],
-                vectorEntries: vectorResults.map(e => ({
-                    id: e.id,
-                    comment: e.comment,
-                    keys: e.keys,
-                    score: e.vectorScore
-                }))
-            });
-            
             if (vectorResults.length > 0) {
                 const keywordIds = result.loreEntries ? new Set(result.loreEntries.map(e => e.id)) : new Set();
                 const newVectorEntries = vectorResults.filter(e => !keywordIds.has(e.id));
-                
-                const duplicates = vectorResults.filter(e => keywordIds.has(e.id));
-                console.info('[calculateContext] Dual-channel deduplication', {
-                    keywordMatchedIds: Array.from(keywordIds),
-                    vectorOnlyCount: newVectorEntries.length,
-                    duplicatesRemoved: duplicates.length,
-                    duplicateEntries: duplicates.map(e => ({
-                        id: e.id,
-                        comment: e.comment,
-                        vectorScore: e.vectorScore
-                    }))
-                });
-                
                 vectorLoreTokens = newVectorEntries.reduce((sum, entry) => {
                     const content = entry.content || '';
                     const tokens = estimateTokens(content);

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -162,12 +162,13 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
     let allRelevantEntries = [];
     let candidates = [];
 
-    // DEBUG: Track entries excluded from keyword scan
+    // DEBUG: Track vector-enabled entries that participate in keyword scan
     let vectorSearchEntries = [];
 
     activeLorebooks.forEach(lb => {
         lb.entries.forEach(entry => {
-            if (entry.enabled !== false && !entry.vectorSearch) {
+            // DUAL-CHANNEL FIX: All entries participate in keyword scan, regardless of vectorSearch flag
+            if (entry.enabled !== false) {
                 if (char && entry.characterFilter) {
                     const { isExclude, names } = entry.characterFilter;
                     if (names && names.length > 0) {
@@ -178,27 +179,25 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
                     }
                 }
                 candidates.push({ ...entry, lorebookName: lb.name, lorebookId: lb.id });
-            } else if (entry.enabled !== false && entry.vectorSearch) {
-                vectorSearchEntries.push({
-                    id: entry.id,
-                    comment: entry.comment,
-                    keys: entry.keys,
-                    lorebookName: lb.name
-                });
+                
+                // Track entries that also have vector search enabled
+                if (entry.vectorSearch) {
+                    vectorSearchEntries.push({
+                        id: entry.id,
+                        comment: entry.comment,
+                        keys: entry.keys,
+                        lorebookName: lb.name
+                    });
+                }
             }
         });
     });
 
-    console.info('[scanLorebooksPure] Keyword scan candidates', {
+    console.info('[scanLorebooksPure] Keyword scan candidates (DUAL-CHANNEL)', {
         totalEntries: activeLorebooks.reduce((sum, lb) => sum + lb.entries.filter(e => e.enabled !== false).length, 0),
         keywordCandidates: candidates.length,
-        vectorSearchEntries: vectorSearchEntries.length,
-        excludedFromKeywordScan: vectorSearchEntries.map(e => ({
-            id: e.id,
-            comment: e.comment,
-            keys: e.keys,
-            lorebook: e.lorebookName
-        }))
+        vectorEnabledEntries: vectorSearchEntries.length,
+        dualChannelInfo: `All ${candidates.length} entries participate in keyword scan. ${vectorSearchEntries.length} of them also have vectorSearch enabled and will participate in vector search if they don't match keywords.`
     });
 
     candidates.filter(e => e.constant).forEach(entry => {

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -484,7 +484,13 @@ function buildPromptMessagesWorker(args) {
 
     let loreByPosition = { worldInfoBefore: [], worldInfoAfter: [], lorebooksMacro: [] };
     if (lorebooks) {
-        const loreEntries = scanLorebooksPure(history || [], char, "", chatId, lorebooks, globalSettings, activations);
+        // DUAL-CHANNEL FIX: Extract current user message for keyword scanning
+        const lastUserMessage = history && history.length > 0 
+            ? history.filter(m => m.role === 'user').slice(-1)[0]
+            : null;
+        const textToScan = lastUserMessage?.content || "";
+        
+        const loreEntries = scanLorebooksPure(history || [], char, textToScan, chatId, lorebooks, globalSettings, activations);
         allLoreEntries = loreEntries;
 
         loreEntries.forEach(entry => {

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -193,11 +193,32 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
         });
     });
 
+    // DEBUG: Check if Alison entry has keys
+    const alisonCandidate = candidates.find(c => 
+        c.comment && (c.comment.toLowerCase().includes('alison') || c.comment.toLowerCase().includes('алисон'))
+    );
+    if (alisonCandidate) {
+        console.warn('[scanLorebooksPure] DEBUG Alison entry found in candidates', {
+            id: alisonCandidate.id,
+            comment: alisonCandidate.comment,
+            keys: alisonCandidate.keys,
+            hasKeys: !!alisonCandidate.keys,
+            keysLength: alisonCandidate.keys?.length,
+            vectorSearch: alisonCandidate.vectorSearch
+        });
+    }
+
     console.info('[scanLorebooksPure] Keyword scan candidates (DUAL-CHANNEL)', {
         totalEntries: activeLorebooks.reduce((sum, lb) => sum + lb.entries.filter(e => e.enabled !== false).length, 0),
         keywordCandidates: candidates.length,
         vectorEnabledEntries: vectorSearchEntries.length,
-        dualChannelInfo: `All ${candidates.length} entries participate in keyword scan. ${vectorSearchEntries.length} of them also have vectorSearch enabled and will participate in vector search if they don't match keywords.`
+        dualChannelInfo: `All ${candidates.length} entries participate in keyword scan. ${vectorSearchEntries.length} of them also have vectorSearch enabled and will participate in vector search if they don't match keywords.`,
+        firstFewCandidates: candidates.slice(0, 3).map(c => ({
+            id: c.id,
+            comment: c.comment,
+            keys: c.keys,
+            vectorSearch: c.vectorSearch
+        }))
     });
 
     candidates.filter(e => e.constant).forEach(entry => {

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -866,6 +866,15 @@ function buildPromptMessagesWorker(args) {
         return m.content && m.content.trim().length > 0;
     });
 
+    console.info('[buildPromptMessagesWorker] Returning loreEntries', {
+        count: allLoreEntries.length,
+        entries: allLoreEntries.map(e => ({
+            id: e.id,
+            comment: e.comment,
+            keys: e.keys
+        }))
+    });
+
     return { messages: filteredMessages, loreEntries: allLoreEntries, notifyObj };
 }
 
@@ -875,6 +884,15 @@ self.onmessage = async function (e) {
     if (type === 'calculateContext' || type === 'generateChatResponse') {
         try {
             const { messages, loreEntries, notifyObj } = buildPromptMessagesWorker(payload);
+            
+            console.info('[generationWorker] After buildPromptMessagesWorker', {
+                type,
+                loreEntriesCount: loreEntries?.length || 0,
+                loreEntriesPreview: loreEntries?.slice(0, 3).map(e => ({
+                    id: e.id,
+                    comment: e.comment
+                })) || []
+            });
 
             const { apiConfig } = payload;
             const maxTokens = apiConfig.maxTokens;

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -162,12 +162,9 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
     let allRelevantEntries = [];
     let candidates = [];
 
-    // DEBUG: Track vector-enabled entries that participate in keyword scan
-    let vectorSearchEntries = [];
-
     activeLorebooks.forEach(lb => {
         lb.entries.forEach(entry => {
-            // DUAL-CHANNEL FIX: All entries participate in keyword scan, regardless of vectorSearch flag
+            // DUAL-CHANNEL: All entries participate in keyword scan, regardless of vectorSearch flag
             if (entry.enabled !== false) {
                 if (char && entry.characterFilter) {
                     const { isExclude, names } = entry.characterFilter;
@@ -179,46 +176,12 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
                     }
                 }
                 candidates.push({ ...entry, lorebookName: lb.name, lorebookId: lb.id });
-                
-                // Track entries that also have vector search enabled
-                if (entry.vectorSearch) {
-                    vectorSearchEntries.push({
-                        id: entry.id,
-                        comment: entry.comment,
-                        keys: entry.keys,
-                        lorebookName: lb.name
-                    });
-                }
             }
         });
     });
-
-    // DEBUG: Check if Alison entry has keys
-    const alisonCandidate = candidates.find(c => 
-        c.comment && (c.comment.toLowerCase().includes('alison') || c.comment.toLowerCase().includes('алисон'))
-    );
-    if (alisonCandidate) {
-        console.warn('[scanLorebooksPure] DEBUG Alison entry found in candidates', {
-            id: alisonCandidate.id,
-            comment: alisonCandidate.comment,
-            keys: alisonCandidate.keys,
-            hasKeys: !!alisonCandidate.keys,
-            keysLength: alisonCandidate.keys?.length,
-            vectorSearch: alisonCandidate.vectorSearch
+                }
+            }
         });
-    }
-
-    console.info('[scanLorebooksPure] Keyword scan candidates (DUAL-CHANNEL)', {
-        totalEntries: activeLorebooks.reduce((sum, lb) => sum + lb.entries.filter(e => e.enabled !== false).length, 0),
-        keywordCandidates: candidates.length,
-        vectorEnabledEntries: vectorSearchEntries.length,
-        dualChannelInfo: `All ${candidates.length} entries participate in keyword scan. ${vectorSearchEntries.length} of them also have vectorSearch enabled and will participate in vector search if they don't match keywords.`,
-        firstFewCandidates: candidates.slice(0, 3).map(c => ({
-            id: c.id,
-            comment: c.comment,
-            keys: c.keys,
-            vectorSearch: c.vectorSearch
-        }))
     });
 
     candidates.filter(e => e.constant).forEach(entry => {
@@ -292,28 +255,6 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
             const scanSource = caseSensitive ?
                 (messagesToScan + textToScan) :
                 (messagesToScan.toLowerCase() + textToScan.toLowerCase());
-            
-            // DEBUG: Log scan source for entries with specific keywords
-            const debugKeywords = ['alison', 'алисон', 'asei', 'асей'];
-            const hasDebugKeyword = primaryKeys.some(key => 
-                debugKeywords.some(dk => String(key || '').toLowerCase().includes(dk))
-            );
-            if (hasDebugKeyword) {
-                console.warn('[scanLorebooksPure] DEBUG keyword scan for entry', {
-                    entryId: entry.id,
-                    comment: entry.comment,
-                    primaryKeys,
-                    secondaryKeys,
-                    caseSensitive,
-                    wholeWords,
-                    scanDepth,
-                    historyMessagesCount: history.length,
-                    messagesToScanLength: messagesToScan.length,
-                    textToScanLength: textToScan.length,
-                    scanSourcePreview: scanSource.substring(0, 500),
-                    scanSourceLength: scanSource.length
-                });
-            }
 
             let isStickyActive = false;
             let isOnCooldown = false;
@@ -336,21 +277,6 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
             if (isOnCooldown) continue;
 
             const matchedPrimary = isStickyActive || primaryKeys.some(key => checkMatch(key, scanSource));
-            
-            // DEBUG: Log match result for entries with debug keywords
-            if (hasDebugKeyword) {
-                const primaryMatchResults = primaryKeys.map(key => ({
-                    key,
-                    matched: checkMatch(key, scanSource)
-                }));
-                console.warn('[scanLorebooksPure] DEBUG match results', {
-                    entryId: entry.id,
-                    comment: entry.comment,
-                    isStickyActive,
-                    matchedPrimary,
-                    primaryMatchResults
-                });
-            }
 
             if (matchedPrimary) {
                 let secondaryMatches = true;
@@ -384,19 +310,7 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
         }
     }
 
-    const finalEntries = allRelevantEntries.sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
-    
-    console.info('[scanLorebooksPure] Keyword scan results', {
-        matched: finalEntries.length,
-        entries: finalEntries.map(e => ({
-            id: e.id,
-            comment: e.comment,
-            keys: e.keys,
-            lorebook: e.lorebookName
-        }))
-    });
-
-    return finalEntries;
+    return allRelevantEntries.sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
 }
 
 function squashHistory(historyMsgs, squashRole) {
@@ -435,14 +349,6 @@ function buildBlockSourceReplacements(char, personaObj, sessionVars, notifyObj, 
 
 function buildPromptMessagesWorker(args) {
     let { char, history, summary, activePreset, mergePrompts, mergeRole, noAssistant, userPrefix, charPrefix, squashRole, personaObj, authorsNote, guidanceText, guidanceType, lorebooks, globalSettings, activations, globalRegexes, sessionVars } = args;
-    
-    console.info('[buildPromptMessagesWorker] Called with', {
-        historyLength: history?.length || 0,
-        lastUserMessage: history?.filter(m => m.role === 'user').slice(-1)[0]?.content?.substring(0, 100) || 'none',
-        lorebooksCount: lorebooks?.length || 0,
-        charId: char?.id
-    });
-    
     if (noAssistant) mergePrompts = true;
 
     const messages = [];
@@ -874,15 +780,6 @@ function buildPromptMessagesWorker(args) {
         return m.content && m.content.trim().length > 0;
     });
 
-    console.info('[buildPromptMessagesWorker] Returning loreEntries', {
-        count: allLoreEntries.length,
-        entries: allLoreEntries.map(e => ({
-            id: e.id,
-            comment: e.comment,
-            keys: e.keys
-        }))
-    });
-
     return { messages: filteredMessages, loreEntries: allLoreEntries, notifyObj };
 }
 
@@ -892,15 +789,6 @@ self.onmessage = async function (e) {
     if (type === 'calculateContext' || type === 'generateChatResponse') {
         try {
             const { messages, loreEntries, notifyObj } = buildPromptMessagesWorker(payload);
-            
-            console.info('[generationWorker] After buildPromptMessagesWorker', {
-                type,
-                loreEntriesCount: loreEntries?.length || 0,
-                loreEntriesPreview: loreEntries?.slice(0, 3).map(e => ({
-                    id: e.id,
-                    comment: e.comment
-                })) || []
-            });
 
             const { apiConfig } = payload;
             const maxTokens = apiConfig.maxTokens;

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -271,6 +271,28 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
             const scanSource = caseSensitive ?
                 (messagesToScan + textToScan) :
                 (messagesToScan.toLowerCase() + textToScan.toLowerCase());
+            
+            // DEBUG: Log scan source for entries with specific keywords
+            const debugKeywords = ['alison', 'алисон', 'asei', 'асей'];
+            const hasDebugKeyword = primaryKeys.some(key => 
+                debugKeywords.some(dk => String(key || '').toLowerCase().includes(dk))
+            );
+            if (hasDebugKeyword) {
+                console.warn('[scanLorebooksPure] DEBUG keyword scan for entry', {
+                    entryId: entry.id,
+                    comment: entry.comment,
+                    primaryKeys,
+                    secondaryKeys,
+                    caseSensitive,
+                    wholeWords,
+                    scanDepth,
+                    historyMessagesCount: history.length,
+                    messagesToScanLength: messagesToScan.length,
+                    textToScanLength: textToScan.length,
+                    scanSourcePreview: scanSource.substring(0, 500),
+                    scanSourceLength: scanSource.length
+                });
+            }
 
             let isStickyActive = false;
             let isOnCooldown = false;
@@ -293,6 +315,21 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
             if (isOnCooldown) continue;
 
             const matchedPrimary = isStickyActive || primaryKeys.some(key => checkMatch(key, scanSource));
+            
+            // DEBUG: Log match result for entries with debug keywords
+            if (hasDebugKeyword) {
+                const primaryMatchResults = primaryKeys.map(key => ({
+                    key,
+                    matched: checkMatch(key, scanSource)
+                }));
+                console.warn('[scanLorebooksPure] DEBUG match results', {
+                    entryId: entry.id,
+                    comment: entry.comment,
+                    isStickyActive,
+                    matchedPrimary,
+                    primaryMatchResults
+                });
+            }
 
             if (matchedPrimary) {
                 let secondaryMatches = true;

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -435,6 +435,14 @@ function buildBlockSourceReplacements(char, personaObj, sessionVars, notifyObj, 
 
 function buildPromptMessagesWorker(args) {
     let { char, history, summary, activePreset, mergePrompts, mergeRole, noAssistant, userPrefix, charPrefix, squashRole, personaObj, authorsNote, guidanceText, guidanceType, lorebooks, globalSettings, activations, globalRegexes, sessionVars } = args;
+    
+    console.info('[buildPromptMessagesWorker] Called with', {
+        historyLength: history?.length || 0,
+        lastUserMessage: history?.filter(m => m.role === 'user').slice(-1)[0]?.content?.substring(0, 100) || 'none',
+        lorebooksCount: lorebooks?.length || 0,
+        charId: char?.id
+    });
+    
     if (noAssistant) mergePrompts = true;
 
     const messages = [];

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -162,6 +162,9 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
     let allRelevantEntries = [];
     let candidates = [];
 
+    // DEBUG: Track entries excluded from keyword scan
+    let vectorSearchEntries = [];
+
     activeLorebooks.forEach(lb => {
         lb.entries.forEach(entry => {
             if (entry.enabled !== false && !entry.vectorSearch) {
@@ -175,8 +178,27 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
                     }
                 }
                 candidates.push({ ...entry, lorebookName: lb.name, lorebookId: lb.id });
+            } else if (entry.enabled !== false && entry.vectorSearch) {
+                vectorSearchEntries.push({
+                    id: entry.id,
+                    comment: entry.comment,
+                    keys: entry.keys,
+                    lorebookName: lb.name
+                });
             }
         });
+    });
+
+    console.info('[scanLorebooksPure] Keyword scan candidates', {
+        totalEntries: activeLorebooks.reduce((sum, lb) => sum + lb.entries.filter(e => e.enabled !== false).length, 0),
+        keywordCandidates: candidates.length,
+        vectorSearchEntries: vectorSearchEntries.length,
+        excludedFromKeywordScan: vectorSearchEntries.map(e => ({
+            id: e.id,
+            comment: e.comment,
+            keys: e.keys,
+            lorebook: e.lorebookName
+        }))
     });
 
     candidates.filter(e => e.constant).forEach(entry => {
@@ -305,7 +327,19 @@ function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalS
         }
     }
 
-    return allRelevantEntries.sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
+    const finalEntries = allRelevantEntries.sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
+    
+    console.info('[scanLorebooksPure] Keyword scan results', {
+        matched: finalEntries.length,
+        entries: finalEntries.map(e => ({
+            id: e.id,
+            comment: e.comment,
+            keys: e.keys,
+            lorebook: e.lorebookName
+        }))
+    });
+
+    return finalEntries;
 }
 
 function squashHistory(historyMsgs, squashRole) {

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -58,7 +58,7 @@ function escapeRegex(string) {
     return string.replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-const GLAZE_BOUNDARIES = '[\\s.,!?;:"\'\\u201C\\u201D\\u2018\\u2019\\u00AB\\u00BB(){}\\[\\]—–]';
+const GLAZE_BOUNDARIES = '[\\s.,!?;:"\'\\u201C\\u201D\\u2018\\u2019\\u00AB\\u00BB(){}\\[\\]—–*]';
 
 function sanitizeRegexFlags(flags) {
     const valid = new Set(['g', 'i', 'm', 's', 'u', 'y']);


### PR DESCRIPTION
## Summary
Fixes dual-channel lorebook retrieval to work as designed: entries with `vectorSearch: true` now participate in BOTH keyword scan AND vector search, with keyword matches prioritized.

## Root Causes Fixed

### 1. **Keyword scan excluded vectorSearch entries**
- **Problem**: `scanLorebooksPure()` had `!entry.vectorSearch` filter, completely excluding vector-enabled entries from keyword matching
- **Fix**: Removed filter — all entries now participate in keyword scan regardless of `vectorSearch` flag
- **Impact**: Entries with both keys and `vectorSearch: true` can now match by keyword

### 2. **Empty textToScan in worker**
- **Problem**: Worker called `scanLorebooksPure(history, char, "", ...)` with empty string for current message
- **Fix**: Extract last user message and pass as `textToScan` parameter
- **Impact**: Keyword scan now checks current user input, not just history

### 3. **GLAZE_BOUNDARIES missing asterisk**
- **Problem**: Roleplay text uses `*actions*` heavily, but `*` wasn't recognized as word boundary
- **Fix**: Added `*` to `GLAZE_BOUNDARIES` pattern
- **Impact**: Keywords like `*Алисон*` or `на Алисон*` now match correctly in `wholeWords: 'glaze'` mode

## Dual-Channel Flow (After Fix)

1. Entry with `vectorSearch: true` + has `keys` → participates in keyword scan
2. If matched by keyword → high priority, **excluded** from vector search results (deduplication)
3. If NOT matched by keyword → participates in vector search → low priority
4. Final order: `[...keywordMatches, ...vectorOnlyMatches]`

## Testing
- Verified keyword matches work for vector-enabled entries
- Verified deduplication removes keyword-matched entries from vector results
- Verified keyword priority (keyword matches appear before vector matches)
- Verified roleplay text matching with asterisks

## Files Modified
- `src/workers/generationWorker.js` — keyword scan filter, textToScan extraction, GLAZE_BOUNDARIES
- `src/core/services/generationService.js` — deduplication logic (already correct)
- `.gitignore` — exclude Roadmap.md and AGENTS.md from git
