### PR TITLE
feat: improve memory books draft workflow and retrieval settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ docs/index.html
 SillyTavern-MemoryBooks/
 UNTESTED_TASKS.md
 TESTING_CHECKLIST.md
+session_todo.md

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -16,11 +16,10 @@ Every roadmap item should be broken into smaller concrete subtasks whenever poss
 
 For each task or subtask, always record:
 - completion status: `done` or `not done`
-- testing status: `tested` or `not tested`
 
 If something is only partially complete, split the unfinished portion into a separate follow-up subtask instead of leaving one broad mixed-status item.
 
-`Roadmap.md` should also explicitly call out what still requires manual user verification, so pending checks are visible and can be tested directly from the roadmap.
+Items requiring manual user verification should be explicitly listed in a "Manual Verification" section at the end of the relevant feature.
 
 ## Current Direction
 
@@ -228,216 +227,216 @@ Goal:
 Build a higher-level long-term memory system on top of the already stabilized summary and vector layers, without introducing a second fragile lore/memory pipeline that will need a rewrite later.
 
 Current pain points that must be solved:
-- [done | tested] First memory creation is no longer manual — Scan Chat + Generate Drafts batch flow available.
-- [done | tested] Per-message markers: MEM (approved), DRAFT (pending drafts), PENDING (automation queue), REBUILD, STALE badges.
-- [done | not tested] Deleting messages or branching a chat can leave orphaned / stale memories that no longer match the current chat history.
-- [done | tested] Imported chats can use Scan Chat to segment history and Generate Drafts to bootstrap memory entries. Auto-draft on import disabled; user must manually trigger.
-- [not done | not tested] Memory books need to behave like lorebooks for retrieval features (vectors, keys, Glaze keys), but they must inject into the summary area and have a separate activation/count budget from normal lorebooks.
-- [not done | not tested] Memory usage should appear in the tokenizer/context UI as summary-like context, not as normal lorebook context.
-- [not done | not tested] Import/export and future cloud sync integration must not break when memory books are introduced.
-- [done | not tested] Cloud sync already exists on `feat/cloud-sync` / PR #20 with `syncEngine`, `syncService`, `syncQueue`, conflict resolution UI, encryption, and `updatedAt`-aware DB changes. Memory books must plug into that model instead of inventing a parallel sync path.
+- [done] First memory creation is no longer manual — Scan Chat + Generate Drafts batch flow available.
+- [done] Per-message markers: MEM (approved), DRAFT (pending drafts), PENDING (automation queue), REBUILD, STALE badges.
+- [done] Deleting messages or branching a chat can leave orphaned / stale memories that no longer match the current chat history.
+- [done] Imported chats can use Scan Chat to segment history and Generate Drafts to bootstrap memory entries. Auto-draft on import disabled; user must manually trigger.
+- [not done] Memory books need to behave like lorebooks for retrieval features (vectors, keys, Glaze keys), but they must inject into the summary area and have a separate activation/count budget from normal lorebooks.
+- [not done] Memory usage should appear in the tokenizer/context UI as summary-like context, not as normal lorebook context.
+- [not done] Import/export and future cloud sync integration must not break when memory books are introduced.
+- [done] Cloud sync already exists on `feat/cloud-sync` / PR #20 with `syncEngine`, `syncService`, `syncQueue`, conflict resolution UI, encryption, and `updatedAt`-aware DB changes. Memory books must plug into that model instead of inventing a parallel sync path.
 
 Architecture direction:
-- [done | not tested] Reuse the existing vector infrastructure rather than creating a separate memory retrieval engine. The current embeddings schema already supports future `sourceType` expansion beyond `lorebook_entry`.
-- [done | not tested] Reuse lorebook-style entry semantics for memory entries: keys, vector search, retrieval hints, and inspectable entry records remain the correct primitive.
-- [done | not tested] Do not make memory books just a hidden naming convention inside normal lorebooks. They need their own container/type so lifecycle, injection budget, UI, and sync/import behavior are explicit.
-- [done | not tested] Keep memory entries structurally compatible with lorebook entries where possible, but store memory-book metadata separately from normal lorebook presentation concerns.
-- [done | not tested] Message-range ownership must be first-class. Memory entries should track the message range or explicit message IDs they summarize so lifecycle operations can be deterministic.
-- [done | not tested] Memory retrieval injects into the summary block path with its own budget. Memory injection filter: entries only eligible when first segment message leaves context window.
+- [done] Reuse the existing vector infrastructure rather than creating a separate memory retrieval engine. The current embeddings schema already supports future `sourceType` expansion beyond `lorebook_entry`.
+- [done] Reuse lorebook-style entry semantics for memory entries: keys, vector search, retrieval hints, and inspectable entry records remain the correct primitive.
+- [done] Do not make memory books just a hidden naming convention inside normal lorebooks. They need their own container/type so lifecycle, injection budget, UI, and sync/import behavior are explicit.
+- [done] Keep memory entries structurally compatible with lorebook entries where possible, but store memory-book metadata separately from normal lorebook presentation concerns.
+- [done] Message-range ownership must be first-class. Memory entries should track the message range or explicit message IDs they summarize so lifecycle operations can be deterministic.
+- [done] Memory retrieval injects into the summary block path with its own budget. Memory injection filter: entries only eligible when first segment message leaves context window.
 
 Recommended implementation shape:
-- [done | not tested] Introduce a dedicated memory book container persisted per chat/session, instead of storing memory books as ordinary lorebooks only.
-- [done | not tested] Keep each memory entry lorebook-compatible internally at the schema level: `content`, `keys`, `vectorSearch`, and `glazeKeys` are now present so retrieval wiring can build on stable entry fields.
-- [done | not tested] Add memory-specific metadata on top of the entry data:
+- [done] Introduce a dedicated memory book container persisted per chat/session, instead of storing memory books as ordinary lorebooks only.
+- [done] Keep each memory entry lorebook-compatible internally at the schema level: `content`, `keys`, `vectorSearch`, and `glazeKeys` are now present so retrieval wiring can build on stable entry fields.
+- [done] Add memory-specific metadata on top of the entry data:
   - `messageRange` / explicit message IDs covered by the entry
   - source session ID
   - derived segment hash/fingerprint
   - lifecycle status (`active`, `stale`, `orphaned`, `needs_rebuild`)
   - creation mode (`manual`, `auto`, `import_bootstrap`)
-- [not done | not tested] Treat the memory book as a dedicated chat-level data container that can feed a summary-like prompt block during generation while still reusing indexing/search internals.
+- [not done] Treat the memory book as a dedicated chat-level data container that can feed a summary-like prompt block during generation while still reusing indexing/search internals.
 
 Why this shape is preferred:
-- [done | not tested] The generation pipeline already distinguishes `summary` and `lorebook` token sources, so memory books can be integrated as a summary-adjacent source without pretending they are ordinary lorebook injections.
-- [done | not tested] Messages already expose `triggeredLorebooks`, which means the chat UI already has a pattern for showing source-trigger metadata on individual messages.
-- [done | not tested] Chat lifecycle events already exist in `ChatView.vue` for delete, branch, import, and save flows, which gives a clear place to attach memory lifecycle maintenance.
-- [done | not tested] Import/export already goes through centralized chat/backup services, so a dedicated memory container is safer than hiding memory state inside ad hoc lorebook fields.
+- [done] The generation pipeline already distinguishes `summary` and `lorebook` token sources, so memory books can be integrated as a summary-adjacent source without pretending they are ordinary lorebook injections.
+- [done] Messages already expose `triggeredLorebooks`, which means the chat UI already has a pattern for showing source-trigger metadata on individual messages.
+- [done] Chat lifecycle events already exist in `ChatView.vue` for delete, branch, import, and save flows, which gives a clear place to attach memory lifecycle maintenance.
+- [done] Import/export already goes through centralized chat/backup services, so a dedicated memory container is safer than hiding memory state inside ad hoc lorebook fields.
 
 Planned execution order:
-- [done | not tested] 4.1. Data model and persistence foundation.
-- [done | not tested] 4.2. Lifecycle maintenance tied to chat mutations.
-- [done | not tested] 4.3. Retrieval and prompt injection integration.
-- [done | not tested] 4.4. UI and tokenizer visualization.
-- [done | not tested] 4.5. Import/export/bootstrap and cloud-sync-safe serialization foundation in this branch.
-- [not done | not tested] 4.6. Automation rules and quality tuning.
+- [done] 4.1. Data model and persistence foundation.
+- [done] 4.2. Lifecycle maintenance tied to chat mutations.
+- [done] 4.3. Retrieval and prompt injection integration.
+- [done] 4.4. UI and tokenizer visualization.
+- [done] 4.5. Import/export/bootstrap and cloud-sync-safe serialization foundation in this branch.
+- [not done] 4.6. Automation rules and quality tuning.
 
 4.1. Data model and persistence foundation:
-- [done | not tested] Add a dedicated persisted memory-book container per chat/session.
-- [done | not tested] Define a memory entry schema that extends lorebook-compatible entry fields with message ownership metadata.
-- [done | not tested] Add deterministic identifiers for memory books and entries so imports, sync merges, and branch operations can reconcile data instead of duplicating it.
-- [done | not tested] Decide whether message ownership uses stable message IDs, timestamps, or both. Current recommendation: introduce explicit stable message IDs and keep timestamps as secondary metadata.
-- [done | not tested] Add DB migration / persistence support so memory books survive chat reloads, backup restore, and future sync.
-- [not done | not tested] Align memory persistence with the cloud-sync data model from PR #20: stable IDs, `updatedAt`, conflict-safe records, and deterministic serialization.
+- [done] Add a dedicated persisted memory-book container per chat/session.
+- [done] Define a memory entry schema that extends lorebook-compatible entry fields with message ownership metadata.
+- [done] Add deterministic identifiers for memory books and entries so imports, sync merges, and branch operations can reconcile data instead of duplicating it.
+- [done] Decide whether message ownership uses stable message IDs, timestamps, or both. Current recommendation: introduce explicit stable message IDs and keep timestamps as secondary metadata.
+- [done] Add DB migration / persistence support so memory books survive chat reloads, backup restore, and future sync.
+- [not done] Align memory persistence with the cloud-sync data model from PR #20: stable IDs, `updatedAt`, conflict-safe records, and deterministic serialization.
 
 4.2. Lifecycle maintenance tied to chat mutations:
-- [done | not tested] On message deletion, detect memory entries whose covered range is now invalid and mark or rebuild them instead of leaving stale memories behind.
-- [done | not tested] On chat branching, reconcile memory books explicitly instead of copying them blindly.
-- [done | not tested] Copy only memory entries whose covered message IDs/ranges are fully preserved inside the new branch history.
-- [done | not tested] If a memory entry only partially survives the fork boundary, do not keep it active; mark it as `needs_rebuild` or convert it into a draft for re-approval.
-- [done | not tested] If a memory entry belongs only to messages that do not exist in the child branch, remove it from the child branch entirely.
-- [not done | not tested] Add a maintenance pass that can recompute memory coverage for an entire session and clean up orphaned entries.
-- [not done | not tested] Surface stale/orphaned state in the memory UI instead of silently keeping broken data.
+- [done] On message deletion, detect memory entries whose covered range is now invalid and mark or rebuild them instead of leaving stale memories behind.
+- [done] On chat branching, reconcile memory books explicitly instead of copying them blindly.
+- [done] Copy only memory entries whose covered message IDs/ranges are fully preserved inside the new branch history.
+- [done] If a memory entry only partially survives the fork boundary, do not keep it active; mark it as `needs_rebuild` or convert it into a draft for re-approval.
+- [done] If a memory entry belongs only to messages that do not exist in the child branch, remove it from the child branch entirely.
+- [not done] Add a maintenance pass that can recompute memory coverage for an entire session and clean up orphaned entries.
+- [not done] Surface stale/orphaned state in the memory UI instead of silently keeping broken data.
 
 4.3. Retrieval and prompt injection integration:
-- [done | not tested] Reuse vector indexing/search for memory entries via a separate `sourceType` such as `memory_entry`.
-- [done | not tested] Support the same activation styles as lorebooks where useful: vectors, keys, and Glaze keys.
+- [done] Reuse vector indexing/search for memory entries via a separate `sourceType` such as `memory_entry`.
+- [done] Support the same activation styles as lorebooks where useful: vectors, keys, and Glaze keys.
 : runtime retrieval now supports key/glaze-key matching plus vector-backed memory entry search; deeper worker-level unification can remain follow-up cleanup.
-- [done | not tested] Keep normal lorebook activation limits separate from memory activation limits.
-- [done | not tested] Inject retrieved memories into the summary block path or an adjacent dedicated memory-summary block, not into the normal lorebook block.
-- [done | not tested] Expose separate memory context accounting in generation metadata so the UI can show memory independently from lorebooks.
-- [done | not tested] Memory retrieval already behaves like a lightweight lorebook-style top-k selection pass: relevant entries are searched, ranked, capped by session settings, and injected into the prompt.
-- [done | not tested] Session settings already include a `maxInjectedEntries`-style memory cap (`количество мемори в памяти`) that controls how many retrieved memory entries can be added to the prompt.
-- [done | not tested] Expose an explicit memory injection target setting in UI so the user can choose whether memory entries are injected into the dedicated summary block path or through the `{{summary}}` macro location.
+- [done] Keep normal lorebook activation limits separate from memory activation limits.
+- [done] Inject retrieved memories into the summary block path or an adjacent dedicated memory-summary block, not into the normal lorebook block.
+- [done] Expose separate memory context accounting in generation metadata so the UI can show memory independently from lorebooks.
+- [done] Memory retrieval already behaves like a lightweight lorebook-style top-k selection pass: relevant entries are searched, ranked, capped by session settings, and injected into the prompt.
+- [done] Session settings already include a `maxInjectedEntries`-style memory cap (`количество мемори в памяти`) that controls how many retrieved memory entries can be added to the prompt.
+- [done] Expose an explicit memory injection target setting in UI so the user can choose whether memory entries are injected into the dedicated summary block path or through the `{{summary}}` macro location.
 
 4.4. UI and tokenizer visualization:
-- [done | not tested] Add per-message markers showing whether a message is already covered by a memory segment / memory entry.
-- [done | not tested] Add a way to inspect which memory entry covers which message range directly from the chat UI.
-- [done | not tested] Add a dedicated memory books window/sheet rather than burying the feature entirely inside the lorebook sheet.
-- [done | not tested] In the tokenizer/context breakdown, display memory usage as summary-like context rather than lorebook usage.
-- [done | not tested] In message trigger UI, show memory-triggered entries distinctly from regular lorebook hits.
+- [done] Add per-message markers showing whether a message is already covered by a memory segment / memory entry.
+- [done] Add a way to inspect which memory entry covers which message range directly from the chat UI.
+- [done] Add a dedicated memory books window/sheet rather than burying the feature entirely inside the lorebook sheet.
+- [done] In the tokenizer/context breakdown, display memory usage as summary-like context rather than lorebook usage.
+- [done] In message trigger UI, show memory-triggered entries distinctly from regular lorebook hits.
 
 Current implementation status notes:
-- [done | not tested] Messages now store compact `contextRefs` and `memoryCoverage` metadata.
-- [done | not tested] Manual memory creation/removal from selected messages is available.
-- [done | not tested] A first visible `Memory Books` entry point exists in the magic drawer.
-- [done | not tested] `Memory Generation` currently supports provider source selection (`current` vs `custom`) and reuses the main API settings for `current` mode.
-- [done | not tested] `Current provider` mode now supports an optional model override without duplicating endpoint/key fields from the main API settings.
-- [done | not tested] `Memory Generation` now has its own rules/prompt preset selection, custom prompts, and temperature override, so memory generation can bypass the main preset configuration.
-- [done | not tested] Prompt rules can now be previewed before selection, and custom prompts can be viewed/edited directly from the manager.
-- [done | not tested] Closing prompt preview now returns to the originating memory sheet flow instead of dropping the user out of the settings/manager stack.
-- [done | not tested] Draft generation now includes a first continuity layer from nearby approved memories instead of sending the segment alone.
-- [done | not tested] Draft generation now also includes compact historical lore-trigger candidates and a summary excerpt for higher-quality extraction context.
-- [done | not tested] Normal generation now injects selected memory-book entries as a separate memory context block and records triggered memories on the source message.
-- [done | not tested] Dialog export now includes a Glaze full-fidelity chat format that preserves memory books, message refs, and memory coverage metadata.
-- [done | not tested] ST chat import/export now preserves Glaze message IDs, context refs, memory coverage, and triggered memories in `extra` when available.
-- [done | not tested] Memory entries and drafts now persist retrieval-facing fields (`keys`, `glazeKeys`, `vectorSearch`) and surface them in Memory Books preview UI.
-- [done | not tested] Approved memory entries can now be edited after approval, including title/content/keys/Glaze keys updates, per-entry `vectorSearch` toggle changes, and manual `Reindex` actions from the Memory Books UI.
-- [done | not tested] Memory Books now expose a session-level vector-search toggle and a selectable key match mode; keyword retrieval uses only the entry `Keys` field while preview cards keep inline `Edit` / `Reindex` / `Delete` actions.
-- [done | not tested] Memory Books now expose a user-facing session-level retrieved-entry cap (`maxInjectedEntries`) as the "количество мемори в памяти" control.
-- [done | not tested] Memory generation prompts now ask for both memory text and optional retrieval keys in a simple text format (`Memory:` / `Keys:`), avoiding JSON-only contracts.
-- [done | not tested] Draft parsing now supports vector-first usage: if the model leaves `Keys:` empty, fallback keys are generated automatically while vector retrieval can still dominate when configured.
-- [not done | not tested] Replace the temporary bottom-sheet implementation with a dedicated polished memory sheet component before considering the UI complete.
-- [done | not tested] Add an explicit session setting for "раз в сколько сообщений создается мемори" so automation/bootstrap can use a user-configurable interval instead of a hardcoded threshold.
-- [done | not tested] Add an explicit session setting for memory injection target selection: `{{summary}}` macro slot vs dedicated chat summary block injection.
-- [done | not tested] Lorebook insertion now has a global default injection position and per-entry `Match Global` / `{{lorebooks}}` targets, so the `{{lorebooks}}` macro is legal at the lorebook-entry level instead of acting as a preset-wide override.
-- [done | not tested] Lorebook ST round-trip now preserves Glaze-specific injection targets via `glazeMetadata`, so `Match Global` / `{{lorebooks}}` are not collapsed during export/import back into Glaze.
+- [done] Messages now store compact `contextRefs` and `memoryCoverage` metadata.
+- [done] Manual memory creation/removal from selected messages is available.
+- [done] A first visible `Memory Books` entry point exists in the magic drawer.
+- [done] `Memory Generation` currently supports provider source selection (`current` vs `custom`) and reuses the main API settings for `current` mode.
+- [done] `Current provider` mode now supports an optional model override without duplicating endpoint/key fields from the main API settings.
+- [done] `Memory Generation` now has its own rules/prompt preset selection, custom prompts, and temperature override, so memory generation can bypass the main preset configuration.
+- [done] Prompt rules can now be previewed before selection, and custom prompts can be viewed/edited directly from the manager.
+- [done] Closing prompt preview now returns to the originating memory sheet flow instead of dropping the user out of the settings/manager stack.
+- [done] Draft generation now includes a first continuity layer from nearby approved memories instead of sending the segment alone.
+- [done] Draft generation now also includes compact historical lore-trigger candidates and a summary excerpt for higher-quality extraction context.
+- [done] Normal generation now injects selected memory-book entries as a separate memory context block and records triggered memories on the source message.
+- [done] Dialog export now includes a Glaze full-fidelity chat format that preserves memory books, message refs, and memory coverage metadata.
+- [done] ST chat import/export now preserves Glaze message IDs, context refs, memory coverage, and triggered memories in `extra` when available.
+- [done] Memory entries and drafts now persist retrieval-facing fields (`keys`, `glazeKeys`, `vectorSearch`) and surface them in Memory Books preview UI.
+- [done] Approved memory entries can now be edited after approval, including title/content/keys/Glaze keys updates, per-entry `vectorSearch` toggle changes, and manual `Reindex` actions from the Memory Books UI.
+- [done] Memory Books now expose a session-level vector-search toggle and a selectable key match mode; keyword retrieval uses only the entry `Keys` field while preview cards keep inline `Edit` / `Reindex` / `Delete` actions.
+- [done] Memory Books now expose a user-facing session-level retrieved-entry cap (`maxInjectedEntries`) as the "количество мемори в памяти" control.
+- [done] Memory generation prompts now ask for both memory text and optional retrieval keys in a simple text format (`Memory:` / `Keys:`), avoiding JSON-only contracts.
+- [done] Draft parsing now supports vector-first usage: if the model leaves `Keys:` empty, fallback keys are generated automatically while vector retrieval can still dominate when configured.
+- [not done] Replace the temporary bottom-sheet implementation with a dedicated polished memory sheet component before considering the UI complete.
+- [done] Add an explicit session setting for "раз в сколько сообщений создается мемори" so automation/bootstrap can use a user-configurable interval instead of a hardcoded threshold.
+- [done] Add an explicit session setting for memory injection target selection: `{{summary}}` macro slot vs dedicated chat summary block injection.
+- [done] Lorebook insertion now has a global default injection position and per-entry `Match Global` / `{{lorebooks}}` targets, so the `{{lorebooks}}` macro is legal at the lorebook-entry level instead of acting as a preset-wide override.
+- [done] Lorebook ST round-trip now preserves Glaze-specific injection targets via `glazeMetadata`, so `Match Global` / `{{lorebooks}}` are not collapsed during export/import back into Glaze.
 
 4.5. Import/export/bootstrap and cloud-sync-safe serialization:
-- [done | not tested] On chat import, add an initial segmentation/bootstrap flow that can create first-pass memory drafts automatically from imported message history when the imported session has no existing memory-book state yet.
-- [done | not tested] Ensure exported chat or backup data includes memory book state in a deterministic form that can be rehydrated without manual repair.
-- [done | not tested] Keep SillyTavern-compatible chat export separate from full-fidelity Glaze-to-Glaze export. ST export may stay lossy, but Glaze-to-Glaze export/import must preserve memory books, message coverage markers, context refs, and related session metadata.
-- [done | not tested] Add a dedicated Glaze-to-Glaze chat/session format or extension path so memory-book state can round-trip without relying on ST JSONL fields that do not support Glaze metadata.
-- [not done | not tested] Keep embeddings export rules explicit: vectors may stay rebuildable/derived, but the core memory entries and message ownership metadata must persist.
-- [done | not tested] Design the stored format so cloud sync can merge or replace memory books predictably using stable IDs and updated timestamps, instead of treating them as opaque blobs.
-- [not done | not tested] Reuse the cloud-sync conflict model from PR #20 so memory books can participate in manual conflict resolution rather than bypassing it.
-- [not done | not tested] Extend cloud sync to include memory-book records and per-message memory metadata, so sync does not silently drop memory coverage or leave orphaned memory state across devices.
+- [done] On chat import, add an initial segmentation/bootstrap flow that can create first-pass memory drafts automatically from imported message history when the imported session has no existing memory-book state yet.
+- [done] Ensure exported chat or backup data includes memory book state in a deterministic form that can be rehydrated without manual repair.
+- [done] Keep SillyTavern-compatible chat export separate from full-fidelity Glaze-to-Glaze export. ST export may stay lossy, but Glaze-to-Glaze export/import must preserve memory books, message coverage markers, context refs, and related session metadata.
+- [done] Add a dedicated Glaze-to-Glaze chat/session format or extension path so memory-book state can round-trip without relying on ST JSONL fields that do not support Glaze metadata.
+- [not done] Keep embeddings export rules explicit: vectors may stay rebuildable/derived, but the core memory entries and message ownership metadata must persist.
+- [done] Design the stored format so cloud sync can merge or replace memory books predictably using stable IDs and updated timestamps, instead of treating them as opaque blobs.
+- [not done] Reuse the cloud-sync conflict model from PR #20 so memory books can participate in manual conflict resolution rather than bypassing it.
+- [not done] Extend cloud sync to include memory-book records and per-message memory metadata, so sync does not silently drop memory coverage or leave orphaned memory state across devices.
 
 4.6. Automation rules and quality tuning:
