### PR TITLE
feat: capture last network trace

### DIFF
--- a/src/components/sheets/RequestPreviewSheet.vue
+++ b/src/components/sheets/RequestPreviewSheet.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 import SheetView from '@/components/ui/SheetView.vue';
 import { getLastPrompt } from '@/core/services/generationService.js';
+import { getLastNetworkTrace, isNetworkDebugEnabled, setNetworkDebugEnabled, clearLastNetworkTrace } from '@/core/services/networkDebugService.js';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import HelpTip from '@/components/ui/HelpTip.vue';
@@ -10,14 +11,32 @@ const t = (key) => translations[currentLang.value]?.[key] || key;
 
 const sheet = ref(null);
 const previewData = ref(null);
+const traceData = ref(null);
 const previewTab = ref('formatted');
 const expandedMessages = ref(new Set());
+const debugEnabled = ref(isNetworkDebugEnabled());
 
 const open = () => {
     const prompt = getLastPrompt();
     previewData.value = prompt;
+    traceData.value = getLastNetworkTrace();
+    debugEnabled.value = isNetworkDebugEnabled();
     expandedMessages.value.clear();
     if (sheet.value) sheet.value.open();
+};
+
+const toggleDebugCapture = () => {
+    const next = !debugEnabled.value;
+    debugEnabled.value = next;
+    setNetworkDebugEnabled(next);
+    if (!next) {
+        clearLastNetworkTrace();
+        traceData.value = null;
+    }
+};
+
+const refreshTrace = () => {
+    traceData.value = getLastNetworkTrace();
 };
 
 const toggleMessage = (index) => {
@@ -54,6 +73,27 @@ const getRawJson = () => {
     return JSON.stringify(clean, null, 2);
 };
 
+const getTraceRequestJson = () => {
+    if (!traceData.value?.request) return '';
+    return JSON.stringify(traceData.value.request, null, 2);
+};
+
+const getTraceResponseJson = () => {
+    if (traceData.value?.rawResponse === null || traceData.value?.rawResponse === undefined) return '';
+    if (typeof traceData.value.rawResponse === 'string') return traceData.value.rawResponse;
+    return JSON.stringify(traceData.value.rawResponse, null, 2);
+};
+
+const getTraceHeadersJson = (headers) => {
+    if (!headers) return '';
+    return JSON.stringify(headers, null, 2);
+};
+
+const getStreamLinesText = () => {
+    if (!traceData.value?.streamLines?.length) return '';
+    return traceData.value.streamLines.join('\n');
+};
+
 defineExpose({ open });
 </script>
 
@@ -64,6 +104,12 @@ defineExpose({ open });
         </template>
         <template #header-bottom>
             <div class="gen-sheet-tabs">
+                <div class="debug-toolbar">
+                    <div class="debug-toggle" :class="{ active: debugEnabled }" @click="toggleDebugCapture">
+                        {{ debugEnabled ? 'Debug Capture On' : 'Debug Capture Off' }}
+                    </div>
+                    <div class="debug-action" @click="refreshTrace">Refresh</div>
+                </div>
                 <div class="segmented-control">
                     <div class="sub-tab-btn" :class="{ active: previewTab === 'formatted' }" @click="previewTab = 'formatted'">{{ t('label_formatted') || 'Formatted' }}</div>
                     <div class="sub-tab-btn" :class="{ active: previewTab === 'raw' }" @click="previewTab = 'raw'">{{ t('label_raw_json') || 'Raw JSON' }}</div>
@@ -73,6 +119,46 @@ defineExpose({ open });
         </template>
         <div class="preview-container" v-if="previewData">
             <div v-if="previewTab === 'formatted'">
+                <div v-if="traceData" class="trace-summary-card">
+                    <div class="preview-section-title">Network Trace</div>
+                    <div class="params-grid">
+                        <div class="param-item">
+                            <div class="param-label">Type</div>
+                            <div class="param-value">{{ traceData.requestType || 'unknown' }}</div>
+                        </div>
+                        <div class="param-item">
+                            <div class="param-label">Status</div>
+                            <div class="param-value">{{ traceData.responseStatus ?? 'pending' }}</div>
+                        </div>
+                        <div class="param-item">
+                            <div class="param-label">Streaming</div>
+                            <div class="param-value">{{ traceData.stream ? 'yes' : 'no' }}</div>
+                        </div>
+                        <div class="param-item">
+                            <div class="param-label">Duration</div>
+                            <div class="param-value">{{ traceData.durationMs ?? 0 }} ms</div>
+                        </div>
+                    </div>
+                    <div class="preview-section-title">Parsed Response</div>
+                    <div class="message-card">
+                        <div class="message-body always-open">
+                            <pre>{{ traceData.parsed?.text || '' }}</pre>
+                        </div>
+                    </div>
+                    <div v-if="traceData.parsed?.reasoning" class="preview-section-title">Parsed Reasoning</div>
+                    <div v-if="traceData.parsed?.reasoning" class="message-card">
+                        <div class="message-body always-open">
+                            <pre>{{ traceData.parsed?.reasoning }}</pre>
+                        </div>
+                    </div>
+                    <div v-if="traceData.parsed?.error" class="preview-section-title">Error</div>
+                    <div v-if="traceData.parsed?.error" class="message-card">
+                        <div class="message-body always-open">
+                            <pre>{{ traceData.parsed?.error }}</pre>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="preview-section-title">{{ t('section_gen_params') || 'Parameters' }}</div>
                 <div class="params-grid">
                     <div v-for="(value, key) in getParams(previewData)" :key="key" class="param-item">
@@ -104,7 +190,20 @@ defineExpose({ open });
                 </div>
             </div>
             <div v-else class="raw-block">
+                <div class="preview-section-title">Prompt JSON</div>
                 <pre>{{ getRawJson() }}</pre>
+                <template v-if="traceData">
+                    <div class="preview-section-title">Request JSON</div>
+                    <pre>{{ getTraceRequestJson() }}</pre>
+                    <div class="preview-section-title">Request Headers</div>
+                    <pre>{{ getTraceHeadersJson(traceData.requestHeaders) }}</pre>
+                    <div class="preview-section-title">Response Headers</div>
+                    <pre>{{ getTraceHeadersJson(traceData.responseHeaders) }}</pre>
+                    <div class="preview-section-title">Raw Response</div>
+                    <pre>{{ getTraceResponseJson() }}</pre>
+                    <div v-if="traceData.streamLines?.length" class="preview-section-title">Raw SSE Lines</div>
+                    <pre v-if="traceData.streamLines?.length">{{ getStreamLinesText() }}</pre>
+                </template>
             </div>
         </div>
         <div class="empty-state" v-else>
@@ -126,6 +225,29 @@ defineExpose({ open });
 .gen-sheet-tabs {
     padding: 10px 16px;
     flex-shrink: 0;
+}
+
+.debug-toolbar {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.debug-toggle,
+.debug-action {
+    padding: 8px 12px;
+    border-radius: 10px;
+    background-color: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.1);
+    font-size: 12px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.debug-toggle.active {
+    background-color: rgba(72, 149, 239, 0.2);
+    border-color: rgba(72, 149, 239, 0.45);
+    color: var(--vk-blue);
 }
 
 .segmented-control {
@@ -306,6 +428,10 @@ defineExpose({ open });
     background-color: rgba(0, 0, 0, 0.2);
 }
 
+.message-body.always-open {
+    border-top: none;
+}
+
 .message-body pre {
     margin: 0;
     white-space: pre-wrap;
@@ -318,5 +444,9 @@ defineExpose({ open });
 .raw-block pre {
     white-space: pre-wrap;
     word-break: break-all;
+}
+
+.trace-summary-card {
+    margin-bottom: 16px;
 }
 </style>

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -448,6 +448,7 @@ export async function generateChatResponse({
             requestReasoning,
             tagStart,
             tagEnd,
+            requestType: 'chat',
             callbacks: { onUpdate, onComplete, onError }
         });
     } catch (e) {
@@ -1044,19 +1045,23 @@ export async function generateMemoryDraft({ history, prompt, controller, apiConf
     let result = "";
     
     let requestError = null;
+    const requestBody = {
+        model,
+        messages: [{ role: 'user', content: finalPrompt }],
+        temperature: temp,
+        max_tokens: memoryDraftMaxTokens,
+        stream: false
+    };
+
+    lastPrompt = JSON.parse(JSON.stringify(requestBody));
     
     await executeRequest({
         apiUrl,
         apiKey,
-        requestBody: {
-            model,
-            messages: [{ role: 'user', content: finalPrompt }],
-            temperature: temp,
-            max_tokens: memoryDraftMaxTokens,
-            stream: false
-        },
+        requestBody,
         stream: false,
         controller,
+        requestType: 'memory_draft',
         callbacks: {
             onUpdate: (chunk, reasoningChunk, effectiveText) => {
                 if (effectiveText) result = effectiveText;

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -4,6 +4,7 @@ import { startGenerationNotification, stopGenerationNotification } from '@/core/
 import { cleanText } from '@/utils/textFormatter.js';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
+import { startNetworkTrace, updateNetworkTrace, appendNetworkTraceLine, finishNetworkTrace } from '@/core/services/networkDebugService.js';
 import { logger } from '../../utils/logger.js';
 
 export async function executeRequest({
@@ -15,6 +16,7 @@ export async function executeRequest({
     requestReasoning,
     tagStart,
     tagEnd,
+    requestType,
     callbacks
 }) {
     const { onUpdate, onComplete, onError } = callbacks;
@@ -67,6 +69,14 @@ export async function executeRequest({
     };
     if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
 
+    startNetworkTrace({
+        requestType,
+        apiUrl,
+        stream,
+        requestBody,
+        headers
+    });
+
     try {
         logger.debug("LLM Request Body:", JSON.stringify(requestBody, null, 2));
 
@@ -85,11 +95,14 @@ export async function executeRequest({
 
             if (response.status >= 400) {
                 const errorData = typeof response.data === 'object' ? JSON.stringify(response.data) : String(response.data || '');
+                updateNetworkTrace({ responseStatus: response.status });
+                finishNetworkTrace({ rawResponse: response.data, error: `API Error: ${response.status} ${errorData}` });
                 throw new Error(`API Error: ${response.status} ${errorData}`);
             }
 
             const data = response.data;
             logger.debug("LLM Response (Native):", data);
+            updateNetworkTrace({ responseStatus: response.status });
             
             // Defensive check: ensure API returned valid structure
             if (!data || !data.choices || !data.choices.length || !data.choices[0] || !data.choices[0].message) {
@@ -118,6 +131,8 @@ export async function executeRequest({
                 finalReasoning = inlineReasoning;
             }
 
+            finishNetworkTrace({ rawResponse: data, text: cleanText(finalText), reasoning: finalReasoning || null });
+
             if (onComplete) onComplete(cleanText(finalText), finalReasoning || null);
 
             // Exit function, finally block will still run for cleanup
@@ -140,8 +155,15 @@ export async function executeRequest({
         if (!response.ok) {
             let errText = "";
             try { errText = await response.text(); } catch (e) { }
+            updateNetworkTrace({ responseStatus: response.status, responseHeaders: Object.fromEntries(response.headers.entries()) });
+            finishNetworkTrace({ rawResponse: errText, error: `API Error: ${response.status} ${errText}` });
             throw new Error(`API Error: ${response.status} ${errText}`);
         }
+
+        updateNetworkTrace({
+            responseStatus: response.status,
+            responseHeaders: Object.fromEntries(response.headers.entries())
+        });
 
         if (stream) {
             if (!response.body || typeof response.body.getReader !== 'function') {
@@ -176,14 +198,16 @@ export async function executeRequest({
                     finalReasoning = inlineReasoning;
                 }
 
+                finishNetworkTrace({ rawResponse: data, text: cleanText(finalText), reasoning: finalReasoning || null });
+
                 if (onComplete) onComplete(cleanText(finalText), finalReasoning || null);
                 return;
             }
 
             const reader = response.body.getReader();
             const decoder = new TextDecoder("utf-8");
-            let isFirst = true;
             let previousEffectiveText = "";
+            let pendingLineBuffer = '';
 
             const resetStreamTimer = () => {
                 if (streamTimer) clearTimeout(streamTimer);
@@ -197,7 +221,9 @@ export async function executeRequest({
                 resetStreamTimer();
 
                 const chunk = decoder.decode(value, { stream: true });
-                const lines = chunk.split('\n');
+                pendingLineBuffer += chunk;
+                const lines = pendingLineBuffer.split('\n');
+                pendingLineBuffer = lines.pop() || '';
 
                 for (const line of lines) {
                     const trimmed = line.trim();
@@ -205,6 +231,7 @@ export async function executeRequest({
 
                     const dataStr = trimmed.substring(6);
                     if (dataStr === '[DONE]') continue;
+                    appendNetworkTraceLine(dataStr);
 
                     try {
                         const json = JSON.parse(dataStr);
@@ -284,6 +311,14 @@ export async function executeRequest({
                 }
             }
 
+            const trailingLine = pendingLineBuffer.trim();
+            if (trailingLine.startsWith('data: ')) {
+                const dataStr = trailingLine.substring(6);
+                if (dataStr && dataStr !== '[DONE]') {
+                    appendNetworkTraceLine(dataStr);
+                }
+            }
+
             if (streamTimer) { clearTimeout(streamTimer); streamTimer = null; }
 
             // Final processing for onComplete
@@ -307,6 +342,15 @@ export async function executeRequest({
             }
 
             logger.debug("Stream finished:", finalText);
+
+            finishNetworkTrace({
+                rawResponse: {
+                    mode: 'sse',
+                    eventCount: null
+                },
+                text: cleanText(finalText),
+                reasoning: finalReasoning || null
+            });
 
             if (onComplete) onComplete(cleanText(finalText), finalReasoning || null);
 
@@ -341,6 +385,8 @@ export async function executeRequest({
                 finalReasoning = inlineReasoning;
             }
 
+            finishNetworkTrace({ rawResponse: data, text: cleanText(finalText), reasoning: finalReasoning || null });
+
             if (onComplete) onComplete(cleanText(finalText), finalReasoning || null);
         }
     } catch (e) {
@@ -348,8 +394,10 @@ export async function executeRequest({
             if (timedOut) {
                 // Timeout-induced abort — treat as error, not user cancellation
                 if (fullText.length > 0) {
+                    finishNetworkTrace({ text: cleanText(fullText), reasoning: requestReasoning ? accumulatedReasoning : null, error: 'Generation timed out' });
                     if (onComplete) onComplete(cleanText(fullText), requestReasoning ? accumulatedReasoning : null, { partialError: "Generation timed out" });
                 } else {
+                    finishNetworkTrace({ error: 'Generation timed out — no response from server' });
                     if (onError) onError(new Error("Generation timed out — no response from server"));
                 }
                 return;
@@ -357,8 +405,10 @@ export async function executeRequest({
 
             // User-initiated abort — save partial text if available
             if (fullText.length > 0) {
+                finishNetworkTrace({ text: cleanText(fullText), reasoning: requestReasoning ? accumulatedReasoning : null, error: 'Generation aborted' });
                 if (onComplete) onComplete(cleanText(fullText), requestReasoning ? accumulatedReasoning : null);
             } else {
+                finishNetworkTrace({ error: e });
                 if (onError) onError(e);
             }
             return;
@@ -368,10 +418,12 @@ export async function executeRequest({
         if (fullText.length > 0) {
             console.warn("Network error during stream, saving partial response:", e);
             const errorMsg = e.message || "Stream Error";
+            finishNetworkTrace({ text: cleanText(fullText), reasoning: requestReasoning ? accumulatedReasoning : null, error: errorMsg });
             if (onComplete) onComplete(cleanText(fullText), requestReasoning ? accumulatedReasoning : null, { partialError: errorMsg });
             return;
         }
 
+        finishNetworkTrace({ error: e });
         if (onError) onError(e);
     } finally {
         if (connectTimer) clearTimeout(connectTimer);

--- a/src/core/services/networkDebugService.js
+++ b/src/core/services/networkDebugService.js
@@ -1,0 +1,121 @@
+const STORAGE_KEY = 'gz_last_network_trace';
+const ENABLED_KEY = 'gz_debug_network_capture';
+const MAX_STREAM_LINES = 200;
+
+let lastNetworkTrace = null;
+
+function clone(value) {
+    if (value === undefined) return undefined;
+    return JSON.parse(JSON.stringify(value));
+}
+
+function persist() {
+    try {
+        if (lastNetworkTrace) {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(lastNetworkTrace));
+        } else {
+            localStorage.removeItem(STORAGE_KEY);
+        }
+    } catch (e) {
+        console.warn('[networkDebug] Failed to persist trace', e);
+    }
+}
+
+function ensureLoaded() {
+    if (lastNetworkTrace !== null) return;
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        lastNetworkTrace = raw ? JSON.parse(raw) : null;
+    } catch (e) {
+        lastNetworkTrace = null;
+    }
+}
+
+function maskHeaders(headers = {}) {
+    const masked = { ...headers };
+    if (masked.Authorization) masked.Authorization = 'Bearer ***';
+    if (masked.authorization) masked.authorization = 'Bearer ***';
+    return masked;
+}
+
+export function isNetworkDebugEnabled() {
+    return localStorage.getItem(ENABLED_KEY) === 'true';
+}
+
+export function setNetworkDebugEnabled(enabled) {
+    localStorage.setItem(ENABLED_KEY, enabled ? 'true' : 'false');
+}
+
+export function getLastNetworkTrace() {
+    ensureLoaded();
+    return clone(lastNetworkTrace);
+}
+
+export function clearLastNetworkTrace() {
+    lastNetworkTrace = null;
+    persist();
+}
+
+export function startNetworkTrace({ requestType = 'unknown', apiUrl, stream, requestBody, headers }) {
+    if (!isNetworkDebugEnabled()) return;
+
+    lastNetworkTrace = {
+        requestType,
+        apiUrl,
+        stream: !!stream,
+        startedAt: Date.now(),
+        completedAt: null,
+        durationMs: null,
+        request: clone(requestBody),
+        requestHeaders: maskHeaders(headers),
+        responseStatus: null,
+        responseHeaders: null,
+        rawResponse: null,
+        streamLines: [],
+        parsed: {
+            text: '',
+            reasoning: '',
+            error: null
+        }
+    };
+
+    persist();
+}
+
+export function updateNetworkTrace(patch = {}) {
+    if (!isNetworkDebugEnabled() || !lastNetworkTrace) return;
+
+    if (patch.responseHeaders) {
+        patch.responseHeaders = maskHeaders(patch.responseHeaders);
+    }
+
+    Object.assign(lastNetworkTrace, clone(patch));
+    persist();
+}
+
+export function appendNetworkTraceLine(line) {
+    if (!isNetworkDebugEnabled() || !lastNetworkTrace || !line) return;
+
+    lastNetworkTrace.streamLines.push(String(line));
+    if (lastNetworkTrace.streamLines.length > MAX_STREAM_LINES) {
+        lastNetworkTrace.streamLines = lastNetworkTrace.streamLines.slice(-MAX_STREAM_LINES);
+    }
+    persist();
+}
+
+export function finishNetworkTrace({ rawResponse, text, reasoning, error } = {}) {
+    if (!isNetworkDebugEnabled() || !lastNetworkTrace) return;
+
+    if (rawResponse !== undefined) lastNetworkTrace.rawResponse = clone(rawResponse);
+    if (text !== undefined) lastNetworkTrace.parsed.text = text || '';
+    if (reasoning !== undefined) lastNetworkTrace.parsed.reasoning = reasoning || '';
+    if (error !== undefined) {
+        lastNetworkTrace.parsed.error = error
+            ? (typeof error === 'string' ? error : (error.message || String(error)))
+            : null;
+    }
+
+    lastNetworkTrace.completedAt = Date.now();
+    lastNetworkTrace.durationMs = Math.max(0, lastNetworkTrace.completedAt - (lastNetworkTrace.startedAt || lastNetworkTrace.completedAt));
+    persist();
+}

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -1029,8 +1029,13 @@ function confirmDeletePreset(id) {
                 iconColor: '#ff4444',
                 isDestructive: true,
                 onClick: () => {
-                    if (id === 'default') return;
+                    if (DEFAULT_PRESETS[id]) {
+                        closeBottomSheet();
+                        return;
+                    }
+
                     delete presetState.presets[id];
+
                     // Clean up connections
                     Object.keys(presetState.connections.character).forEach(k => {
                         if (presetState.connections.character[k] === id) delete presetState.connections.character[k];
@@ -1038,13 +1043,18 @@ function confirmDeletePreset(id) {
                     Object.keys(presetState.connections.chat).forEach(k => {
                         if (presetState.connections.chat[k] === id) delete presetState.connections.chat[k];
                     });
-                    if (presetState.globalPresetId === id) presetState.globalPresetId = 'default';
+
+                    if (presetState.globalPresetId === id) {
+                        setPresetConnection('global', null, null);
+                    }
                     
                     closeBottomSheet();
                     if (editingPresetId.value === id) {
                         editingPresetId.value = null;
                         updateHeaderState();
                     }
+
+                    flushPresetSave();
                 }
             },
             {


### PR DESCRIPTION
## Summary
- Capture the last request and response payloads for both chat and memory draft generations.
- Persist raw SSE data lines, parsed reasoning/text, and response metadata so mobile debugging works without a dev console.
- Expose the captured trace in the existing Request Preview sheet with an on-device debug toggle.