### PR TITLE
fix: close lore and prompt metadata regressions

### DIFF
--- a/src/core/services/__tests__/vectorLoreE2E.test.js
+++ b/src/core/services/__tests__/vectorLoreE2E.test.js
@@ -355,6 +355,94 @@ describe('Vector lorebook E2E verification', () => {
         globalThis.Worker = MockWorker;
     });
 
+    it('respects maxInjectedEntries when vector-only results are added late', async () => {
+        mockGetEmbeddings.mockImplementation(async (texts) => texts.map((text) => [{
+            text,
+            vector: text.includes('Vector extra lore') ? [1, 0, 0] : [0.98, 0.02, 0]
+        }]));
+
+        lorebookState.globalSettings.searchType = 'both';
+        lorebookState.globalSettings.maxInjectedEntries = 1;
+        lorebookState.lorebooks = [{
+            id: 'lb-mixed-limit',
+            name: 'Mixed limit',
+            enabled: true,
+            entries: [
+                {
+                    id: 'entry-keyword',
+                    comment: 'Keyword entry',
+                    keys: ['topic'],
+                    content: 'Keyword lore',
+                    enabled: true,
+                    position: 'worldInfoBefore'
+                },
+                {
+                    id: 'entry-vector-only',
+                    comment: 'Vector only entry',
+                    keys: ['vector'],
+                    content: 'Vector extra lore',
+                    enabled: true,
+                    vectorSearch: true,
+                    useKeywordSearch: false,
+                    position: 'worldInfoBefore'
+                }
+            ]
+        }];
+
+        await indexLorebookEntries('lb-mixed-limit');
+
+        globalThis._genWorker = null;
+        globalThis.Worker = class extends MockWorker {
+            postMessage(message) {
+                const data = {
+                    messages: [
+                        { role: 'system', content: 'Keyword lore' },
+                        { role: 'user', content: 'Current user message', isHistory: true }
+                    ],
+                    loreEntries: [
+                        { id: 'entry-keyword', comment: 'Keyword entry', content: 'Keyword lore', position: 'worldInfoBefore', _source: 'keyword' }
+                    ],
+                    staticTokens: 8,
+                    contextBreakdown: { lorebook: 2 },
+                    needsVarsSave: false,
+                    sessionVars: {}
+                };
+                queueMicrotask(() => {
+                    this.onmessage?.({ data: { id: message.id, success: true, data } });
+                });
+            }
+        };
+
+        let promptReadyPayload = null;
+        await generateChatResponse({
+            text: 'topic and vector extra lore',
+            char: { id: 'char-1', name: 'Tester', sessionId: 'chat-1' },
+            history: [{ role: 'user', content: 'topic and vector extra lore' }],
+            authorsNote: null,
+            summary: '',
+            controller: { signal: { aborted: false } },
+            callbacks: {
+                onUpdate: vi.fn(),
+                onComplete: vi.fn(),
+                onError: vi.fn(),
+                onPromptReady: (payload) => {
+                    promptReadyPayload = payload;
+                }
+            }
+        });
+
+        expect(promptReadyPayload).toBeTruthy();
+        expect(promptReadyPayload.loreEntries.map(entry => entry.id)).toEqual(['entry-keyword']);
+
+        const lastPrompt = getLastPrompt();
+        expect(lastPrompt).toBeTruthy();
+        expect(lastPrompt.messages.some(message => typeof message.content === 'string' && message.content.includes('Vector extra lore'))).toBe(false);
+
+        lorebookState.globalSettings.maxInjectedEntries = 5;
+        globalThis._genWorker = null;
+        globalThis.Worker = MockWorker;
+    });
+
     it('fails generation with a visible error when embedding retrieval crashes', async () => {
         mockGetEmbeddings.mockImplementation(async (texts) => texts.map((text) => {
             if (text.includes('bright blue hair')) {

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -242,11 +242,14 @@ export async function generateChatResponse({
         const vectorResults = await vectorSearchLorebooks(safeHistory || history, text, char, char?.sessionId);
         if (vectorResults.length > 0 && result.loreEntries) {
             const keywordIds = new Set(result.loreEntries.map(e => e.id));
-            newVectorEntries = vectorResults.filter(e => !keywordIds.has(e.id));
-            newVectorEntries.forEach(e => { e._source = 'vector'; });
             result.loreEntries.forEach(e => { if (!e._source) e._source = 'keyword'; });
             const keywordEntries = result.loreEntries.filter(e => e._source === 'keyword');
-            const vectorOnly = newVectorEntries.sort((a, b) => (b.vectorScore || 0) - (a.vectorScore || 0));
+            newVectorEntries = limitVectorLoreEntries(
+                vectorResults.filter(e => !keywordIds.has(e.id)),
+                keywordEntries
+            );
+            newVectorEntries.forEach(e => { e._source = 'vector'; });
+            const vectorOnly = [...newVectorEntries];
             result.loreEntries = [...keywordEntries, ...vectorOnly];
         }
     } catch (e) {
@@ -540,7 +543,13 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             const vectorResults = await vectorSearchLorebooks(safeHistory || history, '', char, char?.sessionId);
             if (vectorResults.length > 0) {
                 const keywordIds = result.loreEntries ? new Set(result.loreEntries.map(e => e.id)) : new Set();
-                const newVectorEntries = vectorResults.filter(e => !keywordIds.has(e.id));
+                const keywordEntries = Array.isArray(result.loreEntries)
+                    ? result.loreEntries.filter(e => (e?._source || 'keyword') === 'keyword')
+                    : [];
+                const newVectorEntries = limitVectorLoreEntries(
+                    vectorResults.filter(e => !keywordIds.has(e.id)),
+                    keywordEntries
+                );
                 vectorLoreTokens = newVectorEntries.reduce((sum, entry) => {
                     const content = entry.content || '';
                     const tokens = estimateTokens(content);
@@ -979,6 +988,16 @@ function combineLoreSources(messages = []) {
         sourceMap.set(item.source, (sourceMap.get(item.source) || 0) + (item.tokens || 0));
     }
     return [...sourceMap.entries()].map(([source, tokens]) => ({ source, tokens }));
+}
+
+function limitVectorLoreEntries(vectorEntries = [], keywordEntries = []) {
+    const maxInjectedEntries = Math.max(1, Math.min(100, Number(lorebookState.globalSettings?.maxInjectedEntries || 5)));
+    const remainingSlots = Math.max(0, maxInjectedEntries - keywordEntries.length);
+    if (remainingSlots <= 0) return [];
+
+    return [...vectorEntries]
+        .sort((a, b) => (b.vectorScore || 0) - (a.vectorScore || 0))
+        .slice(0, remainingSlots);
 }
 
 function buildVectorLoreBlock(entries, position) {

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -3206,6 +3206,44 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         }
     }
     const msgId = currentMessages.value[msgIndex]?.id || genMsgId();
+    const promptMetaSnapshots = new Map();
+
+    const clonePromptMetaList = (items) => Array.isArray(items)
+        ? items.map(item => ({ ...item }))
+        : [];
+
+    const snapshotPromptMeta = (message) => {
+        if (!message?.id || promptMetaSnapshots.has(message.id)) return;
+        promptMetaSnapshots.set(message.id, {
+            hasTriggeredLorebooks: Object.prototype.hasOwnProperty.call(message, 'triggeredLorebooks'),
+            hasTriggeredMemories: Object.prototype.hasOwnProperty.call(message, 'triggeredMemories'),
+            hasContextRefs: Object.prototype.hasOwnProperty.call(message, 'contextRefs'),
+            triggeredLorebooks: clonePromptMetaList(message.triggeredLorebooks),
+            triggeredMemories: clonePromptMetaList(message.triggeredMemories),
+            contextRefs: clonePromptMetaList(message.contextRefs)
+        });
+    };
+
+    const restorePromptMetaOnMessages = (messages) => {
+        if (!Array.isArray(messages) || promptMetaSnapshots.size === 0) return false;
+        let changed = false;
+        messages.forEach(message => {
+            const snapshot = message?.id ? promptMetaSnapshots.get(message.id) : null;
+            if (!snapshot) return;
+
+            if (snapshot.hasTriggeredLorebooks) message.triggeredLorebooks = clonePromptMetaList(snapshot.triggeredLorebooks);
+            else delete message.triggeredLorebooks;
+
+            if (snapshot.hasTriggeredMemories) message.triggeredMemories = clonePromptMetaList(snapshot.triggeredMemories);
+            else delete message.triggeredMemories;
+
+            if (snapshot.hasContextRefs) message.contextRefs = clonePromptMetaList(snapshot.contextRefs);
+            else delete message.contextRefs;
+
+            changed = true;
+        });
+        return changed;
+    };
 
     // Save generation status for DialogList
     localStorage.setItem(`gz_generating_${char.id}_${sessionId}`, 'true');
@@ -3275,6 +3313,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         const idx = currentMessages.value.findIndex(m => m.id === msgId);
         if (idx !== -1) {
             // User is still viewing this chat — update reactive state
+            restorePromptMetaOnMessages(currentMessages.value);
             currentMessages.value[idx].isTyping = false;
 
             if (!isError) {
@@ -3317,6 +3356,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             // User navigated away — clean up directly in DB
             const data = await getChatData(char.id);
             if (data && data.sessions[sessionId]) {
+                restorePromptMetaOnMessages(data.sessions[sessionId]);
                 const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
                 if (dbIdx !== -1) {
                     data.sessions[sessionId][dbIdx].isTyping = false;
@@ -3521,6 +3561,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
                 ];
 
                 const assignRefs = (m) => {
+                    snapshotPromptMeta(m);
                     m.triggeredLorebooks = triggeredLorebooks;
                     m.triggeredMemories = triggeredMemories;
                     m.contextRefs = contextRefs;


### PR DESCRIPTION
## Summary
- enforce lorebook max-injection limits for late vector-only retrieval so vector additions cannot exceed the configured lore cap
- restore prompt metadata cleanly when generation aborts or fails so stale lorebook and memory trigger refs do not remain on messages
- add regression coverage for late vector lore limits to keep prompt assembly aligned with the configured injection budget

## Testing
- npm test -- --run
- npm run build