-- [not done | not tested] Define when automatic memory creation runs: for example after N new messages, after summary update, or on explicit background maintenance.
-- [done | not tested] Make the automatic creation interval user-configurable in UI as "раз в сколько сообщений создается мемори" instead of hardcoding the trigger threshold.
-- [done | not tested] Add a user-facing toggle for delayed automation (`работать с отставанием`) so automatic memory creation can intentionally wait for an extra user+assistant exchange before materializing a memory entry.
-- [done | not tested] Define delayed-trigger semantics for `Create memory every N messages`: when the threshold is reached on an assistant reply, wait until the user replies and receives one more assistant reply; when the threshold is reached on a user message, wait until that user message gets an assistant reply and then wait for one more full user+assistant exchange before creating the memory entry.
-- [done | not tested] Keep delayed automation as the recommended default so users can still edit their last user turn or regenerate the latest assistant reply before a memory entry becomes fixed.
-- [done | not tested] A first session-level delayed automation engine now tracks pending auto-memory triggers and evaluates them after stable assistant reply completion in the normal generation flow.
-- [done | tested] Allow the system to create memory entries via Scan Chat + Generate Drafts when enough chat history exists. Auto-creation on import disabled to prevent unwanted drafts.
-- [done | not tested] Define a first segmentation policy for auto/bootstrap flows: start from the user-configured `N`-message interval, but prefer ending segments on a nearby assistant reply so generated memory windows align better with completed exchanges.
-- [done | not tested] Add a first deduplication/conflict layer so exact-duplicate and high-overlap memory segments are blocked during draft generation and draft approval.
-- [done | not tested] Add a first session-wide Memory Books maintenance pass that can reconcile coverage, clear orphaned pending drafts, remove fully orphaned approved entries, and optionally reindex approved memory entries.
-- [done | not tested] Surface lifecycle state in the Memory Books manager with visible status badges and summary counters for active entries, drafts, needs-rebuild entries, and stale message coverage.
-- [not done | not tested] Add recency/importance controls only after the core lifecycle model is stable.
-- [done | not tested] Add a proper first-pass memory-generation rules manager with built-in prompt presets, user-defined prompts, preview support, and prompt selection independent from the main chat preset.
-- [done | not tested] Add memory-generation temperature override independent from the main chat preset.
-- [done | not tested] Allow `current provider` memory generation to override only the model while still reusing the main endpoint/key.
-- [done | not tested] Ensure memory generation can preview the selected rule text before running drafts.
-- [done | not tested] Ensure prompt preview close returns to the relevant memory settings/manager sheet.
+- [not done] Define when automatic memory creation runs: for example after N new messages, after summary update, or on explicit background maintenance.
+- [done] Make the automatic creation interval user-configurable in UI as "раз в сколько сообщений создается мемори" instead of hardcoding the trigger threshold.
+- [done] Add a user-facing toggle for delayed automation (`работать с отставанием`) so automatic memory creation can intentionally wait for an extra user+assistant exchange before materializing a memory entry.
+- [done] Define delayed-trigger semantics for `Create memory every N messages`: when the threshold is reached on an assistant reply, wait until the user replies and receives one more assistant reply; when the threshold is reached on a user message, wait until that user message gets an assistant reply and then wait for one more full user+assistant exchange before creating the memory entry.
+- [done] Keep delayed automation as the recommended default so users can still edit their last user turn or regenerate the latest assistant reply before a memory entry becomes fixed.
+- [done] A first session-level delayed automation engine now tracks pending auto-memory triggers and evaluates them after stable assistant reply completion in the normal generation flow.
+- [done] Allow the system to create memory entries via Scan Chat + Generate Drafts when enough chat history exists. Auto-creation on import disabled to prevent unwanted drafts.
+- [done] Define a first segmentation policy for auto/bootstrap flows: start from the user-configured `N`-message interval, but prefer ending segments on a nearby assistant reply so generated memory windows align better with completed exchanges.
+- [done] Add a first deduplication/conflict layer so exact-duplicate and high-overlap memory segments are blocked during draft generation and draft approval.
+- [done] Add a first session-wide Memory Books maintenance pass that can reconcile coverage, clear orphaned pending drafts, remove fully orphaned approved entries, and optionally reindex approved memory entries.
+- [done] Surface lifecycle state in the Memory Books manager with visible status badges and summary counters for active entries, drafts, needs-rebuild entries, and stale message coverage.
+- [not done] Add recency/importance controls only after the core lifecycle model is stable.
+- [done] Add a proper first-pass memory-generation rules manager with built-in prompt presets, user-defined prompts, preview support, and prompt selection independent from the main chat preset.
+- [done] Add memory-generation temperature override independent from the main chat preset.
+- [done] Allow `current provider` memory generation to override only the model while still reusing the main endpoint/key.
+- [done] Ensure memory generation can preview the selected rule text before running drafts.
+- [done] Ensure prompt preview close returns to the relevant memory settings/manager sheet.
 
 Memory extraction context algorithm (fixed direction):
-- [not done | not tested] Do not reconstruct extraction context from the current live lorebook inject alone. It may differ from the lore context that existed when the target messages were generated.
-- [not done | not tested] Do not send the full set of triggered lore entries from all messages in the segment to the model. Message-level trigger history is an audit/debug source, not direct prompt payload.
-- [not done | not tested] For each message, store only compact trigger references needed for UI and reconstruction candidates:
+- [not done] Do not reconstruct extraction context from the current live lorebook inject alone. It may differ from the lore context that existed when the target messages were generated.
+- [not done] Do not send the full set of triggered lore entries from all messages in the segment to the model. Message-level trigger history is an audit/debug source, not direct prompt payload.
+- [not done] For each message, store only compact trigger references needed for UI and reconstruction candidates:
   - stable entry ID
   - source type (`lorebook` / `memory`)
   - optional compact label/title
-- [not done | not tested] For a target segment, build extraction context in two stages.
+- [not done] For a target segment, build extraction context in two stages.
 
 Stage A. Candidate collection:
-- [not done | not tested] Collect the target message segment.
-- [not done | not tested] Collect the union of lore entry IDs that were actually triggered on messages inside the segment.
-- [done | not tested] Collect the nearest approved memory entries adjacent to the segment.
-- [done | not tested] Run lightweight retrieval on the segment text itself to get current top lore candidates.
-- [done | not tested] Optionally collect a compact summary excerpt and minimal setting context.
+- [not done] Collect the target message segment.
+- [not done] Collect the union of lore entry IDs that were actually triggered on messages inside the segment.
+- [done] Collect the nearest approved memory entries adjacent to the segment.
+- [done] Run lightweight retrieval on the segment text itself to get current top lore candidates.
+- [done] Optionally collect a compact summary excerpt and minimal setting context.
 
 Stage B. Candidate compression:
-- [not done | not tested] Rank lore candidates by a weighted score combining:
+- [not done] Rank lore candidates by a weighted score combining:
   - trigger frequency within the segment
   - recency inside the segment (later messages weigh more)
   - direct entity/key overlap with the segment text
   - current retrieval score from vector/keyword lookup
-- [not done | not tested] Deduplicate by entry ID before scoring.
-- [not done | not tested] Keep only a hard-capped top-k lore set for the model.
-- [not done | not tested] Keep only a hard-capped top-k memory continuity set for the model.
-- [not done | not tested] Drop low-value context aggressively instead of letting the prompt expand without bound.
+- [not done] Deduplicate by entry ID before scoring.
+- [not done] Keep only a hard-capped top-k lore set for the model.
+- [not done] Keep only a hard-capped top-k memory continuity set for the model.
+- [not done] Drop low-value context aggressively instead of letting the prompt expand without bound.
 
 Prompt payload limits (initial target):
-- [not done | not tested] Message segment: one target segment only.
-- [done | not tested] Memory continuity context: 1-3 approved memory entries max.
-- [not done | not tested] Lore context: 3-5 lore entries max.
-- [not done | not tested] Summary context: one compact excerpt only when needed.
-- [not done | not tested] Setting/card context: compact fallback only, not full card by default.
+- [not done] Message segment: one target segment only.
+- [done] Memory continuity context: 1-3 approved memory entries max.
+- [not done] Lore context: 3-5 lore entries max.
+- [not done] Summary context: one compact excerpt only when needed.
+- [not done] Setting/card context: compact fallback only, not full card by default.
 
 Initial ranking formula direction:
-- [not done | not tested] Historical trigger score is primary when reconstructing older segments.
-- [not done | not tested] Current retrieval score is secondary and used as a tie-breaker / recovery signal, not the sole source of truth.
-- [not done | not tested] Memory continuity relevance outranks generic recency.
-- [not done | not tested] Entries that match both historical triggers and current retrieval should be preferred.
+- [not done] Historical trigger score is primary when reconstructing older segments.
+- [not done] Current retrieval score is secondary and used as a tie-breaker / recovery signal, not the sole source of truth.
+- [not done] Memory continuity relevance outranks generic recency.
+- [not done] Entries that match both historical triggers and current retrieval should be preferred.
 
 Implementation start order (to avoid refactor later):
-- [done | not tested] Step 1. Add stable message IDs and compact per-message trigger references.
-- [done | not tested] Step 2. Add dedicated memory book container + entry schema with message ownership metadata.
-- [done | not tested] Step 3. Add lifecycle helpers for delete/branch/import rebuild detection.
-- [done | not tested] Step 4. Add extraction-context builder with top-k compression.
+- [done] Step 1. Add stable message IDs and compact per-message trigger references.
+- [done] Step 2. Add dedicated memory book container + entry schema with message ownership metadata.
+- [done] Step 3. Add lifecycle helpers for delete/branch/import rebuild detection.
+- [done] Step 4. Add extraction-context builder with top-k compression.
 : implemented as a compact heuristic layer for memory continuity + lore-trigger candidates + summary excerpt; vector-backed memory retrieval is still future work.
-- [done | tested] Step 5. Add draft/approval workflow for one or multiple sequential memory generation jobs (batch generation with Scan Chat + Generate Drafts).
-- [done | not tested] Step 6. Add summary-path injection + tokenizer visualization.
-- [done | not tested] Step 7. Add backup/sync-safe persistence integration.
+- [done] Step 5. Add draft/approval workflow for one or multiple sequential memory generation jobs (batch generation with Scan Chat + Generate Drafts).
+- [done] Step 6. Add summary-path injection + tokenizer visualization.
+- [done] Step 7. Add backup/sync-safe persistence integration.
 
 Manual verification that must stay visible in the roadmap:
-- [not done | not tested] Verify that deleting covered messages marks the related memory entries stale or removes them correctly.
-- [not done | not tested] Verify that branching from the middle of a chat does not carry over active memories for messages that no longer exist in the child branch.
-- [not done | not tested] Verify that partially preserved memory entries after branch are downgraded to `needs_rebuild` instead of staying active.
-- [not done | not tested] Verify that imported chats can bootstrap first memories without requiring a manually created seed entry.
-- [not done | not tested] Verify that `Current provider` generation uses the override model while still keeping the main endpoint/key path unchanged.
-- [not done | not tested] Verify that closing prompt preview returns to `Memory Generation` or the prompt manager instead of closing the whole flow.
-- [not done | not tested] Verify that memory injections count separately from lorebook injections during generation.
-- [not done | not tested] Verify that tokenizer visualization shows memory usage with summary-style accounting.
-- [not done | not tested] Verify that editing an approved memory entry correctly updates persisted content/keys and does not break message coverage metadata.
-- [not done | not tested] Verify that disabling `vectorSearch` deletes the memory-entry embedding, and re-enabling or manual `Reindex` rebuilds it correctly.
-- [not done | not tested] Verify that the Memory Books key match mode (`plain` / `glaze` / `both`) changes retrieval as expected while using only the `Keys` field.
-- [not done | not tested] Verify that `Create memory every N messages` respects delayed mode correctly on both threshold cases: assistant-triggered thresholds wait one extra user+assistant exchange, and user-triggered thresholds wait for the current assistant reply plus one extra user+assistant exchange.
-- [not done | not tested] Verify that disabling `работать с отставанием` switches automation back to immediate threshold behavior without breaking edit/regenerate workflows.
-- [not done | not tested] Verify that lorebook entries set to `Match Global`, `@worldInfoBefore`, `@worldInfoAfter`, and `{{lorebooks}}` inject at the expected locations without preset-level override regressions.
-- [not done | not tested] Current known limitation: lorebook/memory entries now aggregate into single injected blocks per target, but when the target is a macro inside another preset block, the injected content still lands as a separate block adjacent to that area rather than truly inside the host block. Revisit later.
-- [not done | not tested] Verify that Glaze lorebook export/import preserves `Match Global` and `{{lorebooks}}` through the new `glazeMetadata` round-trip path.
-- [not done | not tested] Verify that backup export/import preserves memory books and rebuilds any derived vectors safely.
-- [not done | not tested] Verify that future cloud-sync serialization can round-trip memory books without duplication or orphaned entries.
-- [not done | not tested] Verify that Glaze-to-Glaze export/import preserves memory books, per-message markers, and memory generation settings without loss.
+- [not done] Verify that deleting covered messages marks the related memory entries stale or removes them correctly.
+- [not done] Verify that branching from the middle of a chat does not carry over active memories for messages that no longer exist in the child branch.
+- [not done] Verify that partially preserved memory entries after branch are downgraded to `needs_rebuild` instead of staying active.
+- [not done] Verify that imported chats can bootstrap first memories without requiring a manually created seed entry.
+- [not done] Verify that `Current provider` generation uses the override model while still keeping the main endpoint/key path unchanged.
+- [not done] Verify that closing prompt preview returns to `Memory Generation` or the prompt manager instead of closing the whole flow.
+- [not done] Verify that memory injections count separately from lorebook injections during generation.
+- [not done] Verify that tokenizer visualization shows memory usage with summary-style accounting.
+- [not done] Verify that editing an approved memory entry correctly updates persisted content/keys and does not break message coverage metadata.
+- [not done] Verify that disabling `vectorSearch` deletes the memory-entry embedding, and re-enabling or manual `Reindex` rebuilds it correctly.
+- [not done] Verify that the Memory Books key match mode (`plain` / `glaze` / `both`) changes retrieval as expected while using only the `Keys` field.
+- [not done] Verify that `Create memory every N messages` respects delayed mode correctly on both threshold cases: assistant-triggered thresholds wait one extra user+assistant exchange, and user-triggered thresholds wait for the current assistant reply plus one extra user+assistant exchange.
+- [not done] Verify that disabling `работать с отставанием` switches automation back to immediate threshold behavior without breaking edit/regenerate workflows.
+- [not done] Verify that lorebook entries set to `Match Global`, `@worldInfoBefore`, `@worldInfoAfter`, and `{{lorebooks}}` inject at the expected locations without preset-level override regressions.
+- [not done] Current known limitation: lorebook/memory entries now aggregate into single injected blocks per target, but when the target is a macro inside another preset block, the injected content still lands as a separate block adjacent to that area rather than truly inside the host block. Revisit later.
+- [not done] Verify that Glaze lorebook export/import preserves `Match Global` and `{{lorebooks}}` through the new `glazeMetadata` round-trip path.
+- [not done] Verify that backup export/import preserves memory books and rebuilds any derived vectors safely.
+- [not done] Verify that future cloud-sync serialization can round-trip memory books without duplication or orphaned entries.
+- [not done] Verify that Glaze-to-Glaze export/import preserves memory books, per-message markers, and memory generation settings without loss.
 
 Important constraint:
-- [done | not tested] Do not implement memory books as a quick lorebook hack that hides lifecycle state in entry text or comments. That would reintroduce later refactor pressure.
-- [done | not tested] Summary and vector foundations are stable enough to build on, but memory books should be added as a thin new layer over those primitives, not by forking them.
+- [done] Do not implement memory books as a quick lorebook hack that hides lifecycle state in entry text or comments. That would reintroduce later refactor pressure.
+- [done] Summary and vector foundations are stable enough to build on, but memory books should be added as a thin new layer over those primitives, not by forking them.
 
 Expected result:
-- [not done | not tested] A durable memory layer with deterministic ownership over chat history, reusable retrieval infrastructure, separate injection accounting, and import/export/sync-safe persistence.
-- [done | not tested] A durable memory layer foundation with deterministic ownership over chat history, separate injection accounting, tokenizer visibility, and Glaze chat round-trip persistence is now in place.
+- [not done] A durable memory layer with deterministic ownership over chat history, reusable retrieval infrastructure, separate injection accounting, and import/export/sync-safe persistence.
+- [done] A durable memory layer foundation with deterministic ownership over chat history, separate injection accounting, tokenizer visibility, and Glaze chat round-trip persistence is now in place.
 
 ## Post-Merge Conflict Audit (COMPLETED — 2026-04-16)
 
@@ -531,12 +530,12 @@ This order is deliberate:
 ## Next Up
 
 The immediate next milestone is:
-- [done | not tested] Lorebook injection/export fixes are folded into `feat/memorybook`; continue shipping them together with Memory Books instead of splitting a separate PR/branch.
-- [done | not tested] Vectors are in maintenance mode: WORKS, do not touch without a concrete bug report.
-- [not done | not tested] Improve vector ranking only if a real user-facing retrieval miss forces it.
-- [not done | not tested] Summary simple mode prompts — proper defaults and editability.
-- [done | not tested] Memory books data model foundation exists; continue with generation UX, inspection UX, lifecycle cleanup, and automation instead of reopening the schema.
-- [not done | not tested] Finish the remaining Memory Books gaps in this branch, then ship one combined PR with both Memory Books and lorebook fixes.
+- [done] Lorebook injection/export fixes are folded into `feat/memorybook`; continue shipping them together with Memory Books instead of splitting a separate PR/branch.
+- [done] Vectors are in maintenance mode: WORKS, do not touch without a concrete bug report.
+- [not done] Improve vector ranking only if a real user-facing retrieval miss forces it.
+- [not done] Summary simple mode prompts — proper defaults and editability.
+- [done] Memory books data model foundation exists; continue with generation UX, inspection UX, lifecycle cleanup, and automation instead of reopening the schema.
+- [not done] Finish the remaining Memory Books gaps in this branch, then ship one combined PR with both Memory Books and lorebook fixes.
 
 ## Resume Notes
 
@@ -556,44 +555,44 @@ Active branch: `fast-fixes`
 
 ### ✅ DONE (Batch 1)
 1. **Fix: `memoryDraftTimer` is not defined (CRITICAL CRASH)**
-   - Status: `done | tested (code path)`
+   - Status: `done (code path)`
    - Fix: Moved functions from `<script>` to `<script setup>` scope
    - Testing: Message with `isTyping` should not crash Vue
 
 2. **Fix: vector search toggle should disable keyword search UI**
-   - Status: `done | tested (code path)`
+   - Status: `done (code path)`
    - Fix: Hide keys/secondary keys/logic selectors when `vectorSearch=true`
    - Testing: Enable vector search on entry → UI shows only index button and vector badges
 
 3. **Fix: embedding API key inheritance bug**
-   - Status: `done | tested (code path)`
+   - Status: `done (code path)`
    - Fix: Reset `endpoint/key/model` fields when `useSame=true` in `loadEmbeddingSettings()`
    - Testing: Switch from "Use LLM API" → fields should clear, not show LLM key
 
 4. **Fix: tokenizer doesn't count vector lorebook tokens in breakdown**
-   - Status: `done | tested (code path)`
+   - Status: `done (code path)`
    - Fix: Add `vectorLore` to context breakdown, aggregate tokens from `newVectorEntries`
    - Testing: Generate with vector lorebook entries → breakdown shows purple "Vector Lorebook" segment
 
 5. **Add NovelAI model to Naistera image generation**
-   - Status: `done | tested (code path)`
+   - Status: `done (code path)`
    - Fix: Add 'novelai' to `normalizeNaisteraModel()`, UI selector, disable references for it
    - Testing: Select NovelAI → no reference images sent (per API behavior)
 
 6. **Fix: LorebookSheet.vue build error (Invalid end tag)**
-   - Status: `done | tested`
+   - Status: `done`
    - Fix: Removed extra `</div>` at line 1001, changed `<template v-if>` to `<div v-if>` for reliability
    - Testing: `npm run build` passes without Vue template errors
 
 7. **Fix: Memory books Key Match Mode visible during vector search**
-   - Status: `done | not tested`
+   - Status: `done`
    - Fix: Wrap Key Match Mode selector in `${!vectorEnabled ? '...' : ''}` in `openMemoryBooksSheet()`
    - Testing: Enable vector search in Memory Books → Key Match Mode should be hidden
 
 ### ✅ DONE (Batch 3 — merged into PR #30)
 
 8. **Fix: lorebook injections shown for user but not assistant messages**
-    - Status: `done | tested`
+    - Status: `done`
     - Complexity: easy
     - Issue: Injection badges only appear on user messages, missing on assistant replies
     - Root cause: `onPromptReady` in `ChatView.vue` redirected `triggeredLorebooks`/`triggeredMemories`/`contextRefs` to `msgIndex - 1` (user message) only
@@ -601,7 +600,7 @@ Active branch: `fast-fixes`
     - PR: #30
 
 9. **Add i18n keys for new features**
-    - Status: `done | tested`
+    - Status: `done`
     - Complexity: easy
     - Added 12 missing keys + 2 asymmetric fixes to both `en/index.json` and `ru/index.json`
     - New keys: `api_create_preset_desc`, `api_presets`, `avatar`, `desc_show_reasoning`, `error_generation`, `imggen_notification_body`, `imggen_notification_title`, `label_custom_model`, `label_model`, `label_show_reasoning`, `no_models_found`, `no_prompt`
@@ -609,7 +608,7 @@ Active branch: `fast-fixes`
     - PR: #30
 
 10. **Fix: streaming quote formatting breaks mid-quote**
-    - Status: `done | tested`
+    - Status: `done`
     - Complexity: medium
     - Issue: Blue quote styling doesn't apply to streaming text when opening quote arrives without closing quote
     - Root cause: `textFormatter.js` regex matches complete quote pairs only
@@ -617,7 +616,7 @@ Active branch: `fast-fixes`
     - PR: #30
 
 11. **Fix: messages stuck in "generating" state**
-    - Status: `done | tested`
+    - Status: `done`
     - Complexity: medium-hard
     - Issue: Message stays with typing indicator after generation should complete (both streaming and non-streaming)
     - Root causes found:
@@ -636,7 +635,7 @@ Active branch: `fast-fixes`
     - PR: #30
 
 12. **Multi-vector retrieval with MaxSim and dual-channel lorebook search**
-    - Status: `done | tested`
+    - Status: `done`
     - Complexity: hard
     - Implementation:
       - **Multi-vector storage**: Entries chunked (512 tokens default), each chunk embedded separately
@@ -665,7 +664,7 @@ Active branch: `fast-fixes`
 ### ⏳ PENDING
 
 13. **Sync infrastructure fixes — encryption optional + redirect URI fix**
-    - Status: `done | not tested`
+    - Status: `done`
     - Complexity: medium-hard
     - Branch: `feat/sync-infrastructure-fixes` (linear chain from `feat/multi-vector-retrieval`)
     - Changes:
@@ -700,7 +699,7 @@ Active branch: `fast-fixes`
       - OAuth/app token setup instructions per platform
 
 14. **Fix: Tokenizer lorebook display and reserve visualization**
-    - Status: `done | tested`
+    - Status: `done`
     - Complexity: medium
     - Branch: `bug-fixes`
     - Issue: Lorebook tokens not counted or displayed incorrectly in tokenizer breakdown
@@ -840,7 +839,7 @@ Goal: Clean up technical debt, fix UX issues, improve user-facing workflows
 
 Three deep-dive explorations completed on 2026-04-17:
 1. **Tokenizer**: Currently working correctly, recently fixed. No critical issues found. Uses SheetView bottom sheet pattern. Architecture is clean.
-2. **Memory Books**: Functionally complete but uses temporary bottom sheet UI. Many features marked `done | not tested`. Needs polished dedicated component.
+2. **Memory Books**: Functionally complete but uses temporary bottom sheet UI. Many features marked `done`. Needs polished dedicated component.
 3. **Vectors/Lorebooks**: Backend dual-channel (vector+keyword) works correctly, but UI presents it as mutually exclusive. Creates user confusion.
 
 ### Phase 1: Vector/Lorebook UX Fixes (CRITICAL — misleading UI)
@@ -934,19 +933,19 @@ Status: `partially done | ready for testing` (Commits: b5857d0, 78be7ed)
    - Reference: https://github.com/aikohanasaki/SillyTavern-MemoryBooks
 
 **Remaining Tasks**:
-1. [not done | not tested] **Extract memory books UI into dedicated component**
+1. [not done] **Extract memory books UI into dedicated component**
    - Create `src/components/sheets/MemoryBooksSheet.vue`
    - Move logic from ChatView.vue:1684-2070 (openMemoryBooksSheet)
    - Move settings from ChatView.vue:1300-1551 (openMemoryGenerationSettings)
    - Move prompt manager from ChatView.vue:1553-1629 (openMemoryPromptManager)
    - Deferred: Technical debt, not blocking users
    
-2. [not done | not tested] **Fix: Memory menu in chat doesn't persist settings state**
+2. [not done] **Fix: Memory menu in chat doesn't persist settings state**
    - Settings from main Memory Books sheet should sync with in-chat memory UI
    - Both should use same session.memoryBooks[sessionId].settings source
    - Deferred: Need to investigate where in-chat memory menu is located
    
-3. [not done | not tested] **Add comprehensive testing for memory lifecycle**
+3. [not done] **Add comprehensive testing for memory lifecycle**
    - Test: Message deletion → memory reconciliation (ChatView.vue:2072-2096)
    - Test: Memory automation triggers (ChatView.vue:1022-1092)
    - Test: Vector search toggle for memories
@@ -978,15 +977,15 @@ Status: `done | ready for testing` (Commit: b5857d0)
    - Tokenizer now opens faster on repeated access
 
 **Remaining Tasks (Deferred)**:
-1. [not done | not tested] **Migrate tokenizer sheet display to dedicated component** (Optional)
+1. [not done] **Migrate tokenizer sheet display to dedicated component** (Optional)
    - Refactor ChatView.vue:2633-2745 (openContextSheet) to use SheetView.vue pattern
    - Note: This is LOW priority — current implementation works fine
    
-2. [not done | not tested] **Add separate menus for different injection types**
+2. [not done] **Add separate menus for different injection types**
    - Current: All lorebooks shown together in one view
    - Requested: Separate views for vector-only, keyword-injected, memory books
    
-3. [not done | not tested] **Fix: All menus should return to previous screen on save/cancel**
+3. [not done] **Fix: All menus should return to previous screen on save/cancel**
    - Apply to: Tokenizer, Memory Books, Lorebook sheets
    - Use navigation stack pattern (already exists for prompt preview)
 
@@ -1048,10 +1047,10 @@ PR: #34
 - Files: `ChatInput.vue` (v-if canDeleteSelected), `ChatView.vue` (selectionIncludesLast computed, openMessageActions guard)
 
 **5.3. Batch Draft Generation**
-- [done | tested] Scan Chat: finds uncovered messages, segments by interval, stores in `automation.plannedSegments`
-- [done | tested] Generate Drafts: quick picks (1/3/5/All) + custom number input field
-- [done | tested] Sequential generation with progress toasts, planned segments removed after success
-- [done | tested] DRAFT badge (purple) on messages covered by pending drafts
+- [done] Scan Chat: finds uncovered messages, segments by interval, stores in `automation.plannedSegments`
+- [done] Generate Drafts: quick picks (1/3/5/All) + custom number input field
+- [done] Sequential generation with progress toasts, planned segments removed after success
+- [done] DRAFT badge (purple) on messages covered by pending drafts
 - Files: `ChatView.vue` (runBatchDraftGeneration, Scan Chat handler, batch UI), `ChatMessage.vue` (isDraftMemory prop, draft-memory CSS)
 
 **5.4. Import Cleanup**
@@ -1154,7 +1153,7 @@ PR: #34
 **Tasks:**
 
 1. **Extract Tokenizer to TokenizerSheet.vue**
-   - Status: `done | tested`
+   - Status: `done`
    - Create `src/components/sheets/TokenizerSheet.vue` using SheetView
    - Props: breakdown, historyHidePreview, contextSegments, contextLegendItems, contextBreakdownItems, shouldRecommendHide, historyUsagePercent, isCalculating
    - Emits: close, hide-messages, open-settings
@@ -1166,7 +1165,7 @@ PR: #34
    - Commit: `3d03952`
 
 2. **Extract Memory Books to MemoryBooksSheet.vue**
-   - Status: `done | tested`
+   - Status: `done`
    - Create dedicated component for memory book management UI
    - Extract `openMemoryBooksSheet()` logic (~500+ lines inline HTML)
    - Complexity: high — many event handlers, dynamic sections (drafts/entries/settings)
@@ -1213,7 +1212,7 @@ PR: #34
 **Tasks:**
 
 1. **Create Memory Books Service**
-   - Status: `done | tested`
+   - Status: `done`
    - File: `src/core/services/memoryBooksService.js` (616 lines)
    - Extracted 68+ pure functions:
      - Core management (ensureSessionMemoryBook, reconcileMemoryBookForMessages)
@@ -1227,7 +1226,7 @@ PR: #34
    - Commit: `4f43d51`
 
 2. **Create Memory Books Composable**
-   - Status: `done | tested`
+   - Status: `done`
    - File: `src/composables/chat/useMemoryBooks.js` (650 lines)
    - Reactive state:
      - currentMemoryBookData, pendingMemoryMessageIds, draftMemoryMessageIds
@@ -1246,14 +1245,14 @@ PR: #34
    - Commit: `4f43d51`
 
 3. **Create Context Service (Placeholder)**
-   - Status: `done | not tested`
+   - Status: `done`
    - File: `src/core/services/contextService.js` (empty placeholder)
    - Prepared for future Phase 9 (context/tokenizer extraction)
    - Build: passes ✓
    - Commit: `4f43d51`
 
 4. **Update ChatView.vue**
-   - Status: `done | tested`
+   - Status: `done`
    - Changes:
      - Added imports for memoryBooksService and useMemoryBooks composable
      - Replaced 68+ local functions with service imports
@@ -1288,7 +1287,7 @@ PR: #34
 **Tasks:**
 
 1. **Create Context Service**
-   - Status: `done | tested`
+   - Status: `done`
    - File: `src/core/services/contextService.js` (~120 lines)
    - Extracted functions:
      - Validation: clampHistoryFillThreshold, clampHistoryHidePercent
@@ -1298,7 +1297,7 @@ PR: #34
    - Commit: `412c6ab`
 
 2. **Fix Sheet Navigation**
-   - Status: `done | tested`
+   - Status: `done`
    - Problem: Sheets were closing completely instead of returning to MagicDrawer
    - Solution:
      - Added `showBack` prop to TokenizerSheet and MemoryBooksSheet
@@ -1310,7 +1309,7 @@ PR: #34
    - Commit: `412c6ab`
 
 3. **Update ChatView**
-   - Status: `done | tested`
+   - Status: `done`
    - Replaced local context functions with contextService imports
    - Simplified history settings initialization
    - Added @back handlers for sheets

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,23 @@
+## Summary
+
+- Prevent keyboard overlap CSS variables from being incorrectly applied on desktop/web platforms
+- Fix Magic Drawer not opening on desktop (viewport-based keyboard detection was closing drawer on mount)
+- Fix console.timeEnd errors for updateContextCutoff timer
+
+## Changes
+
+- **keyboardHandler.js**: Early return on non-native platforms, set --keyboard-overlap to 0px on desktop, skip native keyboard listeners
+- **SheetView.vue**: Remove desktop focus-based keyboard state tracking that incorrectly applied keyboard-open CSS class
+- **BottomSheet.vue**: checkFocus() now always resets isLocalKeyboardOpen = false on desktop platforms
+- **ChatInput.vue**: Add Capacitor.isNativePlatform() guard for viewport-based keyboard detection on mount
+- **ChatView.vue**: Remove console.timeEnd calls that caused Timer does not exist errors when cache was used
+
+## Testing
+
+- [x] Magic Drawer opens correctly on desktop
+- [x] No false keyboard open state on desktop when focusing inputs
+- [x] Build passes
+
+## Note
+
+The gray artifact issue when Generate Drafts opens on desktop exists in upstream (verified by testing upstream/dev) - this PR does not fix that existing bug.

--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -27,7 +27,7 @@ const props = defineProps({
 const emit = defineEmits([
     'update:modelValue', 'send', 'scroll-to-bottom', 
     'magic-regenerate', 'magic-impersonate', 'magic-notes', 'magic-context', 'magic-stats', 'magic-sessions', 'magic-summary', 'magic-api', 'magic-presets', 'magic-char-card', 'magic-lorebooks', 'magic-memory-books', 'magic-regex', 'magic-image-gen', 'magic-glossary',
-    'search-next', 'search-prev', 'delete-selected', 'hide-selected', 'cancel-selection', 'create-memory-selected', 'remove-memory-selected', 'configure-memory-selected', 'generate-memory-draft-selected'
+    'search-next', 'search-prev', 'delete-selected', 'hide-selected', 'cancel-selection', 'create-memory-selected', 'remove-memory-selected', 'generate-memory-draft-selected'
 ]);
 
 const t = (key) => translations[currentLang.value]?.[key] || key;

--- a/src/components/sheets/LorebookSheet.vue
+++ b/src/components/sheets/LorebookSheet.vue
@@ -823,6 +823,46 @@ defineExpose({ open, openEntry, close, openLorebook });
                                  <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
                              </div>
                         </div>
+
+                        <!-- Vector Search Global Settings -->
+                        <div class="settings-item-checkbox">
+                            <label>Vector Search</label>
+                            <input type="checkbox" v-model="lorebookState.globalSettings.vectorSearchEnabled" class="vk-switch">
+                        </div>
+
+                        <template v-if="lorebookState.globalSettings.vectorSearchEnabled">
+                            <div class="settings-item-checkbox">
+                                <label>Key Search</label>
+                                <input type="checkbox" v-model="lorebookState.globalSettings.keySearchEnabled" class="vk-switch">
+                            </div>
+
+                            <div class="settings-row">
+                                <div class="settings-col">
+                                    <label>{{ lorebookState.globalSettings.keySearchEnabled ? (t('label_scan_depth_lore') || 'Scan Depth') : (t('label_vector_scan_depth') || 'Vector Scan Depth') }}</label>
+                                    <input v-if="lorebookState.globalSettings.keySearchEnabled" type="number" v-model="lorebookState.globalSettings.scanDepth" min="1" max="50">
+                                    <input v-else type="number" v-model="lorebookState.globalSettings.vectorScanDepth" min="1" max="50">
+                                </div>
+                                <div class="settings-col">
+                                    <label>{{ t('label_top_k') || 'Max Vector Results' }}</label>
+                                    <input type="number" v-model="lorebookState.globalSettings.vectorTopK" min="1" max="50">
+                                </div>
+                            </div>
+
+                            <div class="settings-item-range">
+                                <div class="range-row">
+                                    <label>{{ t('label_similarity_threshold') || 'Similarity Threshold' }}</label>
+                                    <input type="number" v-model.number="lorebookState.globalSettings.vectorThreshold" class="range-input-val" step="0.01">
+                                </div>
+                                <input type="range" v-model.number="lorebookState.globalSettings.vectorThreshold" min="0" max="1" step="0.01">
+                            </div>
+                        </template>
+
+                        <div v-if="!lorebookState.globalSettings.vectorSearchEnabled" class="settings-row">
+                            <div class="settings-col">
+                                <label>{{ t('label_scan_depth_lore') }}</label>
+                                <input type="number" v-model="lorebookState.globalSettings.scanDepth" min="1" max="50">
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/src/components/sheets/LorebookSheet.vue
+++ b/src/components/sheets/LorebookSheet.vue
@@ -867,6 +867,15 @@ defineExpose({ open, openEntry, close, openLorebook });
                                   <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
                               </div>
                           </div>
+
+                          <!-- Vector Threshold -->
+                          <div v-if="lorebookState.globalSettings.searchType !== 'keys'" class="settings-item-range">
+                              <div class="range-row">
+                                  <label>{{ t('label_similarity_threshold') || 'Similarity Threshold' }}</label>
+                                  <input type="number" v-model.number="lorebookState.globalSettings.vectorThreshold" class="range-input-val" step="0.01">
+                              </div>
+                              <input type="range" v-model.number="lorebookState.globalSettings.vectorThreshold" min="0" max="1" step="0.01">
+                          </div>
                       </div>
                   </div>
 

--- a/src/components/sheets/LorebookSheet.vue
+++ b/src/components/sheets/LorebookSheet.vue
@@ -721,12 +721,39 @@ defineExpose({ open, openEntry, close, openLorebook });
                     </div>
                     
                     <div v-if="isGlobalSettingsExpanded" class="global-settings-content">
+                        <!-- Search Type Selector -->
+                        <div class="settings-item">
+                            <label>{{ t('label_search_type') || 'Search Type' }}</label>
+                            <div class="clickable-selector" @click="openOptionSelector({
+                                title: t('label_search_type') || 'Search Type',
+                                options: [
+                                    { value: 'keys', label: t('search_type_keys') || 'Keys' },
+                                    { value: 'vector', label: t('search_type_vector') || 'Vector' },
+                                    { value: 'both', label: t('search_type_both') || 'Combined' }
+                                ],
+                                currentValue: lorebookState.globalSettings.searchType,
+                                onSelect: (v) => lorebookState.globalSettings.searchType = v
+                            })">
+                                <span>
+                                    {{ lorebookState.globalSettings.searchType === 'vector' ? (t('search_type_vector') || 'Vector') :
+                                       lorebookState.globalSettings.searchType === 'both' ? (t('search_type_both') || 'Combined') :
+                                       (t('search_type_keys') || 'Keys') }}
+                                </span>
+                                <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+                            </div>
+                        </div>
+
+                        <!-- Scan Depth based on search type -->
                         <div class="settings-row">
                             <div class="settings-col">
-                                <label>{{ t('label_scan_depth_lore') }}</label>
-                                <input type="number" v-model="lorebookState.globalSettings.scanDepth">
+                                <label>
+                                    {{ lorebookState.globalSettings.searchType === 'vector' ? (t('label_vector_scan_depth') || 'Vector Scan Depth') :
+                                       lorebookState.globalSettings.searchType === 'both' ? (t('label_combined_scan_depth') || 'Combined Scan Depth') :
+                                       (t('label_scan_depth_lore') || 'Scan Depth') }}
+                                </label>
+                                <input type="number" v-model="lorebookState.globalSettings.scanDepth" min="1" max="50">
                             </div>
-                             <div class="settings-col">
+                            <div class="settings-col">
                                 <label>{{ t('label_lorebook_reserve_mode') }}</label>
                                 <div class="clickable-selector" @click="openOptionSelector({
                                     title: t('label_lorebook_reserve_mode'),
@@ -807,64 +834,41 @@ defineExpose({ open, openEntry, close, openLorebook });
                              <label>{{ t('label_case_sensitive_global') }}</label>
                              <input type="checkbox" v-model="lorebookState.globalSettings.caseSensitive" class="vk-switch small-switch">
                         </div>
-                         <div class="settings-item">
-                             <label>{{ t('label_match_whole_words_global') }}</label>
-                             <div class="clickable-selector" @click="openOptionSelector({
-                                 title: t('label_match_whole_words_global'),
-                                 options: [
-                                     { value: false, label: t('off') },
-                                     { value: true, label: t('match_whole_words_st') },
-                                     { value: 'glaze', label: t('match_whole_words_glaze') }
-                                 ],
-                                 currentValue: lorebookState.globalSettings.matchWholeWords,
-                                 onSelect: (v) => lorebookState.globalSettings.matchWholeWords = v
-                             })">
-                                 <span>{{ lorebookState.globalSettings.matchWholeWords === 'glaze' ? t('match_whole_words_glaze') : (lorebookState.globalSettings.matchWholeWords ? t('match_whole_words_st') : t('off')) }}</span>
-                                 <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
-                             </div>
-                        </div>
+<div class="settings-item">
+                              <label>{{ t('label_match_whole_words_global') }}</label>
+                              <div class="clickable-selector" @click="openOptionSelector({
+                                  title: t('label_match_whole_words_global'),
+                                  options: [
+                                      { value: false, label: t('off') },
+                                      { value: true, label: t('match_whole_words_st') },
+                                      { value: 'glaze', label: t('match_whole_words_glaze') }
+                                  ],
+                                  currentValue: lorebookState.globalSettings.matchWholeWords,
+                                  onSelect: (v) => lorebookState.globalSettings.matchWholeWords = v
+                              })">
+                                  <span>{{ lorebookState.globalSettings.matchWholeWords === 'glaze' ? t('match_whole_words_glaze') : (lorebookState.globalSettings.matchWholeWords ? t('match_whole_words_st') : t('off')) }}</span>
+                                  <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+                              </div>
+                          </div>
 
-                        <!-- Vector Search Global Settings -->
-                        <div class="settings-item-checkbox">
-                            <label>Vector Search</label>
-                            <input type="checkbox" v-model="lorebookState.globalSettings.vectorSearchEnabled" class="vk-switch">
-                        </div>
-
-                        <template v-if="lorebookState.globalSettings.vectorSearchEnabled">
-                            <div class="settings-item-checkbox">
-                                <label>Key Search</label>
-                                <input type="checkbox" v-model="lorebookState.globalSettings.keySearchEnabled" class="vk-switch">
-                            </div>
-
-                            <div class="settings-row">
-                                <div class="settings-col">
-                                    <label>{{ lorebookState.globalSettings.keySearchEnabled ? (t('label_scan_depth_lore') || 'Scan Depth') : (t('label_vector_scan_depth') || 'Vector Scan Depth') }}</label>
-                                    <input v-if="lorebookState.globalSettings.keySearchEnabled" type="number" v-model="lorebookState.globalSettings.scanDepth" min="1" max="50">
-                                    <input v-else type="number" v-model="lorebookState.globalSettings.vectorScanDepth" min="1" max="50">
-                                </div>
-                                <div class="settings-col">
-                                    <label>{{ t('label_top_k') || 'Max Vector Results' }}</label>
-                                    <input type="number" v-model="lorebookState.globalSettings.vectorTopK" min="1" max="50">
-                                </div>
-                            </div>
-
-                            <div class="settings-item-range">
-                                <div class="range-row">
-                                    <label>{{ t('label_similarity_threshold') || 'Similarity Threshold' }}</label>
-                                    <input type="number" v-model.number="lorebookState.globalSettings.vectorThreshold" class="range-input-val" step="0.01">
-                                </div>
-                                <input type="range" v-model.number="lorebookState.globalSettings.vectorThreshold" min="0" max="1" step="0.01">
-                            </div>
-                        </template>
-
-                        <div v-if="!lorebookState.globalSettings.vectorSearchEnabled" class="settings-row">
-                            <div class="settings-col">
-                                <label>{{ t('label_scan_depth_lore') }}</label>
-                                <input type="number" v-model="lorebookState.globalSettings.scanDepth" min="1" max="50">
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                          <!-- Embedding Target (only when vector search is enabled) -->
+                          <div v-if="lorebookState.globalSettings.searchType !== 'keys'" class="settings-item">
+                              <label>{{ t('label_embedding_target') || 'Embedding Target' }}</label>
+                              <div class="clickable-selector" @click="openOptionSelector({
+                                  title: t('label_embedding_target') || 'Embedding Target',
+                                  options: [
+                                      { value: 'content', label: t('target_content') || 'Entry Content' },
+                                      { value: 'keys', label: t('target_keys') || 'Entry Keys' }
+                                  ],
+                                  currentValue: lorebookState.globalSettings.embeddingTarget,
+                                  onSelect: (v) => lorebookState.globalSettings.embeddingTarget = v
+                              })">
+                                  <span>{{ lorebookState.globalSettings.embeddingTarget === 'keys' ? (t('target_keys') || 'Keys') : (t('target_content') || 'Content') }}</span>
+                                  <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
 
                 <div v-if="lorebookState.lorebooks.length === 0" class="empty-state">
                     <svg class="empty-icon" viewBox="0 0 24 24"><path d="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z"/></svg>

--- a/src/components/sheets/MemoryBooksSheet.vue
+++ b/src/components/sheets/MemoryBooksSheet.vue
@@ -100,6 +100,10 @@ const keyMatchMode = computed(() => {
   return 'Plain contains';
 });
 
+const draftsNeedingGeneration = computed(() => {
+  return pendingDrafts.value.filter(d => !d.content && d.status === 'pending_generation');
+});
+
 const uncoveredSegments = computed(() => {
   const coveredIds = new Set();
   for (const entry of entries.value) {
@@ -108,14 +112,14 @@ const uncoveredSegments = computed(() => {
   for (const draft of pendingDrafts.value) {
     if (Array.isArray(draft.messageIds)) draft.messageIds.forEach(id => coveredIds.add(id));
   }
-  
-  const stableMessages = props.currentMessages.filter(m => 
+
+  const stableMessages = props.currentMessages.filter(m =>
     m && !m.isTyping && !m.isHidden && !m.isError && (m.role === 'user' || m.role === 'char')
   );
   const uncovered = stableMessages.filter(m => m.id && !coveredIds.has(m.id));
   const interval = normalizeAutoCreateInterval(props.memoryBook);
   const segmentsNeeded = Math.ceil(uncovered.length / interval);
-  
+
   return {
     count: uncovered.length,
     segmentsNeeded,
@@ -343,23 +347,32 @@ defineExpose({ open, close });
       </div>
 
       <!-- Batch Actions (Scan & Generate) -->
-      <div v-if="uncoveredSegments.count > 0" class="memory-batch-actions">
-        <div class="memory-batch-info">
-          <strong>{{ uncoveredSegments.count }}</strong> uncovered messages ({{ uncoveredSegments.segmentsNeeded }} segments of {{ uncoveredSegments.interval }})
-        </div>
-        <div class="memory-batch-buttons">
-          <button type="button" class="memory-btn memory-btn-secondary" @click="handleScanChat">
-            Scan Chat
-          </button>
-          <button
-            type="button"
-            class="memory-btn memory-btn-primary"
-            :disabled="memoryDraftState.active"
-            @click="handleBatchGenerate"
-          >
-            Generate Drafts
-          </button>
-        </div>
+      <div v-if="draftsNeedingGeneration.length > 0 || uncoveredSegments.count > 0" class="memory-batch-actions">
+        <template v-if="draftsNeedingGeneration.length > 0">
+          <div class="memory-batch-info">
+            <strong>{{ draftsNeedingGeneration.length }}</strong> draft{{ draftsNeedingGeneration.length > 1 ? 's' : '' }} need generation
+          </div>
+          <div class="memory-batch-buttons">
+            <button
+              type="button"
+              class="memory-btn memory-btn-primary"
+              :disabled="memoryDraftState.active"
+              @click="handleBatchGenerate"
+            >
+              Generate Batch
+            </button>
+          </div>
+        </template>
+        <template v-else-if="uncoveredSegments.count > 0">
+          <div class="memory-batch-info">
+            <strong>{{ uncoveredSegments.count }}</strong> uncovered messages ({{ uncoveredSegments.segmentsNeeded }} segments of {{ uncoveredSegments.interval }})
+          </div>
+          <div class="memory-batch-buttons">
+            <button type="button" class="memory-btn memory-btn-secondary" @click="handleScanChat">
+              Scan Chat
+            </button>
+          </div>
+        </template>
       </div>
 
       <!-- Draft Generation Progress -->

--- a/src/components/sheets/MemoryBooksSheet.vue
+++ b/src/components/sheets/MemoryBooksSheet.vue
@@ -163,8 +163,8 @@ function normalizeEntryMessageIds(entry) {
 }
 
 const currentlyGeneratingDraft = computed(() => {
-  if (!memoryDraftState.value?.active) return null;
-  const label = memoryDraftState.value.label || '';
+  if (!props.memoryDraftState?.active) return null;
+  const label = props.memoryDraftState.label || '';
   // Match draft by checking if any pendingDraft has matching messageIds pattern
   // This is a simple heuristic - the actual tracking happens in the parent
   return null;

--- a/src/components/sheets/MemoryBooksSheet.vue
+++ b/src/components/sheets/MemoryBooksSheet.vue
@@ -44,6 +44,7 @@ const emit = defineEmits([
   'reindex-all',
   'scan-chat',
   'batch-generate',
+  'generate-draft',
   'approve-draft',
   'delete-draft',
   'delete-entry',
@@ -138,9 +139,32 @@ function formatElapsedSeconds(ms) {
   return `${sec}s`;
 }
 
+function formatGenerationTime(timestamp) {
+  if (!timestamp) return '';
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
 function normalizeEntryMessageIds(entry) {
   return Array.isArray(entry?.messageIds) ? entry.messageIds : [];
 }
+
+const currentlyGeneratingDraft = computed(() => {
+  if (!memoryDraftState.value?.active) return null;
+  const label = memoryDraftState.value.label || '';
+  // Match draft by checking if any pendingDraft has matching messageIds pattern
+  // This is a simple heuristic - the actual tracking happens in the parent
+  return null;
+});
 
 // Event handlers
 function open() {
@@ -183,6 +207,10 @@ function handleScanChat() {
 
 function handleBatchGenerate() {
   emit('batch-generate');
+}
+
+function handleGenerateDraft(draftId) {
+  emit('generate-draft', draftId);
 }
 
 function handleCancelDraft() {
@@ -359,23 +387,45 @@ defineExpose({ open, close });
             v-for="draft in pendingDrafts"
             :key="draft.id"
             class="memory-entry-card"
+            :class="{ 'is-generating': memoryDraftState.active && draft === currentlyGeneratingDraft }"
             @click="handleDraftClick(draft)"
           >
             <div class="memory-entry-head">
               <div>
                 <div class="memory-entry-title">{{ draft.title || 'Untitled draft' }}</div>
                 <div class="memory-entry-meta">
-                  {{ draft.content && !memoryDraftState.active ? 'pending approval' : 'generating' }}
-                  {{ vectorEnabled ? ' • hybrid' : ' • keys' }}
-                  <template v-if="draft.keys && draft.keys.length">
+                  <template v-if="!draft.content && draft.status === 'pending_generation'">
+                    <span style="color:#ffd700;">needs generation</span>
+                    <template v-if="draft.messageRange"> • messages {{ draft.messageRange.start }}-{{ draft.messageRange.end }}</template>
+                  </template>
+                  <template v-else-if="memoryDraftState.active && draft === currentlyGeneratingDraft">
+                    <span style="color:#ffd700;">generating...</span>
+                  </template>
+                  <template v-else>
+                    <span>pending approval</span>
+                    <template v-if="draft.generatedAt"> • generated {{ formatGenerationTime(draft.generatedAt) }}</template>
+                  </template>
+                  <template v-if="vectorEnabled && draft.content"> • hybrid</template>
+                  <template v-if="draft.keys && draft.keys.length && draft.content">
                     • {{ draft.keys.slice(0, 3).join(', ') }}
                   </template>
                 </div>
               </div>
               <div class="memory-draft-actions" @click.stop>
-                <span class="memory-status-badge draft">draft</span>
+                <span v-if="!draft.content && draft.status === 'pending_generation'" class="memory-status-badge" style="background:rgba(255,215,0,0.1);color:#ffd700;">needs gen</span>
+                <span v-else class="memory-status-badge draft">draft</span>
                 <span v-if="vectorEnabled" class="memory-status-badge vector">vec</span>
                 <button
+                  v-if="!draft.content && draft.status === 'pending_generation'"
+                  type="button"
+                  class="memory-entry-generate"
+                  :disabled="memoryDraftState.active"
+                  @click="handleGenerateDraft(draft.id)"
+                >
+                  Generate
+                </button>
+                <button
+                  v-else
                   type="button"
                   class="memory-entry-approve"
                   :disabled="!draft.content || memoryDraftState.active"
@@ -396,8 +446,8 @@ defineExpose({ open, close });
               <template v-if="draft.content">
                 {{ draft.content.slice(0, 180) }}
               </template>
-              <span v-else-if="memoryDraftState.active" style="color:#ffd700;">⏳ Generating...</span>
-              <span v-else style="color:var(--text-gray);">No content yet</span>
+              <span v-else-if="memoryDraftState.active && draft === currentlyGeneratingDraft" style="color:#ffd700;">⏳ Generating...</span>
+              <span v-else style="color:var(--text-gray);">No content yet — click Generate to create</span>
             </div>
           </div>
         </div>
@@ -778,6 +828,11 @@ defineExpose({ open, close });
   background: rgba(255, 184, 77, 0.05);
 }
 
+.memory-entry-card.is-generating {
+  border-color: rgba(255, 215, 0, 0.4);
+  background: rgba(255, 215, 0, 0.05);
+}
+
 .memory-entry-head {
   display: flex;
   justify-content: space-between;
@@ -854,7 +909,8 @@ defineExpose({ open, close });
 }
 
 .memory-entry-approve,
-.memory-entry-delete {
+.memory-entry-delete,
+.memory-entry-generate {
   padding: 6px 12px;
   border: none;
   border-radius: 8px;
@@ -870,6 +926,16 @@ defineExpose({ open, close });
   color: #4caf50;
 }
 
+.memory-entry-generate {
+  background: rgba(255, 215, 0, 0.15);
+  color: #ffd700;
+}
+
+.memory-entry-generate:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .memory-entry-approve:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -881,7 +947,8 @@ defineExpose({ open, close });
 }
 
 .memory-entry-approve:active:not(:disabled),
-.memory-entry-delete:active {
+.memory-entry-delete:active,
+.memory-entry-generate:active:not(:disabled) {
   opacity: 0.7;
 }
 

--- a/src/components/sheets/MemoryBooksSheet.vue
+++ b/src/components/sheets/MemoryBooksSheet.vue
@@ -39,12 +39,12 @@ const emit = defineEmits([
   'open-settings',
   'open-maintenance',
   'open-preview',
-  'update-key-mode',
-  'toggle-vector-search',
+  'update-search-type',
   'reindex-all',
   'scan-chat',
   'batch-generate',
   'generate-draft',
+  'delete-all-drafts',
   'approve-draft',
   'delete-draft',
   'delete-entry',
@@ -57,6 +57,13 @@ const t = (key) => translations[currentLang.value]?.[key] || key;
 // Computed properties
 const vectorEnabled = computed(() => {
   return props.memoryBook?.settings?.vectorSearchEnabled !== false;
+});
+
+const memorySearchType = computed(() => {
+  const settings = props.memoryBook?.settings || {};
+  if (settings.vectorSearchEnabled === false) return 'keys';
+  if ((settings.keyMatchMode || 'glaze') === 'both') return 'both';
+  return 'vector';
 });
 
 const entries = computed(() => {
@@ -78,7 +85,8 @@ const generationSettingsSummary = computed(() => {
   const delayed = props.memoryBook.settings?.useDelayedAutomation !== false ? 'delayed' : 'immediate';
   const target = props.memoryBook.settings?.injectionTarget === 'summary_macro' ? '{{summary}}' : 'summary block';
   const maxEntries = Math.max(1, Math.min(20, Number(props.memoryBook.settings?.maxInjectedEntries || 3)));
-  return `${interval} msgs • ${delayed} • ${target} • ${maxEntries} in prompt`;
+  const batchSize = Math.max(1, Math.min(50, Number(props.memoryBook.settings?.batchSize || 1)));
+  return `${interval} msgs • batch ${batchSize} • ${delayed} • ${target} • ${maxEntries} in prompt`;
 });
 
 const statusSummary = computed(() => {
@@ -101,7 +109,7 @@ const keyMatchMode = computed(() => {
 });
 
 const draftsNeedingGeneration = computed(() => {
-  return pendingDrafts.value.filter(d => !d.content && d.status === 'pending_generation');
+  return pendingDrafts.value.filter(d => !d.content && d.status === 'pending_generation' && !isDraftGenerating(d.id));
 });
 
 const uncoveredSegments = computed(() => {
@@ -118,12 +126,14 @@ const uncoveredSegments = computed(() => {
   );
   const uncovered = stableMessages.filter(m => m.id && !coveredIds.has(m.id));
   const interval = normalizeAutoCreateInterval(props.memoryBook);
-  const segmentsNeeded = Math.ceil(uncovered.length / interval);
+  const segmentsNeeded = Math.floor(uncovered.length / interval);
+  const remainder = uncovered.length % interval;
 
   return {
     count: uncovered.length,
     segmentsNeeded,
-    interval
+    interval,
+    remainder
   };
 });
 
@@ -162,13 +172,14 @@ function normalizeEntryMessageIds(entry) {
   return Array.isArray(entry?.messageIds) ? entry.messageIds : [];
 }
 
-const currentlyGeneratingDraft = computed(() => {
-  if (!props.memoryDraftState?.active) return null;
-  const label = props.memoryDraftState.label || '';
-  // Match draft by checking if any pendingDraft has matching messageIds pattern
-  // This is a simple heuristic - the actual tracking happens in the parent
-  return null;
-});
+function getDraftProgress(draftId) {
+  if (!draftId) return null;
+  return props.memoryDraftState?.activeDrafts?.[draftId] || null;
+}
+
+function isDraftGenerating(draftId) {
+  return !!getDraftProgress(draftId);
+}
 
 // Event handlers
 function open() {
@@ -214,20 +225,17 @@ function handleBatchGenerate() {
 }
 
 function handleGenerateDraft(draftId) {
+  console.debug('[MemoryBooksSheet] handleGenerateDraft', { draftId });
   emit('generate-draft', draftId);
 }
 
-function handleCancelDraft() {
-  emit('cancel-draft');
+function handleCancelDraft(draftId) {
+  emit('cancel-draft', draftId);
 }
 
-function handleKeyModeClick() {
-  emit('update-key-mode');
+function handleSearchTypeClick() {
+  emit('update-search-type');
   close();
-}
-
-function handleVectorToggle(event) {
-  emit('toggle-vector-search', event.target.checked);
 }
 
 function handleEntryClick(entry) {
@@ -236,6 +244,7 @@ function handleEntryClick(entry) {
 }
 
 function handleDraftClick(draft) {
+  if (!draft?.content) return;
   emit('open-preview', { entry: draft, kind: 'Memory Draft' });
   close();
 }
@@ -246,6 +255,10 @@ function handleApproveDraft(draftId) {
 
 function handleDeleteDraft(draftId) {
   emit('delete-draft', draftId);
+}
+
+function handleDeleteAllDrafts() {
+  emit('delete-all-drafts');
 }
 
 function handleDeleteEntry(entryId) {
@@ -277,29 +290,15 @@ defineExpose({ open, close });
         <div class="memory-session-overview-meta">{{ generationSettingsSummary }}</div>
       </div>
 
-      <!-- Key Match Mode (only when vector search is disabled) -->
-      <div v-if="!vectorEnabled" class="memory-settings-item">
-        <label>Key Match Mode</label>
-        <div class="memory-clickable-selector" @click="handleKeyModeClick">
-          <span>{{ keyMatchMode }}</span>
+      <div class="memory-settings-item">
+        <label>Search Type</label>
+        <div class="memory-clickable-selector" @click="handleSearchTypeClick">
+          <span>
+            {{ memorySearchType === 'both' ? 'Combined' : memorySearchType === 'vector' ? 'Vector' : 'Keys' }}
+          </span>
           <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
         </div>
-        <div class="memory-note">Keyword retrieval uses only the entry Keys field.</div>
-      </div>
-
-      <!-- Vector Search Toggle -->
-      <div class="memory-settings-item-checkbox">
-        <div class="memory-settings-text-col">
-          <label>Vector Search</label>
-          <div class="memory-settings-desc">One shared retrieval mode for all memory entries in this session.</div>
-        </div>
-        <input
-          type="checkbox"
-          class="vk-switch"
-          :checked="vectorEnabled"
-          :disabled="!shouldEnableVectorSearch"
-          @change="handleVectorToggle"
-        />
+        <div class="memory-note">Choose keyword retrieval, vector retrieval, or a combined mode for this session.</div>
       </div>
       <div v-if="!shouldEnableVectorSearch" class="memory-note">
         Embeddings are not configured, so vector search is unavailable.
@@ -348,71 +347,76 @@ defineExpose({ open, close });
 
       <!-- Batch Actions (Scan & Generate) -->
       <div v-if="draftsNeedingGeneration.length > 0 || uncoveredSegments.count > 0" class="memory-batch-actions">
-        <template v-if="draftsNeedingGeneration.length > 0">
+        <template v-if="draftsNeedingGeneration.length > 0 || memoryDraftState.active">
           <div class="memory-batch-info">
-            <strong>{{ draftsNeedingGeneration.length }}</strong> draft{{ draftsNeedingGeneration.length > 1 ? 's' : '' }} need generation
+            <template v-if="memoryDraftState.active">
+              <strong>Generating</strong>
+              <template v-if="memoryDraftState.activeCount > 1">
+                {{ memoryDraftState.activeCount }} drafts in parallel
+              </template>
+              <template v-else>
+                {{ memoryDraftState.label || 'memory draft' }}
+              </template>
+            </template>
+            <template v-else>
+              <strong>{{ draftsNeedingGeneration.length }}</strong> draft{{ draftsNeedingGeneration.length > 1 ? 's' : '' }} need generation
+            </template>
           </div>
           <div class="memory-batch-buttons">
             <button
               type="button"
               class="memory-btn memory-btn-primary"
-              :disabled="memoryDraftState.active"
-              @click="handleBatchGenerate"
+              :disabled="draftsNeedingGeneration.length === 0"
+              @click.stop.prevent="handleBatchGenerate"
+              @touchend.stop.prevent="handleBatchGenerate"
             >
-              Generate Batch
+              {{ memoryDraftState.active ? 'Generate Remaining' : 'Generate Batch' }}
             </button>
           </div>
         </template>
         <template v-else-if="uncoveredSegments.count > 0">
           <div class="memory-batch-info">
-            <strong>{{ uncoveredSegments.count }}</strong> uncovered messages ({{ uncoveredSegments.segmentsNeeded }} segments of {{ uncoveredSegments.interval }})
+            <strong>{{ uncoveredSegments.count }}</strong> uncovered messages ({{ uncoveredSegments.segmentsNeeded }} full segments of {{ uncoveredSegments.interval }})
+            <template v-if="uncoveredSegments.remainder > 0"> • {{ uncoveredSegments.remainder }} left over</template>
           </div>
           <div class="memory-batch-buttons">
-            <button type="button" class="memory-btn memory-btn-secondary" @click="handleScanChat">
+            <button type="button" class="memory-btn memory-btn-secondary" :disabled="uncoveredSegments.segmentsNeeded === 0" @click.stop.prevent="handleScanChat" @touchend.stop.prevent="handleScanChat">
               Scan Chat
             </button>
           </div>
         </template>
       </div>
 
-      <!-- Draft Generation Progress -->
-      <div v-if="memoryDraftState.active" class="memory-generation-status-card">
-        <div class="memory-generation-status-row">
-          <strong>{{ memoryDraftState.label || 'Generating memory draft' }}</strong>
-          <span>{{ formatElapsedSeconds(memoryDraftState.elapsedMs) }}</span>
-        </div>
-        <div class="memory-generation-status-row" style="margin-top: 6px;">
-          <div class="memory-note" style="margin: 0;">Timer updates automatically.</div>
-          <button type="button" class="memory-btn memory-btn-destructive memory-btn-sm" @click="handleCancelDraft">
-            Stop
-          </button>
-        </div>
-      </div>
-
       <!-- Pending Drafts Section -->
       <div v-if="pendingDrafts.length > 0" class="memory-sheet-section">
         <div class="memory-sheet-section-head">
           <label>Pending Drafts</label>
-          <span>{{ pendingDrafts.length }}</span>
+          <div class="memory-section-head-actions">
+            <button type="button" class="memory-head-btn destructive" @click.stop.prevent="handleDeleteAllDrafts">
+              Delete All Pending
+            </button>
+            <span>{{ pendingDrafts.length }}</span>
+          </div>
         </div>
         <div class="memory-entry-list">
           <div
             v-for="draft in pendingDrafts"
             :key="draft.id"
             class="memory-entry-card"
-            :class="{ 'is-generating': memoryDraftState.active && draft === currentlyGeneratingDraft }"
+            :class="{ 'is-generating': isDraftGenerating(draft.id) }"
             @click="handleDraftClick(draft)"
           >
             <div class="memory-entry-head">
               <div>
                 <div class="memory-entry-title">{{ draft.title || 'Untitled draft' }}</div>
                 <div class="memory-entry-meta">
-                  <template v-if="!draft.content && draft.status === 'pending_generation'">
+                  <template v-if="isDraftGenerating(draft.id)">
+                    <span style="color:#ffd700;">generating...</span>
+                    <template v-if="getDraftProgress(draft.id)?.elapsedMs > 0"> • {{ formatElapsedSeconds(getDraftProgress(draft.id).elapsedMs) }}</template>
+                  </template>
+                  <template v-else-if="!draft.content && draft.status === 'pending_generation'">
                     <span style="color:#ffd700;">needs generation</span>
                     <template v-if="draft.messageRange"> • messages {{ draft.messageRange.start }}-{{ draft.messageRange.end }}</template>
-                  </template>
-                  <template v-else-if="memoryDraftState.active && draft === currentlyGeneratingDraft">
-                    <span style="color:#ffd700;">generating...</span>
                   </template>
                   <template v-else>
                     <span>pending approval</span>
@@ -425,15 +429,25 @@ defineExpose({ open, close });
                 </div>
               </div>
               <div class="memory-draft-actions" @click.stop>
-                <span v-if="!draft.content && draft.status === 'pending_generation'" class="memory-status-badge" style="background:rgba(255,215,0,0.1);color:#ffd700;">needs gen</span>
+                <span v-if="isDraftGenerating(draft.id)" class="memory-status-badge" style="background:rgba(255,215,0,0.1);color:#ffd700;">generating</span>
+                <span v-else-if="!draft.content && draft.status === 'pending_generation'" class="memory-status-badge" style="background:rgba(255,215,0,0.1);color:#ffd700;">needs gen</span>
                 <span v-else class="memory-status-badge draft">draft</span>
                 <span v-if="vectorEnabled" class="memory-status-badge vector">vec</span>
                 <button
-                  v-if="!draft.content && draft.status === 'pending_generation'"
+                  v-if="isDraftGenerating(draft.id)"
+                  type="button"
+                  class="memory-entry-delete"
+                  @click.stop.prevent="handleCancelDraft(draft.id)"
+                  @touchend.stop.prevent="handleCancelDraft(draft.id)"
+                >
+                  Stop
+                </button>
+                <button
+                  v-else-if="!draft.content && draft.status === 'pending_generation'"
                   type="button"
                   class="memory-entry-generate"
-                  :disabled="memoryDraftState.active"
-                  @click="handleGenerateDraft(draft.id)"
+                  @click.stop.prevent="handleGenerateDraft(draft.id)"
+                  @touchend.stop.prevent="handleGenerateDraft(draft.id)"
                 >
                   Generate
                 </button>
@@ -441,15 +455,17 @@ defineExpose({ open, close });
                   v-else
                   type="button"
                   class="memory-entry-approve"
-                  :disabled="!draft.content || memoryDraftState.active"
-                  @click="handleApproveDraft(draft.id)"
+                  :disabled="!draft.content || isDraftGenerating(draft.id)"
+                  @click.stop.prevent="handleApproveDraft(draft.id)"
+                  @touchend.stop.prevent="handleApproveDraft(draft.id)"
                 >
                   Approve
                 </button>
                 <button
                   type="button"
                   class="memory-entry-delete"
-                  @click="handleDeleteDraft(draft.id)"
+                  @click.stop.prevent="handleDeleteDraft(draft.id)"
+                  @touchend.stop.prevent="handleDeleteDraft(draft.id)"
                 >
                   Delete
                 </button>
@@ -459,7 +475,7 @@ defineExpose({ open, close });
               <template v-if="draft.content">
                 {{ draft.content.slice(0, 180) }}
               </template>
-              <span v-else-if="memoryDraftState.active && draft === currentlyGeneratingDraft" style="color:#ffd700;">⏳ Generating...</span>
+              <span v-else-if="isDraftGenerating(draft.id)" style="color:#ffd700;">Generating... {{ formatElapsedSeconds(getDraftProgress(draft.id)?.elapsedMs || 0) }}</span>
               <span v-else style="color:var(--text-gray);">No content yet — click Generate to create</span>
             </div>
           </div>
@@ -813,6 +829,28 @@ defineExpose({ open, close });
   border-radius: 12px;
 }
 
+.memory-section-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.memory-head-btn {
+  border: none;
+  border-radius: 10px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.memory-head-btn.destructive {
+  background: rgba(255, 68, 68, 0.1);
+  color: #ff4444;
+  border: 1px solid rgba(255, 68, 68, 0.3);
+}
+
 /* Entry List */
 .memory-entry-list {
   display: flex;
@@ -919,6 +957,9 @@ defineExpose({ open, close });
   display: flex;
   gap: 8px;
   align-items: center;
+  position: relative;
+  z-index: 3;
+  pointer-events: auto;
 }
 
 .memory-entry-approve,
@@ -932,6 +973,10 @@ defineExpose({ open, close });
   cursor: pointer;
   transition: all 0.2s;
   font-family: inherit;
+  position: relative;
+  z-index: 4;
+  pointer-events: auto;
+  touch-action: manipulation;
 }
 
 .memory-entry-approve {

--- a/src/composables/chat/useMemoryBooks.js
+++ b/src/composables/chat/useMemoryBooks.js
@@ -288,21 +288,21 @@ export function useMemoryBooks(deps) {
     }
 
     /**
-     * Handle memory scan chat
+     * Handle memory scan chat - creates draft placeholders without auto-generating
      * @param {Object} activeChatChar - Active character object
      * @param {Array} currentMessages - Current messages array
      * @param {Object} memoryBooksSheet - Memory books sheet ref
      */
     async function handleMemoryScanChat(activeChatChar, currentMessages, memoryBooksSheet) {
         if (!activeChatChar || !currentMemoryBookData.value) return;
-        
+
         const chatData = await getChatData(activeChatChar.id);
         const sessionId = activeChatChar.sessionId || chatData.currentId;
         const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
-        
+
         const entries = Array.isArray(memoryBook.entries) ? memoryBook.entries : [];
         const pendingDrafts = Array.isArray(memoryBook.pendingDrafts) ? memoryBook.pendingDrafts : [];
-        
+
         const coveredIds = new Set();
         for (const entry of entries) {
             if (Array.isArray(entry.messageIds)) entry.messageIds.forEach(id => coveredIds.add(id));
@@ -310,32 +310,73 @@ export function useMemoryBooks(deps) {
         for (const draft of pendingDrafts) {
             if (Array.isArray(draft.messageIds)) draft.messageIds.forEach(id => coveredIds.add(id));
         }
-        
-        const stableMessages = currentMessages.filter(m => m && !m.isTyping && !m.isHidden && !m.isError && (m.role === 'user' || m.role === 'char'));
-        const uncovered = stableMessages.filter(m => m.id && !coveredIds.has(m.id));
-        
+
+        // Scan ALL messages including hidden for memory book purposes
+        const allMessages = currentMessages.filter(m => m && !m.isTyping && !m.isError && (m.role === 'user' || m.role === 'char'));
+        const uncovered = allMessages.filter(m => m.id && !coveredIds.has(m.id));
+
         if (!uncovered.length) {
             showToast('All messages are already covered');
             return;
         }
-        
+
         const interval = normalizeAutoCreateInterval(memoryBook);
         const segments = [];
         for (let i = 0; i < uncovered.length; i += interval) {
             segments.push(uncovered.slice(i, i + interval));
         }
-        
-        // Store planned segments
+
+        // Create pending draft entries with empty content (user will generate manually)
+        if (!Array.isArray(memoryBook.pendingDrafts)) memoryBook.pendingDrafts = [];
+
+        for (let i = 0; i < segments.length; i++) {
+            const segment = segments[i];
+            const segmentIds = segment.map(m => m.id);
+            const firstMsg = segment[0];
+            const lastMsg = segment[segment.length - 1];
+
+            // Find message indices for display
+            const firstIdx = allMessages.findIndex(m => m.id === firstMsg.id);
+            const lastIdx = allMessages.findIndex(m => m.id === lastMsg.id);
+            const rangeDisplay = firstIdx >= 0 && lastIdx >= 0 ? `${firstIdx + 1}-${lastIdx + 1}` : `${i * interval + 1}-${Math.min((i + 1) * interval, uncovered.length)}`;
+
+            // Check if draft already exists for these messages
+            const existingDraft = memoryBook.pendingDrafts.find(d =>
+                d.messageIds && JSON.stringify(d.messageIds.sort()) === JSON.stringify(segmentIds.sort())
+            );
+            if (existingDraft) continue;
+
+            memoryBook.pendingDrafts.push({
+                id: `draft_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`,
+                title: rangeDisplay,
+                content: '',
+                keys: [],
+                glazeKeys: [],
+                vectorSearch: false,
+                messageIds: segmentIds,
+                messageRange: {
+                    start: firstIdx >= 0 ? firstIdx + 1 : i * interval + 1,
+                    end: lastIdx >= 0 ? lastIdx + 1 : Math.min((i + 1) * interval, uncovered.length)
+                },
+                status: 'pending_generation',
+                source: 'scan_chat',
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+                generatedAt: null
+            });
+        }
+
+        // Clear planned segments since we now have actual draft placeholders
         if (!memoryBook.automation) memoryBook.automation = {};
-        memoryBook.automation.plannedSegments = segments.map(seg => seg.map(m => m.id));
+        memoryBook.automation.plannedSegments = [];
         memoryBook.updatedAt = Date.now();
         await db.saveChat(activeChatChar.id, chatData);
-        
+
         // Mark all uncovered as pending
         const allUncoveredIds = new Set(uncovered.map(m => m.id));
         pendingMemoryMessageIds.value = allUncoveredIds;
-        
-        showToast(`Scanned: ${segments.length} segments planned (${uncovered.length} messages)`);
+
+        showToast(`${segments.length} draft placeholders created (${uncovered.length} messages)`);
         await loadCurrentMemoryBook(activeChatChar);
         setTimeout(() => memoryBooksSheet.value?.open(), 50);
     }
@@ -378,6 +419,25 @@ export function useMemoryBooks(deps) {
         memoryBook.entries.push(approvedEntry);
         memoryBook.pendingDrafts = memoryBook.pendingDrafts.filter(entry => entry.id !== draftId);
         memoryBook.updatedAt = Date.now();
+
+        // Update memoryCoverage on messages covered by this entry
+        if (Array.isArray(approvedEntry.messageIds)) {
+            for (const msg of currentMessages) {
+                if (!msg || !msg.id) continue;
+                if (approvedEntry.messageIds.includes(msg.id)) {
+                    if (!msg.memoryCoverage || typeof msg.memoryCoverage !== 'object') {
+                        msg.memoryCoverage = { entryIds: [], needsRebuild: false, stale: false };
+                    }
+                    if (!Array.isArray(msg.memoryCoverage.entryIds)) {
+                        msg.memoryCoverage.entryIds = [];
+                    }
+                    if (!msg.memoryCoverage.entryIds.includes(approvedEntry.id)) {
+                        msg.memoryCoverage.entryIds.push(approvedEntry.id);
+                    }
+                }
+            }
+        }
+
         reconcileSessionMemoryState(chatData, sessionId, currentMessages);
         chatData.sessions[sessionId] = currentMessages;
         await db.saveChat(activeChatChar.id, chatData);

--- a/src/composables/chat/useMemoryBooks.js
+++ b/src/composables/chat/useMemoryBooks.js
@@ -56,56 +56,110 @@ export function useMemoryBooks(deps) {
     const draftMemoryMessageIds = ref(new Set());
     const memoryDraftState = ref({
         active: false,
-        startedAt: 0,
-        elapsedMs: 0,
-        label: ''
+        activeCount: 0,
+        label: '',
+        draftId: null,
+        activeDrafts: {}
     });
 
     let memoryDraftTimer = null;
-    let memoryDraftAbortController = null;
+    const memoryDraftAbortControllers = new Map();
+    const memoryDraftProgressEntries = new Map();
+
+    function syncMemoryDraftState() {
+        const activeDrafts = {};
+        let firstDraftId = null;
+
+        for (const [draftId, entry] of memoryDraftProgressEntries.entries()) {
+            activeDrafts[draftId] = {
+                draftId,
+                startedAt: entry.startedAt,
+                elapsedMs: entry.elapsedMs,
+                label: entry.label
+            };
+            if (!firstDraftId) firstDraftId = draftId;
+        }
+
+        const activeCount = memoryDraftProgressEntries.size;
+        const primaryEntry = firstDraftId ? activeDrafts[firstDraftId] : null;
+        memoryDraftState.value = {
+            active: activeCount > 0,
+            activeCount,
+            label: activeCount > 1 ? `${activeCount} drafts` : (primaryEntry?.label || ''),
+            draftId: activeCount === 1 ? firstDraftId : null,
+            activeDrafts
+        };
+
+        if (!activeCount && memoryDraftTimer) {
+            clearInterval(memoryDraftTimer);
+            memoryDraftTimer = null;
+        }
+    }
+
+    function ensureMemoryDraftTimer() {
+        if (memoryDraftTimer || !memoryDraftProgressEntries.size) return;
+        memoryDraftTimer = setInterval(() => {
+            const now = Date.now();
+            for (const entry of memoryDraftProgressEntries.values()) {
+                entry.elapsedMs = now - entry.startedAt;
+            }
+            syncMemoryDraftState();
+        }, 100);
+    }
+
+    function setMemoryDraftAbortController(controller, draftId = null) {
+        const key = draftId || '__global__';
+        if (controller) {
+            memoryDraftAbortControllers.set(key, controller);
+        } else {
+            memoryDraftAbortControllers.delete(key);
+        }
+    }
+
+    function getMemoryDraftAbortController(draftId = null) {
+        const key = draftId || '__global__';
+        return memoryDraftAbortControllers.get(key) || null;
+    }
 
     // ========================================================================
     // DRAFT PROGRESS TRACKING
     // ========================================================================
 
-    function stopMemoryDraftProgress() {
-        if (memoryDraftTimer) {
-            clearInterval(memoryDraftTimer);
-            memoryDraftTimer = null;
+    function stopMemoryDraftProgress(draftId = null) {
+        if (draftId) {
+            memoryDraftProgressEntries.delete(draftId);
+            memoryDraftAbortControllers.delete(draftId);
+        } else {
+            memoryDraftProgressEntries.clear();
+            memoryDraftAbortControllers.clear();
         }
-        memoryDraftAbortController = null;
-        memoryDraftState.value = {
-            active: false,
-            startedAt: 0,
-            elapsedMs: 0,
-            label: ''
-        };
+        syncMemoryDraftState();
     }
 
-    function cancelMemoryDraft() {
-        if (memoryDraftAbortController) {
-            memoryDraftAbortController.abort();
+    function cancelMemoryDraft(draftId = null) {
+        if (draftId) {
+            memoryDraftAbortControllers.get(draftId)?.abort();
+            stopMemoryDraftProgress(draftId);
+        } else {
+            for (const controller of memoryDraftAbortControllers.values()) {
+                controller?.abort?.();
+            }
+            stopMemoryDraftProgress();
         }
-        stopMemoryDraftProgress();
         showToast('Memory draft generation cancelled');
     }
 
-    function startMemoryDraftProgress(label = 'Generating memory draft') {
-        if (memoryDraftTimer) clearInterval(memoryDraftTimer);
+    function startMemoryDraftProgress(label = 'Generating memory draft', draftId = null) {
+        const progressId = draftId || `memory_draft_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
         const startedAt = Date.now();
-        memoryDraftState.value = {
-            active: true,
+        memoryDraftProgressEntries.set(progressId, {
             startedAt,
             elapsedMs: 0,
             label
-        };
-        memoryDraftTimer = setInterval(() => {
-            memoryDraftState.value = {
-                ...memoryDraftState.value,
-                active: true,
-                elapsedMs: Date.now() - startedAt
-            };
-        }, 100);
+        });
+        ensureMemoryDraftTimer();
+        syncMemoryDraftState();
+        return progressId;
     }
 
     // ========================================================================
@@ -119,15 +173,26 @@ export function useMemoryBooks(deps) {
     async function loadCurrentMemoryBook(activeChatChar) {
         if (!activeChatChar) {
             currentMemoryBookData.value = null;
+            stopMemoryDraftProgress();
             return;
         }
         const chatData = await getChatData(activeChatChar.id);
         if (!chatData) {
             currentMemoryBookData.value = null;
+            stopMemoryDraftProgress();
             return;
         }
         const sessionId = activeChatChar.sessionId || chatData.currentId;
         const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
+        let shouldPersistReset = false;
+        if (memoryBook.automation?.isGeneratingDraft && !memoryDraftState.value.active) {
+            memoryBook.automation.isGeneratingDraft = false;
+            shouldPersistReset = true;
+        }
+        if (shouldPersistReset) {
+            memoryBook.updatedAt = Date.now();
+            await db.saveChat(activeChatChar.id, chatData);
+        }
         currentMemoryBookData.value = memoryBook;
     }
 
@@ -176,7 +241,7 @@ export function useMemoryBooks(deps) {
      * @param {Object} activeChatChar - Active character object
      * @param {Object} memoryBooksSheet - Memory books sheet ref
      */
-    async function handleMemoryKeyModeUpdate(activeChatChar, memoryBooksSheet) {
+    async function handleMemorySearchTypeUpdate(activeChatChar, memoryBooksSheet) {
         if (!activeChatChar || !currentMemoryBookData.value) return;
         
         const chatData = await getChatData(activeChatChar.id);
@@ -184,22 +249,12 @@ export function useMemoryBooks(deps) {
         const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
         
         showBottomSheet({
-            title: 'Memory Key Match Mode',
+            title: 'Memory Search Type',
             items: [
                 {
-                    label: 'Plain contains',
+                    label: 'Keys',
                     onClick: async () => {
-                        memoryBook.settings.keyMatchMode = 'plain';
-                        memoryBook.updatedAt = Date.now();
-                        await db.saveChat(activeChatChar.id, chatData);
-                        closeBottomSheet();
-                        await loadCurrentMemoryBook(activeChatChar);
-                        setTimeout(() => memoryBooksSheet.value?.open(), 50);
-                    }
-                },
-                {
-                    label: 'Glaze boundaries',
-                    onClick: async () => {
+                        memoryBook.settings.vectorSearchEnabled = false;
                         memoryBook.settings.keyMatchMode = 'glaze';
                         memoryBook.updatedAt = Date.now();
                         await db.saveChat(activeChatChar.id, chatData);
@@ -209,9 +264,28 @@ export function useMemoryBooks(deps) {
                     }
                 },
                 {
-                    label: 'Plain + Glaze',
+                    label: 'Vector',
                     onClick: async () => {
+                        memoryBook.settings.vectorSearchEnabled = true;
+                        memoryBook.settings.keyMatchMode = 'plain';
+                        setMemoryVectorSearchOnEntries(memoryBook, true);
+                        showToast('Reindexing memory entries...', 1500);
+                        await reindexAllMemoryEntries(memoryBook, activeChatChar.id, sessionId);
+                        memoryBook.updatedAt = Date.now();
+                        await db.saveChat(activeChatChar.id, chatData);
+                        closeBottomSheet();
+                        await loadCurrentMemoryBook(activeChatChar);
+                        setTimeout(() => memoryBooksSheet.value?.open(), 50);
+                    }
+                },
+                {
+                    label: 'Combined',
+                    onClick: async () => {
+                        memoryBook.settings.vectorSearchEnabled = true;
                         memoryBook.settings.keyMatchMode = 'both';
+                        setMemoryVectorSearchOnEntries(memoryBook, true);
+                        showToast('Reindexing memory entries...', 1500);
+                        await reindexAllMemoryEntries(memoryBook, activeChatChar.id, sessionId);
                         memoryBook.updatedAt = Date.now();
                         await db.saveChat(activeChatChar.id, chatData);
                         closeBottomSheet();
@@ -322,8 +396,13 @@ export function useMemoryBooks(deps) {
 
         const interval = normalizeAutoCreateInterval(memoryBook);
         const segments = [];
-        for (let i = 0; i < uncovered.length; i += interval) {
+        for (let i = 0; i + interval <= uncovered.length; i += interval) {
             segments.push(uncovered.slice(i, i + interval));
+        }
+
+        if (!segments.length) {
+            showToast(`Need ${interval} uncovered messages before creating a draft segment`);
+            return;
         }
 
         // Create pending draft entries with empty content (user will generate manually)
@@ -372,11 +451,8 @@ export function useMemoryBooks(deps) {
         memoryBook.updatedAt = Date.now();
         await db.saveChat(activeChatChar.id, chatData);
 
-        // Mark all uncovered as pending
-        const allUncoveredIds = new Set(uncovered.map(m => m.id));
-        pendingMemoryMessageIds.value = allUncoveredIds;
-
         showToast(`${segments.length} draft placeholders created (${uncovered.length} messages)`);
+        await updatePendingMemoryMessageIds(activeChatChar);
         await loadCurrentMemoryBook(activeChatChar);
         setTimeout(() => memoryBooksSheet.value?.open(), 50);
     }
@@ -443,6 +519,7 @@ export function useMemoryBooks(deps) {
         await db.saveChat(activeChatChar.id, chatData);
         await indexMemoryEntryIfNeeded(approvedEntry, activeChatChar.id, sessionId);
         
+        await updatePendingMemoryMessageIds(activeChatChar);
         await loadCurrentMemoryBook(activeChatChar);
         setTimeout(() => memoryBooksSheet.value?.open(), 50);
     }
@@ -459,12 +536,34 @@ export function useMemoryBooks(deps) {
         const chatData = await getChatData(activeChatChar.id);
         const sessionId = activeChatChar.sessionId || chatData.currentId;
         const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
+        if (memoryDraftState.value?.activeDrafts?.[draftId]) {
+            cancelMemoryDraft(draftId);
+        }
         
         memoryBook.pendingDrafts = memoryBook.pendingDrafts.filter(entry => entry.id !== draftId);
         memoryBook.updatedAt = Date.now();
         await db.saveChat(activeChatChar.id, chatData);
         
+        await updatePendingMemoryMessageIds(activeChatChar);
         await loadCurrentMemoryBook(activeChatChar);
+        setTimeout(() => memoryBooksSheet.value?.open(), 50);
+    }
+
+    async function handleMemoryDeleteAllDrafts(activeChatChar, memoryBooksSheet) {
+        if (!activeChatChar || !currentMemoryBookData.value) return;
+
+        const chatData = await getChatData(activeChatChar.id);
+        const sessionId = activeChatChar.sessionId || chatData.currentId;
+        const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
+
+        cancelMemoryDraft();
+        memoryBook.pendingDrafts = [];
+        memoryBook.updatedAt = Date.now();
+        await db.saveChat(activeChatChar.id, chatData);
+
+        await updatePendingMemoryMessageIds(activeChatChar);
+        await loadCurrentMemoryBook(activeChatChar);
+        showToast('All pending drafts deleted');
         setTimeout(() => memoryBooksSheet.value?.open(), 50);
     }
 
@@ -489,6 +588,7 @@ export function useMemoryBooks(deps) {
         chatData.sessions[sessionId] = currentMessages;
         await db.saveChat(activeChatChar.id, chatData);
         
+        await updatePendingMemoryMessageIds(activeChatChar);
         await loadCurrentMemoryBook(activeChatChar);
         setTimeout(() => memoryBooksSheet.value?.open(), 50);
     }
@@ -496,8 +596,8 @@ export function useMemoryBooks(deps) {
     /**
      * Handle memory cancel draft
      */
-    function handleMemoryCancelDraft() {
-        cancelMemoryDraft();
+    function handleMemoryCancelDraft(draftId = null) {
+        cancelMemoryDraft(draftId);
     }
 
     /**
@@ -576,14 +676,17 @@ export function useMemoryBooks(deps) {
         startMemoryDraftProgress,
         stopMemoryDraftProgress,
         cancelMemoryDraft,
+        setMemoryDraftAbortController,
+        getMemoryDraftAbortController,
         
         // UI handlers
-        handleMemoryKeyModeUpdate,
+        handleMemorySearchTypeUpdate,
         handleMemoryVectorToggle,
         handleMemoryReindexAll,
         handleMemoryScanChat,
         handleMemoryApproveDraft,
         handleMemoryDeleteDraft,
+        handleMemoryDeleteAllDrafts,
         handleMemoryDeleteEntry,
         handleMemoryCancelDraft,
         handleMemoryOpenMaintenance

--- a/src/core/config/embeddingSettings.js
+++ b/src/core/config/embeddingSettings.js
@@ -1,23 +1,3 @@
-import { normalizeEndpoint } from '@/core/config/APISettings.js';
-
-function normalizeEmbeddingEndpoint(url) {
-    if (!url) return '';
-    let normalized = url.trim();
-    if (!/^https?:\/\//i.test(normalized)) {
-        normalized = 'https://' + normalized;
-    }
-    if (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
-    const suffix = '/embeddings';
-    if (normalized.toLowerCase().endsWith(suffix)) {
-        normalized = normalized.slice(0, -suffix.length);
-    }
-    if (normalized.endsWith('/v1')) {
-        // keep /v1, it's the base path
-    }
-    if (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
-    return normalized;
-}
-
 export function getEmbeddingConfig() {
     const useSame = localStorage.getItem('gz_embedding_use_same') !== 'false';
 
@@ -31,18 +11,20 @@ export function getEmbeddingConfig() {
     };
 
     if (useSame) {
+        const rawEndpoint = (localStorage.getItem('api-endpoint') || '').trim();
         return {
             ...base,
-            endpoint: normalizeEndpoint(localStorage.getItem('api-endpoint') || ''),
+            endpoint: rawEndpoint,
             apiKey: localStorage.getItem('api-key') || '',
             model: localStorage.getItem('api-model') || '',
             useSame: true
         };
     }
 
+    const rawEndpoint = (localStorage.getItem('gz_embedding_endpoint') || '').trim();
     return {
         ...base,
-        endpoint: normalizeEmbeddingEndpoint(localStorage.getItem('gz_embedding_endpoint') || ''),
+        endpoint: rawEndpoint,
         apiKey: localStorage.getItem('gz_embedding_key') || '',
         model: localStorage.getItem('gz_embedding_model') || '',
         useSame: false

--- a/src/core/services/backupService.js
+++ b/src/core/services/backupService.js
@@ -7,7 +7,7 @@ import { db } from '@/utils/db.js';
 
 
 const DB_NAME = 'SillyCradleDB';
-const DB_VERSION = 7;
+const DB_VERSION = 8;
 const STORE_KEYVALUE = 'keyvalue';
 const STORE_CHARACTERS = 'characters';
 const STORE_PERSONAS = 'personas';
@@ -22,7 +22,7 @@ export async function exportFullBackupAsync() {
 
         const workerCode = `
             const DB_NAME = 'SillyCradleDB';
-            const DB_VERSION = 7;
+            const DB_VERSION = 8;
             const STORE_KEYVALUE = 'keyvalue';
             const STORE_CHARACTERS = 'characters';
             const STORE_PERSONAS = 'personas';
@@ -107,7 +107,7 @@ export async function importFullBackupAsync(jsonString) {
     return new Promise((resolve, reject) => {
         const workerCode = `
             const DB_NAME = 'SillyCradleDB';
-            const DB_VERSION = 7;
+            const DB_VERSION = 8;
             const STORE_KEYVALUE = 'keyvalue';
             const STORE_CHARACTERS = 'characters';
             const STORE_PERSONAS = 'personas';

--- a/src/core/services/embeddingService.js
+++ b/src/core/services/embeddingService.js
@@ -81,8 +81,9 @@ async function callEmbeddingAPI(url, headers, requestBody) {
         data = await res.json();
     }
 
-    if (!data.data || !Array.isArray(data.data)) {
-        throw new Error('Invalid embedding response: missing data array');
+    if (!data || !Array.isArray(data.data)) {
+        const providerMessage = data?.error?.message || data?.message || '';
+        throw new Error(providerMessage ? `Invalid embedding response: ${providerMessage}` : 'Invalid embedding response: missing data array');
     }
 
     return data.data.sort((a, b) => a.index - b.index).map(item => item.embedding);

--- a/src/core/services/embeddingService.js
+++ b/src/core/services/embeddingService.js
@@ -100,7 +100,8 @@ export async function getEmbeddings(texts) {
     if (!config.endpoint) throw new Error('Embedding endpoint not configured');
     if (!config.model) throw new Error('Embedding model not configured');
 
-    const url = `${config.endpoint}/embeddings`;
+    const endpoint = config.endpoint;
+    const url = /\/embeddings\/?$/i.test(endpoint) ? endpoint : `${endpoint.replace(/\/+$/, '')}/embeddings`;
     const headers = { 'Content-Type': 'application/json' };
     if (config.apiKey) headers['Authorization'] = `Bearer ${config.apiKey}`;
 

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -265,11 +265,15 @@ export async function generateChatResponse({
     }
 
     const safeContext = contextSize - maxTokens;
+    const cutoffOriginalIndex = result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
+        ? result.cutoffOriginalIndex
+        : (result.cutoffIndex !== undefined ? result.cutoffIndex : -1);
     const memoryInjection = await buildMemoryInjection({
         char,
         history: safeHistory || history,
         summary,
-        safeContext
+        safeContext,
+        cutoffOriginalIndex
     });
     let messages = result.messages;
 
@@ -516,11 +520,15 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
         }));
 
         const result = await processPromptAsync(payload);
+        const cutoffOriginalIndex = result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
+            ? result.cutoffOriginalIndex
+            : (result.cutoffIndex !== undefined ? result.cutoffIndex : -1);
         const memoryInjection = await buildMemoryInjection({
             char,
             history: safeHistory,
             summary,
-            safeContext: safeContextLimit
+            safeContext: safeContextLimit,
+            cutoffOriginalIndex
         });
 
         // Calculate vector lorebook tokens for accurate breakdown display
@@ -786,7 +794,7 @@ export async function deleteMemoryEntryIndex(entryId) {
     await db.deleteEmbedding(entryId);
 }
 
-async function buildMemoryInjection({ char, history, summary, safeContext }) {
+async function buildMemoryInjection({ char, history, summary, safeContext, cutoffOriginalIndex = -1 }) {
     const charId = char?.id;
     const sessionId = char?.sessionId;
     if (!charId || !sessionId) return { messages: [], entries: [], tokens: 0, injectionTarget: 'summary_block', macroContent: '' };
@@ -801,7 +809,20 @@ async function buildMemoryInjection({ char, history, summary, safeContext }) {
 
     const recentHistory = Array.isArray(history) ? history.slice(-12) : [];
     const historyText = recentHistory.map(item => item?.content || item?.text || '').filter(Boolean).join('\n').toLowerCase();
-    const recentMessageIds = new Set(recentHistory.map(item => item?.messageId).filter(Boolean));
+
+    const inPromptMessageIds = new Set();
+    if (cutoffOriginalIndex >= 0 && Array.isArray(history)) {
+        for (const m of history) {
+            if ((m.chatId ?? -1) >= cutoffOriginalIndex && m.messageId) {
+                inPromptMessageIds.add(m.messageId);
+            }
+        }
+    } else {
+        recentHistory.forEach(item => {
+            if (item?.messageId) inPromptMessageIds.add(item.messageId);
+        });
+    }
+
     const recentLabels = new Set();
     recentHistory.forEach(item => {
         (Array.isArray(item?.contextRefs) ? item.contextRefs : []).forEach(ref => {
@@ -826,18 +847,18 @@ async function buildMemoryInjection({ char, history, summary, safeContext }) {
 
     const vectorResults = await vectorSearchMemoryEntries(activeEntries, history, currentText).catch(() => []);
     const vectorScores = new Map(vectorResults.map(item => [item.id, item.vectorScore || item.score || 0]));
+
     const eligibleEntries = activeEntries.filter(entry => {
         const messageIds = normalizeMessageIdList(entry);
         if (!messageIds.length) return true;
-        const firstMsgId = messageIds[0];
-        return !recentMessageIds.has(firstMsgId);
+        return !messageIds.some(id => inPromptMessageIds.has(id));
     });
 
     const scoredEntries = eligibleEntries.map((entry, index) => {
         const haystack = `${entry.title || ''}\n${entry.content || ''}`.toLowerCase();
         const messageIds = normalizeMessageIdList(entry);
         let score = 0;
-        if (messageIds.some(id => !recentMessageIds.has(id))) score += 8;
+        if (messageIds.length > 0) score += 2;
         if (keywordMatchedIds.has(entry.id)) score += 6;
         if (vectorScores.has(entry.id)) score += Math.max(0, (vectorScores.get(entry.id) || 0) * 5);
         (Array.isArray(entry.contextRefs) ? entry.contextRefs : []).forEach(ref => {

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -157,7 +157,11 @@ export async function generateChatResponse({
     const squashRole = activePreset?.squashRole || 'assistant';
 
     if (activePreset && typeof activePreset.reasoningEnabled === 'boolean') {
-        requestReasoning = activePreset.reasoningEnabled;
+        // Only override if preset explicitly enables it, otherwise keep user setting
+        if (activePreset.reasoningEnabled === true) {
+            requestReasoning = true;
+        }
+        // If preset is false and user enabled reasoning in API settings, keep user's choice
     }
     if (activePreset && activePreset.reasoningEffort) {
         reasoningEffort = activePreset.reasoningEffort;
@@ -171,6 +175,11 @@ export async function generateChatResponse({
     const varsKey = `gz_vars_${charId}_${sessionId}`;
     let sessionVars = {};
     try { sessionVars = JSON.parse(localStorage.getItem(varsKey)) || {}; } catch (e) { }
+
+    // Set reasoning macros for {{reasoningPrefix}} and {{reasoningSuffix}}
+    sessionVars.reasoningPrefix = tagStart;
+    sessionVars.reasoningSuffix = tagEnd;
+    localStorage.setItem(varsKey, JSON.stringify(sessionVars));
 
     let globalRegexes = [];
     try { globalRegexes = JSON.parse(localStorage.getItem('regex_scripts')) || []; } catch (e) { }
@@ -380,9 +389,12 @@ export async function generateChatResponse({
         messages: messages,
         temperature: temp,
         top_p: topP,
-        stream: stream,
-        reasoning_effort: reasoningEffort || 'medium'
+        stream: stream
     };
+
+    if (reasoningEffort && reasoningEffort !== 'auto') {
+        requestBody.reasoning_effort = reasoningEffort;
+    }
 
     if (maxTokens > 0) {
         requestBody.max_tokens = maxTokens;
@@ -413,6 +425,12 @@ export async function generateChatResponse({
         if (m.name) cleanMsg.name = m.name;
         return cleanMsg;
     });
+
+    // Final abort check before API call
+    if (controller?.signal?.aborted) {
+        if (onError) onError(new DOMException('Aborted', 'AbortError'));
+        return;
+    }
 
     // Call LLM API
     try {

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -144,6 +144,42 @@ export async function executeRequest({
         }
 
         if (stream) {
+            if (!response.body || typeof response.body.getReader !== 'function') {
+                console.warn('[llmApi] Streaming body is unavailable on this platform/runtime, falling back to non-streaming response handling.');
+
+                const data = await response.json();
+                logger.debug('LLM Response (stream fallback):', data);
+
+                if (!data || !data.choices || !data.choices.length || !data.choices[0] || !data.choices[0].message) {
+                    throw new Error('Invalid API response structure (stream fallback): ' + JSON.stringify(data));
+                }
+
+                const content = data.choices[0].message.content;
+                const rawReasoning = data.choices[0].message.reasoning_content;
+
+                let finalText = content || '';
+                let finalReasoning = requestReasoning ? (rawReasoning || '') : '';
+                let inlineReasoning = '';
+
+                if (hasInlineTags && content && content.includes(tagStart)) {
+                    const startIndex = content.indexOf(tagStart);
+                    const endIndex = content.indexOf(tagEnd, startIndex);
+                    if (endIndex !== -1) {
+                        inlineReasoning = content.substring(startIndex + tagStart.length, endIndex);
+                        finalText = content.substring(0, startIndex) + content.substring(endIndex + tagEnd.length);
+                    }
+                }
+
+                if (finalReasoning && inlineReasoning) {
+                    finalReasoning = `${headerModel}\n${finalReasoning}\n\n---\n\n${headerInline}\n${inlineReasoning}`;
+                } else if (inlineReasoning) {
+                    finalReasoning = inlineReasoning;
+                }
+
+                if (onComplete) onComplete(cleanText(finalText), finalReasoning || null);
+                return;
+            }
+
             const reader = response.body.getReader();
             const decoder = new TextDecoder("utf-8");
             let isFirst = true;

--- a/src/core/services/memoryBooksService.js
+++ b/src/core/services/memoryBooksService.js
@@ -247,12 +247,17 @@ export function normalizeMemoryEntryShape(entry) {
         id: entry.id || genMemoryEntryId(),
         title: entry.title || '',
         content: entry.content || '',
+        rawContent: entry.rawContent || entry.content || '',
         keys: Array.isArray(entry.keys) ? entry.keys : [],
+        glazeKeys: Array.isArray(entry.glazeKeys) ? entry.glazeKeys : [],
         messageIds: normalizeEntryMessageIds(entry),
+        messageRange: entry.messageRange && typeof entry.messageRange === 'object' ? { ...entry.messageRange } : null,
         status: entry.status || 'active',
         vectorSearch: !!entry.vectorSearch,
+        source: entry.source || 'manual',
         createdAt: entry.createdAt || Date.now(),
-        updatedAt: entry.updatedAt || Date.now()
+        updatedAt: entry.updatedAt || Date.now(),
+        generatedAt: entry.generatedAt || null
     };
     
     return normalized;

--- a/src/core/states/lorebookState.js
+++ b/src/core/states/lorebookState.js
@@ -253,10 +253,9 @@ export const lorebookState = reactive({
         matchWholeWords: false,
         useGroupScoring: false,
         alertOnOverflow: false,
-        // Vector search global settings
-        vectorSearchEnabled: false,
-        keySearchEnabled: true,
-        vectorScanDepth: 5,
+        // Search type: 'keys' | 'vector' | 'both'
+        searchType: 'keys',
+        embeddingTarget: 'content', // 'content' or 'keys'
         vectorThreshold: 0.45,
         vectorTopK: 10
     },
@@ -771,7 +770,8 @@ export async function indexLorebookEntry(entry, lorebookId) {
     }
 
     const config = getEmbeddingConfig();
-    const text = getEntryIndexingText(entry, config.target);
+    const target = lorebookState.globalSettings.embeddingTarget || config.target || 'content';
+    const text = getEntryIndexingText(entry, target);
 
     const textHash = await computeTextHash(buildEmbeddingFingerprint(entry, text));
 
@@ -836,7 +836,8 @@ export async function indexLorebookEntries(lorebookId, onProgress, options = {})
 
     for (let i = 0; i < processedEntries.length; i++) {
         const entry = processedEntries[i];
-        const text = getEntryIndexingText(entry, config.target);
+        const target = lorebookState.globalSettings.embeddingTarget || config.target || 'content';
+        const text = getEntryIndexingText(entry, target);
         const textHash = await computeTextHash(buildEmbeddingFingerprint(entry, text));
 
         if (!text) {
@@ -929,9 +930,9 @@ export async function deleteLorebookEmbeddings(lorebookId) {
 }
 
 export async function vectorSearchLorebooks(history = [], currentText = '', char = null, chatId = null) {
-    // Check global vector search setting
-    if (!lorebookState.globalSettings.vectorSearchEnabled) {
-        console.info('[vectorSearchLorebooks] skipped: global vector search disabled');
+    // Check global search type setting - skip if keys-only
+    if (lorebookState.globalSettings.searchType === 'keys') {
+        console.info('[vectorSearchLorebooks] skipped: keys-only search mode');
         return [];
     }
 

--- a/src/core/states/lorebookState.js
+++ b/src/core/states/lorebookState.js
@@ -252,7 +252,13 @@ export const lorebookState = reactive({
         caseSensitive: false,
         matchWholeWords: false,
         useGroupScoring: false,
-        alertOnOverflow: false
+        alertOnOverflow: false,
+        // Vector search global settings
+        vectorSearchEnabled: false,
+        keySearchEnabled: true,
+        vectorScanDepth: 5,
+        vectorThreshold: 0.45,
+        vectorTopK: 10
     },
     activations: {
         character: {},
@@ -923,11 +929,13 @@ export async function deleteLorebookEmbeddings(lorebookId) {
 }
 
 export async function vectorSearchLorebooks(history = [], currentText = '', char = null, chatId = null) {
-    const config = getEmbeddingConfig();
-    if (!config.enabled) {
-        console.info('[vectorSearchLorebooks] skipped: vector search disabled');
+    // Check global vector search setting
+    if (!lorebookState.globalSettings.vectorSearchEnabled) {
+        console.info('[vectorSearchLorebooks] skipped: global vector search disabled');
         return [];
     }
+
+    const config = getEmbeddingConfig();
     if (!isEmbeddingConfigured()) {
         console.info('[vectorSearchLorebooks] skipped: embedding config incomplete');
         return [];
@@ -1036,6 +1044,10 @@ export async function vectorSearchLorebooks(history = [], currentText = '', char
         return [];
     }
 
+    const globalSettings = lorebookState.globalSettings;
+    const effectiveThreshold = globalSettings.vectorThreshold || 0.45;
+    const effectiveTopK = globalSettings.vectorTopK || 10;
+
     console.info('[vectorSearchLorebooks] querying embeddings', {
         charId,
         chatId,
@@ -1048,8 +1060,9 @@ export async function vectorSearchLorebooks(history = [], currentText = '', char
         fallbackQueryLength: fallbackQueryText.length,
         hasCurrentText: !!(currentText && currentText.trim()),
         queryLength: queryText.length,
-        threshold: config.threshold || 0.6,
-        topK: config.topK || 5
+        threshold: effectiveThreshold,
+        topK: effectiveTopK,
+        usingGlobalSettings: true
     });
 
     try {
@@ -1130,8 +1143,8 @@ export async function vectorSearchLorebooks(history = [], currentText = '', char
 
         const results = Array.from(combined.values())
             .sort((a, b) => b.score - a.score)
-            .filter(result => result.score >= (config.threshold || 0.55))
-            .slice(0, config.topK || 5);
+            .filter(result => result.score >= effectiveThreshold)
+            .slice(0, effectiveTopK);
 
         console.info('[vectorSearchLorebooks] results ready', {
             matches: results.length,

--- a/src/utils/macroEngine.js
+++ b/src/utils/macroEngine.js
@@ -44,9 +44,28 @@ export function replaceMacros(text, char, persona, sessionVarsIn = null, notifyO
         return "";
     });
 
+    // {{setglobalvar::name::value}}
+    result = result.replace(/{{setglobalvar::([\s\S]*?)::([\s\S]*?)}}/gi, (match, name, value) => {
+        _setGlobalVar(name, value);
+        return "";
+    });
+
     // {{getvar::name}}
     result = result.replace(/{{getvar::([\s\S]*?)}}/gi, (match, name) => {
         return sessionVars[name] !== undefined ? sessionVars[name] : "";
+    });
+
+    // {{getglobalvar::name}}
+    result = result.replace(/{{getglobalvar::([\s\S]*?)}}/gi, (match, name) => {
+        const val = _getGlobalVar(name);
+        return val !== null ? val : "";
+    });
+
+    // {{lumiaDef}}, {{lumiaOOC}}, {{loomRetrofits}}, etc. - custom macros from preset
+    // These are treated as global variables set via setglobalvar
+    result = result.replace(/\{\{(lumiaDef|lumiaOOC|lumiaOOCErotic|lumiaOOCEroticBleed|lumiaPersonality|loomRetrofits|loomStyle|loomSummary|loomUtils|sim_tracker|suggest)\}\}/gi, (match, name) => {
+        const val = _getGlobalVar(name);
+        return val !== null ? val : match; // return original macro if not found
     });
 
     // {{random::a::b::c}}
@@ -68,6 +87,20 @@ export function replaceMacros(text, char, persona, sessionVarsIn = null, notifyO
     // {{roll::1d20}}
     result = result.replace(/{{roll::(.*?)}}/gi, (match, dice) => {
         return _rollDice(dice);
+    });
+
+    // {{date}} / {{time}} / {{weekday}} - current datetime
+    const now = new Date();
+    result = result.replace(/\{\{date\}\}/gi, () => now.toLocaleDateString());
+    result = result.replace(/\{\{time\}\}/gi, () => now.toLocaleTimeString());
+    result = result.replace(/\{\{weekday\}\}/gi, () => now.toLocaleDateString('en-US', { weekday: 'long' }));
+
+    // {{reasoningPrefix}} / {{reasoningSuffix}} - reasoning tags from sessionVars or localStorage
+    result = result.replace(/\{\{reasoningPrefix\}\}/gi, () => {
+        return sessionVars.reasoningPrefix || localStorage.getItem('gz_api_reasoning_start') || '<think>';
+    });
+    result = result.replace(/\{\{reasoningSuffix\}\}/gi, () => {
+        return sessionVars.reasoningSuffix || localStorage.getItem('gz_api_reasoning_end') || '';
     });
 
     // --- Escaping: \{\{ → {{ and \}\} → }} ---
@@ -93,6 +126,23 @@ function _getSessionVars(charId, sessionId) {
 function _saveSessionVars(charId, sessionId, vars) {
     const key = `gz_vars_${charId}_${sessionId}`;
     localStorage.setItem(key, JSON.stringify(vars));
+}
+
+function _getGlobalVar(name) {
+    try {
+        const globalVars = JSON.parse(localStorage.getItem('gz_global_vars') || '{}');
+        return globalVars[name] !== undefined ? globalVars[name] : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function _setGlobalVar(name, value) {
+    try {
+        const globalVars = JSON.parse(localStorage.getItem('gz_global_vars') || '{}');
+        globalVars[name] = value;
+        localStorage.setItem('gz_global_vars', JSON.stringify(globalVars));
+    } catch (e) { }
 }
 
 function _simpleHash(str) {

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -70,10 +70,6 @@ function loadEmbeddingSettings() {
     embeddingSettings.endpoint = config.useSame ? '' : config.endpoint.replace(/\/embeddings$/, '');
     embeddingSettings.key = config.useSame ? '' : config.apiKey;
     embeddingSettings.model = config.useSame ? '' : config.model;
-    embeddingSettings.target = config.target;
-    embeddingSettings.scanDepth = config.scanDepth;
-    embeddingSettings.threshold = config.threshold;
-    embeddingSettings.topK = config.topK;
     embeddingSettings.maxChunkTokens = config.maxChunkTokens;
     embeddingSettings.enabled = config.enabled;
 }
@@ -260,6 +256,7 @@ function openModelSelector() {
 
 function openReasoningEffortSelector() {
     const options = [
+        { value: 'auto', label: t('reasoning_effort_auto') || 'Auto' },
         { value: 'low', label: t('reasoning_effort_low') || 'Low' },
         { value: 'medium', label: t('reasoning_effort_medium') || 'Medium' },
         { value: 'high', label: t('reasoning_effort_high') || 'High' }
@@ -669,37 +666,7 @@ onBeforeUnmount(() => {
                             </div>
                         </template>
                         <div class="settings-item">
-                            <label>{{ t('label_embedding_target') || 'Embedding Target' }}</label>
-                            <div class="clickable-selector" @click="openOptionSelector({
-                                title: t('label_embedding_target') || 'Embedding Target',
-                                options: [
-                                    { value: 'content', label: t('target_content') || 'Entry Content' },
-                                    { value: 'keys', label: t('target_keys') || 'Entry Keys' }
-                                ],
-                                currentValue: embeddingSettings.target,
-                                onSelect: (v) => { embeddingSettings.target = v; onEmbeddingInput('gz_embedding_target', v); }
-                            })">
-                                <span>{{ embeddingSettings.target === 'keys' ? (t('target_keys') || 'Keys') : (t('target_content') || 'Content') }}</span>
-                                <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
-                            </div>
-                        </div>
-                        <div class="settings-item">
-                            <label>{{ t('label_vector_scan_depth') || 'Scan Depth' }}</label>
-                            <input type="number" v-model.number="embeddingSettings.scanDepth" @input="onEmbeddingInput('gz_embedding_scan_depth', $event.target.value)" min="1" max="50">
-                        </div>
-                        <div class="settings-item-range">
-                            <div class="range-row">
-                                <label>{{ t('label_similarity_threshold') || 'Similarity Threshold' }}</label>
-                                <input type="number" v-model.number="embeddingSettings.threshold" @input="onEmbeddingInput('gz_embedding_threshold', $event.target.value)" class="range-input-val" step="0.01">
-                            </div>
-                            <input type="range" v-model.number="embeddingSettings.threshold" @input="onEmbeddingInput('gz_embedding_threshold', $event.target.value)" min="0" max="1" step="0.01">
-                        </div>
-                        <div class="settings-item">
-                            <label>{{ t('label_top_k') || 'Max Vector Results' }}</label>
-                            <input type="number" v-model.number="embeddingSettings.topK" @input="onEmbeddingInput('gz_embedding_top_k', $event.target.value)" min="1" max="50">
-                        </div>
-                        <div class="settings-item">
-                            <label>{{ t('label_max_chunk_tokens') || 'Max Tokens Per Chunk' }}</label>
+                                <label>{{ t('label_max_chunk_tokens') || 'Max Tokens Per Chunk' }}</label>
                             <input type="number" v-model.number="embeddingSettings.maxChunkTokens" @input="onEmbeddingInput('gz_embedding_max_chunk_tokens', $event.target.value)" min="128" max="32768">
                             <div class="settings-desc" style="margin-top:4px;">{{ t('desc_max_chunk_tokens') || 'Auto-splits long texts into chunks' }}</div>
                         </div>

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -67,7 +67,7 @@ const embeddingDimension = ref(null);
 function loadEmbeddingSettings() {
     const config = getEmbeddingConfig();
     embeddingSettings.useSame = config.useSame;
-    embeddingSettings.endpoint = config.useSame ? '' : config.endpoint.replace(/\/embeddings$/, '');
+    embeddingSettings.endpoint = config.useSame ? '' : config.endpoint;
     embeddingSettings.key = config.useSame ? '' : config.apiKey;
     embeddingSettings.model = config.useSame ? '' : config.model;
     embeddingSettings.maxChunkTokens = config.maxChunkTokens;

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -63,6 +63,7 @@ const embeddingSettings = reactive({
 
 const embeddingStatus = ref('idle');
 const embeddingDimension = ref(null);
+const embeddingError = ref('');
 
 function loadEmbeddingSettings() {
     const config = getEmbeddingConfig();
@@ -89,6 +90,7 @@ async function testEmbedding() {
         embeddingStatus.value = 'connected';
     } catch (e) {
         console.warn('Embedding test failed:', e);
+        embeddingError.value = e?.message || String(e);
         embeddingStatus.value = 'failed';
     }
 }
@@ -675,7 +677,7 @@ onBeforeUnmount(() => {
                                 {{ embeddingStatus === 'connecting' ? (t('btn_testing') || 'Testing...') : (t('btn_test_connection') || 'Test Connection') }}
                             </button>
                             <div v-if="embeddingStatus === 'connected'" class="settings-desc" style="margin-top:8px; color: #34c759;">{{ t('embedding_connected') || 'Connected' }} (dim: {{ embeddingDimension }})</div>
-                            <div v-if="embeddingStatus === 'failed'" class="settings-desc" style="margin-top:8px; color: #ff3b30;">{{ t('embedding_failed') || 'Connection failed' }}</div>
+                            <div v-if="embeddingStatus === 'failed'" class="settings-desc" style="margin-top:8px; color: #ff3b30;">{{ embeddingError || t('embedding_failed') || 'Connection failed' }}</div>
                         </div>
                     </template>
                 </div>

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -225,9 +225,6 @@ const lorebookSheet = ref(null);
 const regexSheet = ref(null);
 const activeChar = ref(null);
 const regexRevision = ref(0);
-// Memory draft abort controller (used by runBatchDraftGeneration and generateMemoryDraftForMessages)
-let memoryDraftAbortController = null;
-
 // Initialize Memory Books composable
 const {
     currentMemoryBookData,
@@ -239,12 +236,14 @@ const {
     startMemoryDraftProgress,
     stopMemoryDraftProgress,
     cancelMemoryDraft,
-    handleMemoryKeyModeUpdate: handleMemoryKeyModeUpdate_composable,
-    handleMemoryVectorToggle: handleMemoryVectorToggle_composable,
+    setMemoryDraftAbortController,
+    getMemoryDraftAbortController,
+    handleMemorySearchTypeUpdate: handleMemorySearchTypeUpdate_composable,
     handleMemoryReindexAll: handleMemoryReindexAll_composable,
     handleMemoryScanChat: handleMemoryScanChat_composable,
     handleMemoryApproveDraft: handleMemoryApproveDraft_composable,
     handleMemoryDeleteDraft: handleMemoryDeleteDraft_composable,
+    handleMemoryDeleteAllDrafts: handleMemoryDeleteAllDrafts_composable,
     handleMemoryDeleteEntry: handleMemoryDeleteEntry_composable,
     handleMemoryCancelDraft: handleMemoryCancelDraft_composable,
     handleMemoryOpenMaintenance: handleMemoryOpenMaintenance_composable
@@ -514,9 +513,12 @@ function parseMemoryDraftResponse(rawText, fallbackKeys = []) {
         ? keysLine.split(',').map(item => item.trim()).filter(Boolean)
         : [];
 
+    const content = memory || text;
+
     return {
-        content: memory || text,
-        keys: parsedKeys.length ? parsedKeys : buildMemoryKeysFromText(memory || text, fallbackKeys)
+        content,
+        raw: text,
+        keys: parsedKeys.length ? parsedKeys : buildMemoryKeysFromText(content, fallbackKeys)
     };
 }
 
@@ -605,16 +607,22 @@ async function generateMemoryDraftFromSelection() {
 
 async function generateMemoryDraftForMessages(selectedMessages, { openSheet = false, source = 'auto_delayed', existingDraftId = null } = {}) {
     if (!activeChatChar || !Array.isArray(selectedMessages) || !selectedMessages.length) return false;
+    console.debug('[MemoryBooks] generateMemoryDraftForMessages:start', { source, existingDraftId, inputCount: selectedMessages.length });
 
-    const selected = selectedMessages.filter(msg => msg && !msg.isTyping && !msg.isHidden && !msg.isError);
-    if (!selected.length) return false;
+    const selected = selectedMessages.filter(msg => msg && !msg.isTyping && !msg.isError);
+    console.debug('[MemoryBooks] generateMemoryDraftForMessages:filtered', { source, existingDraftId, filteredCount: selected.length });
+    if (!selected.length) {
+        showToast('No valid messages found for memory draft generation');
+        return false;
+    }
 
     const chatData = await getChatData(activeChatChar.id);
     const sessionId = activeChatChar.sessionId || chatData.currentId;
     const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
     const automation = ensureMemoryAutomationState(memoryBook);
+    const isManualDraftRequest = source === 'manual_draft' || source === 'manual_regenerate';
 
-    if (automation.isGeneratingDraft) {
+    if (automation.isGeneratingDraft && !isManualDraftRequest) {
         showToast('Already generating a draft. Please wait...');
         return false;
     }
@@ -660,6 +668,13 @@ async function generateMemoryDraftForMessages(selectedMessages, { openSheet = fa
     const lastMessage = selected[selected.length - 1];
     const selectedIds = selected.map(msg => msg.id).filter(Boolean);
     if (!selectedIds.length) return false;
+    const progressDraftId = existingDraftId || `memory_draft_${selectedIds[0]}`;
+    const generatedAt = Date.now();
+
+    if (existingDraftId && memoryDraftState.value?.activeDrafts?.[progressDraftId]) {
+        showToast('This draft is already generating');
+        return false;
+    }
 
     // Find existing draft if ID provided
     let existingDraft = null;
@@ -685,43 +700,54 @@ async function generateMemoryDraftForMessages(selectedMessages, { openSheet = fa
         memoryBook.updatedAt = Date.now();
         await db.saveChat(activeChatChar.id, chatData);
 
-        startMemoryDraftProgress(source === 'manual_draft' ? 'Generating selected memory draft' : 'Generating memory draft');
-        if (bottomSheetState.title === 'Memory Books' && bottomSheetState.isOpen) {
-            closeBottomSheet();
-            setTimeout(() => openMemoryBooksSheet(), 50);
-        } else if (source === 'manual_draft' || source === 'manual_regenerate') {
-            // Open Memory Books sheet immediately so user sees generation progress
-            setTimeout(() => openMemoryBooksSheet(), 50);
+        const progressLabel = existingDraftId
+            ? `Draft ${existingDraft?.title || 'generation'}`
+            : (source === 'manual_draft' ? 'Generating selected memory draft' : 'Generating memory draft');
+        startMemoryDraftProgress(progressLabel, progressDraftId);
+        if (!existingDraftId || source !== 'manual_draft') {
+            showToast('Generating memory draft...', 2000);
         }
-        showToast('Generating memory draft...', 2000);
-        memoryDraftAbortController = new AbortController();
+        const memoryDraftAbortController = new AbortController();
+        setMemoryDraftAbortController(memoryDraftAbortController, progressDraftId);
         const draftText = await generateMemoryDraft({ history, prompt: finalPrompt, controller: memoryDraftAbortController, apiConfigOverride });
+        console.debug('[MemoryBooks] generateMemoryDraftForMessages:request-complete', { existingDraftId, textLength: draftText?.length || 0 });
         const parsedDraft = parseMemoryDraftResponse(draftText || '', [playerName, activeChatChar?.name || 'Character']);
 
-        if (!Array.isArray(memoryBook.pendingDrafts)) memoryBook.pendingDrafts = [];
+        const latestChatData = await getChatData(activeChatChar.id);
+        const latestSessionId = activeChatChar.sessionId || latestChatData.currentId;
+        const latestMemoryBook = ensureSessionMemoryBook(latestChatData, latestSessionId);
+        const latestAutomation = ensureMemoryAutomationState(latestMemoryBook);
 
-        if (existingDraft) {
+        if (!Array.isArray(latestMemoryBook.pendingDrafts)) latestMemoryBook.pendingDrafts = [];
+
+        const latestExistingDraft = existingDraftId
+            ? latestMemoryBook.pendingDrafts.find(d => d.id === existingDraftId)
+            : null;
+
+        if (latestExistingDraft) {
             // Update existing draft
-            existingDraft.content = (parsedDraft.content || '').trim();
-            existingDraft.keys = parsedDraft.keys || [];
-            existingDraft.glazeKeys = [];
-            existingDraft.vectorSearch = vectorEnabled;
-            existingDraft.status = 'pending_approval';
-            existingDraft.source = source;
-            existingDraft.updatedAt = Date.now();
-            existingDraft.generatedAt = Date.now();
+            latestExistingDraft.content = (parsedDraft.content || parsedDraft.raw || '').trim();
+            latestExistingDraft.rawContent = (parsedDraft.raw || parsedDraft.content || '').trim();
+            latestExistingDraft.keys = parsedDraft.keys || [];
+            latestExistingDraft.glazeKeys = [];
+            latestExistingDraft.vectorSearch = vectorEnabled;
+            latestExistingDraft.status = 'pending_approval';
+            latestExistingDraft.source = source;
+            latestExistingDraft.updatedAt = generatedAt;
+            latestExistingDraft.generatedAt = generatedAt;
         } else {
             // Create new draft
             // Calculate message range for title
             const allMsgs = currentMessages.value.filter(m => m && !m.isTyping && !m.isError && (m.role === 'user' || m.role === 'char'));
             const firstIdx = allMsgs.findIndex(m => m.id === firstMessage.id);
             const lastIdx = allMsgs.findIndex(m => m.id === lastMessage.id);
-            const rangeDisplay = firstIdx >= 0 && lastIdx >= 0 ? `${firstIdx + 1}-${lastIdx + 1}` : `Draft ${memoryBook.pendingDrafts.length + 1}`;
+            const rangeDisplay = firstIdx >= 0 && lastIdx >= 0 ? `${firstIdx + 1}-${lastIdx + 1}` : `Draft ${latestMemoryBook.pendingDrafts.length + 1}`;
 
-            memoryBook.pendingDrafts.push(normalizeMemoryEntryShape({
+            latestMemoryBook.pendingDrafts.push(normalizeMemoryEntryShape({
                 id: genMemoryEntryId(),
                 title: rangeDisplay,
-                content: (parsedDraft.content || '').trim(),
+                content: (parsedDraft.content || parsedDraft.raw || '').trim(),
+                rawContent: (parsedDraft.raw || parsedDraft.content || '').trim(),
                 keys: parsedDraft.keys,
                 glazeKeys: [],
                 vectorSearch: vectorEnabled,
@@ -732,28 +758,41 @@ async function generateMemoryDraftForMessages(selectedMessages, { openSheet = fa
                 },
                 status: 'pending_approval',
                 source,
-                createdAt: Date.now(),
-                updatedAt: Date.now(),
-                generatedAt: Date.now()
+                createdAt: generatedAt,
+                updatedAt: generatedAt,
+                generatedAt
             }));
         }
-        memoryBook.updatedAt = Date.now();
-        automation.isGeneratingDraft = false;
-        await db.saveChat(activeChatChar.id, chatData);
-        stopMemoryDraftProgress();
-        updatePendingMemoryMessageIds(activeChatChar);
-        showToast(existingDraft ? 'Draft updated' : 'Memory draft created');
-        if (openSheet) openMemoryBooksSheet();
+        latestAutomation.isGeneratingDraft = true;
+        latestMemoryBook.updatedAt = generatedAt;
+        await db.saveChat(activeChatChar.id, latestChatData);
+        stopMemoryDraftProgress(progressDraftId);
+        const postSaveChatData = await getChatData(activeChatChar.id);
+        const postSaveSessionId = activeChatChar.sessionId || postSaveChatData.currentId;
+        const postSaveMemoryBook = ensureSessionMemoryBook(postSaveChatData, postSaveSessionId);
+        const postSaveAutomation = ensureMemoryAutomationState(postSaveMemoryBook);
+        postSaveAutomation.isGeneratingDraft = Object.keys(memoryDraftState.value.activeDrafts || {}).length > 0;
+        postSaveMemoryBook.updatedAt = Date.now();
+        await db.saveChat(activeChatChar.id, postSaveChatData);
+        await updatePendingMemoryMessageIds(activeChatChar);
+        await loadCurrentMemoryBook(activeChatChar);
+        showToast(latestExistingDraft ? 'Draft updated' : 'Memory draft created');
+        if (openSheet && (!bottomSheetState.isOpen || bottomSheetState.title !== 'Memory Books')) {
+            openMemoryBooksSheet();
+        }
         return true;
     } catch (error) {
-        automation.isGeneratingDraft = false;
-        memoryBook.updatedAt = Date.now();
-        await db.saveChat(activeChatChar.id, chatData);
-        stopMemoryDraftProgress();
+        stopMemoryDraftProgress(progressDraftId);
+        const latestChatData = await getChatData(activeChatChar.id);
+        const latestSessionId = activeChatChar.sessionId || latestChatData.currentId;
+        const latestMemoryBook = ensureSessionMemoryBook(latestChatData, latestSessionId);
+        const latestAutomation = ensureMemoryAutomationState(latestMemoryBook);
+        latestAutomation.isGeneratingDraft = Object.keys(memoryDraftState.value.activeDrafts || {}).length > 0;
+        latestMemoryBook.updatedAt = Date.now();
+        await db.saveChat(activeChatChar.id, latestChatData);
+        await loadCurrentMemoryBook(activeChatChar);
         console.error('Failed to generate memory draft:', error);
-        // Close sheet first so toast is visible, then show error
-        closeBottomSheet();
-        setTimeout(() => showToast(`Memory draft failed: ${formatError(error)}`, 5000), 100);
+        showToast(`Memory draft failed: ${formatError(error)}`, 5000);
         return false;
     }
 }
@@ -865,39 +904,29 @@ async function bootstrapImportedMemoryDrafts(charId, sessionId) {
 
 async function runBatchDraftGeneration(chatData, sessionId, memoryBook, segments, count) {
     const toGenerate = segments.slice(0, count);
-    let generated = 0;
-    let failed = 0;
-    
-    for (let i = 0; i < toGenerate.length; i++) {
-        // Check if cancelled
-        if (memoryDraftAbortController?.signal?.aborted) break;
-        
-        const segmentIds = toGenerate[i];
+    const results = await Promise.all(toGenerate.map(async (segmentIds) => {
         const messages = currentMessages.value.filter(m => m && segmentIds.includes(m.id));
-        if (!messages.length) continue;
-        
-        showToast(`Generating draft ${i + 1} of ${toGenerate.length}...`, 3000);
-        
-        const success = await generateMemoryDraftForMessages(messages, { 
-            openSheet: false, 
-            source: 'manual_draft' 
+        if (!messages.length) return false;
+
+        const success = await generateMemoryDraftForMessages(messages, {
+            openSheet: false,
+            source: 'manual_draft'
         });
-        
-        if (success) {
-            generated++;
-            // Remove generated segment from planned list
-            if (memoryBook.automation?.plannedSegments) {
-                memoryBook.automation.plannedSegments = memoryBook.automation.plannedSegments.filter(
-                    seg => JSON.stringify(seg) !== JSON.stringify(segmentIds)
-                );
-            }
-        } else {
-            failed++;
+
+        if (success && memoryBook.automation?.plannedSegments) {
+            memoryBook.automation.plannedSegments = memoryBook.automation.plannedSegments.filter(
+                seg => JSON.stringify(seg) !== JSON.stringify(segmentIds)
+            );
         }
-    }
-    
-    // Refresh data
-    updatePendingMemoryMessageIds(activeChatChar);
+
+        return success;
+    }));
+
+    const generated = results.filter(Boolean).length;
+    const failed = results.length - generated;
+
+    await updatePendingMemoryMessageIds(activeChatChar);
+    await loadCurrentMemoryBook(activeChatChar);
     
     const msg = failed > 0 
         ? `Batch complete: ${generated} generated, ${failed} failed`
@@ -909,35 +938,30 @@ async function runBatchDraftGeneration(chatData, sessionId, memoryBook, segments
 
 async function runBatchDraftGenerationFromIds(chatData, sessionId, memoryBook, drafts, count) {
     const toGenerate = drafts.slice(0, count);
-    let generated = 0;
-    let failed = 0;
-
-    for (let i = 0; i < toGenerate.length; i++) {
-        if (memoryDraftAbortController?.signal?.aborted) break;
-
-        const draft = toGenerate[i];
+    const batchJobs = toGenerate.map(async (draft) => {
         const messages = currentMessages.value.filter(m => m && draft.messageIds.includes(m.id));
         if (!messages.length) {
-            failed++;
-            continue;
+            return false;
         }
 
-        showToast(`Generating draft ${i + 1} of ${toGenerate.length}...`, 3000);
-
         try {
-            await generateMemoryDraftForMessages(messages, {
+            return await generateMemoryDraftForMessages(messages, {
                 openSheet: false,
                 source: 'manual_draft',
                 existingDraftId: draft.id
             });
-            generated++;
         } catch (error) {
-            failed++;
             console.error('Failed to generate draft:', error);
+            return false;
         }
-    }
+    });
 
-    updatePendingMemoryMessageIds(activeChatChar);
+    const results = await Promise.all(batchJobs);
+    const generated = results.filter(Boolean).length;
+    const failed = results.length - generated;
+
+    await updatePendingMemoryMessageIds(activeChatChar);
+    await loadCurrentMemoryBook(activeChatChar);
 
     const msg = failed > 0
         ? `Batch complete: ${generated} generated, ${failed} failed`
@@ -949,6 +973,12 @@ async function runBatchDraftGenerationFromIds(chatData, sessionId, memoryBook, d
 
 async function generateSingleDraft(draftId) {
     if (!activeChatChar || !currentMemoryBookData.value) return;
+    console.debug('[MemoryBooks] generateSingleDraft:start', { draftId });
+
+    if (memoryDraftState.value?.activeDrafts?.[draftId]) {
+        showToast('This draft is already generating');
+        return;
+    }
 
     const chatData = await getChatData(activeChatChar.id);
     const sessionId = activeChatChar.sessionId || chatData.currentId;
@@ -958,6 +988,7 @@ async function generateSingleDraft(draftId) {
         .find(d => d.id === draftId);
 
     if (!draft) {
+        console.debug('[MemoryBooks] generateSingleDraft:draft-not-found', { draftId });
         showToast('Draft not found');
         return;
     }
@@ -968,20 +999,26 @@ async function generateSingleDraft(draftId) {
     }
 
     const messages = currentMessages.value.filter(m => m && draft.messageIds.includes(m.id));
+    console.debug('[MemoryBooks] generateSingleDraft:resolved-messages', {
+        draftId,
+        messageIds: draft.messageIds,
+        resolvedCount: messages.length,
+        hiddenCount: messages.filter(m => m?.isHidden).length
+    });
     if (!messages.length) {
         showToast('Messages not found for this draft');
         return;
     }
 
-    memoryBooksSheet.value?.close();
-
     try {
-        await generateMemoryDraftForMessages(messages, {
+        const success = await generateMemoryDraftForMessages(messages, {
             openSheet: true,
             source: 'manual_draft',
             existingDraftId: draft.id
         });
-        showToast('Draft generated');
+        if (success) {
+            showToast('Draft generated');
+        }
     } catch (error) {
         console.error('Failed to generate draft:', error);
         showToast(`Generation failed: ${formatError(error)}`);
@@ -1211,6 +1248,9 @@ async function openMemoryGenerationSettings() {
         autoCreateInterval: Number.isFinite(Number(settings.autoCreateInterval)) && Number(settings.autoCreateInterval) > 0
             ? Number(settings.autoCreateInterval)
             : 12,
+        batchSize: Number.isFinite(Number(settings.batchSize)) && Number(settings.batchSize) > 0
+            ? Number(settings.batchSize)
+            : 1,
         useDelayedAutomation: settings.useDelayedAutomation !== false,
         maxInjectedEntries: Number.isFinite(Number(settings.maxInjectedEntries)) && Number(settings.maxInjectedEntries) > 0
             ? Number(settings.maxInjectedEntries)
@@ -1272,6 +1312,11 @@ async function openMemoryGenerationSettings() {
                 <label>Create Memory Every N Messages</label>
                 <input id="memory-auto-interval-input" type="number" min="1" max="200" step="1" value="${state.autoCreateInterval}" placeholder="12">
                 <div class="context-sheet-note">User-facing interval for future automatic memory creation and import bootstrap segmentation.</div>
+            </div>
+            <div class="settings-item">
+                <label>Max Generate Batch</label>
+                <input id="memory-batch-size-input" type="number" min="1" max="50" step="1" value="${state.batchSize}" placeholder="1">
+                <div class="context-sheet-note">Limits how many pending drafts the batch generate button starts at once.</div>
             </div>
             <div class="settings-item-checkbox">
                 <div class="settings-text-col">
@@ -1424,6 +1469,8 @@ async function openMemoryGenerationSettings() {
             settings.generationTemperature = tempValue === '' ? null : Number(tempValue);
             const autoIntervalValue = Number(content.querySelector('#memory-auto-interval-input')?.value || state.autoCreateInterval || 12);
             settings.autoCreateInterval = Math.max(1, Math.min(200, Number.isFinite(autoIntervalValue) ? Math.round(autoIntervalValue) : 12));
+            const batchSizeValue = Number(content.querySelector('#memory-batch-size-input')?.value || state.batchSize || 1);
+            settings.batchSize = Math.max(1, Math.min(50, Number.isFinite(batchSizeValue) ? Math.round(batchSizeValue) : 1));
             settings.useDelayedAutomation = !!content.querySelector('#memory-delayed-automation-toggle')?.checked;
             const maxInjectedValue = Number(content.querySelector('#memory-max-injected-input')?.value || state.maxInjectedEntries || 3);
             settings.maxInjectedEntries = Math.max(1, Math.min(20, Number.isFinite(maxInjectedValue) ? Math.round(maxInjectedValue) : 3));
@@ -1585,12 +1632,8 @@ async function openMemoryBooksSheet() {
 }
 
 // Memory Books Sheet event handlers (wrappers for composable handlers)
-async function handleMemoryKeyModeUpdate() {
-    await handleMemoryKeyModeUpdate_composable(activeChatChar, memoryBooksSheet);
-}
-
-async function handleMemoryVectorToggle(enabled) {
-    await handleMemoryVectorToggle_composable(enabled, activeChatChar, memoryBooksSheet);
+async function handleMemorySearchTypeUpdate() {
+    await handleMemorySearchTypeUpdate_composable(activeChatChar, memoryBooksSheet);
 }
 
 async function handleMemoryReindexAll() {
@@ -1610,65 +1653,21 @@ async function handleMemoryBatchGenerate() {
 
     // Get drafts that need generation (no content yet)
     const draftsNeedingGeneration = (Array.isArray(memoryBook.pendingDrafts) ? memoryBook.pendingDrafts : [])
-        .filter(d => !d.content && d.status === 'pending_generation');
+        .filter(d => !d.content && d.status === 'pending_generation' && !memoryDraftState.value?.activeDrafts?.[d.id]);
+    const maxBatchSize = Math.max(1, Math.min(50, Number(memoryBook.settings?.batchSize) || 1));
 
     if (!draftsNeedingGeneration.length) {
-        showToast('No drafts need generation');
+        showToast(memoryDraftState.value?.activeCount ? 'All remaining drafts are already generating' : 'No drafts need generation');
         return;
     }
 
-    // Close Memory Books sheet before showing bottomSheet picker
-    memoryBooksSheet.value?.close();
-
-    const totalToGenerate = draftsNeedingGeneration.length;
-    const quickItems = [];
-    const quickPicks = [1, 3, 5];
-    for (const n of quickPicks) {
-        if (n > totalToGenerate) break;
-        quickItems.push({
-            label: `${n} draft${n > 1 ? 's' : ''}`,
-            onClick: async () => {
-                closeBottomSheet();
-                await runBatchDraftGenerationFromIds(chatData, sessionId, memoryBook, draftsNeedingGeneration, n);
-            }
-        });
-    }
-    if (!quickItems.some(it => it.label.includes(String(totalToGenerate)))) {
-        quickItems.push({
-            label: `All ${totalToGenerate}`,
-            onClick: async () => {
-                closeBottomSheet();
-                await runBatchDraftGenerationFromIds(chatData, sessionId, memoryBook, draftsNeedingGeneration, totalToGenerate);
-            }
-        });
-    }
-
-    // Add Cancel button to return to Memory Books
-    quickItems.push({
-        label: 'Cancel',
-        onClick: () => {
-            closeBottomSheet();
-            setTimeout(() => memoryBooksSheet.value?.open(), 50);
-        }
-    });
-
-    showBottomSheet({
-        title: `Generate Drafts (${totalToGenerate} need generation)`,
-        items: quickItems,
-        input: {
-            placeholder: `Enter number (1-${totalToGenerate})`,
-            confirmLabel: 'Generate',
-            onConfirm: async (val) => {
-                const num = parseInt(val, 10);
-                if (isNaN(num) || num < 1 || num > totalToGenerate) {
-                    showToast(`Enter a number between 1 and ${totalToGenerate}`);
-                    return;
-                }
-                closeBottomSheet();
-                await runBatchDraftGenerationFromIds(chatData, sessionId, memoryBook, draftsNeedingGeneration, num);
-            }
-        }
-    });
+    await runBatchDraftGenerationFromIds(
+        chatData,
+        sessionId,
+        memoryBook,
+        draftsNeedingGeneration,
+        Math.min(draftsNeedingGeneration.length, maxBatchSize)
+    );
 }
 
 async function handleMemoryGenerateSingleDraft(draftId) {
@@ -1683,6 +1682,10 @@ async function handleMemoryDeleteDraft(draftId) {
     await handleMemoryDeleteDraft_composable(draftId, activeChatChar, memoryBooksSheet);
 }
 
+async function handleMemoryDeleteAllDrafts() {
+    await handleMemoryDeleteAllDrafts_composable(activeChatChar, memoryBooksSheet);
+}
+
 async function handleMemoryDeleteEntry(entryId) {
     await handleMemoryDeleteEntry_composable(entryId, activeChatChar, currentMessages.value, memoryBooksSheet);
 }
@@ -1691,8 +1694,8 @@ function handleMemoryOpenMaintenance() {
     handleMemoryOpenMaintenance_composable(activeChatChar, memoryBooksSheet);
 }
 
-function handleMemoryCancelDraft() {
-    cancelMemoryDraft();
+function handleMemoryCancelDraft(draftId = null) {
+    cancelMemoryDraft(draftId || null);
 }
 
 function handleMemoryPreview({ entry, kind }) {
@@ -2260,6 +2263,24 @@ function confirmHideTopMessages() {
             }
         ]
     });
+}
+
+async function unhideAllMessages() {
+    if (!activeChatChar) return;
+
+    let changed = 0;
+    for (const msg of currentMessages.value) {
+        if (!msg || msg.isTyping || !msg.isHidden) continue;
+        msg.isHidden = false;
+        changed += 1;
+    }
+
+    if (!changed) return;
+
+    await saveCurrentMessages();
+    await updateContextCutoff();
+    closeBottomSheet();
+    showToast(`Unhid ${changed} message${changed === 1 ? '' : 's'}`);
 }
 
 async function openContextSheet() {
@@ -3919,6 +3940,17 @@ function openMessageActions(msg, index) {
         }
     });
 
+    const hiddenCount = currentMessages.value.filter(m => m && !m.isTyping && m.isHidden).length;
+    if (hiddenCount > 0) {
+        items.push({
+            label: `Unhide All (${hiddenCount})`,
+            icon: '<svg viewBox="0 0 24 24"><path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5 2.29 0 4.42-.65 6.22-1.78l-1.46-1.46A9.44 9.44 0 0 1 12 17.5c-3.73 0-6.96-2.1-8.56-5.5C5.04 8.6 8.27 6.5 12 6.5c1.41 0 2.75.3 3.96.85l1.53-1.53A11.4 11.4 0 0 0 12 4.5zm8.78 1.72-17 17 1.41 1.41 2.68-2.68A11.79 11.79 0 0 0 12 19.5c5 0 9.27-3.11 11-7.5a11.81 11.81 0 0 0-3.09-4.47l2.28-2.28-1.41-1.41z"/></svg>',
+            onClick: () => {
+                unhideAllMessages();
+            }
+        });
+    }
+
     // 6. Delete (only allow deleting the last message)
     if (index === currentMessages.value.length - 1) items.push({
         label: t('action_delete_msg'),
@@ -4741,23 +4773,6 @@ watch(() => currentMessages.value.length, () => {
     updateContextCutoff();
 });
 
-// Watch memory draft state and update timer in DOM if Memory Books sheet is open
-watch(() => memoryDraftState.value.elapsedMs, (newElapsed) => {
-    if (!memoryDraftState.value.active) return;
-    const timerEl = document.getElementById('memory-draft-timer');
-    if (timerEl) {
-        timerEl.textContent = formatElapsedSeconds(newElapsed);
-    }
-});
-
-// Watch memoryDraftState.active to show/hide draft generation progress card
-watch(() => memoryDraftState.value.active, (isActive) => {
-    // If Memory Books sheet is currently open, refresh it to show/hide draftProgressCard
-    if (bottomSheetState.title === 'Memory Books' && bottomSheetState.isOpen) {
-        openMemoryBooksSheet();
-    }
-});
-
 watch(activeChar, async (newVal) => {
     if (!newVal) return;
     
@@ -4974,7 +4989,6 @@ onUnmounted(() => {
                 @magic-glossary="openGlossarySheet"
                 @delete-selected="deleteSelectedMessages"
                 @hide-selected="toggleHideSelectedMessages"
-                @configure-memory-selected="openMemoryGenerationSettings"
                 @generate-memory-draft-selected="generateMemoryDraftFromSelection"
                 @create-memory-selected="createMemoryFromSelection"
                 @remove-memory-selected="removeMemoryFromSelection"
@@ -5021,12 +5035,12 @@ onUnmounted(() => {
             @open-settings="handleMemoryOpenSettings"
             @open-maintenance="handleMemoryOpenMaintenance"
             @open-preview="handleMemoryPreview"
-            @update-key-mode="handleMemoryKeyModeUpdate"
-            @toggle-vector-search="handleMemoryVectorToggle"
+            @update-search-type="handleMemorySearchTypeUpdate"
             @reindex-all="handleMemoryReindexAll"
             @scan-chat="handleMemoryScanChat"
             @batch-generate="handleMemoryBatchGenerate"
             @generate-draft="handleMemoryGenerateSingleDraft"
+            @delete-all-drafts="handleMemoryDeleteAllDrafts"
             @approve-draft="handleMemoryApproveDraft"
             @delete-draft="handleMemoryDeleteDraft"
             @delete-entry="handleMemoryDeleteEntry"

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -603,7 +603,7 @@ async function generateMemoryDraftFromSelection() {
     await generateMemoryDraftForMessages(selected, { openSheet: true, source: 'manual_draft' });
 }
 
-async function generateMemoryDraftForMessages(selectedMessages, { openSheet = false, source = 'auto_delayed' } = {}) {
+async function generateMemoryDraftForMessages(selectedMessages, { openSheet = false, source = 'auto_delayed', existingDraftId = null } = {}) {
     if (!activeChatChar || !Array.isArray(selectedMessages) || !selectedMessages.length) return false;
 
     const selected = selectedMessages.filter(msg => msg && !msg.isTyping && !msg.isHidden && !msg.isError);
@@ -613,7 +613,7 @@ async function generateMemoryDraftForMessages(selectedMessages, { openSheet = fa
     const sessionId = activeChatChar.sessionId || chatData.currentId;
     const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
     const automation = ensureMemoryAutomationState(memoryBook);
-    
+
     if (automation.isGeneratingDraft) {
         showToast('Already generating a draft. Please wait...');
         return false;
@@ -661,7 +661,14 @@ async function generateMemoryDraftForMessages(selectedMessages, { openSheet = fa
     const selectedIds = selected.map(msg => msg.id).filter(Boolean);
     if (!selectedIds.length) return false;
 
-    // Skip conflict check for manual drafts — user explicitly wants to create a draft
+    // Find existing draft if ID provided
+    let existingDraft = null;
+    if (existingDraftId) {
+        existingDraft = (Array.isArray(memoryBook.pendingDrafts) ? memoryBook.pendingDrafts : [])
+            .find(d => d.id === existingDraftId);
+    }
+
+    // Skip conflict check for manual drafts — user explicitly wants to create/update a draft
     if (source !== 'manual_draft' && source !== 'manual_regenerate') {
         const conflictingEntry = findConflictingMemoryEntry(memoryBook, selectedIds, {
             includeEntries: true,
@@ -692,29 +699,50 @@ async function generateMemoryDraftForMessages(selectedMessages, { openSheet = fa
         const parsedDraft = parseMemoryDraftResponse(draftText || '', [playerName, activeChatChar?.name || 'Character']);
 
         if (!Array.isArray(memoryBook.pendingDrafts)) memoryBook.pendingDrafts = [];
-        memoryBook.pendingDrafts.push(normalizeMemoryEntryShape({
-            id: genMemoryEntryId(),
-            title: `Draft ${memoryBook.pendingDrafts.length + 1}`,
-            content: (parsedDraft.content || '').trim(),
-            keys: parsedDraft.keys,
-            glazeKeys: [],
-            vectorSearch: vectorEnabled,
-            messageIds: selectedIds,
-            messageRange: {
-                startMessageId: firstMessage.id,
-                endMessageId: lastMessage.id
-            },
-            status: 'pending_approval',
-            source,
-            createdAt: Date.now(),
-            updatedAt: Date.now()
-        }));
+
+        if (existingDraft) {
+            // Update existing draft
+            existingDraft.content = (parsedDraft.content || '').trim();
+            existingDraft.keys = parsedDraft.keys || [];
+            existingDraft.glazeKeys = [];
+            existingDraft.vectorSearch = vectorEnabled;
+            existingDraft.status = 'pending_approval';
+            existingDraft.source = source;
+            existingDraft.updatedAt = Date.now();
+            existingDraft.generatedAt = Date.now();
+        } else {
+            // Create new draft
+            // Calculate message range for title
+            const allMsgs = currentMessages.value.filter(m => m && !m.isTyping && !m.isError && (m.role === 'user' || m.role === 'char'));
+            const firstIdx = allMsgs.findIndex(m => m.id === firstMessage.id);
+            const lastIdx = allMsgs.findIndex(m => m.id === lastMessage.id);
+            const rangeDisplay = firstIdx >= 0 && lastIdx >= 0 ? `${firstIdx + 1}-${lastIdx + 1}` : `Draft ${memoryBook.pendingDrafts.length + 1}`;
+
+            memoryBook.pendingDrafts.push(normalizeMemoryEntryShape({
+                id: genMemoryEntryId(),
+                title: rangeDisplay,
+                content: (parsedDraft.content || '').trim(),
+                keys: parsedDraft.keys,
+                glazeKeys: [],
+                vectorSearch: vectorEnabled,
+                messageIds: selectedIds,
+                messageRange: {
+                    startMessageId: firstMessage.id,
+                    endMessageId: lastMessage.id
+                },
+                status: 'pending_approval',
+                source,
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+                generatedAt: Date.now()
+            }));
+        }
         memoryBook.updatedAt = Date.now();
         automation.isGeneratingDraft = false;
         await db.saveChat(activeChatChar.id, chatData);
         stopMemoryDraftProgress();
         updatePendingMemoryMessageIds(activeChatChar);
-        showToast('Memory draft created');
+        showToast(existingDraft ? 'Draft updated' : 'Memory draft created');
         if (openSheet) openMemoryBooksSheet();
         return true;
     } catch (error) {
@@ -877,6 +905,87 @@ async function runBatchDraftGeneration(chatData, sessionId, memoryBook, segments
     showToast(msg, 3000);
     
     setTimeout(() => openMemoryBooksSheet(), 100);
+}
+
+async function runBatchDraftGenerationFromIds(chatData, sessionId, memoryBook, drafts, count) {
+    const toGenerate = drafts.slice(0, count);
+    let generated = 0;
+    let failed = 0;
+
+    for (let i = 0; i < toGenerate.length; i++) {
+        if (memoryDraftAbortController?.signal?.aborted) break;
+
+        const draft = toGenerate[i];
+        const messages = currentMessages.value.filter(m => m && draft.messageIds.includes(m.id));
+        if (!messages.length) {
+            failed++;
+            continue;
+        }
+
+        showToast(`Generating draft ${i + 1} of ${toGenerate.length}...`, 3000);
+
+        try {
+            await generateMemoryDraftForMessages(messages, {
+                openSheet: false,
+                source: 'manual_draft',
+                existingDraftId: draft.id
+            });
+            generated++;
+        } catch (error) {
+            failed++;
+            console.error('Failed to generate draft:', error);
+        }
+    }
+
+    updatePendingMemoryMessageIds(activeChatChar);
+
+    const msg = failed > 0
+        ? `Batch complete: ${generated} generated, ${failed} failed`
+        : `Batch complete: ${generated} draft${generated > 1 ? 's' : ''} generated`;
+    showToast(msg, 3000);
+
+    setTimeout(() => openMemoryBooksSheet(), 100);
+}
+
+async function generateSingleDraft(draftId) {
+    if (!activeChatChar || !currentMemoryBookData.value) return;
+
+    const chatData = await getChatData(activeChatChar.id);
+    const sessionId = activeChatChar.sessionId || chatData.currentId;
+    const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
+
+    const draft = (Array.isArray(memoryBook.pendingDrafts) ? memoryBook.pendingDrafts : [])
+        .find(d => d.id === draftId);
+
+    if (!draft) {
+        showToast('Draft not found');
+        return;
+    }
+
+    if (draft.content) {
+        showToast('Draft already has content. Use regenerate.');
+        return;
+    }
+
+    const messages = currentMessages.value.filter(m => m && draft.messageIds.includes(m.id));
+    if (!messages.length) {
+        showToast('Messages not found for this draft');
+        return;
+    }
+
+    memoryBooksSheet.value?.close();
+
+    try {
+        await generateMemoryDraftForMessages(messages, {
+            openSheet: true,
+            source: 'manual_draft',
+            existingDraftId: draft.id
+        });
+        showToast('Draft generated');
+    } catch (error) {
+        console.error('Failed to generate draft:', error);
+        showToast(`Generation failed: ${formatError(error)}`);
+    }
 }
 
 function openMemoryTextPreview(entry, kind = 'Memory') {
@@ -1494,66 +1603,46 @@ async function handleMemoryScanChat() {
 
 async function handleMemoryBatchGenerate() {
     if (!activeChatChar || !currentMemoryBookData.value) return;
-    
+
     const chatData = await getChatData(activeChatChar.id);
     const sessionId = activeChatChar.sessionId || chatData.currentId;
     const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
-    
-    const entries = Array.isArray(memoryBook.entries) ? memoryBook.entries : [];
-    const pendingDrafts = Array.isArray(memoryBook.pendingDrafts) ? memoryBook.pendingDrafts : [];
-    const planned = memoryBook.automation?.plannedSegments || [];
-    
-    const coveredIds = new Set();
-    for (const entry of entries) {
-        if (Array.isArray(entry.messageIds)) entry.messageIds.forEach(id => coveredIds.add(id));
-    }
-    for (const draft of pendingDrafts) {
-        if (Array.isArray(draft.messageIds)) draft.messageIds.forEach(id => coveredIds.add(id));
-    }
-    
-    // If no planned segments, build them on the fly
-    let segments = planned;
-    if (!segments.length) {
-        const stableMessages = currentMessages.value.filter(m => m && !m.isTyping && !m.isHidden && !m.isError && (m.role === 'user' || m.role === 'char'));
-        const uncovered = stableMessages.filter(m => m.id && !coveredIds.has(m.id));
-        const interval = normalizeAutoCreateInterval(memoryBook);
-        segments = [];
-        for (let i = 0; i < uncovered.length; i += interval) {
-            segments.push(uncovered.slice(i, i + interval).map(m => m.id));
-        }
-    }
-    
-    if (!segments.length) {
-        showToast('No uncovered segments to generate');
+
+    // Get drafts that need generation (no content yet)
+    const draftsNeedingGeneration = (Array.isArray(memoryBook.pendingDrafts) ? memoryBook.pendingDrafts : [])
+        .filter(d => !d.content && d.status === 'pending_generation');
+
+    if (!draftsNeedingGeneration.length) {
+        showToast('No drafts need generation');
         return;
     }
-    
+
     // Close Memory Books sheet before showing bottomSheet picker
     memoryBooksSheet.value?.close();
-    
-    const totalSegments = segments.length;
+
+    const totalToGenerate = draftsNeedingGeneration.length;
     const quickItems = [];
     const quickPicks = [1, 3, 5];
     for (const n of quickPicks) {
-        if (n > totalSegments) break;
+        if (n > totalToGenerate) break;
         quickItems.push({
             label: `${n} draft${n > 1 ? 's' : ''}`,
             onClick: async () => {
                 closeBottomSheet();
-                await runBatchDraftGeneration(chatData, sessionId, memoryBook, segments, n);
+                await runBatchDraftGenerationFromIds(chatData, sessionId, memoryBook, draftsNeedingGeneration, n);
             }
         });
     }
-    if (!quickItems.some(it => it.label.includes(String(totalSegments)))) {
+    if (!quickItems.some(it => it.label.includes(String(totalToGenerate)))) {
         quickItems.push({
-            label: `All ${totalSegments}`,
+            label: `All ${totalToGenerate}`,
             onClick: async () => {
                 closeBottomSheet();
-                await runBatchDraftGeneration(chatData, sessionId, memoryBook, segments, totalSegments);
+                await runBatchDraftGenerationFromIds(chatData, sessionId, memoryBook, draftsNeedingGeneration, totalToGenerate);
             }
         });
     }
-    
+
     // Add Cancel button to return to Memory Books
     quickItems.push({
         label: 'Cancel',
@@ -1562,24 +1651,28 @@ async function handleMemoryBatchGenerate() {
             setTimeout(() => memoryBooksSheet.value?.open(), 50);
         }
     });
-    
+
     showBottomSheet({
-        title: `Generate Drafts (${totalSegments} available)`,
+        title: `Generate Drafts (${totalToGenerate} need generation)`,
         items: quickItems,
         input: {
-            placeholder: `Enter number (1-${totalSegments})`,
+            placeholder: `Enter number (1-${totalToGenerate})`,
             confirmLabel: 'Generate',
             onConfirm: async (val) => {
                 const num = parseInt(val, 10);
-                if (isNaN(num) || num < 1 || num > totalSegments) {
-                    showToast(`Enter a number between 1 and ${totalSegments}`);
+                if (isNaN(num) || num < 1 || num > totalToGenerate) {
+                    showToast(`Enter a number between 1 and ${totalToGenerate}`);
                     return;
                 }
                 closeBottomSheet();
-                await runBatchDraftGeneration(chatData, sessionId, memoryBook, segments, num);
+                await runBatchDraftGenerationFromIds(chatData, sessionId, memoryBook, draftsNeedingGeneration, num);
             }
         }
     });
+}
+
+async function handleMemoryGenerateSingleDraft(draftId) {
+    await generateSingleDraft(draftId);
 }
 
 async function handleMemoryApproveDraft(draftId) {
@@ -4933,6 +5026,7 @@ onUnmounted(() => {
             @reindex-all="handleMemoryReindexAll"
             @scan-chat="handleMemoryScanChat"
             @batch-generate="handleMemoryBatchGenerate"
+            @generate-draft="handleMemoryGenerateSingleDraft"
             @approve-draft="handleMemoryApproveDraft"
             @delete-draft="handleMemoryDeleteDraft"
             @delete-entry="handleMemoryDeleteEntry"

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -1791,14 +1791,14 @@ function openAuthorsNoteSheet() {
         debounceTimer = setTimeout(save, 500);
     };
 
-    content.querySelector('#an-role').addEventListener('change', save);
-    content.querySelector('#an-mode').addEventListener('change', (e) => {
+    content.querySelector('#an-role')?.addEventListener('change', save);
+    content.querySelector('#an-mode')?.addEventListener('change', (e) => {
         const depthContainer = content.querySelector('#an-depth-container');
         depthContainer.style.display = e.target.value === 'depth' ? 'block' : 'none';
         save();
     });
-    content.querySelector('#an-depth').addEventListener('input', save);
-    content.querySelector('#an-content').addEventListener('input', debouncedSave);
+    content.querySelector('#an-depth')?.addEventListener('input', save);
+    content.querySelector('#an-content')?.addEventListener('input', debouncedSave);
 
     const toggleAction = (e) => {
         data.enabled = !data.enabled;
@@ -1918,22 +1918,24 @@ function openSummarySheet() {
         debounceTimer = setTimeout(save, 500);
     };
 
-    content.querySelector('#summary-role').addEventListener('change', save);
-    content.querySelector('#summary-mode').addEventListener('change', (e) => {
-        content.querySelector('#summary-depth-container').style.display = e.target.value === 'depth' ? 'block' : 'none';
+    content.querySelector('#summary-role')?.addEventListener('change', save);
+    content.querySelector('#summary-mode')?.addEventListener('change', (e) => {
+        const depthContainer = content.querySelector('#summary-depth-container');
+        if (depthContainer) depthContainer.style.display = e.target.value === 'depth' ? 'block' : 'none';
         save();
     });
-    content.querySelector('#summary-depth').addEventListener('input', save);
-    content.querySelector('#summary-prefix').addEventListener('input', save);
-    content.querySelector('#summary-content').addEventListener('input', (e) => {
+    content.querySelector('#summary-depth')?.addEventListener('input', save);
+    content.querySelector('#summary-prefix')?.addEventListener('input', save);
+    content.querySelector('#summary-content')?.addEventListener('input', (e) => {
         updateDraftState(e.target.value);
         debouncedSave();
     });
-    content.querySelector('#summary-custom-model-enabled').addEventListener('change', (e) => {
-        content.querySelector('#summary-custom-model-row').style.display = e.target.checked ? 'block' : 'none';
+    content.querySelector('#summary-custom-model-enabled')?.addEventListener('change', (e) => {
+        const modelRow = content.querySelector('#summary-custom-model-row');
+        if (modelRow) modelRow.style.display = e.target.checked ? 'block' : 'none';
         persistSummaryModelSettings();
     });
-    content.querySelector('#summary-custom-model').addEventListener('input', persistSummaryModelSettings);
+    content.querySelector('#summary-custom-model')?.addEventListener('input', persistSummaryModelSettings);
 
     const runSummaryGeneration = async (mode) => {
         if (isGenerating) return;
@@ -1977,13 +1979,13 @@ function openSummarySheet() {
         }
     };
 
-    content.querySelector('#btn-summary-generate').addEventListener('click', () => {
+    content.querySelector('#btn-summary-generate')?.addEventListener('click', () => {
         runSummaryGeneration('generate');
     });
-    content.querySelector('#btn-summary-update').addEventListener('click', () => {
+    content.querySelector('#btn-summary-update')?.addEventListener('click', () => {
         runSummaryGeneration('update');
     });
-    content.querySelector('#btn-summary-save').addEventListener('click', () => {
+    content.querySelector('#btn-summary-save')?.addEventListener('click', () => {
         save();
         data.savedContent = content.querySelector('#summary-content').value;
         char.summary = data.savedContent;

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -127,6 +127,7 @@ function openSquashRoleSelector() {
 
 function openReasoningEffortSelector() {
     const options = [
+        { value: 'auto', label: t('reasoning_effort_auto') || 'Auto' },
         { value: 'low', label: t('reasoning_effort_low') || 'Low' },
         { value: 'medium', label: t('reasoning_effort_medium') || 'Medium' },
         { value: 'high', label: t('reasoning_effort_high') || 'High' }

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -148,6 +148,11 @@ function applyRegexes(text, placementFilter, ephemeralityFilter, allScripts, opt
 }
 
 function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalSettings, activations) {
+    // If vector search is enabled globally but key search is disabled, skip keyword scan
+    if (globalSettings?.vectorSearchEnabled && globalSettings?.keySearchEnabled === false) {
+        return [];
+    }
+
     const charId = char?.id;
 
     const activeLorebooks = lorebooks.filter(lb => {

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -148,8 +148,8 @@ function applyRegexes(text, placementFilter, ephemeralityFilter, allScripts, opt
 }
 
 function scanLorebooksPure(history, char, textToScan, chatId, lorebooks, globalSettings, activations) {
-    // If vector search is enabled globally but key search is disabled, skip keyword scan
-    if (globalSettings?.vectorSearchEnabled && globalSettings?.keySearchEnabled === false) {
+    // If search type is 'vector' only, skip keyword scan
+    if (globalSettings?.searchType === 'vector') {
         return [];
     }
 


### PR DESCRIPTION
## Summary
This update focuses on making Memory Books much easier to use in real chats, while also smoothing out retrieval, reasoning, and provider compatibility issues.

## Patch Notes
- Reworked Memory Books draft flow: Scan Chat now creates draft placeholders first, with per-draft Generate instead of forcing immediate generation.
- Added Generate Remaining, parallel draft generation, per-draft progress, per-draft Stop, and Delete All Pending for faster cleanup and recovery.
- Added Max Generate Batch so users can limit how many pending drafts start at once.
- Improved pending draft behavior so generated results save back into the correct draft more reliably and no longer restart drafts that are already in progress.
- Draft cards now show clearer message ranges and generation timestamps.
- Memory injection now only uses memory entries once their linked messages have actually fallen out of prompt context, reducing premature memory echoes.
- Lorebook retrieval UI was simplified into Search Type: Keys / Vector / Combined, with vector threshold control restored in the lorebook sheet.
- Embedding endpoint handling is more compatible with different providers: raw endpoints are respected, and embedding errors now surface provider messages more clearly.
- Added fallback handling for environments where streaming readers are unavailable, improving mobile/runtime resilience.
- Improved reasoning support: uto reasoning effort, better preset behavior, and added SillyTavern/Lucid Loom compatible macros such as date/time, reasoning prefix/suffix, and global variable macros.
- Fixed export/backup schema version mismatch affecting newer data.