### PR TITLE
refactor: untangle network architecture and chat generation flow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -271,7 +271,223 @@ MemorySettings: {
 
 ---
 
-## 6. Cloud Sync
+## 6. Network / LLM Requests
+
+### Files
+- `src/components/chat/ChatInput.vue` — Starts user send flow and exposes request preview sheet entry points
+- `src/components/chat/MagicDrawer.vue` — Secondary request preview entry point
+- `src/components/sheets/RequestPreviewSheet.vue` — Displays the last built prompt and optional captured network trace
+- `src/views/ChatView.vue` — Owns chat generation session lifecycle, placeholder message state, abort/cleanup, and persistence
+- `src/views/ApiView.vue` — API settings UI, model discovery, preset CRUD, and connection test UX
+- `src/core/config/APISettings.js` — Runtime API config reads, endpoint normalization, provider blacklist checks, and `/models` discovery
+- `src/core/services/generationService.js` — Prompt orchestration, enrichment, request body construction, and direct `executeRequest()` callers
+- `src/workers/generationWorker.js` — Prompt assembly, macro/regex application, keyword lore scan, and token accounting
+- `src/core/services/llmApi.js` — `/chat/completions` transport, streaming/non-stream parsing, native/mobile branching, timeouts, reasoning extraction, and runtime side effects
+- `src/core/services/networkDebugService.js` — Stores the last captured request/response trace for on-device inspection
+
+### Request Types
+- `chat` — Main character response generation from `ChatView.vue` via `generateChatResponse()`
+- `summary` — Preset/summary generation via `generateSummary()`
+- `memory_draft` — MemoryBook draft generation via `generateMemoryDraft()`
+- `model_discovery` — `/models` fetch from `ApiView.vue` via `fetchRemoteModels()`
+
+### Current End-to-End Flow
+
+**Chat Generation:**
+1. `ChatInput.vue` emits send-related events and `ChatView.vue` receives them.
+2. `ChatView.vue:startGeneration()` performs UI/session orchestration:
+   - checks basic API config availability
+   - creates `AbortController`
+   - creates or reuses the typing placeholder message
+   - snapshots visible history
+   - starts timers and `generatingStates`
+3. `generationService.js:generateChatResponse()` resolves the effective request inputs:
+   - loads API config from `APISettings.js`
+   - resolves active preset and reasoning tag settings
+   - collects session vars, persona, regexes, and prompt options
+   - sends prompt building to `generationWorker.js`
+4. After the worker returns, `generationService.js` performs late enrichment:
+   - vector lore retrieval
+   - memory injection
+   - context breakdown assembly
+   - request-body creation and sanitization
+   - `lastPrompt` snapshot for request preview UI
+5. `generationService.js` calls `llmApi.js:executeRequest()` with transport config, reasoning config, request type, abort controller, and callbacks.
+6. `llmApi.js` executes `/chat/completions` using either:
+   - `CapacitorHttp.post()` for native non-stream local HTTP requests
+   - `fetch()` for web and streaming requests
+7. `llmApi.js` parses either:
+   - one-shot JSON response
+   - SSE stream via `response.body.getReader()`
+   - one-shot fallback when a stream request has no readable body on the current runtime
+8. `llmApi.js` extracts assistant text plus reasoning from:
+   - native `reasoning_content`
+   - inline reasoning tags in `content`
+9. Callback flow returns to `ChatView.vue`:
+   - `onUpdate()` applies streaming text/reasoning to the placeholder message
+   - `onComplete()` finalizes the message, stores metadata, and clears generation state
+   - `onError()` restores UI/DB state and writes formatted error output
+
+**Summary + Memory Draft Requests:**
+1. `PresetView.vue` or `ChatView.vue` call `generateSummary()` / `generateMemoryDraft()`.
+2. `generationService.js` builds a simpler single-message request body.
+3. Both still reuse `llmApi.js:executeRequest()`.
+4. Request preview and network trace are still global, so these requests can overwrite the last visible chat debug payload.
+
+**Model Discovery:**
+1. `ApiView.vue` normalizes the endpoint and calls `fetchRemoteModels()`.
+2. `APISettings.js` requests `/models` using `fetch()` on web or `CapacitorHttp.get()` on native.
+3. Returned model IDs feed the API settings selector UI.
+
+### Current Responsibility Split
+
+**UI / Session Lifecycle:**
+- `ChatView.vue` owns generation session state, placeholder message creation, timers, background persistence, abort handling, and generation-end events.
+- `RequestPreviewSheet.vue` owns display of the last built prompt and the last stored network trace.
+- `ApiView.vue` owns API settings editing, preset CRUD, and `/models` connectivity UX.
+
+**Prompt Pipeline:**
+- `generationWorker.js` builds prompt blocks, applies macros and regexes, scans keyword lore, and returns prompt/context metadata.
+- `generationService.js` enriches worker output with vector lore and MemoryBook injection, computes final request payloads, and exposes generation entry points.
+
+**Transport / Runtime:**
+- `llmApi.js` owns request dispatch, timeout handling, streaming parser behavior, native runtime branching, wake-lock/background behavior, trace capture hooks, and reasoning extraction.
+- `networkDebugService.js` owns the persisted "last trace" singleton.
+
+**Config / Storage:**
+- `APISettings.js` reads runtime API values from `localStorage` and API presets from IndexedDB.
+- `ApiView.vue` writes many of those values directly back to `localStorage`, and also mutates the active API preset record.
+- `ChatView.vue` still performs some direct localStorage reads for preflight config checks.
+
+### Transport Behavior Today
+- Request endpoint is always `${apiUrl}/chat/completions` for generation and `${apiUrl}/models` for model discovery.
+- `CONNECT_TIMEOUT` and `STREAM_TIMEOUT` are read directly from `localStorage` inside `llmApi.js`.
+- Streaming requests use SSE parsing with `data: ...` lines and `[DONE]` termination.
+- If a streaming response body is unavailable on the current runtime, `llmApi.js` falls back to one-shot JSON parsing instead of hard-failing.
+- Abort handling is dual-purpose:
+  - user abort may still preserve partial text
+  - timeout-triggered abort is treated as an error and may preserve partial text with `partialError`
+- The transport contract is callback-based rather than event-object-based:
+  - `onUpdate(chunk, reasoningChunk, effectiveText, effectiveReasoning, textDelta)`
+  - `onComplete(text, reasoning, meta?)`
+  - `onError(error)`
+
+### Temporary Network Trace Debugging
+
+**Files:**
+- `src/core/services/networkDebugService.js` — Stores the last captured request/response trace in localStorage
+- `src/core/services/llmApi.js` — Starts/updates/completes capture during chat + memory draft requests
+- `src/core/services/generationService.js` — Tags captures by request type and exposes the last request body for preview
+- `src/components/sheets/RequestPreviewSheet.vue` — On-device viewer/toggle for the last captured trace
+
+**Purpose:**
+- Debug mobile/provider-specific failures without a dev console
+- Confirm whether providers return native `reasoning_content`, inline reasoning tags, or neither
+- Inspect exact memory draft request payloads and raw responses when summaries appear truncated
+
+**Stored Trace Shape:**
+- Request metadata: `requestType`, `apiUrl`, `stream`, timestamps, duration
+- Request payload: masked request headers + JSON body
+- Response metadata: HTTP status + response headers
+- Parsed output: final `text`, `reasoning`, and `error`
+- Stream-only diagnostics: bounded buffer of raw SSE `data:` lines
+
+**Operational Notes:**
+- Capture is gated by localStorage toggle `gz_debug_network_capture`
+- Last trace persists in localStorage key `gz_last_network_trace`
+- Request preview stays usable even when trace capture is disabled; the trace section is optional diagnostics only
+
+**Current Limitation:**
+- Trace storage is global and single-entry. A summary or memory draft request can overwrite the last chat trace.
+
+**Safe Removal Path:**
+- Remove `networkDebugService.js`
+- Remove its imports/calls from `llmApi.js`
+- Remove trace UI/toggle from `RequestPreviewSheet.vue`
+- Keep `generationService.js:getLastPrompt()` and prompt preview JSON unless request preview itself is being removed
+- Keep trace capture non-blocking; generation success must never depend on diagnostics state
+
+### Current Design Problems
+- `ChatView.vue` owns too much of the generation lifecycle: API prechecks, placeholder creation, DB sync, abort handling, UI streaming updates, and cleanup logic.
+- `generationService.js` mixes use-case orchestration, prompt enrichment, config resolution, debug preview state, and transport dispatch.
+- `llmApi.js` is not a pure transport client; it also handles reasoning extraction, network tracing, wake-lock/background behavior, and notification side effects.
+- Runtime config has multiple owners: `localStorage`, IndexedDB API presets, reactive `ApiView.vue` state, onboarding writes, and direct reads in feature views.
+- Debug state is global singleton state (`lastPrompt`, `lastNetworkTrace`) rather than per-generation or per-message state.
+- Request types are implicit instead of modeled as separate use cases with a shared transport contract.
+- Worker/service boundaries are not documented clearly: keyword lore lives in the worker, vector retrieval and memory injection happen later in the service layer.
+- Callback signatures are flexible but brittle across chat, summary, and memory-draft flows.
+
+### Better Target Structure
+
+**Current Foundation Added In This Branch:**
+- `src/core/llm/contracts/providerContracts.js` introduces provider IDs, request kinds, and baseline capability flags
+- `src/core/llm/providers/providerRegistry.js` introduces a registry boundary instead of hard-coding all provider behavior into settings/transport files
+- `src/core/llm/providers/openaiCompatibleProvider.js` wraps the current OpenAI-like endpoint normalization, auth header strategy, `/models` discovery, and chat completion URL building as the first adapter
+
+This is intentionally small and compatibility-first: the current request flow still behaves as before, but provider-specific behavior now has an explicit place to live. At this stage, model discovery and chat transport setup already route through the provider boundary, while parsing and response normalization still live in `llmApi.js`.
+
+**Config Layer:**
+- `src/core/llm/config/apiConfigStore.js` — read/write active runtime config without raw localStorage access in views
+- `src/core/llm/config/apiPresetStore.js` — preset CRUD only
+- `src/core/llm/config/endpointUtils.js` — endpoint normalization and blacklist helpers
+
+**Transport Layer:**
+- `src/core/llm/transport/chatCompletionsClient.js` — POST `/chat/completions`
+- `src/core/llm/transport/modelDiscoveryClient.js` — GET `/models`
+- `src/core/llm/transport/sseParser.js` — SSE line parsing only
+- `src/core/llm/transport/responseNormalizer.js` — unify streaming and non-stream outputs into one shape
+- `src/core/llm/transport/runtimePolicy.js` — wake lock, background mode, and native/web branching rules
+
+**Transport Extraction Started In This Branch:**
+- `src/core/llm/transport/responseNormalizer.js` now owns shared final-response extraction for OpenAI-like one-shot/native/fallback responses
+- `llmApi.js` still owns streaming delta parsing and callback dispatch, but repeated non-stream result shaping is no longer duplicated inline
+
+**Prompt Layer:**
+- `src/core/llm/prompt/promptBuilderService.js` — wraps `generationWorker.js`
+- `src/core/llm/prompt/promptEnrichmentService.js` — vector lore + memory injection + rebudgeting
+- `src/core/llm/prompt/promptPreviewStore.js` — preview payloads separate from raw network traces
+
+**Assembler Layer Started In This Branch:**
+- `src/core/llm/assemblers/requestIntents.js` defines app-level request intents for `chat`, `summary`, and `memory_draft`
+- `src/core/llm/assemblers/payloadBuilderRegistry.js` is the first explicit boundary for provider-specific payload builders
+- `src/core/llm/assemblers/requestAssemblers.js` now bridges use cases to provider payload builders without keeping payload-shape details inline in `generationService.js`
+- `generationService.js` still decides what semantic request should be sent, but the OpenAI-like payload assembly no longer lives inline in every use case
+- this is the bridge toward future provider-specific payload builders without changing current prompt semantics
+
+**Use Cases:**
+- `src/core/llm/usecases/generateChat.js`
+- `src/core/llm/usecases/generateSummary.js`
+- `src/core/llm/usecases/generateMemoryDraft.js`
+- `src/core/llm/usecases/calculateContext.js`
+
+**UI Session Layer:**
+- `src/composables/chat/useGenerationSession.js` — placeholder message lifecycle, abort controller ownership, streaming UI application, persistence throttling, and cleanup
+
+**Debug / Observability:**
+- `src/core/llm/debug/requestTraceStore.js` — raw request/response traces keyed by generation
+- `src/core/llm/debug/requestHistoryStore.js` — last N traces instead of a single global trace
+- `src/core/llm/debug/previewAssembler.js` — joins prompt preview with request traces for the UI
+
+### Recommended Refactor Sequence
+1. Centralize runtime API config reads/writes so feature views stop reading localStorage keys directly.
+2. Split `llmApi.js` into smaller transport-focused modules without changing external behavior.
+3. Extract chat/session lifecycle code out of `ChatView.vue` into a dedicated generation-session composable.
+4. Separate prompt preview state from transport trace state, then store traces per generation/message instead of globally.
+5. Promote explicit request use cases (`chat`, `summary`, `memory_draft`, `model_discovery`) with a shared normalized transport result shape.
+6. Document the worker/service split so future prompt and retrieval changes have a stable boundary.
+
+### Migration Guardrails
+- Keep streaming and non-streaming behavior functionally identical while splitting modules.
+- Preserve the native/mobile fallback where stream bodies are unavailable.
+- Preserve partial-response recovery on abort/timeout until a new event contract fully replaces callbacks.
+- Keep network trace capture optional and removable.
+- Avoid changing prompt semantics during the initial transport/config refactor.
+- Keep the embedding/vectorization stack out of this refactor until the chat/provider architecture stabilizes.
+- Keep `MemoryBooks -> generateMemoryDraft(apiConfigOverride)` behavior compatible until a later step adds explicit provider selection for custom memory generation.
+
+---
+
+## 7. Cloud Sync
 
 ### Files
 - `src/components/sheets/SyncSheet.vue` — UI for provider auth, encryption setup, push/pull, and conflict entry points
@@ -375,6 +591,16 @@ MemorySettings: {
 - Session vars loaded from `localStorage` and saved back if changed
 - Global vars persist across all chats
 
+### API Settings ↔ Network Requests
+- `ApiView.vue` edits runtime request settings and connection presets
+- `APISettings.js` normalizes endpoints and serves as the current read boundary for generation requests
+- `ChatView.vue`, `generationService.js`, and `llmApi.js` still depend on those settings directly or indirectly during request setup
+
+### Prompt Preview ↔ Network Trace
+- `generationService.js:getLastPrompt()` stores the last built request body before transport sanitization is sent
+- `networkDebugService.js` stores the last raw request/response trace after transport begins
+- `RequestPreviewSheet.vue` combines both views, which is useful for debugging but currently couples unrelated request types through shared singleton state
+
 ---
 
 ## Settings Ownership
@@ -395,6 +621,12 @@ MemorySettings: {
 | Connected sync provider | Sync state | `syncState.js` → localStorage |
 | Sync OAuth tokens | Sync state | IndexedDB via `SYNC_TOKENS_KEY` |
 | Recovery phrase-derived key | Crypto | IndexedDB via `keyManager.js` |
+| API endpoint/key/model | API runtime config | `APISettings.js` ↔ localStorage |
+| API stream/temp/topP/max tokens/context | API runtime config | `APISettings.js` ↔ localStorage |
+| Reasoning toggle/tags/effort | API runtime + preset override | `APISettings.js`, `PresetView.vue`, localStorage |
+| API connection presets | API presets | IndexedDB `gz_api_connection_presets` |
+| Last built prompt preview | Generation debug state | `generationService.js` singleton memory |
+| Last network trace | Network debug state | `networkDebugService.js` ↔ localStorage |
 
 ---
 
@@ -435,6 +667,16 @@ MemorySettings: {
 - [ ] Native reasoning_content field displayed
 - [ ] Both sources combined without duplication
 - [ ] Mobile/native stream fallback returns a full response instead of hard-failing when streaming body is unavailable
+
+### Network / LLM Requests
+- [ ] Chat requests succeed in both streaming and non-streaming modes
+- [ ] Native non-stream requests still work through `CapacitorHttp`
+- [ ] Missing stream reader fallback still produces a complete response
+- [ ] User abort preserves partial text when expected
+- [ ] Timeout abort reports an error and does not leave phantom typing state
+- [ ] Summary and memory-draft requests do not regress while chat transport is refactored
+- [ ] Request preview still shows the final built payload after prompt assembly
+- [ ] Network trace capture remains optional and does not affect generation success
 
 ### Cloud Sync
 - [ ] Provider buttons only appear when their env keys are configured

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -426,6 +426,11 @@ MemorySettings: {
 
 This is intentionally small and compatibility-first: the current request flow still behaves as before, but provider-specific behavior now has an explicit place to live. At this stage, model discovery and chat transport setup already route through the provider boundary, while parsing and response normalization still live in `llmApi.js`.
 
+**Additional Progress Already Landed On The Refactor Branch:**
+- `APISettings.js` now owns a shared runtime-config boundary via `getApiRuntimeStorage()`, `saveApiRuntimeSetting()`, `applyApiRuntimeConfig()`, and `getApiReasoningTags()`
+- `ApiView.vue`, `OnboardingView.vue`, `ToolsView.vue`, `ChatView.vue`, `generationService.js`, `macroEngine.js`, and `ChatMessage.vue` have started moving off ad-hoc raw runtime config reads/writes toward those helpers
+- the refactor branch has also re-applied the merged regression safeguards from the bugfix chain, so late vector lore limits and prompt-metadata rollback still hold while refactor work continues
+
 **Config Layer:**
 - `src/core/llm/config/apiConfigStore.js` — read/write active runtime config without raw localStorage access in views
 - `src/core/llm/config/apiPresetStore.js` — preset CRUD only
@@ -470,7 +475,9 @@ This is intentionally small and compatibility-first: the current request flow st
 
 ### Recommended Refactor Sequence
 1. Centralize runtime API config reads/writes so feature views stop reading localStorage keys directly.
+   Status: partially done in this branch via `APISettings.js` helpers; remaining callers should be migrated incrementally.
 2. Split `llmApi.js` into smaller transport-focused modules without changing external behavior.
+   Status: partially done; one-shot response normalization moved out, but SSE parsing and runtime-policy side effects still live inline.
 3. Extract chat/session lifecycle code out of `ChatView.vue` into a dedicated generation-session composable.
 4. Separate prompt preview state from transport trace state, then store traces per generation/message instead of globally.
 5. Promote explicit request use cases (`chat`, `summary`, `memory_draft`, `model_discovery`) with a shared normalized transport result shape.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -875,6 +875,7 @@ Done and tested:
 - [done] `llmApi.js` transport extraction continued:
   - `transport/requestOutcome.js` now owns structured completion, streaming finalization, and partial-result handling for abort/error paths
   - `transport/requestExecution.js` now owns native/fetch execution branches and fetch response validation
+  - `transport/requestLifecycle.js` now owns timeout config, abort guards, request headers, and network-trace bootstrap
   - `transport/responseHandling.js` now owns fetch JSON completion and SSE capability detection/fallback shaping
   - `transport/streamingSse.js` now owns SSE read/parse/update consumption while preserving the existing callback contract
 - [done] Generation lifecycle extraction started in `ChatView.vue` without behavior changes:

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -872,6 +872,15 @@ Done and tested:
 - [done] Runtime API config centralization started:
   - `APISettings.js` now exposes `getApiRuntimeStorage()`, `saveApiRuntimeSetting()`, `applyApiRuntimeConfig()`, and `getApiReasoningTags()`
   - hot-path callers (`ApiView.vue`, `OnboardingView.vue`, `ToolsView.vue`, `ChatView.vue`, `generationService.js`, `macroEngine.js`, `ChatMessage.vue`) now use these helpers instead of duplicating raw runtime config reads/writes.
+- [done] Generation lifecycle extraction started in `ChatView.vue` without behavior changes:
+  - `useGenerationRegistry.js` owns per-chat generation session state and persisted generating flags
+  - `usePromptMetadataSnapshots.js` owns prompt metadata snapshot/restore for abort/error rollback
+  - `useTypingStateCleanup.js` centralizes `isTyping` cleanup across stale/error/abort paths
+  - `useGenerationStateRestore.js` now owns generation abort/error restore flow for swipe rollback, message removal, and DB fallback cleanup
+  - `useGenerationErrorHandler.js` now owns error-path cleanup and persisted error-state writes after generation failures
+  - `useGenerationCompleteHandler.js` now owns completion-path cleanup, visible/background completion writes, and stale/abort finalization checks
+  - `useGenerationStreamUpdate.js` now owns stream fan-out and throttled background DB persistence during active generation
+  - `useGenerationPromptReady.js` now owns prompt metadata assignment and prompt-ready persistence for triggered lorebooks/memories/context refs
 
 Tested status:
 - [done] `npm test -- --run`

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -883,6 +883,7 @@ Done and tested:
   - `useGenerationPromptReady.js` now owns prompt metadata assignment and prompt-ready persistence for triggered lorebooks/memories/context refs
   - `useGenerationPreparation.js` now owns authors-note assembly, placeholder message creation, and request history shaping for chat generation
   - `useGenerationStateSetup.js` now owns initial guidance patching plus per-generation UI update/timer state wiring
+  - `useGenerationPreparation.js` also resolves generation session context for active and background chat starts
 
 Tested status:
 - [done] `npm test -- --run`

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -872,6 +872,10 @@ Done and tested:
 - [done] Runtime API config centralization started:
   - `APISettings.js` now exposes `getApiRuntimeStorage()`, `saveApiRuntimeSetting()`, `applyApiRuntimeConfig()`, and `getApiReasoningTags()`
   - hot-path callers (`ApiView.vue`, `OnboardingView.vue`, `ToolsView.vue`, `ChatView.vue`, `generationService.js`, `macroEngine.js`, `ChatMessage.vue`) now use these helpers instead of duplicating raw runtime config reads/writes.
+- [done] `llmApi.js` transport extraction continued:
+  - `transport/requestOutcome.js` now owns structured completion, streaming finalization, and partial-result handling for abort/error paths
+  - `transport/requestExecution.js` now owns native/fetch execution branches and fetch response validation
+  - `transport/streamingSse.js` now owns SSE read/parse/update consumption while preserving the existing callback contract
 - [done] Generation lifecycle extraction started in `ChatView.vue` without behavior changes:
   - `useGenerationRegistry.js` owns per-chat generation session state and persisted generating flags
   - `usePromptMetadataSnapshots.js` owns prompt metadata snapshot/restore for abort/error rollback
@@ -897,7 +901,8 @@ Still not done:
 - [not done] Promote explicit request use cases (`generateChat`, `generateSummary`, `generateMemoryDraft`, `calculateContext`) instead of keeping orchestration concentrated in `generationService.js`.
 
 Immediate next refactor step:
-- [not done] Extract SSE parsing and stream normalization out of `llmApi.js` first, because that is the highest-complexity remaining transport logic and the biggest blocker to finishing the provider/network split cleanly.
+- [done] Extracted SSE parsing and stream normalization out of `llmApi.js` first, because that was the highest-complexity remaining transport logic and the biggest blocker to finishing the provider/network split cleanly.
+- [not done] Continue splitting the remaining `llmApi.js` orchestration path into a dedicated transport client boundary once the SSE slice is stabilized.
 
 ## Refactoring Phase — Tokenizer, Memory Books, Vectors/Lorebooks (Active)
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -881,6 +881,7 @@ Done and tested:
   - `useGenerationCompleteHandler.js` now owns completion-path cleanup, visible/background completion writes, and stale/abort finalization checks
   - `useGenerationStreamUpdate.js` now owns stream fan-out and throttled background DB persistence during active generation
   - `useGenerationPromptReady.js` now owns prompt metadata assignment and prompt-ready persistence for triggered lorebooks/memories/context refs
+  - `useGenerationPreparation.js` now owns authors-note assembly, placeholder message creation, and request history shaping for chat generation
 
 Tested status:
 - [done] `npm test -- --run`

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -838,11 +838,54 @@ Active branch: `fast-fixes`
     - Background/location detail enrichment from lorebooks
 
 ### Branch Strategy (updated)
-- Current: `feat/refactor-tokenizer-memorybooks` (from `origin/dev` at 210efa4)
+- Current bugfix chain: merged and closed (`fixes/mobile-network-memorybooks-batch1` -> PR #46, `fixes/regressions-post-merge` -> PR #47)
+- Current refactor branch: `feat/network-architecture-refactor`
 - Previous: Merged branches deleted (bug-fixes, feat/dual-lorebook-debug)
 - Policy: **Linear chain workflow** — each feature branches from previous feature OR origin/dev for new chains
 - Never create branches from dev that contain multiple unmerged features
 - All PRs target `upstream/dev`, never `main`
+
+## Provider / Network Refactor (Active)
+
+Branch: `feat/network-architecture-refactor`
+Status: In progress
+Goal: finish moving chat/provider request architecture toward explicit provider, assembler, and transport boundaries without changing prompt semantics or regressing mobile/network behavior.
+
+### Current State
+
+Done and tested:
+- [done] Added provider-oriented foundation under `src/core/llm/`:
+  - `contracts/providerContracts.js`
+  - `providers/providerRegistry.js`
+  - `providers/openaiCompatibleProvider.js`
+  - `assemblers/requestIntents.js`
+  - `assemblers/payloadBuilderRegistry.js`
+  - `assemblers/requestAssemblers.js`
+  - `transport/responseNormalizer.js`
+- [done] `generationService.js` now builds chat/summary/memory-draft payloads through request assemblers instead of inlining OpenAI-like payload shape in each use case.
+- [done] `APISettings.js` now routes endpoint normalization and model discovery through provider adapters.
+- [done] `ApiView.vue` preset creation/apply flow persists `providerId` with API presets.
+- [done] Refactor branch was rebased onto the merged mobile/memory/lorebook fixes and re-applied the regression safeguards from PR #47.
+- [done] Regression safeguards preserved on refactor branch:
+  - late vector lore respects `maxInjectedEntries`
+  - prompt metadata is restored on abort/error instead of leaving stale lore/memory refs behind
+- [done] Runtime API config centralization started:
+  - `APISettings.js` now exposes `getApiRuntimeStorage()`, `saveApiRuntimeSetting()`, `applyApiRuntimeConfig()`, and `getApiReasoningTags()`
+  - hot-path callers (`ApiView.vue`, `OnboardingView.vue`, `ToolsView.vue`, `ChatView.vue`, `generationService.js`, `macroEngine.js`, `ChatMessage.vue`) now use these helpers instead of duplicating raw runtime config reads/writes.
+
+Tested status:
+- [done] `npm test -- --run`
+- [done] `npm run build`
+
+Still not done:
+- [not done] Split `llmApi.js` into smaller transport modules (`chatCompletionsClient`, `sseParser`, runtime policy pieces) while preserving the current callback contract.
+- [not done] Move more remaining direct runtime API config access behind `APISettings.js` helpers, especially lower-priority UI code and legacy toggles.
+- [not done] Extract generation session lifecycle out of `ChatView.vue` into a dedicated composable/service.
+- [not done] Separate prompt preview storage from network trace storage and stop relying on singleton global last-trace state.
+- [not done] Promote explicit request use cases (`generateChat`, `generateSummary`, `generateMemoryDraft`, `calculateContext`) instead of keeping orchestration concentrated in `generationService.js`.
+
+Immediate next refactor step:
+- [not done] Extract SSE parsing and stream normalization out of `llmApi.js` first, because that is the highest-complexity remaining transport logic and the biggest blocker to finishing the provider/network split cleanly.
 
 ## Refactoring Phase — Tokenizer, Memory Books, Vectors/Lorebooks (Active)
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -873,6 +873,7 @@ Done and tested:
   - `APISettings.js` now exposes `getApiRuntimeStorage()`, `saveApiRuntimeSetting()`, `applyApiRuntimeConfig()`, and `getApiReasoningTags()`
   - hot-path callers (`ApiView.vue`, `OnboardingView.vue`, `ToolsView.vue`, `ChatView.vue`, `generationService.js`, `macroEngine.js`, `ChatMessage.vue`) now use these helpers instead of duplicating raw runtime config reads/writes.
 - [done] `llmApi.js` transport extraction continued:
+  - `transport/chatCompletionsClient.js` now owns fetch-path request orchestration, including streaming fallback and stream finalization
   - `transport/requestOutcome.js` now owns structured completion, streaming finalization, and partial-result handling for abort/error paths
   - `transport/requestExecution.js` now owns native/fetch execution branches and fetch response validation
   - `transport/requestLifecycle.js` now owns timeout config, abort guards, request headers, and network-trace bootstrap

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -875,6 +875,7 @@ Done and tested:
 - [done] `llmApi.js` transport extraction continued:
   - `transport/requestOutcome.js` now owns structured completion, streaming finalization, and partial-result handling for abort/error paths
   - `transport/requestExecution.js` now owns native/fetch execution branches and fetch response validation
+  - `transport/responseHandling.js` now owns fetch JSON completion and SSE capability detection/fallback shaping
   - `transport/streamingSse.js` now owns SSE read/parse/update consumption while preserving the existing callback contract
 - [done] Generation lifecycle extraction started in `ChatView.vue` without behavior changes:
   - `useGenerationRegistry.js` owns per-chat generation session state and persisted generating flags

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -882,6 +882,7 @@ Done and tested:
   - `useGenerationStreamUpdate.js` now owns stream fan-out and throttled background DB persistence during active generation
   - `useGenerationPromptReady.js` now owns prompt metadata assignment and prompt-ready persistence for triggered lorebooks/memories/context refs
   - `useGenerationPreparation.js` now owns authors-note assembly, placeholder message creation, and request history shaping for chat generation
+  - `useGenerationStateSetup.js` now owns initial guidance patching plus per-generation UI update/timer state wiring
 
 Tested status:
 - [done] `npm test -- --run`

--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -12,7 +12,7 @@ import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetStat
 import { hideMessageId, hideGenerationTime, hideTokenCount } from '@/core/config/APPSettings.js';
 import RollingNumber from '@/components/ui/RollingNumber.vue';
 import SheetView from '@/components/ui/SheetView.vue';
-import { getBlacklistedProvider } from '@/core/config/APISettings.js';
+import { getBlacklistedProvider, getApiRuntimeStorage } from '@/core/config/APISettings.js';
 import { saveFile } from '@/core/services/fileSaver.js';
 
 const props = defineProps({
@@ -560,8 +560,7 @@ const showFooter = computed(() => {
 
 const blacklistedErrorProvider = computed(() => {
     if (!props.message.isError) return null;
-    const endpoint = localStorage.getItem('gz_api_endpoint_normalized')
-        || localStorage.getItem('api-endpoint') || '';
+    const endpoint = getApiRuntimeStorage().normalizedEndpoint || '';
     return getBlacklistedProvider(endpoint);
 });
 

--- a/src/composables/chat/useGenerationCompleteHandler.js
+++ b/src/composables/chat/useGenerationCompleteHandler.js
@@ -1,0 +1,291 @@
+function applyCompletionToMessage({
+    msg,
+    response,
+    finalReasoning,
+    duration,
+    meta,
+    guidanceText,
+    guidanceType,
+    estimateTokens,
+    char,
+    sessionId,
+    addMessageStats,
+    addRegenerationStats,
+    triggerAutoSyncCheck,
+    includeInitialGuidanceMeta = true
+}) {
+    msg.text = response;
+    msg.reasoning = finalReasoning;
+    msg.genTime = duration;
+    msg.tokens = estimateTokens(response);
+    msg.isTyping = false;
+
+    if (meta?.partialError) {
+        msg.isPartial = true;
+        msg.partialErrorMsg = meta.partialError;
+    }
+
+    if (!msg.swipes) msg.swipes = [];
+    if (!msg.swipesMeta) msg.swipesMeta = [];
+
+    if (msg.swipes.length === 1 && msg.swipes[0] === '') {
+        msg.swipes[0] = response;
+        msg.swipesMeta[0] = includeInitialGuidanceMeta
+            ? {
+                genTime: duration,
+                reasoning: finalReasoning,
+                tokens: msg.tokens,
+                guidanceText: msg.guidanceText,
+                guidanceType: msg.guidanceType
+            }
+            : {
+                genTime: duration,
+                reasoning: finalReasoning,
+                tokens: msg.tokens
+            };
+        addMessageStats(char.id, sessionId, msg.tokens, response.length, msg.timestamp);
+        triggerAutoSyncCheck();
+    } else {
+        msg.swipes[msg.swipeId || 0] = response;
+        if (!msg.swipesMeta[msg.swipeId || 0]) msg.swipesMeta[msg.swipeId || 0] = {};
+        msg.swipesMeta[msg.swipeId || 0].genTime = duration;
+        msg.swipesMeta[msg.swipeId || 0].reasoning = finalReasoning;
+        msg.swipesMeta[msg.swipeId || 0].tokens = msg.tokens;
+        msg.swipesMeta[msg.swipeId || 0].guidanceText = guidanceText;
+        msg.swipesMeta[msg.swipeId || 0].guidanceType = guidanceType;
+        addRegenerationStats(char.id, sessionId, msg.tokens, response.length);
+    }
+}
+
+export async function handleGenerationComplete({
+    response,
+    finalReasoning,
+    meta,
+    char,
+    sessionId,
+    msgId,
+    genId,
+    startTime,
+    controller,
+    guidanceText,
+    guidanceType,
+    activeChatChar,
+    isGenerating,
+    currentMessages,
+    displayMessages,
+    getGenerationState,
+    clearGenerationState,
+    clearPersistedGeneration,
+    clearBackgroundUpdateTimer,
+    clearTypingStateForMessage,
+    getChatData,
+    db,
+    cleanText,
+    estimateTokens,
+    updateSessionMessage,
+    processMessageImages,
+    userAvatar,
+    isItemVisible,
+    scrollToIndex,
+    smartScroll,
+    sendMessageNotification,
+    runMemoryAutomationAfterStableTurn,
+    addMessageStats,
+    addRegenerationStats,
+    triggerAutoSyncCheck
+}) {
+    const ensureCleanup = () => {
+        const currentState = getGenerationState(char.id);
+        if (currentState && currentState.timerId) clearInterval(currentState.timerId);
+        if (typeof clearBackgroundUpdateTimer === 'function') {
+            clearBackgroundUpdateTimer();
+        }
+        clearPersistedGeneration(char.id, sessionId);
+        clearGenerationState(char.id);
+        if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
+    };
+
+    const ensureStaleCleanup = () => {
+        if (typeof clearBackgroundUpdateTimer === 'function') {
+            clearBackgroundUpdateTimer();
+        }
+        clearPersistedGeneration(char.id, sessionId);
+    };
+
+    try {
+        const currentState = getGenerationState(char.id);
+        if (typeof clearBackgroundUpdateTimer === 'function') {
+            clearBackgroundUpdateTimer();
+        }
+
+        if (!currentState || currentState.genId !== genId) {
+            await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
+            ensureStaleCleanup();
+            window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId } }));
+            return;
+        }
+
+        if (currentState.timerId) clearInterval(currentState.timerId);
+        clearPersistedGeneration(char.id, sessionId);
+
+        const hasCompletionPayload = !!(response || finalReasoning || meta?.partialError);
+        if (controller.signal.aborted && !hasCompletionPayload) {
+            await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
+            ensureCleanup();
+            window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId } }));
+            return;
+        }
+
+        let wasVisible = false;
+        let displayIndex = -1;
+        const foundIndex = currentMessages.value.findIndex(m => m.id === currentState.msgId);
+
+        if (foundIndex !== -1) {
+            displayIndex = displayMessages.value.findIndex(m => m.type === 'message' && m.originalIndex === foundIndex);
+            if (displayIndex !== -1) {
+                wasVisible = isItemVisible(displayIndex);
+            }
+        }
+
+        clearGenerationState(char.id);
+        if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
+
+        const now = new Date();
+        const cleanedResponse = cleanText(response);
+        const time = now.getHours() + ':' + String(now.getMinutes()).padStart(2, '0');
+        const duration = ((Date.now() - startTime) / 1000).toFixed(2) + 's';
+
+        if (activeChatChar && activeChatChar.id === char.id && foundIndex !== -1) {
+            const msg = currentMessages.value[foundIndex];
+            msg.time = time;
+            applyCompletionToMessage({
+                msg,
+                response: cleanedResponse,
+                finalReasoning,
+                duration,
+                meta,
+                guidanceText,
+                guidanceType,
+                estimateTokens,
+                char,
+                sessionId,
+                addMessageStats,
+                addRegenerationStats,
+                triggerAutoSyncCheck,
+                includeInitialGuidanceMeta: true
+            });
+
+            updateSessionMessage(char, foundIndex, msg);
+
+            processMessageImages(msg.text, (updatedText) => {
+                msg.text = updatedText;
+                msg.swipes[msg.swipeId || 0] = updatedText;
+                if (!updatedText.includes('imggen-loading')) {
+                    updateSessionMessage(char, foundIndex, msg);
+                }
+            }, {
+                charAvatar: char.avatar || null,
+                userAvatar,
+                messages: currentMessages.value,
+                currentMsgIndex: foundIndex
+            }).then(finalText => {
+                if (finalText !== msg.text) {
+                    msg.text = finalText;
+                    msg.swipes[msg.swipeId || 0] = finalText;
+                    updateSessionMessage(char, foundIndex, msg);
+                }
+            }).catch(e => console.error('[ImageGen] processMessageImages failed:', e));
+
+            if (wasVisible) {
+                scrollToIndex(displayIndex, 'smooth', 'top');
+            } else {
+                smartScroll();
+            }
+
+            sendMessageNotification(char.name, cleanedResponse, char.avatar, char.id, sessionId, msgId);
+
+            if (guidanceType === 'GENERATION') {
+                const autoData = await getChatData(char.id);
+                if (autoData) {
+                    const autoSessionId = char.sessionId || autoData.currentId;
+                    autoData.sessions[autoSessionId] = currentMessages.value;
+                    await runMemoryAutomationAfterStableTurn(autoData, autoSessionId, currentMessages.value, { allowImmediate: true });
+                }
+            }
+
+            window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId } }));
+            return;
+        }
+
+        const bgData = await getChatData(char.id);
+        if (bgData && bgData.sessions[sessionId]) {
+            const bIdx = bgData.sessions[sessionId].findIndex(m => m.id === msgId);
+            if (bIdx !== -1) {
+                const msg = bgData.sessions[sessionId][bIdx];
+                msg.time = time;
+                applyCompletionToMessage({
+                    msg,
+                    response: cleanedResponse,
+                    finalReasoning,
+                    duration,
+                    meta,
+                    guidanceText,
+                    guidanceType,
+                    estimateTokens,
+                    char,
+                sessionId,
+                addMessageStats,
+                addRegenerationStats,
+                triggerAutoSyncCheck,
+                includeInitialGuidanceMeta: false
+            });
+
+                processMessageImages(cleanedResponse, (updatedText) => {
+                    msg.text = updatedText;
+                    msg.swipes[msg.swipeId || 0] = updatedText;
+                    if (!updatedText.includes('imggen-loading')) {
+                        db.saveChat(char.id, bgData);
+                    }
+            }, {
+                charAvatar: char.avatar || null,
+                userAvatar,
+                messages: bgData.sessions[sessionId],
+                currentMsgIndex: bIdx
+            }).then(finalText => {
+                    if (finalText !== msg.text) {
+                        msg.text = finalText;
+                        msg.swipes[msg.swipeId || 0] = finalText;
+                        db.saveChat(char.id, bgData);
+                    }
+                }).catch(e => console.error('[ImageGen] background processMessageImages failed:', e));
+
+                await db.saveChat(char.id, bgData);
+
+                if (guidanceType === 'GENERATION') {
+                    await runMemoryAutomationAfterStableTurn(bgData, sessionId, bgData.sessions[sessionId], { allowImmediate: true });
+                }
+
+                sendMessageNotification(char.name, cleanedResponse, char.avatar, char.id, sessionId, msgId);
+
+                db.get('gz_unread').then(unread => {
+                    const newUnread = unread || {};
+                    newUnread[char.id] = true;
+                    db.set('gz_unread', newUnread);
+                    window.dispatchEvent(new CustomEvent('chat-updated'));
+                });
+
+                window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId } }));
+            }
+        }
+    } catch (completeErr) {
+        console.error('[onComplete] Completion handler failed:', completeErr);
+        ensureCleanup();
+        await clearTypingStateForMessage({
+            charId: char.id,
+            sessionId,
+            msgId,
+            errorLabel: '[onComplete]'
+        });
+        window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId } }));
+    }
+}

--- a/src/composables/chat/useGenerationErrorHandler.js
+++ b/src/composables/chat/useGenerationErrorHandler.js
@@ -1,0 +1,92 @@
+export async function handleGenerationError({
+    error,
+    char,
+    sessionId,
+    msgId,
+    genId,
+    rawStreamText,
+    activeChatChar,
+    isGenerating,
+    currentMessages,
+    getGenerationState,
+    clearGenerationState,
+    restoreState,
+    clearBackgroundUpdateTimer,
+    clearTypingStateForMessage,
+    getChatData,
+    db,
+    formatError,
+    sendMessageNotification
+}) {
+    const state = getGenerationState(char.id);
+    if (!state || state.genId !== genId) return;
+
+    if (typeof clearBackgroundUpdateTimer === 'function') {
+        clearBackgroundUpdateTimer();
+    }
+
+    const ensureTypingCleared = async () => {
+        await clearTypingStateForMessage({
+            charId: char.id,
+            sessionId,
+            msgId,
+            errorLabel: '[onError]'
+        });
+    };
+
+    try {
+        if (error.message === 'Context limit exceeded') {
+            await restoreState(false);
+            clearGenerationState(char.id);
+            if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
+            window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId } }));
+            return;
+        }
+
+        await restoreState(true);
+        clearGenerationState(char.id);
+        if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
+
+        sendMessageNotification(
+            `Error - ${char.name}`,
+            error.message || 'Generation failed',
+            char.avatar,
+            char.id,
+            sessionId,
+            msgId
+        );
+
+        const idx = currentMessages.value.findIndex(m => m.id === msgId);
+        if (idx !== -1) {
+            const msg = currentMessages.value[idx];
+            msg.text = formatError(error, rawStreamText);
+            msg.isError = true;
+            if (msg.swipes && msg.swipes.length > 0) {
+                msg.swipes[msg.swipeId || 0] = msg.text;
+            }
+        } else {
+            const data = await getChatData(char.id);
+            if (data && data.sessions[sessionId]) {
+                const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
+                if (dbIdx !== -1) {
+                    const msg = data.sessions[sessionId][dbIdx];
+                    msg.text = formatError(error, rawStreamText);
+                    msg.isError = true;
+                    msg.isTyping = false;
+                    if (msg.swipes && msg.swipes.length > 0) {
+                        msg.swipes[msg.swipeId || 0] = msg.text;
+                    }
+                    await db.saveChat(char.id, data);
+                }
+            }
+        }
+
+        window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId } }));
+    } catch (handlerErr) {
+        console.error('[onError] Error handler failed:', handlerErr);
+        await ensureTypingCleared();
+        clearGenerationState(char.id);
+        if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
+        window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId } }));
+    }
+}

--- a/src/composables/chat/useGenerationPreparation.js
+++ b/src/composables/chat/useGenerationPreparation.js
@@ -1,0 +1,80 @@
+export function buildGenerationAuthorsNote({ getEffectivePreset, charId, sessionId, anContent }) {
+    const effectivePreset = getEffectivePreset(charId, sessionId ? `${charId}_${sessionId}` : null);
+    const anBlock = effectivePreset?.blocks?.find(block => block.id === 'authors_note');
+    const normalizedContent = typeof anContent === 'object' && anContent !== null
+        ? anContent.content
+        : anContent;
+
+    if (!anBlock || !anBlock.enabled || !normalizedContent) {
+        return null;
+    }
+
+    return {
+        content: normalizedContent,
+        role: anBlock.role || 'system',
+        enabled: true,
+        depth: anBlock.depth !== undefined ? anBlock.depth : 0,
+        insertion_mode: anBlock.insertion_mode || 'relative'
+    };
+}
+
+export async function ensureGenerationPlaceholderMessage({
+    msgIndex,
+    text,
+    guidanceText,
+    guidanceType,
+    currentMessages,
+    createBaseMessageMeta,
+    genMsgId,
+    charId,
+    sessionId,
+    getChatData,
+    db,
+    scrollToBottom
+}) {
+    if (msgIndex !== -1 || text) {
+        return msgIndex;
+    }
+
+    const now = new Date();
+    const time = now.getHours() + ':' + String(now.getMinutes()).padStart(2, '0');
+    const msg = {
+        id: genMsgId(),
+        role: 'char',
+        text: '',
+        time,
+        timestamp: Date.now(),
+        swipes: [''],
+        swipeId: 0,
+        isTyping: true,
+        guidanceText,
+        guidanceType,
+        ...createBaseMessageMeta()
+    };
+
+    currentMessages.value.push(msg);
+    const nextMsgIndex = currentMessages.value.length - 1;
+    const data = await getChatData(charId);
+    if (data) {
+        data.sessions[sessionId] = currentMessages.value;
+        await db.saveChat(charId, data);
+    }
+    scrollToBottom();
+
+    return nextMsgIndex;
+}
+
+export function buildGenerationHistory(currentMessages) {
+    return currentMessages.value
+        .map((message, index) => ({ ...message, originalIndex: index }))
+        .filter(message => !message.isTyping && !message.isHidden)
+        .map(message => ({
+            role: message.role === 'user' ? 'user' : 'assistant',
+            content: message.text || '',
+            text: message.text || '',
+            image: (message.image && !message.imageHidden) ? message.image : null,
+            chatId: message.originalIndex,
+            messageId: message.id || null,
+            contextRefs: Array.isArray(message.contextRefs) ? message.contextRefs : []
+        }));
+}

--- a/src/composables/chat/useGenerationPreparation.js
+++ b/src/composables/chat/useGenerationPreparation.js
@@ -18,6 +18,44 @@ export function buildGenerationAuthorsNote({ getEffectivePreset, charId, session
     };
 }
 
+export async function resolveGenerationSessionContext({
+    char,
+    db
+}) {
+    let chatData = null;
+    let sessionId = char.sessionId || null;
+    let summary = char.summary !== undefined ? char.summary : null;
+    let anContent = char.authors_note !== undefined ? char.authors_note : null;
+
+    if (!char.sessionId) {
+        chatData = await db.getChat(char.id);
+        sessionId = chatData?.currentId;
+
+        if (summary === null) {
+            summary = chatData?.summaries?.[sessionId];
+        }
+
+        if (anContent === null) {
+            anContent = chatData?.authorsNotes?.[sessionId];
+        }
+    }
+
+    if (typeof summary === 'object' && summary !== null) {
+        summary = summary.content;
+    }
+
+    if (typeof anContent === 'object' && anContent !== null) {
+        anContent = anContent.content;
+    }
+
+    return {
+        chatData,
+        sessionId,
+        summary,
+        anContent
+    };
+}
+
 export async function ensureGenerationPlaceholderMessage({
     msgIndex,
     text,

--- a/src/composables/chat/useGenerationPromptReady.js
+++ b/src/composables/chat/useGenerationPromptReady.js
@@ -1,0 +1,75 @@
+function mapTriggeredLorebooks(loreEntries) {
+    return loreEntries.map(entry => ({
+        id: entry.id,
+        name: entry.comment || entry.name || entry.keys?.[0] || 'Entry',
+        content: entry.content,
+        lorebookName: entry.lorebookName,
+        lorebookId: entry.lorebookId,
+        _source: entry._source || 'keyword'
+    }));
+}
+
+function mapTriggeredMemories(memoryEntries) {
+    return (memoryEntries || []).map(entry => ({
+        id: entry.id,
+        name: entry.title || 'Memory',
+        content: entry.content || '',
+        messageIds: Array.isArray(entry.messageIds) ? entry.messageIds : []
+    }));
+}
+
+function buildContextRefs(triggeredLorebooks, triggeredMemories, sessionId) {
+    return [
+        ...triggeredLorebooks.map(entry => ({
+            id: entry.id,
+            type: 'lorebook',
+            label: entry.name,
+            sourceId: entry.lorebookId || null,
+            sourceName: entry.lorebookName || null
+        })),
+        ...triggeredMemories.map(entry => ({
+            id: entry.id,
+            type: 'memory',
+            label: entry.name,
+            sourceId: sessionId,
+            sourceName: 'Memory Book'
+        }))
+    ];
+}
+
+export async function handleGenerationPromptReady({
+    loreEntries,
+    memoryEntries,
+    currentMessages,
+    msgIndex,
+    char,
+    sessionId,
+    getChatData,
+    db,
+    snapshotPromptMeta
+}) {
+    const triggeredLorebooks = mapTriggeredLorebooks(loreEntries);
+    const triggeredMemories = mapTriggeredMemories(memoryEntries);
+    const contextRefs = buildContextRefs(triggeredLorebooks, triggeredMemories, sessionId);
+
+    const assignRefs = (message) => {
+        snapshotPromptMeta(message);
+        message.triggeredLorebooks = triggeredLorebooks;
+        message.triggeredMemories = triggeredMemories;
+        message.contextRefs = contextRefs;
+    };
+
+    if (msgIndex !== -1 && currentMessages.value[msgIndex]) {
+        assignRefs(currentMessages.value[msgIndex]);
+    }
+
+    if (msgIndex > 0 && currentMessages.value[msgIndex - 1]?.role === 'user') {
+        assignRefs(currentMessages.value[msgIndex - 1]);
+    }
+
+    const data = await getChatData(char.id);
+    if (data) {
+        data.sessions[sessionId] = currentMessages.value;
+        await db.saveChat(char.id, data);
+    }
+}

--- a/src/composables/chat/useGenerationRegistry.js
+++ b/src/composables/chat/useGenerationRegistry.js
@@ -1,0 +1,49 @@
+const generationStates = {};
+let generationIdCounter = 0;
+
+function getGeneratingStorageKey(charId, sessionId) {
+    return `gz_generating_${charId}_${sessionId}`;
+}
+
+export function useGenerationRegistry() {
+    return {
+        nextGenerationId() {
+            generationIdCounter += 1;
+            return generationIdCounter;
+        },
+
+        listGeneratingCharIds() {
+            return Object.keys(generationStates);
+        },
+
+        getGenerationState(charId) {
+            return generationStates[charId] || null;
+        },
+
+        hasGenerationState(charId) {
+            return !!generationStates[charId];
+        },
+
+        setGenerationState(charId, state) {
+            generationStates[charId] = state;
+            return generationStates[charId];
+        },
+
+        clearGenerationState(charId, expectedGenId = null) {
+            const currentState = generationStates[charId];
+            if (!currentState) return false;
+            if (expectedGenId !== null && currentState.genId !== expectedGenId) return false;
+
+            delete generationStates[charId];
+            return true;
+        },
+
+        markGenerationPersisted(charId, sessionId) {
+            localStorage.setItem(getGeneratingStorageKey(charId, sessionId), 'true');
+        },
+
+        clearPersistedGeneration(charId, sessionId) {
+            localStorage.removeItem(getGeneratingStorageKey(charId, sessionId));
+        }
+    };
+}

--- a/src/composables/chat/useGenerationStateRestore.js
+++ b/src/composables/chat/useGenerationStateRestore.js
@@ -1,0 +1,96 @@
+function rollbackPendingSwipe(message, { restoreSwipeMeta = false } = {}) {
+    if (!message?.swipes || message.swipes.length <= 1) {
+        return false;
+    }
+
+    const currentSwipeId = message.swipeId || 0;
+    message.swipes.splice(currentSwipeId, 1);
+    if (message.swipesMeta) message.swipesMeta.splice(currentSwipeId, 1);
+
+    let newSwipeId = currentSwipeId - 1;
+    if (newSwipeId < 0) newSwipeId = 0;
+
+    message.swipeId = newSwipeId;
+    message.text = message.swipes[newSwipeId] || '';
+
+    if (restoreSwipeMeta) {
+        if (message.swipesMeta && message.swipesMeta[newSwipeId]) {
+            message.guidanceText = message.swipesMeta[newSwipeId].guidanceText || null;
+            message.guidanceType = message.swipesMeta[newSwipeId].guidanceType || 'GENERATION';
+            message.reasoning = message.swipesMeta[newSwipeId].reasoning;
+            message.genTime = message.swipesMeta[newSwipeId].genTime;
+        } else {
+            message.guidanceText = null;
+            message.guidanceType = 'GENERATION';
+        }
+    }
+
+    return true;
+}
+
+export async function restoreGenerationState({
+    currentMessages,
+    getChatData,
+    db,
+    getGenerationState,
+    clearPersistedGeneration,
+    char,
+    sessionId,
+    msgId,
+    isError = false,
+    onAbort = null,
+    restorePromptMetaOnMessages,
+    clearBackgroundUpdateTimer,
+    updateSessionMessage
+}) {
+    if (typeof clearBackgroundUpdateTimer === 'function') {
+        clearBackgroundUpdateTimer();
+    }
+
+    const timerId = getGenerationState(char.id)?.timerId;
+    if (timerId) clearInterval(timerId);
+    clearPersistedGeneration(char.id, sessionId);
+
+    const idx = currentMessages.value.findIndex(m => m.id === msgId);
+    if (idx !== -1) {
+        restorePromptMetaOnMessages(currentMessages.value);
+        currentMessages.value[idx].isTyping = false;
+
+        if (!isError) {
+            const msg = currentMessages.value[idx];
+            const revertedSwipe = rollbackPendingSwipe(msg, { restoreSwipeMeta: true });
+
+            if (revertedSwipe) {
+                await updateSessionMessage(char, idx, msg);
+            } else {
+                currentMessages.value.splice(idx, 1);
+                const data = await getChatData(char.id);
+                if (data && sessionId && data.sessions[sessionId]) {
+                    data.sessions[sessionId] = currentMessages.value;
+                    await db.saveChat(char.id, data);
+                }
+            }
+        }
+    } else {
+        const data = await getChatData(char.id);
+        if (data && data.sessions[sessionId]) {
+            restorePromptMetaOnMessages(data.sessions[sessionId]);
+            const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
+            if (dbIdx !== -1) {
+                data.sessions[sessionId][dbIdx].isTyping = false;
+
+                if (!isError) {
+                    const msg = data.sessions[sessionId][dbIdx];
+                    const revertedSwipe = rollbackPendingSwipe(msg);
+                    if (!revertedSwipe) {
+                        data.sessions[sessionId].splice(dbIdx, 1);
+                    }
+                }
+
+                await db.saveChat(char.id, data);
+            }
+        }
+    }
+
+    if (onAbort) onAbort(isError);
+}

--- a/src/composables/chat/useGenerationStateSetup.js
+++ b/src/composables/chat/useGenerationStateSetup.js
@@ -1,0 +1,69 @@
+export function applyGenerationGuidanceState({
+    currentMessages,
+    msgIndex,
+    guidanceText,
+    guidanceType
+}) {
+    if (msgIndex === -1 || !currentMessages.value[msgIndex]) {
+        return;
+    }
+
+    const msg = currentMessages.value[msgIndex];
+    msg.guidanceText = guidanceText;
+    msg.guidanceType = guidanceType;
+
+    if (msg.swipesMeta && msg.swipesMeta[msg.swipeId || 0]) {
+        msg.swipesMeta[msg.swipeId || 0].guidanceText = null;
+        msg.swipesMeta[msg.swipeId || 0].guidanceType = null;
+    }
+}
+
+export function setupGenerationState({
+    char,
+    msgId,
+    genId,
+    controller,
+    startTime,
+    currentMessages,
+    activeChatChar,
+    setGenerationState,
+    getGenerationState,
+    smartScroll
+}) {
+    const initialUIUpdate = (text, reasoning, isTyping, textDelta) => {
+        const idx = currentMessages.value.findIndex(message => message.id === msgId);
+        if (idx === -1) {
+            return;
+        }
+
+        const message = currentMessages.value[idx];
+        if (textDelta) {
+            message.text = message.text.replace(/class="stream-char"/g, 'class="stream-char-done"');
+            message.text += `<span class="stream-char">${textDelta}</span>`;
+        } else {
+            message.text = text;
+        }
+        message.reasoning = reasoning;
+        message.isTyping = isTyping;
+        smartScroll();
+    };
+
+    setGenerationState(char.id, {
+        genId,
+        controller,
+        startTime,
+        msgId,
+        timerId: null,
+        onUIUpdate: initialUIUpdate
+    });
+
+    getGenerationState(char.id).timerId = setInterval(() => {
+        if (activeChatChar && activeChatChar.id === char.id) {
+            const idx = currentMessages.value.findIndex(message => message.id === msgId);
+            if (idx !== -1) {
+                const elapsed = ((Date.now() - startTime) / 1000).toFixed(1) + 's';
+                currentMessages.value[idx].genTime = elapsed;
+            }
+        }
+    }, 100);
+}

--- a/src/composables/chat/useGenerationStreamUpdate.js
+++ b/src/composables/chat/useGenerationStreamUpdate.js
@@ -1,0 +1,66 @@
+export function createGenerationStreamUpdater({
+    char,
+    sessionId,
+    msgId,
+    genId,
+    getGenerationState,
+    getChatData,
+    db,
+    onRawText
+}) {
+    let backgroundUpdateTimer = null;
+    let backgroundPendingText = null;
+    let backgroundPendingReasoning = null;
+
+    const clearBackgroundUpdateTimer = () => {
+        if (backgroundUpdateTimer) {
+            clearTimeout(backgroundUpdateTimer);
+            backgroundUpdateTimer = null;
+        }
+    };
+
+    const onUpdate = async (chunk, reasoningChunk, effectiveText, effectiveReasoning, textDelta) => {
+        if (typeof onRawText === 'function') {
+            onRawText(effectiveText, chunk);
+        }
+
+        const state = getGenerationState(char.id);
+        if (state && state.genId === genId && state.onUIUpdate) {
+            state.onUIUpdate(effectiveText, effectiveReasoning, true, textDelta);
+            return;
+        }
+
+        if (!state || state.genId !== genId) {
+            return;
+        }
+
+        backgroundPendingText = effectiveText;
+        backgroundPendingReasoning = effectiveReasoning;
+        if (backgroundUpdateTimer) {
+            return;
+        }
+
+        backgroundUpdateTimer = setTimeout(async () => {
+            backgroundUpdateTimer = null;
+            if (backgroundPendingText === null) return;
+
+            const latestState = getGenerationState(char.id);
+            if (!latestState || latestState.genId !== genId) return;
+
+            const data = await getChatData(char.id);
+            if (data && data.sessions[sessionId]) {
+                const dbMsg = data.sessions[sessionId].find(m => m.id === msgId);
+                if (dbMsg) {
+                    dbMsg.text = backgroundPendingText;
+                    dbMsg.reasoning = backgroundPendingReasoning;
+                    await db.saveChat(char.id, data);
+                }
+            }
+        }, 2000);
+    };
+
+    return {
+        onUpdate,
+        clearBackgroundUpdateTimer
+    };
+}

--- a/src/composables/chat/usePromptMetadataSnapshots.js
+++ b/src/composables/chat/usePromptMetadataSnapshots.js
@@ -1,0 +1,51 @@
+function clonePromptMetaList(items) {
+    return Array.isArray(items)
+        ? items.map(item => ({ ...item }))
+        : [];
+}
+
+export function usePromptMetadataSnapshots() {
+    const promptMetaSnapshots = new Map();
+
+    return {
+        snapshotPromptMeta(message) {
+            if (!message?.id || promptMetaSnapshots.has(message.id)) return;
+
+            promptMetaSnapshots.set(message.id, {
+                hasTriggeredLorebooks: Object.prototype.hasOwnProperty.call(message, 'triggeredLorebooks'),
+                hasTriggeredMemories: Object.prototype.hasOwnProperty.call(message, 'triggeredMemories'),
+                hasContextRefs: Object.prototype.hasOwnProperty.call(message, 'contextRefs'),
+                triggeredLorebooks: clonePromptMetaList(message.triggeredLorebooks),
+                triggeredMemories: clonePromptMetaList(message.triggeredMemories),
+                contextRefs: clonePromptMetaList(message.contextRefs)
+            });
+        },
+
+        restorePromptMetaOnMessages(messages) {
+            if (!Array.isArray(messages) || promptMetaSnapshots.size === 0) return false;
+
+            let changed = false;
+            messages.forEach(message => {
+                const snapshot = message?.id ? promptMetaSnapshots.get(message.id) : null;
+                if (!snapshot) return;
+
+                if (snapshot.hasTriggeredLorebooks) message.triggeredLorebooks = clonePromptMetaList(snapshot.triggeredLorebooks);
+                else delete message.triggeredLorebooks;
+
+                if (snapshot.hasTriggeredMemories) message.triggeredMemories = clonePromptMetaList(snapshot.triggeredMemories);
+                else delete message.triggeredMemories;
+
+                if (snapshot.hasContextRefs) message.contextRefs = clonePromptMetaList(snapshot.contextRefs);
+                else delete message.contextRefs;
+
+                changed = true;
+            });
+
+            return changed;
+        }
+    };
+}
+
+export function createPromptMetadataSnapshots() {
+    return usePromptMetadataSnapshots();
+}

--- a/src/composables/chat/useTypingStateCleanup.js
+++ b/src/composables/chat/useTypingStateCleanup.js
@@ -1,0 +1,23 @@
+export function useTypingStateCleanup({ currentMessages, getChatData, db }) {
+    return {
+        async clearTypingStateForMessage({ charId, sessionId, msgId, errorLabel = '[generation]' }) {
+            const idx = currentMessages.value.findIndex(m => m.id === msgId);
+            if (idx !== -1) {
+                currentMessages.value[idx].isTyping = false;
+            }
+
+            try {
+                const data = await getChatData(charId);
+                if (data && data.sessions[sessionId]) {
+                    const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
+                    if (dbIdx !== -1) {
+                        data.sessions[sessionId][dbIdx].isTyping = false;
+                        await db.saveChat(charId, data);
+                    }
+                }
+            } catch (dbErr) {
+                console.error(`${errorLabel} Failed to clear isTyping in DB:`, dbErr);
+            }
+        }
+    };
+}

--- a/src/core/config/APISettings.js
+++ b/src/core/config/APISettings.js
@@ -1,5 +1,6 @@
-import { Capacitor, CapacitorHttp } from '@capacitor/core';
 import { db } from '@/utils/db.js';
+import { DEFAULT_PROVIDER_ID } from '@/core/llm/contracts/providerContracts.js';
+import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
 
 export const PROVIDER_BLACKLIST = [
     { name: 'EllyAI', match: 'ellyai' },
@@ -14,6 +15,7 @@ export function getBlacklistedProvider(url) {
 
 export async function initSettings() {
     // Ensure defaults exist
+    if (localStorage.getItem('gz_api_provider') === null) localStorage.setItem('gz_api_provider', DEFAULT_PROVIDER_ID);
     if (localStorage.getItem('gz_api_temp') === null) localStorage.setItem('gz_api_temp', '0.7');
     if (localStorage.getItem('gz_api_topp') === null) localStorage.setItem('gz_api_topp', '0.9');
     if (localStorage.getItem('gz_api_stream') === null) localStorage.setItem('gz_api_stream', 'true');
@@ -25,26 +27,18 @@ export async function initSettings() {
 }
 
 export function normalizeEndpoint(url) {
-    if (!url) return '';
-    let normalized = url.trim();
-    if (!/^https?:\/\//i.test(normalized)) {
-        normalized = 'https://' + normalized;
-    }
-    if (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
+    return getProviderById(getApiProviderId()).normalizeEndpoint(url);
+}
 
-    const suffix = '/chat/completions';
-    if (normalized.toLowerCase().endsWith(suffix)) {
-        normalized = normalized.slice(0, -suffix.length);
-    }
-    if (normalized.endsWith('/')) normalized = normalized.slice(0, -1);
-
-    return normalized;
+export function getApiProviderId() {
+    return localStorage.getItem('gz_api_provider') || DEFAULT_PROVIDER_ID;
 }
 
 export function getApiConfig() {
     const mt = parseInt(localStorage.getItem('api-max-tokens'));
     const ctx = parseInt(localStorage.getItem('api-context'));
     return {
+        providerId: getApiProviderId(),
         apiKey: localStorage.getItem('api-key') || '',
         apiUrl: localStorage.getItem('gz_api_endpoint_normalized') || localStorage.getItem('api-endpoint') || '',
         model: localStorage.getItem('api-model') || '',
@@ -60,38 +54,9 @@ export function getApiConfig() {
     };
 }
 
-export async function fetchRemoteModels(endpoint, key) {
-    if (!endpoint) throw new Error("No endpoint");
-
-    let url = endpoint;
-    if (url.endsWith('/chat/completions')) url = url.replace('/chat/completions', '');
-    if (url.endsWith('/')) url = url.slice(0, -1);
-    if (!url.endsWith('/models')) url += '/models';
-
-    const headers = {};
-    if (key) headers['Authorization'] = `Bearer ${key}`;
-
-    let data;
-    if (Capacitor.isNativePlatform()) {
-        const response = await CapacitorHttp.get({
-            url: url,
-            headers: headers
-        });
-        if (response.status >= 400) throw new Error(`HTTP ${response.status}`);
-        data = response.data;
-    } else {
-        const res = await fetch(url, { headers });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        data = await res.json();
-    }
-
-    let models = [];
-    if (data.data && Array.isArray(data.data)) {
-        models = data.data.map(m => m.id);
-    } else if (Array.isArray(data)) {
-        models = data.map(m => m.id);
-    }
-    return models.sort();
+export async function fetchRemoteModels(endpoint, key, providerId = getApiProviderId()) {
+    const provider = getProviderById(providerId);
+    return provider.listModels({ endpoint, apiKey: key });
 }
 
 export async function getApiPresets() {
@@ -103,6 +68,7 @@ export async function getApiPresets() {
     return [{
         id: 'default',
         name: 'Default',
+        providerId: getApiProviderId(),
         endpoint: localStorage.getItem('api-endpoint') || '',
         key: localStorage.getItem('api-key') || '',
         model: localStorage.getItem('api-model') || '',

--- a/src/core/config/APISettings.js
+++ b/src/core/config/APISettings.js
@@ -34,23 +34,93 @@ export function getApiProviderId() {
     return localStorage.getItem('gz_api_provider') || DEFAULT_PROVIDER_ID;
 }
 
-export function getApiConfig() {
-    const mt = parseInt(localStorage.getItem('api-max-tokens'));
-    const ctx = parseInt(localStorage.getItem('api-context'));
+export function getApiReasoningTags() {
+    return {
+        start: localStorage.getItem('gz_api_reasoning_start') || '<think>',
+        end: localStorage.getItem('gz_api_reasoning_end') || '</think>'
+    };
+}
+
+export function getApiRuntimeStorage() {
+    const maxTokens = parseInt(localStorage.getItem('api-max-tokens'));
+    const contextSize = parseInt(localStorage.getItem('api-context'));
     return {
         providerId: getApiProviderId(),
-        apiKey: localStorage.getItem('api-key') || '',
-        apiUrl: localStorage.getItem('gz_api_endpoint_normalized') || localStorage.getItem('api-endpoint') || '',
+        endpoint: localStorage.getItem('api-endpoint') || '',
+        normalizedEndpoint: localStorage.getItem('gz_api_endpoint_normalized') || localStorage.getItem('api-endpoint') || '',
+        key: localStorage.getItem('api-key') || '',
         model: localStorage.getItem('api-model') || '',
-        stream: localStorage.getItem('gz_api_stream') === 'true',
-        requestReasoning: localStorage.getItem('gz_api_request_reasoning') === 'true',
+        maxTokens: isNaN(maxTokens) ? 8000 : maxTokens,
+        contextSize: isNaN(contextSize) ? 32000 : contextSize,
         temp: parseFloat(localStorage.getItem('gz_api_temp')) || 0.7,
         topP: parseFloat(localStorage.getItem('gz_api_topp')) || 0.9,
-        maxTokens: isNaN(mt) ? 8000 : mt,
-        contextSize: isNaN(ctx) ? 32000 : ctx,
+        stream: localStorage.getItem('gz_api_stream') === 'true',
+        requestReasoning: localStorage.getItem('gz_api_request_reasoning') === 'true',
         autoHideImages: localStorage.getItem('gz_api_auto_hide_images') === 'true',
         autoHideImagesN: parseInt(localStorage.getItem('gz_api_auto_hide_images_n') || '1', 10),
-        reasoningEffort: localStorage.getItem('gz_api_reasoning_effort') || 'medium'
+        reasoningEffort: localStorage.getItem('gz_api_reasoning_effort') || 'medium',
+        reasoningTags: getApiReasoningTags()
+    };
+}
+
+export function saveApiRuntimeSetting(key, value) {
+    if (key === 'api-endpoint') {
+        localStorage.setItem('gz_api_endpoint_normalized', normalizeEndpoint(value));
+    }
+
+    localStorage.setItem(key, value);
+
+    if (key === 'api-context' || key === 'api-max-tokens') {
+        window.dispatchEvent(new CustomEvent('api-context-settings-changed'));
+    }
+}
+
+export function applyApiRuntimeConfig({
+    providerId,
+    endpoint,
+    apiKey,
+    model,
+    maxTokens,
+    contextSize,
+    temp,
+    topP,
+    stream,
+    autoHideImages,
+    autoHideImagesN,
+    requestReasoning,
+    reasoningEffort
+} = {}) {
+    if (providerId !== undefined) localStorage.setItem('gz_api_provider', providerId);
+    if (endpoint !== undefined) saveApiRuntimeSetting('api-endpoint', endpoint);
+    if (apiKey !== undefined) saveApiRuntimeSetting('api-key', apiKey);
+    if (model !== undefined) saveApiRuntimeSetting('api-model', model);
+    if (maxTokens !== undefined) saveApiRuntimeSetting('api-max-tokens', String(maxTokens));
+    if (contextSize !== undefined) saveApiRuntimeSetting('api-context', String(contextSize));
+    if (temp !== undefined) saveApiRuntimeSetting('gz_api_temp', String(temp));
+    if (topP !== undefined) saveApiRuntimeSetting('gz_api_topp', String(topP));
+    if (stream !== undefined) saveApiRuntimeSetting('gz_api_stream', String(stream));
+    if (autoHideImages !== undefined) saveApiRuntimeSetting('gz_api_auto_hide_images', String(autoHideImages));
+    if (autoHideImagesN !== undefined) saveApiRuntimeSetting('gz_api_auto_hide_images_n', String(autoHideImagesN));
+    if (requestReasoning !== undefined) saveApiRuntimeSetting('gz_api_request_reasoning', String(requestReasoning));
+    if (reasoningEffort !== undefined) saveApiRuntimeSetting('gz_api_reasoning_effort', String(reasoningEffort));
+}
+
+export function getApiConfig() {
+    const runtime = getApiRuntimeStorage();
+    return {
+        providerId: runtime.providerId,
+        apiKey: runtime.key,
+        apiUrl: runtime.normalizedEndpoint,
+        model: runtime.model,
+        stream: runtime.stream,
+        requestReasoning: runtime.requestReasoning,
+        temp: runtime.temp,
+        topP: runtime.topP,
+        maxTokens: runtime.maxTokens,
+        contextSize: runtime.contextSize,
+        autoHideImages: runtime.autoHideImages,
+        autoHideImagesN: runtime.autoHideImagesN,
+        reasoningEffort: runtime.reasoningEffort
     };
 }
 

--- a/src/core/llm/assemblers/payloadBuilderRegistry.js
+++ b/src/core/llm/assemblers/payloadBuilderRegistry.js
@@ -1,0 +1,93 @@
+import { REQUEST_KINDS } from '@/core/llm/contracts/providerContracts.js';
+
+function stripEmbeddedMedia(text) {
+    if (!text || text.length < 256) return text;
+    let cleaned = text.replace(/<img\s[^>]*src\s*=\s*["']data:image\/[^"']{256,}["'][^>]*\/?>/gi, '');
+    cleaned = cleaned.replace(/data:image\/[a-z+]+;base64,[A-Za-z0-9+/=\n\r]{256,}/gi, '');
+    return cleaned;
+}
+
+function sanitizeChatMessages(messages = []) {
+    return messages.map(message => {
+        const cleanMsg = {
+            role: message.role,
+            content: stripEmbeddedMedia(message.content)
+        };
+
+        if (message.image) {
+            cleanMsg.content = [
+                { type: 'text', text: message.content || '' },
+                { type: 'image_url', image_url: { url: message.image } }
+            ];
+        }
+
+        if (message.name) cleanMsg.name = message.name;
+        return cleanMsg;
+    });
+}
+
+function buildOpenAiCompatiblePayload(intent) {
+    switch (intent.kind) {
+        case REQUEST_KINDS.CHAT: {
+            const previewBody = {
+                model: intent.model,
+                messages: intent.messages,
+                temperature: intent.temperature,
+                top_p: intent.topP,
+                stream: intent.stream
+            };
+
+            if (intent.reasoningEffort && intent.reasoningEffort !== 'auto') {
+                previewBody.reasoning_effort = intent.reasoningEffort;
+            }
+
+            if (intent.maxTokens > 0) {
+                previewBody.max_tokens = intent.maxTokens;
+            }
+
+            if (intent.stopString) {
+                previewBody.stop = [intent.stopString];
+            }
+
+            return {
+                previewBody,
+                requestBody: {
+                    ...previewBody,
+                    messages: sanitizeChatMessages(intent.messages)
+                }
+            };
+        }
+
+        case REQUEST_KINDS.SUMMARY: {
+            const requestBody = {
+                model: intent.model,
+                messages: [{ role: 'user', content: intent.prompt }],
+                temperature: intent.temperature
+            };
+            return { previewBody: requestBody, requestBody };
+        }
+
+        case REQUEST_KINDS.MEMORY_DRAFT: {
+            const requestBody = {
+                model: intent.model,
+                messages: [{ role: 'user', content: intent.prompt }],
+                temperature: intent.temperature,
+                max_tokens: intent.maxTokens,
+                stream: false
+            };
+            return { previewBody: requestBody, requestBody };
+        }
+
+        default:
+            throw new Error(`Unsupported request intent kind: ${intent.kind}`);
+    }
+}
+
+const payloadBuilders = new Map([
+    ['openai_compatible', buildOpenAiCompatiblePayload]
+]);
+
+export function buildProviderPayload(providerId, intent) {
+    const builder = payloadBuilders.get(providerId) || payloadBuilders.get('openai_compatible');
+    return builder(intent);
+}

--- a/src/core/llm/assemblers/requestAssemblers.js
+++ b/src/core/llm/assemblers/requestAssemblers.js
@@ -1,0 +1,27 @@
+import { buildProviderPayload } from '@/core/llm/assemblers/payloadBuilderRegistry.js';
+import { createChatRequestIntent, createSummaryRequestIntent, createMemoryDraftRequestIntent } from '@/core/llm/assemblers/requestIntents.js';
+
+export function buildChatRequestPayload({ providerId, model, messages, temperature, topP, stream, reasoningEffort, maxTokens, stopString }) {
+    const intent = createChatRequestIntent({
+        model,
+        messages,
+        temperature,
+        topP,
+        stream,
+        reasoningEffort,
+        maxTokens,
+        stopString
+    });
+
+    return buildProviderPayload(providerId, intent);
+}
+
+export function buildSummaryRequestPayload({ providerId, model, prompt, temperature }) {
+    const intent = createSummaryRequestIntent({ model, prompt, temperature });
+    return buildProviderPayload(providerId, intent);
+}
+
+export function buildMemoryDraftRequestPayload({ providerId, model, prompt, temperature, maxTokens }) {
+    const intent = createMemoryDraftRequestIntent({ model, prompt, temperature, maxTokens });
+    return buildProviderPayload(providerId, intent);
+}

--- a/src/core/llm/assemblers/requestIntents.js
+++ b/src/core/llm/assemblers/requestIntents.js
@@ -1,0 +1,36 @@
+import { REQUEST_KINDS } from '@/core/llm/contracts/providerContracts.js';
+
+export function createChatRequestIntent({ model, messages, temperature, topP, stream, reasoningEffort, maxTokens, stopString }) {
+    return {
+        kind: REQUEST_KINDS.CHAT,
+        model,
+        messages,
+        temperature,
+        topP,
+        stream,
+        reasoningEffort,
+        maxTokens,
+        stopString
+    };
+}
+
+export function createSummaryRequestIntent({ model, prompt, temperature }) {
+    return {
+        kind: REQUEST_KINDS.SUMMARY,
+        model,
+        prompt,
+        temperature,
+        stream: false
+    };
+}
+
+export function createMemoryDraftRequestIntent({ model, prompt, temperature, maxTokens }) {
+    return {
+        kind: REQUEST_KINDS.MEMORY_DRAFT,
+        model,
+        prompt,
+        temperature,
+        maxTokens,
+        stream: false
+    };
+}

--- a/src/core/llm/contracts/providerContracts.js
+++ b/src/core/llm/contracts/providerContracts.js
@@ -1,0 +1,31 @@
+export const DEFAULT_PROVIDER_ID = 'openai_compatible';
+
+export const REQUEST_KINDS = Object.freeze({
+    CHAT: 'chat',
+    SUMMARY: 'summary',
+    MEMORY_DRAFT: 'memory_draft',
+    MODEL_DISCOVERY: 'model_discovery'
+});
+
+export const CAPABILITY_FLAGS = Object.freeze({
+    CHAT_COMPLETIONS: 'chat_completions',
+    MODEL_DISCOVERY: 'model_discovery',
+    STREAMING: 'streaming',
+    REASONING_FIELD: 'reasoning_field',
+    INLINE_REASONING: 'inline_reasoning',
+    SYSTEM_ROLE: 'system_role',
+    IMAGES: 'images'
+});
+
+export function createProviderCapabilities(overrides = {}) {
+    return Object.freeze({
+        [CAPABILITY_FLAGS.CHAT_COMPLETIONS]: false,
+        [CAPABILITY_FLAGS.MODEL_DISCOVERY]: false,
+        [CAPABILITY_FLAGS.STREAMING]: false,
+        [CAPABILITY_FLAGS.REASONING_FIELD]: false,
+        [CAPABILITY_FLAGS.INLINE_REASONING]: false,
+        [CAPABILITY_FLAGS.SYSTEM_ROLE]: false,
+        [CAPABILITY_FLAGS.IMAGES]: false,
+        ...overrides
+    });
+}

--- a/src/core/llm/providers/openaiCompatibleProvider.js
+++ b/src/core/llm/providers/openaiCompatibleProvider.js
@@ -1,0 +1,101 @@
+import { Capacitor, CapacitorHttp } from '@capacitor/core';
+import { CAPABILITY_FLAGS, DEFAULT_PROVIDER_ID, createProviderCapabilities } from '@/core/llm/contracts/providerContracts.js';
+
+function trimTrailingSlash(value = '') {
+    return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function normalizeBaseEndpoint(endpoint = '') {
+    let normalized = String(endpoint || '').trim();
+    if (!normalized) return '';
+
+    if (!/^https?:\/\//i.test(normalized)) {
+        normalized = `https://${normalized}`;
+    }
+
+    normalized = trimTrailingSlash(normalized);
+
+    const chatSuffix = '/chat/completions';
+    if (normalized.toLowerCase().endsWith(chatSuffix)) {
+        normalized = normalized.slice(0, -chatSuffix.length);
+    }
+
+    return trimTrailingSlash(normalized);
+}
+
+function buildAuthHeaders(apiKey) {
+    const headers = {};
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+    return headers;
+}
+
+function parseModelList(data) {
+    if (data?.data && Array.isArray(data.data)) {
+        return data.data.map(model => model.id).filter(Boolean).sort();
+    }
+
+    if (Array.isArray(data)) {
+        return data.map(model => model?.id).filter(Boolean).sort();
+    }
+
+    return [];
+}
+
+export const openaiCompatibleProvider = Object.freeze({
+    id: DEFAULT_PROVIDER_ID,
+    label: 'OpenAI Compatible',
+    capabilities: createProviderCapabilities({
+        [CAPABILITY_FLAGS.CHAT_COMPLETIONS]: true,
+        [CAPABILITY_FLAGS.MODEL_DISCOVERY]: true,
+        [CAPABILITY_FLAGS.STREAMING]: true,
+        [CAPABILITY_FLAGS.REASONING_FIELD]: true,
+        [CAPABILITY_FLAGS.INLINE_REASONING]: true,
+        [CAPABILITY_FLAGS.SYSTEM_ROLE]: true,
+        [CAPABILITY_FLAGS.IMAGES]: true
+    }),
+
+    normalizeEndpoint(endpoint) {
+        return normalizeBaseEndpoint(endpoint);
+    },
+
+    buildChatCompletionsUrl(endpoint) {
+        const base = normalizeBaseEndpoint(endpoint);
+        return base ? `${base}/chat/completions` : '';
+    },
+
+    buildModelsUrl(endpoint) {
+        const base = normalizeBaseEndpoint(endpoint);
+        return base ? `${base}/models` : '';
+    },
+
+    buildAuthHeaders(apiKey) {
+        return buildAuthHeaders(apiKey);
+    },
+
+    parseModelList(data) {
+        return parseModelList(data);
+    },
+
+    async listModels({ endpoint, apiKey }) {
+        const url = this.buildModelsUrl(endpoint);
+        if (!url) throw new Error('No endpoint');
+
+        const headers = this.buildAuthHeaders(apiKey);
+
+        let data;
+        if (Capacitor.isNativePlatform()) {
+            const response = await CapacitorHttp.get({
+                url,
+                headers
+            });
+            if (response.status >= 400) throw new Error(`HTTP ${response.status}`);
+            data = response.data;
+        } else {
+            const response = await fetch(url, { headers });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            data = await response.json();
+        }
+
+        return this.parseModelList(data);
+    }
+});

--- a/src/core/llm/providers/providerRegistry.js
+++ b/src/core/llm/providers/providerRegistry.js
@@ -1,0 +1,18 @@
+import { DEFAULT_PROVIDER_ID } from '@/core/llm/contracts/providerContracts.js';
+import { openaiCompatibleProvider } from '@/core/llm/providers/openaiCompatibleProvider.js';
+
+const providers = new Map([
+    [openaiCompatibleProvider.id, openaiCompatibleProvider]
+]);
+
+export function getProviderById(providerId = DEFAULT_PROVIDER_ID) {
+    return providers.get(providerId) || providers.get(DEFAULT_PROVIDER_ID);
+}
+
+export function listProviders() {
+    return [...providers.values()];
+}
+
+export function getDefaultProvider() {
+    return getProviderById(DEFAULT_PROVIDER_ID);
+}

--- a/src/core/llm/transport/chatCompletionsClient.js
+++ b/src/core/llm/transport/chatCompletionsClient.js
@@ -1,0 +1,92 @@
+import { executeFetchRequest, validateFetchResponse } from '@/core/llm/transport/requestExecution.js';
+import { completeJsonResponse, getStreamingResponseMode } from '@/core/llm/transport/responseHandling.js';
+import { finalizeStreamResponse } from '@/core/llm/transport/requestOutcome.js';
+import { consumeStreamingSseResponse } from '@/core/llm/transport/streamingSse.js';
+
+export async function executeFetchChatCompletions({
+    requestUrl,
+    requestBody,
+    controller,
+    requestLifecycle,
+    stream,
+    requestReasoning,
+    hasInlineTags,
+    tagStart,
+    tagEnd,
+    headerModel,
+    headerInline,
+    streamAccumulator,
+    onUpdate,
+    onComplete
+}) {
+    requestLifecycle.startConnectTimeout();
+
+    const response = await executeFetchRequest({
+        requestUrl,
+        headers: requestLifecycle.headers,
+        requestBody,
+        controller
+    });
+
+    requestLifecycle.throwIfAborted();
+    requestLifecycle.clearConnectTimeout();
+
+    await validateFetchResponse(response);
+
+    if (!stream) {
+        await completeJsonResponse({
+            response,
+            throwIfAborted: requestLifecycle.throwIfAborted,
+            contextLabel: 'API response structure',
+            logLabel: 'LLM Response:',
+            requestReasoning,
+            hasInlineTags,
+            tagStart,
+            tagEnd,
+            headerModel,
+            headerInline,
+            onComplete
+        });
+        return;
+    }
+
+    const { contentType, supportsStreamingBody, canStreamSse } = getStreamingResponseMode(response);
+
+    if (!canStreamSse) {
+        if (!supportsStreamingBody) {
+            console.warn('[llmApi] Streaming body is unavailable on this platform/runtime, falling back to non-streaming response handling.');
+        } else {
+            console.warn('[llmApi] Stream requested but provider returned a non-SSE response, falling back to non-streaming handling.', { contentType });
+        }
+
+        await completeJsonResponse({
+            response,
+            throwIfAborted: requestLifecycle.throwIfAborted,
+            contextLabel: 'API response structure (stream fallback)',
+            logLabel: 'LLM Response (stream fallback):',
+            requestReasoning,
+            hasInlineTags,
+            tagStart,
+            tagEnd,
+            headerModel,
+            headerInline,
+            onComplete
+        });
+        return;
+    }
+
+    await consumeStreamingSseResponse({
+        responseBody: response.body,
+        controller: requestLifecycle.createStreamingTimeoutController(),
+        streamTimeout: requestLifecycle.streamTimeout,
+        throwIfAborted: requestLifecycle.throwIfAborted,
+        requestReasoning,
+        streamAccumulator,
+        onUpdate
+    });
+
+    finalizeStreamResponse({
+        streamAccumulator,
+        onComplete
+    });
+}

--- a/src/core/llm/transport/requestExecution.js
+++ b/src/core/llm/transport/requestExecution.js
@@ -1,0 +1,64 @@
+import { Capacitor, CapacitorHttp } from '@capacitor/core';
+import { updateNetworkTrace, finishNetworkTrace } from '@/core/services/networkDebugService.js';
+
+export function shouldUseNativeNonStreamingRequest({ apiUrl, stream }) {
+    return Capacitor.isNativePlatform() && apiUrl.startsWith('http:') && !apiUrl.includes('https:') && !stream;
+}
+
+export async function executeNativeNonStreamingRequest({
+    requestUrl,
+    headers,
+    requestBody,
+    connectTimeout,
+    streamTimeout
+}) {
+    const response = await CapacitorHttp.post({
+        url: requestUrl,
+        headers,
+        data: requestBody,
+        responseType: 'json',
+        connectTimeout,
+        readTimeout: streamTimeout
+    });
+
+    if (response.status >= 400) {
+        const errorData = typeof response.data === 'object'
+            ? JSON.stringify(response.data)
+            : String(response.data || '');
+        updateNetworkTrace({ responseStatus: response.status });
+        finishNetworkTrace({ rawResponse: response.data, error: `API Error: ${response.status} ${errorData}` });
+        throw new Error(`API Error: ${response.status} ${errorData}`);
+    }
+
+    updateNetworkTrace({ responseStatus: response.status });
+    return response.data;
+}
+
+export async function executeFetchRequest({
+    requestUrl,
+    headers,
+    requestBody,
+    controller
+}) {
+    return fetch(requestUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(requestBody),
+        signal: controller ? controller.signal : undefined
+    });
+}
+
+export async function validateFetchResponse(response) {
+    if (!response.ok) {
+        let errText = '';
+        try { errText = await response.text(); } catch (e) {}
+        updateNetworkTrace({ responseStatus: response.status, responseHeaders: Object.fromEntries(response.headers.entries()) });
+        finishNetworkTrace({ rawResponse: errText, error: `API Error: ${response.status} ${errText}` });
+        throw new Error(`API Error: ${response.status} ${errText}`);
+    }
+
+    updateNetworkTrace({
+        responseStatus: response.status,
+        responseHeaders: Object.fromEntries(response.headers.entries())
+    });
+}

--- a/src/core/llm/transport/requestLifecycle.js
+++ b/src/core/llm/transport/requestLifecycle.js
@@ -1,0 +1,72 @@
+import { startNetworkTrace } from '@/core/services/networkDebugService.js';
+
+export function createRequestLifecycle({
+    provider,
+    apiKey,
+    controller,
+    requestType,
+    apiUrl,
+    stream,
+    requestBody
+}) {
+    const connectTimeout = parseInt(localStorage.getItem('gz_api_connect_timeout')) || 90000;
+    const streamTimeout = parseInt(localStorage.getItem('gz_api_stream_timeout')) || 120000;
+    let connectTimer = null;
+    let timedOut = false;
+
+    const createAbortError = () => {
+        const error = new Error('Generation aborted');
+        error.name = 'AbortError';
+        return error;
+    };
+
+    const throwIfAborted = () => {
+        if (controller?.signal?.aborted) {
+            throw createAbortError();
+        }
+    };
+
+    const headers = {
+        'Content-Type': 'application/json'
+    };
+    Object.assign(headers, provider.buildAuthHeaders(apiKey));
+
+    startNetworkTrace({
+        requestType,
+        apiUrl,
+        stream,
+        requestBody,
+        headers
+    });
+
+    return {
+        headers,
+        connectTimeout,
+        streamTimeout,
+        throwIfAborted,
+        get timedOut() {
+            return timedOut;
+        },
+        startConnectTimeout() {
+            connectTimer = setTimeout(() => {
+                timedOut = true;
+                if (controller) controller.abort();
+            }, connectTimeout);
+        },
+        clearConnectTimeout() {
+            if (!connectTimer) return;
+            clearTimeout(connectTimer);
+            connectTimer = null;
+        },
+        createStreamingTimeoutController() {
+            if (!controller) return null;
+
+            return {
+                abort() {
+                    timedOut = true;
+                    controller.abort();
+                }
+            };
+        }
+    };
+}

--- a/src/core/llm/transport/requestOutcome.js
+++ b/src/core/llm/transport/requestOutcome.js
@@ -1,0 +1,91 @@
+import { cleanText } from '@/utils/textFormatter.js';
+import { finishNetworkTrace } from '@/core/services/networkDebugService.js';
+import { extractOpenAiMessage, normalizeReasoningOutput } from '@/core/llm/transport/responseNormalizer.js';
+import { logger } from '../../../utils/logger.js';
+
+export function completeStructuredResponse({
+    data,
+    contextLabel,
+    logLabel,
+    requestReasoning,
+    hasInlineTags,
+    tagStart,
+    tagEnd,
+    headerModel,
+    headerInline,
+    onComplete
+}) {
+    logger.debug(logLabel, data);
+
+    const { content, reasoningContent } = extractOpenAiMessage(data, contextLabel);
+    const normalized = normalizeReasoningOutput({
+        content,
+        requestReasoning,
+        rawReasoning: reasoningContent,
+        hasInlineTags,
+        tagStart,
+        tagEnd,
+        headerModel,
+        headerInline
+    });
+
+    const cleanedText = cleanText(normalized.text);
+    finishNetworkTrace({ rawResponse: data, text: cleanedText, reasoning: normalized.reasoning });
+    if (onComplete) onComplete(cleanedText, normalized.reasoning);
+}
+
+export function finalizeStreamResponse({ streamAccumulator, onComplete }) {
+    const finalResult = streamAccumulator.finalize();
+    const finalText = cleanText(finalResult.text);
+
+    logger.debug('Stream finished:', finalResult.text);
+
+    finishNetworkTrace({
+        rawResponse: {
+            mode: 'sse',
+            eventCount: null
+        },
+        text: finalText,
+        reasoning: finalResult.reasoning
+    });
+
+    if (onComplete) onComplete(finalText, finalResult.reasoning);
+}
+
+export function handleAbortOutcome({ timedOut, streamAccumulator, onComplete, onError, abortError }) {
+    const partial = streamAccumulator.getPartial();
+
+    if (timedOut) {
+        if (partial.text.length > 0) {
+            finishNetworkTrace({ text: cleanText(partial.text), reasoning: partial.reasoning, error: 'Generation timed out' });
+            if (onComplete) onComplete(cleanText(partial.text), partial.reasoning, { partialError: 'Generation timed out' });
+        } else {
+            finishNetworkTrace({ error: 'Generation timed out - no response from server' });
+            if (onError) onError(new Error('Generation timed out - no response from server'));
+        }
+        return;
+    }
+
+    if (partial.text.length > 0) {
+        finishNetworkTrace({ text: cleanText(partial.text), reasoning: partial.reasoning, error: 'Generation aborted' });
+        if (onComplete) onComplete(cleanText(partial.text), partial.reasoning);
+        return;
+    }
+
+    finishNetworkTrace({ error: abortError });
+    if (onError) onError(abortError);
+}
+
+export function handleRequestFailure({ error, streamAccumulator, onComplete, onError }) {
+    const partial = streamAccumulator.getPartial();
+    if (partial.text.length > 0) {
+        console.warn('Network error during stream, saving partial response:', error);
+        const errorMsg = error.message || 'Stream Error';
+        finishNetworkTrace({ text: cleanText(partial.text), reasoning: partial.reasoning, error: errorMsg });
+        if (onComplete) onComplete(cleanText(partial.text), partial.reasoning, { partialError: errorMsg });
+        return;
+    }
+
+    finishNetworkTrace({ error });
+    if (onError) onError(error);
+}

--- a/src/core/llm/transport/requestRuntimePolicy.js
+++ b/src/core/llm/transport/requestRuntimePolicy.js
@@ -1,0 +1,57 @@
+import { BackgroundMode } from '@anuradev/capacitor-background-mode';
+import { Capacitor } from '@capacitor/core';
+import { startGenerationNotification, stopGenerationNotification } from '@/core/services/notificationService.js';
+
+export async function setupRequestRuntimePolicy({ notificationTitle, notificationBody }) {
+    let wakeLock = null;
+
+    const requestWakeLock = async () => {
+        if ('wakeLock' in navigator && document.visibilityState === 'visible') {
+            try {
+                wakeLock = await navigator.wakeLock.request('screen');
+            } catch (e) {
+                console.warn('WakeLock error:', e);
+            }
+        }
+    };
+
+    await requestWakeLock();
+
+    const handleVisibilityChange = () => {
+        if (document.visibilityState === 'visible') requestWakeLock();
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    const platform = Capacitor.getPlatform();
+    const isAndroid = platform === 'android';
+    const isIos = platform === 'ios';
+
+    if (isAndroid) {
+        await startGenerationNotification(notificationTitle, notificationBody);
+    } else if (isIos) {
+        try {
+            await BackgroundMode.enable();
+        } catch (e) {
+            console.warn('BackgroundMode enable failed:', e);
+        }
+    }
+
+    return {
+        async cleanup() {
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
+            if (wakeLock) {
+                try {
+                    await wakeLock.release();
+                } catch (e) { }
+            }
+
+            if (isAndroid) {
+                await stopGenerationNotification();
+            } else if (isIos) {
+                try {
+                    await BackgroundMode.disable();
+                } catch (e) { }
+            }
+        }
+    };
+}

--- a/src/core/llm/transport/responseHandling.js
+++ b/src/core/llm/transport/responseHandling.js
@@ -1,0 +1,45 @@
+import { completeStructuredResponse } from '@/core/llm/transport/requestOutcome.js';
+
+export function getStreamingResponseMode(response) {
+    const contentType = (response.headers.get('content-type') || '').toLowerCase();
+    const supportsStreamingBody = !!response.body && typeof response.body.getReader === 'function';
+    const isSseResponse = contentType.includes('text/event-stream');
+
+    return {
+        contentType,
+        supportsStreamingBody,
+        isSseResponse,
+        canStreamSse: supportsStreamingBody && isSseResponse
+    };
+}
+
+export async function completeJsonResponse({
+    response,
+    data,
+    throwIfAborted,
+    contextLabel,
+    logLabel,
+    requestReasoning,
+    hasInlineTags,
+    tagStart,
+    tagEnd,
+    headerModel,
+    headerInline,
+    onComplete
+}) {
+    const resolvedData = data ?? await response.json();
+    throwIfAborted();
+
+    completeStructuredResponse({
+        data: resolvedData,
+        contextLabel,
+        logLabel,
+        requestReasoning,
+        hasInlineTags,
+        tagStart,
+        tagEnd,
+        headerModel,
+        headerInline,
+        onComplete
+    });
+}

--- a/src/core/llm/transport/responseNormalizer.js
+++ b/src/core/llm/transport/responseNormalizer.js
@@ -1,0 +1,36 @@
+export function extractOpenAiMessage(data, contextLabel = 'API response structure') {
+    if (!data || !data.choices || !data.choices.length || !data.choices[0] || !data.choices[0].message) {
+        throw new Error(`Invalid ${contextLabel}: ${JSON.stringify(data)}`);
+    }
+
+    return {
+        content: data.choices[0].message.content || '',
+        reasoningContent: data.choices[0].message.reasoning_content || ''
+    };
+}
+
+export function normalizeReasoningOutput({ content, requestReasoning, rawReasoning, hasInlineTags, tagStart, tagEnd, headerModel, headerInline }) {
+    let finalText = content || '';
+    let finalReasoning = requestReasoning ? (rawReasoning || '') : '';
+    let inlineReasoning = '';
+
+    if (hasInlineTags && content && content.includes(tagStart)) {
+        const startIndex = content.indexOf(tagStart);
+        const endIndex = content.indexOf(tagEnd, startIndex);
+        if (endIndex !== -1) {
+            inlineReasoning = content.substring(startIndex + tagStart.length, endIndex);
+            finalText = content.substring(0, startIndex) + content.substring(endIndex + tagEnd.length);
+        }
+    }
+
+    if (finalReasoning && inlineReasoning) {
+        finalReasoning = `${headerModel}\n${finalReasoning}\n\n---\n\n${headerInline}\n${inlineReasoning}`;
+    } else if (inlineReasoning) {
+        finalReasoning = inlineReasoning;
+    }
+
+    return {
+        text: finalText,
+        reasoning: finalReasoning || null
+    };
+}

--- a/src/core/llm/transport/sseParser.js
+++ b/src/core/llm/transport/sseParser.js
@@ -1,0 +1,25 @@
+export function consumeSseDataLines(buffer = '', chunk = '') {
+    const pending = `${buffer}${chunk}`;
+    const lines = pending.split('\n');
+    const remaining = lines.pop() || '';
+    const dataLines = [];
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith('data: ')) continue;
+
+        const dataStr = trimmed.substring(6);
+        if (dataStr === '[DONE]') continue;
+        dataLines.push(dataStr);
+    }
+
+    return { dataLines, remaining };
+}
+
+export function getTrailingSseDataLine(buffer = '') {
+    const trimmed = buffer.trim();
+    if (!trimmed.startsWith('data: ')) return null;
+
+    const dataStr = trimmed.substring(6);
+    return dataStr && dataStr !== '[DONE]' ? dataStr : null;
+}

--- a/src/core/llm/transport/streamAccumulator.js
+++ b/src/core/llm/transport/streamAccumulator.js
@@ -1,0 +1,106 @@
+function decodeHtmlEntities(text) {
+    return text
+        .replace(/&amp;/g, '&')
+        .replace(/&gt;/g, '>')
+        .replace(/&lt;/g, '<')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'");
+}
+
+function extractInlineReasoning(rawText, tagStart, tagEnd, hasInlineTags) {
+    if (!hasInlineTags || !rawText.includes(tagStart)) {
+        return { text: rawText, inlineReasoning: '' };
+    }
+
+    const startIndex = rawText.indexOf(tagStart);
+    const endIndex = rawText.indexOf(tagEnd, startIndex);
+
+    if (endIndex !== -1) {
+        return {
+            text: rawText.substring(0, startIndex) + rawText.substring(endIndex + tagEnd.length),
+            inlineReasoning: rawText.substring(startIndex + tagStart.length, endIndex)
+        };
+    }
+
+    return {
+        text: rawText.substring(0, startIndex),
+        inlineReasoning: rawText.substring(startIndex + tagStart.length)
+    };
+}
+
+function combineReasoningSections(modelReasoning, inlineReasoning, headerModel, headerInline) {
+    if (modelReasoning && inlineReasoning) {
+        return `${headerModel}\n${modelReasoning}\n\n---\n\n${headerInline}\n${inlineReasoning}`;
+    }
+
+    return inlineReasoning || modelReasoning;
+}
+
+export function createStreamAccumulator({
+    requestReasoning,
+    tagStart,
+    tagEnd,
+    hasInlineTags,
+    headerModel,
+    headerInline
+}) {
+    let fullText = '';
+    let rawAccumulated = '';
+    let accumulatedReasoning = '';
+    let previousEffectiveText = '';
+
+    return {
+        consumeDelta({ content = '', reasoning = '' }) {
+            fullText += content;
+            rawAccumulated += content;
+            if (reasoning) accumulatedReasoning += reasoning;
+
+            const extracted = extractInlineReasoning(rawAccumulated, tagStart, tagEnd, hasInlineTags);
+            let effectiveText = decodeHtmlEntities(extracted.text.replace(/^\s+/, ''));
+            const effectiveReasoning = combineReasoningSections(
+                requestReasoning ? accumulatedReasoning : '',
+                extracted.inlineReasoning,
+                headerModel,
+                headerInline
+            );
+
+            // Buffer text ending in an incomplete HTML entity, flush it in the next delta.
+            const incompleteEntity = effectiveText.match(/&[a-zA-Z0-9#]*$/);
+            if (incompleteEntity) {
+                effectiveText = effectiveText.substring(0, incompleteEntity.index);
+            }
+
+            let textDelta = null;
+            if (effectiveText.startsWith(previousEffectiveText)) {
+                textDelta = effectiveText.substring(previousEffectiveText.length);
+            }
+            previousEffectiveText = effectiveText;
+
+            return {
+                effectiveText,
+                effectiveReasoning,
+                textDelta
+            };
+        },
+
+        finalize() {
+            const extracted = extractInlineReasoning(fullText, tagStart, tagEnd, hasInlineTags);
+            return {
+                text: extracted.text,
+                reasoning: combineReasoningSections(
+                    requestReasoning ? accumulatedReasoning : '',
+                    extracted.inlineReasoning,
+                    headerModel,
+                    headerInline
+                ) || null
+            };
+        },
+
+        getPartial() {
+            return {
+                text: fullText,
+                reasoning: requestReasoning ? accumulatedReasoning : null
+            };
+        }
+    };
+}

--- a/src/core/llm/transport/streamingSse.js
+++ b/src/core/llm/transport/streamingSse.js
@@ -1,0 +1,86 @@
+import { appendNetworkTraceLine } from '@/core/services/networkDebugService.js';
+import { consumeSseDataLines, getTrailingSseDataLine } from '@/core/llm/transport/sseParser.js';
+import { logger } from '../../../utils/logger.js';
+
+export async function consumeStreamingSseResponse({
+    responseBody,
+    controller,
+    streamTimeout,
+    throwIfAborted,
+    requestReasoning,
+    streamAccumulator,
+    onUpdate
+}) {
+    const reader = responseBody.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let pendingLineBuffer = '';
+    let streamTimer = null;
+
+    const resetStreamTimer = () => {
+        if (streamTimer) clearTimeout(streamTimer);
+        streamTimer = setTimeout(() => {
+            if (controller) controller.abort();
+        }, streamTimeout);
+    };
+
+    try {
+        resetStreamTimer();
+
+        while (true) {
+            throwIfAborted();
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            resetStreamTimer();
+            throwIfAborted();
+
+            const chunk = decoder.decode(value, { stream: true });
+            const parsedChunk = consumeSseDataLines(pendingLineBuffer, chunk);
+            pendingLineBuffer = parsedChunk.remaining;
+
+            for (const dataStr of parsedChunk.dataLines) {
+                appendNetworkTraceLine(dataStr);
+                throwIfAborted();
+
+                try {
+                    const json = JSON.parse(dataStr);
+
+                    if (json.error) {
+                        throw new Error(`API Stream Error: ${json.error.message || JSON.stringify(json.error)}`);
+                    }
+
+                    if (!json.choices || !json.choices.length) continue;
+
+                    const delta = json.choices[0].delta;
+                    if (delta && (delta.content || delta.reasoning_content)) {
+                        const content = delta.content || '';
+                        const reasoning = (requestReasoning && delta.reasoning_content) || null;
+
+                        if (content) logger.debug(content);
+
+                        const { effectiveText, effectiveReasoning, textDelta } = streamAccumulator.consumeDelta({
+                            content,
+                            reasoning
+                        });
+
+                        if (onUpdate) onUpdate(content, reasoning, effectiveText, effectiveReasoning, textDelta);
+                    }
+                } catch (e) {
+                    if (e.message && e.message.startsWith('API Stream Error')) {
+                        throw e;
+                    }
+                    console.warn('Error parsing stream chunk', e);
+                }
+            }
+        }
+
+        const trailingDataLine = getTrailingSseDataLine(pendingLineBuffer);
+        if (trailingDataLine) {
+            appendNetworkTraceLine(trailingDataLine);
+        }
+
+        throwIfAborted();
+    } finally {
+        if (streamTimer) clearTimeout(streamTimer);
+    }
+}

--- a/src/core/services/__tests__/vectorLoreE2E.test.js
+++ b/src/core/services/__tests__/vectorLoreE2E.test.js
@@ -355,6 +355,94 @@ describe('Vector lorebook E2E verification', () => {
         globalThis.Worker = MockWorker;
     });
 
+    it('respects maxInjectedEntries when vector-only results are added late', async () => {
+        mockGetEmbeddings.mockImplementation(async (texts) => texts.map((text) => [{
+            text,
+            vector: text.includes('Vector extra lore') ? [1, 0, 0] : [0.98, 0.02, 0]
+        }]));
+
+        lorebookState.globalSettings.searchType = 'both';
+        lorebookState.globalSettings.maxInjectedEntries = 1;
+        lorebookState.lorebooks = [{
+            id: 'lb-mixed-limit',
+            name: 'Mixed limit',
+            enabled: true,
+            entries: [
+                {
+                    id: 'entry-keyword',
+                    comment: 'Keyword entry',
+                    keys: ['topic'],
+                    content: 'Keyword lore',
+                    enabled: true,
+                    position: 'worldInfoBefore'
+                },
+                {
+                    id: 'entry-vector-only',
+                    comment: 'Vector only entry',
+                    keys: ['vector'],
+                    content: 'Vector extra lore',
+                    enabled: true,
+                    vectorSearch: true,
+                    useKeywordSearch: false,
+                    position: 'worldInfoBefore'
+                }
+            ]
+        }];
+
+        await indexLorebookEntries('lb-mixed-limit');
+
+        globalThis._genWorker = null;
+        globalThis.Worker = class extends MockWorker {
+            postMessage(message) {
+                const data = {
+                    messages: [
+                        { role: 'system', content: 'Keyword lore' },
+                        { role: 'user', content: 'Current user message', isHistory: true }
+                    ],
+                    loreEntries: [
+                        { id: 'entry-keyword', comment: 'Keyword entry', content: 'Keyword lore', position: 'worldInfoBefore', _source: 'keyword' }
+                    ],
+                    staticTokens: 8,
+                    contextBreakdown: { lorebook: 2 },
+                    needsVarsSave: false,
+                    sessionVars: {}
+                };
+                queueMicrotask(() => {
+                    this.onmessage?.({ data: { id: message.id, success: true, data } });
+                });
+            }
+        };
+
+        let promptReadyPayload = null;
+        await generateChatResponse({
+            text: 'topic and vector extra lore',
+            char: { id: 'char-1', name: 'Tester', sessionId: 'chat-1' },
+            history: [{ role: 'user', content: 'topic and vector extra lore' }],
+            authorsNote: null,
+            summary: '',
+            controller: { signal: { aborted: false } },
+            callbacks: {
+                onUpdate: vi.fn(),
+                onComplete: vi.fn(),
+                onError: vi.fn(),
+                onPromptReady: (payload) => {
+                    promptReadyPayload = payload;
+                }
+            }
+        });
+
+        expect(promptReadyPayload).toBeTruthy();
+        expect(promptReadyPayload.loreEntries.map(entry => entry.id)).toEqual(['entry-keyword']);
+
+        const lastPrompt = getLastPrompt();
+        expect(lastPrompt).toBeTruthy();
+        expect(lastPrompt.messages.some(message => typeof message.content === 'string' && message.content.includes('Vector extra lore'))).toBe(false);
+
+        lorebookState.globalSettings.maxInjectedEntries = 5;
+        globalThis._genWorker = null;
+        globalThis.Worker = MockWorker;
+    });
+
     it('fails generation with a visible error when embedding retrieval crashes', async () => {
         mockGetEmbeddings.mockImplementation(async (texts) => texts.map((text) => {
             if (text.includes('bright blue hair')) {

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -94,6 +94,38 @@ function processPromptAsync(payload) {
     });
 }
 
+function getSafeContextLimit(contextSize, maxTokens) {
+    return contextSize - maxTokens > 0 ? contextSize - maxTokens : 8000;
+}
+
+function trimHistoryForContextWindow(history, safeContextLimit) {
+    const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent || '');
+    const memoryLimitFactor = isIOS ? 15 : 5;
+    const maxHistoryRetention = Math.max(100, Math.ceil(safeContextLimit / memoryLimitFactor));
+
+    if (history && history.length > maxHistoryRetention) {
+        return history.slice(-maxHistoryRetention);
+    }
+
+    return history;
+}
+
+function buildMergedContextBreakdown(contextBreakdown, { vectorLoreTokens = 0, memoryTokens = 0 } = {}) {
+    if (!contextBreakdown) return null;
+
+    return {
+        ...contextBreakdown,
+        memory: memoryTokens,
+        vectorLore: (contextBreakdown.vectorLore || 0) + vectorLoreTokens,
+        summaryBase: contextBreakdown.summary || 0,
+        summary: (contextBreakdown.summary || 0) + memoryTokens,
+        fixedBase: (contextBreakdown.fixedBase || 0) + memoryTokens,
+        fixedTotal: (contextBreakdown.fixedTotal || 0) + memoryTokens,
+        totalUsed: (contextBreakdown.totalUsed || 0) + memoryTokens,
+        remaining: Math.max(0, (contextBreakdown.remaining || 0) - memoryTokens)
+    };
+}
+
 export async function generateChatResponse({
     text,
     char,
@@ -178,14 +210,8 @@ export async function generateChatResponse({
     let result;
     let safeHistory = history;
     try {
-        const safeContextLimit = contextSize - maxTokens > 0 ? contextSize - maxTokens : 8000;
-        const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent || '');
-        const memoryLimitFactor = isIOS ? 15 : 5;
-        const maxHistoryRetention = Math.max(100, Math.ceil(safeContextLimit / memoryLimitFactor));
-
-        if (history && history.length > maxHistoryRetention) {
-            safeHistory = history.slice(-maxHistoryRetention);
-        }
+        const safeContextLimit = getSafeContextLimit(contextSize, maxTokens);
+        safeHistory = trimHistoryForContextWindow(history, safeContextLimit);
 
         const payload = JSON.parse(JSON.stringify({
             char,
@@ -350,32 +376,10 @@ export async function generateChatResponse({
     }
 
     if (callbacks.onPromptReady) {
-        const contextBreakdown = result.contextBreakdown
-            ? (() => {
-                const totalLoreTokens = (result.contextBreakdown.lorebook || 0) + vectorLoreTokens;
-                const reserveTokens = result.contextBreakdown.lorebookReserve || 0;
-                
-                // All lorebooks (keyword + vector) must fit within the reserve
-                // Reserve remains unchanged, lorebooks are displayed within it
-                const effectiveReserve = reserveTokens - totalLoreTokens;
-                
-                return {
-                    ...result.contextBreakdown,
-                    memory: memoryInjection.tokens || 0,
-                    vectorLore: (result.contextBreakdown.vectorLore || 0) + vectorLoreTokens,
-                    summaryBase: result.contextBreakdown.summary || 0,
-                    summary: (result.contextBreakdown.summary || 0) + (memoryInjection.tokens || 0),
-                    // Keep lorebook and vectorLore separate for UI display
-                    // lorebook = keyword-matched entries only (from generationWorker)
-                    // vectorLore = vector-retrieved entries only (from this service)
-                    // lorebookReserve stays the same - lorebooks are shown within it
-                    fixedBase: (result.contextBreakdown.fixedBase || 0) + (memoryInjection.tokens || 0),
-                    fixedTotal: (result.contextBreakdown.fixedTotal || 0) + (memoryInjection.tokens || 0),
-                    totalUsed: (result.contextBreakdown.totalUsed || 0) + (memoryInjection.tokens || 0),
-                    remaining: Math.max(0, (result.contextBreakdown.remaining || 0) - (memoryInjection.tokens || 0))
-                };
-            })()
-            : null;
+        const contextBreakdown = buildMergedContextBreakdown(result.contextBreakdown, {
+            vectorLoreTokens,
+            memoryTokens: memoryInjection.tokens || 0
+        });
 
         callbacks.onPromptReady({
             loreEntries: result.loreEntries,
@@ -459,15 +463,8 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
     try { globalRegexes = JSON.parse(localStorage.getItem('regex_scripts')) || []; } catch (e) { }
 
     try {
-        const safeContextLimit = apiConfig.contextSize - apiConfig.maxTokens > 0 ? apiConfig.contextSize - apiConfig.maxTokens : 8000;
-        const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent || '');
-        const memoryLimitFactor = isIOS ? 15 : 5;
-        const maxHistoryRetention = Math.max(100, Math.ceil(safeContextLimit / memoryLimitFactor));
-
-        let safeHistory = history;
-        if (history && history.length > maxHistoryRetention) {
-            safeHistory = history.slice(-maxHistoryRetention);
-        }
+        const safeContextLimit = getSafeContextLimit(apiConfig.contextSize, apiConfig.maxTokens);
+        const safeHistory = trimHistoryForContextWindow(history, safeContextLimit);
 
         const payload = JSON.parse(JSON.stringify({
             char,
@@ -529,29 +526,10 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             ? result.cutoffOriginalIndex
             : result.cutoffIndex;
 
-        const contextBreakdown = result.contextBreakdown
-            ? (() => {
-                const totalLoreTokens = (result.contextBreakdown.lorebook || 0) + vectorLoreTokens;
-                const reserveTokens = result.contextBreakdown.lorebookReserve || 0;
-                
-                // All lorebooks (keyword + vector) must fit within the reserve
-                // Reserve remains unchanged, lorebooks are displayed within it
-                const effectiveReserve = reserveTokens - totalLoreTokens;
-                
-                return {
-                    ...result.contextBreakdown,
-                    memory: memoryInjection.tokens || 0,
-                    vectorLore: (result.contextBreakdown.vectorLore || 0) + vectorLoreTokens,
-                    summaryBase: result.contextBreakdown.summary || 0,
-                    summary: (result.contextBreakdown.summary || 0) + (memoryInjection.tokens || 0),
-                    // All lorebooks must fit within reserve - don't add to fixedBase
-                    fixedBase: (result.contextBreakdown.fixedBase || 0) + (memoryInjection.tokens || 0),
-                    fixedTotal: (result.contextBreakdown.fixedTotal || 0) + (memoryInjection.tokens || 0),
-                    totalUsed: (result.contextBreakdown.totalUsed || 0) + (memoryInjection.tokens || 0),
-                    remaining: Math.max(0, (result.contextBreakdown.remaining || 0) - (memoryInjection.tokens || 0))
-                };
-            })()
-            : null;
+        const contextBreakdown = buildMergedContextBreakdown(result.contextBreakdown, {
+            vectorLoreTokens,
+            memoryTokens: memoryInjection.tokens || 0
+        });
 
         return {
             cutoffIndex: resolvedCutoff,

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -243,6 +243,16 @@ function estimateVectorLoreTokens(entries = []) {
     return entries.reduce((sum, entry) => sum + estimateTokens(entry?.content || ''), 0);
 }
 
+function buildContextCalculationResult(result, { vectorLoreTokens = 0, memoryTokens = 0 } = {}) {
+    return {
+        cutoffIndex: resolvePromptCutoffIndex(result),
+        contextBreakdown: buildMergedContextBreakdown(result?.contextBreakdown, {
+            vectorLoreTokens,
+            memoryTokens
+        })
+    };
+}
+
 export async function generateChatResponse({
     text,
     char,
@@ -567,17 +577,10 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             console.warn('[calculateContext] Vector search failed:', e);
         }
 
-        const resolvedCutoff = resolvePromptCutoffIndex(result);
-
-        const contextBreakdown = buildMergedContextBreakdown(result.contextBreakdown, {
+        return buildContextCalculationResult(result, {
             vectorLoreTokens,
             memoryTokens: memoryInjection.tokens || 0
         });
-
-        return {
-            cutoffIndex: resolvedCutoff,
-            contextBreakdown
-        };
     } catch (e) {
         console.error("Calculate context worker error", e);
         return {

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -211,6 +211,38 @@ async function buildPromptMemoryInjection({ char, history, summary, safeContext,
     });
 }
 
+function normalizeKeywordLoreEntries(loreEntries = []) {
+    if (!Array.isArray(loreEntries)) return [];
+    loreEntries.forEach(entry => {
+        if (entry && !entry._source) entry._source = 'keyword';
+    });
+    return loreEntries.filter(entry => entry?._source === 'keyword');
+}
+
+function mergeLateVectorLoreEntries(result, vectorResults = []) {
+    const keywordEntries = normalizeKeywordLoreEntries(result?.loreEntries || []);
+    const keywordIds = new Set(keywordEntries.map(entry => entry.id));
+    const vectorEntries = limitVectorLoreEntries(
+        vectorResults.filter(entry => !keywordIds.has(entry.id)),
+        keywordEntries
+    );
+
+    vectorEntries.forEach(entry => { entry._source = 'vector'; });
+
+    if (Array.isArray(result?.loreEntries)) {
+        result.loreEntries = [...keywordEntries, ...vectorEntries];
+    }
+
+    return {
+        keywordEntries,
+        vectorEntries
+    };
+}
+
+function estimateVectorLoreTokens(entries = []) {
+    return entries.reduce((sum, entry) => sum + estimateTokens(entry?.content || ''), 0);
+}
+
 export async function generateChatResponse({
     text,
     char,
@@ -317,17 +349,8 @@ export async function generateChatResponse({
     let vectorLoreTokens = 0;
     try {
         const vectorResults = await vectorSearchLorebooks(safeHistory || history, text, char, char?.sessionId);
-        if (vectorResults.length > 0 && result.loreEntries) {
-            const keywordIds = new Set(result.loreEntries.map(e => e.id));
-            result.loreEntries.forEach(e => { if (!e._source) e._source = 'keyword'; });
-            const keywordEntries = result.loreEntries.filter(e => e._source === 'keyword');
-            newVectorEntries = limitVectorLoreEntries(
-                vectorResults.filter(e => !keywordIds.has(e.id)),
-                keywordEntries
-            );
-            newVectorEntries.forEach(e => { e._source = 'vector'; });
-            const vectorOnly = [...newVectorEntries];
-            result.loreEntries = [...keywordEntries, ...vectorOnly];
+        if (vectorResults.length > 0) {
+            ({ vectorEntries: newVectorEntries } = mergeLateVectorLoreEntries(result, vectorResults));
         }
     } catch (e) {
         console.warn('[generateChatResponse] Vector search failed:', e);
@@ -537,19 +560,8 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
         try {
             const vectorResults = await vectorSearchLorebooks(safeHistory || history, '', char, char?.sessionId);
             if (vectorResults.length > 0) {
-                const keywordIds = result.loreEntries ? new Set(result.loreEntries.map(e => e.id)) : new Set();
-                const keywordEntries = Array.isArray(result.loreEntries)
-                    ? result.loreEntries.filter(e => (e?._source || 'keyword') === 'keyword')
-                    : [];
-                const newVectorEntries = limitVectorLoreEntries(
-                    vectorResults.filter(e => !keywordIds.has(e.id)),
-                    keywordEntries
-                );
-                vectorLoreTokens = newVectorEntries.reduce((sum, entry) => {
-                    const content = entry.content || '';
-                    const tokens = estimateTokens(content);
-                    return sum + tokens;
-                }, 0);
+                const { vectorEntries } = mergeLateVectorLoreEntries(result, vectorResults);
+                vectorLoreTokens = estimateVectorLoreTokens(vectorEntries);
             }
         } catch (e) {
             console.warn('[calculateContext] Vector search failed:', e);

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -126,6 +126,74 @@ function buildMergedContextBreakdown(contextBreakdown, { vectorLoreTokens = 0, m
     };
 }
 
+function getSessionVarsKey(char) {
+    const charId = char?.id || 'default';
+    const sessionId = char?.sessionId || 'current';
+    return `gz_vars_${charId}_${sessionId}`;
+}
+
+function loadSessionVars(char) {
+    const varsKey = getSessionVarsKey(char);
+    let sessionVars = {};
+    try { sessionVars = JSON.parse(localStorage.getItem(varsKey)) || {}; } catch (e) { }
+    return { varsKey, sessionVars };
+}
+
+function loadGlobalRegexes() {
+    let globalRegexes = [];
+    try { globalRegexes = JSON.parse(localStorage.getItem('regex_scripts')) || []; } catch (e) { }
+    return globalRegexes;
+}
+
+function getPromptWorkerOptions(char, activePreset) {
+    return {
+        mergePrompts: activePreset?.mergePrompts || false,
+        mergeRole: activePreset?.mergeRole || 'system',
+        noAssistant: activePreset?.noAssistant || false,
+        userPrefix: activePreset?.userPrefix || '',
+        charPrefix: activePreset?.charPrefix || '',
+        squashRole: activePreset?.squashRole || 'assistant',
+        personaObj: getEffectivePersona(char?.id, char?.sessionId) || { name: 'User', prompt: '' }
+    };
+}
+
+function buildPromptWorkerPayload({
+    char,
+    history,
+    summary,
+    activePreset,
+    promptOptions,
+    authorsNote,
+    guidanceText,
+    guidanceType,
+    globalRegexes,
+    sessionVars,
+    apiConfig
+}) {
+    return JSON.parse(JSON.stringify({
+        char,
+        history,
+        summary,
+        activePreset,
+        mergePrompts: promptOptions.mergePrompts,
+        mergeRole: promptOptions.mergeRole,
+        noAssistant: promptOptions.noAssistant,
+        userPrefix: promptOptions.userPrefix,
+        charPrefix: promptOptions.charPrefix,
+        squashRole: promptOptions.squashRole,
+        personaObj: promptOptions.personaObj,
+        authorsNote: (authorsNote && authorsNote.enabled) ? authorsNote : null,
+        guidanceText,
+        guidanceType,
+        lorebooks: lorebookState.lorebooks,
+        globalSettings: lorebookState.globalSettings,
+        activations: lorebookState.activations,
+        globalRegexes,
+        sessionVars,
+        apiConfig
+    }));
+}
+
 export async function generateChatResponse({
     text,
     char,
@@ -168,16 +236,8 @@ export async function generateChatResponse({
     const tagStart = activePreset?.reasoningStart || reasoningTags.start;
     const tagEnd = activePreset?.reasoningEnd || reasoningTags.end;
 
-    // Merge Settings from Preset
-    const mergePrompts = activePreset?.mergePrompts || false;
-    const mergeRole = activePreset?.mergeRole || 'system';
-
-    // NoAssistant Settings from Preset
-    const noAssistant = activePreset?.noAssistant || false;
+    const promptOptions = getPromptWorkerOptions(char, activePreset);
     const stopString = activePreset?.stopString || '';
-    const userPrefix = activePreset?.userPrefix || '';
-    const charPrefix = activePreset?.charPrefix || '';
-    const squashRole = activePreset?.squashRole || 'assistant';
 
     if (activePreset && typeof activePreset.reasoningEnabled === 'boolean') {
         // Only override if preset explicitly enables it, otherwise keep user setting
@@ -190,22 +250,14 @@ export async function generateChatResponse({
         reasoningEffort = activePreset.reasoningEffort;
     }
 
-    // Get Persona object for macros
-    const personaObj = getEffectivePersona(char?.id, char?.sessionId) || { name: "User", prompt: "" };
-
-    const charId = char?.id || "default";
-    const sessionId = char?.sessionId || "current";
-    const varsKey = `gz_vars_${charId}_${sessionId}`;
-    let sessionVars = {};
-    try { sessionVars = JSON.parse(localStorage.getItem(varsKey)) || {}; } catch (e) { }
+    const { varsKey, sessionVars } = loadSessionVars(char);
 
     // Set reasoning macros for {{reasoningPrefix}} and {{reasoningSuffix}}
     sessionVars.reasoningPrefix = tagStart;
     sessionVars.reasoningSuffix = tagEnd;
     localStorage.setItem(varsKey, JSON.stringify(sessionVars));
 
-    let globalRegexes = [];
-    try { globalRegexes = JSON.parse(localStorage.getItem('regex_scripts')) || []; } catch (e) { }
+    const globalRegexes = loadGlobalRegexes();
 
     let result;
     let safeHistory = history;
@@ -213,28 +265,19 @@ export async function generateChatResponse({
         const safeContextLimit = getSafeContextLimit(contextSize, maxTokens);
         safeHistory = trimHistoryForContextWindow(history, safeContextLimit);
 
-        const payload = JSON.parse(JSON.stringify({
+        const payload = buildPromptWorkerPayload({
             char,
             history: safeHistory,
             summary,
             activePreset,
-            mergePrompts,
-            mergeRole,
-            noAssistant,
-            userPrefix,
-            charPrefix,
-            squashRole,
-            personaObj,
-            authorsNote: (authorsNote && authorsNote.enabled) ? authorsNote : null,
+            promptOptions,
+            authorsNote,
             guidanceText,
             guidanceType: type,
-            lorebooks: lorebookState.lorebooks,
-            globalSettings: lorebookState.globalSettings,
-            activations: lorebookState.activations,
             globalRegexes,
             sessionVars,
             apiConfig
-        }));
+        });
 
         result = await processPromptAsync(payload);
     } catch (e) {
@@ -443,49 +486,28 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
     const apiConfig = getEffectiveApiConfig();
     const activePreset = loadActivePreset(char, char?.sessionId);
 
-    const mergePrompts = activePreset?.mergePrompts || false;
-    const mergeRole = activePreset?.mergeRole || 'system';
-    const noAssistant = activePreset?.noAssistant || false;
-    const userPrefix = activePreset?.userPrefix || '';
-    const charPrefix = activePreset?.charPrefix || '';
-    const squashRole = activePreset?.squashRole || 'assistant';
-    const personaObj = getEffectivePersona(char?.id, char?.sessionId) || { name: "User", prompt: "" };
+    const promptOptions = getPromptWorkerOptions(char, activePreset);
 
     const anData = authorsNote;
 
-    const charId = char?.id || "default";
-    const sessionId = char?.sessionId || "current";
-    const varsKey = `gz_vars_${charId}_${sessionId}`;
-    let sessionVars = {};
-    try { sessionVars = JSON.parse(localStorage.getItem(varsKey)) || {}; } catch (e) { }
-
-    let globalRegexes = [];
-    try { globalRegexes = JSON.parse(localStorage.getItem('regex_scripts')) || []; } catch (e) { }
+    const { sessionVars } = loadSessionVars(char);
+    const globalRegexes = loadGlobalRegexes();
 
     try {
         const safeContextLimit = getSafeContextLimit(apiConfig.contextSize, apiConfig.maxTokens);
         const safeHistory = trimHistoryForContextWindow(history, safeContextLimit);
 
-        const payload = JSON.parse(JSON.stringify({
+        const payload = buildPromptWorkerPayload({
             char,
             history: safeHistory,
             summary,
             activePreset,
-            mergePrompts,
-            mergeRole,
-            noAssistant,
-            userPrefix,
-            charPrefix,
-            squashRole,
-            personaObj,
-            authorsNote: (anData && anData.enabled) ? anData : null,
-            lorebooks: lorebookState.lorebooks,
-            globalSettings: lorebookState.globalSettings,
-            activations: lorebookState.activations,
+            promptOptions,
+            authorsNote: anData,
             globalRegexes,
             sessionVars,
             apiConfig
-        }));
+        });
 
         const result = await processPromptAsync(payload);
         const cutoffOriginalIndex = result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -194,6 +194,23 @@ function buildPromptWorkerPayload({
     }));
 }
 
+function resolvePromptCutoffIndex(result) {
+    if (!result) return -1;
+    return result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
+        ? result.cutoffOriginalIndex
+        : (result.cutoffIndex !== undefined ? result.cutoffIndex : -1);
+}
+
+async function buildPromptMemoryInjection({ char, history, summary, safeContext, result }) {
+    return buildMemoryInjection({
+        char,
+        history,
+        summary,
+        safeContext,
+        cutoffOriginalIndex: resolvePromptCutoffIndex(result)
+    });
+}
+
 export async function generateChatResponse({
     text,
     char,
@@ -328,15 +345,12 @@ export async function generateChatResponse({
     }
 
     const safeContext = contextSize - maxTokens;
-    const cutoffOriginalIndex = result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
-        ? result.cutoffOriginalIndex
-        : (result.cutoffIndex !== undefined ? result.cutoffIndex : -1);
-    const memoryInjection = await buildMemoryInjection({
+    const memoryInjection = await buildPromptMemoryInjection({
         char,
         history: safeHistory || history,
         summary,
         safeContext,
-        cutoffOriginalIndex
+        result
     });
     let messages = result.messages;
 
@@ -510,15 +524,12 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
         });
 
         const result = await processPromptAsync(payload);
-        const cutoffOriginalIndex = result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
-            ? result.cutoffOriginalIndex
-            : (result.cutoffIndex !== undefined ? result.cutoffIndex : -1);
-        const memoryInjection = await buildMemoryInjection({
+        const memoryInjection = await buildPromptMemoryInjection({
             char,
             history: safeHistory,
             summary,
             safeContext: safeContextLimit,
-            cutoffOriginalIndex
+            result
         });
 
         // Calculate vector lorebook tokens for accurate breakdown display
@@ -544,9 +555,7 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             console.warn('[calculateContext] Vector search failed:', e);
         }
 
-        const resolvedCutoff = result.cutoffOriginalIndex !== undefined && result.cutoffOriginalIndex !== -1
-            ? result.cutoffOriginalIndex
-            : result.cutoffIndex;
+        const resolvedCutoff = resolvePromptCutoffIndex(result);
 
         const contextBreakdown = buildMergedContextBreakdown(result.contextBreakdown, {
             vectorLoreTokens,

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -10,6 +10,7 @@ import { presetState, initPresetState, getEffectivePreset } from '@/core/states/
 import { lorebookState, scanLorebooks, initLorebookState, vectorSearchLorebooks } from '@/core/states/lorebookState.js';
 import { getEffectivePersona } from '@/core/states/personaState.js';
 import { applyRegexes } from '@/core/services/regexService.js';
+import { buildChatRequestPayload, buildSummaryRequestPayload, buildMemoryDraftRequestPayload } from '@/core/llm/assemblers/requestAssemblers.js';
 import { db } from '@/utils/db.js';
 import { getEmbeddings } from '@/core/services/embeddingService.js';
 import { getEmbeddingConfig, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
@@ -20,16 +21,6 @@ let lastPrompt = null;
 
 export function getLastPrompt() {
     return lastPrompt;
-}
-
-/**
- * Strips embedded base64 media from text so it doesn't inflate token counts limits.
- */
-function stripEmbeddedMedia(text) {
-    if (!text || text.length < 256) return text;
-    let cleaned = text.replace(/<img\s[^>]*src\s*=\s*["']data:image\/[^"']{256,}["'][^>]*\/?>/gi, '');
-    cleaned = cleaned.replace(/data:image\/[a-z+]+;base64,[A-Za-z0-9+/=\n\r]{256,}/gi, '');
-    return cleaned;
 }
 
 // --- Helpers ---
@@ -117,7 +108,7 @@ export async function generateChatResponse({
 }) {
     const { onUpdate, onComplete, onError } = callbacks;
     let apiConfig = getEffectiveApiConfig();
-    let { apiKey, apiUrl, model, stream, requestReasoning, reasoningEffort, temp, topP, maxTokens, contextSize } = apiConfig;
+    let { providerId, apiKey, apiUrl, model, stream, requestReasoning, reasoningEffort, temp, topP, maxTokens, contextSize } = apiConfig;
 
     const t = (key) => translations[currentLang.value]?.[key] || key;
 
@@ -390,47 +381,20 @@ export async function generateChatResponse({
         });
     }
 
-    const requestBody = {
-        model: model,
-        messages: messages,
+    const { previewBody, requestBody } = buildChatRequestPayload({
+        providerId,
+        model,
+        messages,
         temperature: temp,
-        top_p: topP,
-        stream: stream
-    };
-
-    if (reasoningEffort && reasoningEffort !== 'auto') {
-        requestBody.reasoning_effort = reasoningEffort;
-    }
-
-    if (maxTokens > 0) {
-        requestBody.max_tokens = maxTokens;
-    }
-
-    if (stopString) {
-        requestBody.stop = [stopString];
-    }
-
+        topP,
+        stream,
+        reasoningEffort,
+        maxTokens,
+        stopString
+    });
 
     // Save for preview
-    lastPrompt = JSON.parse(JSON.stringify(requestBody));
-
-    // Sanitize messages for API (strict OpenAI compliance: only role, content, name)
-    requestBody.messages = requestBody.messages.map(m => {
-        const cleanMsg = {
-            role: m.role,
-            content: stripEmbeddedMedia(m.content)
-        };
-
-        if (m.image) {
-            cleanMsg.content = [
-                { type: "text", text: m.content || "" },
-                { type: "image_url", image_url: { url: m.image } }
-            ];
-        }
-
-        if (m.name) cleanMsg.name = m.name;
-        return cleanMsg;
-    });
+    lastPrompt = JSON.parse(JSON.stringify(previewBody));
 
     // Final abort check before API call
     if (controller?.signal?.aborted) {
@@ -442,6 +406,7 @@ export async function generateChatResponse({
     try {
         logger.debug('[GenerationService] Final Request:', requestBody);
         await executeRequest({
+            providerId,
             apiUrl,
             apiKey,
             requestBody,
@@ -597,7 +562,7 @@ export async function generateSummary({ history, prompt, controller, apiConfigOv
         ...getEffectiveApiConfig(),
         ...(apiConfigOverride || {})
     };
-    const { apiKey, apiUrl, model, temp } = effectiveConfig;
+    const { providerId, apiKey, apiUrl, model, temp } = effectiveConfig;
 
     if (!apiUrl || !model) {
         throw new Error("API Not Configured");
@@ -613,14 +578,18 @@ export async function generateSummary({ history, prompt, controller, apiConfigOv
 
     let result = "";
 
+    const { requestBody } = buildSummaryRequestPayload({
+        providerId,
+        model,
+        prompt: finalPrompt,
+        temperature: temp
+    });
+
     await executeRequest({
+        providerId,
         apiUrl,
         apiKey,
-        requestBody: {
-            model,
-            messages: [{ role: 'user', content: finalPrompt }],
-            temperature: temp
-        },
+        requestBody,
         controller,
         callbacks: {
             onComplete: (text) => { result = text; }
@@ -1047,7 +1016,7 @@ export async function generateMemoryDraft({ history, prompt, controller, apiConf
         ...getEffectiveApiConfig(),
         ...(apiConfigOverride || {})
     };
-    const { apiKey, apiUrl, model, temp } = effectiveConfig;
+    const { providerId, apiKey, apiUrl, model, temp } = effectiveConfig;
 
     // Memory drafts need enough output budget for long summaries even when the
     // provider has a small default completion limit.
@@ -1085,17 +1054,18 @@ export async function generateMemoryDraft({ history, prompt, controller, apiConf
     let result = "";
     
     let requestError = null;
-    const requestBody = {
+    const { previewBody, requestBody } = buildMemoryDraftRequestPayload({
+        providerId,
         model,
-        messages: [{ role: 'user', content: finalPrompt }],
+        prompt: finalPrompt,
         temperature: temp,
-        max_tokens: memoryDraftMaxTokens,
-        stream: false
-    };
+        maxTokens: memoryDraftMaxTokens
+    });
 
-    lastPrompt = JSON.parse(JSON.stringify(requestBody));
+    lastPrompt = JSON.parse(JSON.stringify(previewBody));
     
     await executeRequest({
+        providerId,
         apiUrl,
         apiKey,
         requestBody,

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -1,4 +1,4 @@
-import { getApiConfig } from '@/core/config/APISettings.js';
+import { getApiConfig, getApiRuntimeStorage, getApiReasoningTags } from '@/core/config/APISettings.js';
 import { estimateTokens } from '@/utils/tokenizer.js';
 import { replaceMacros } from '@/utils/macroEngine.js';
 import { translations } from '@/utils/i18n.js';
@@ -27,13 +27,12 @@ export function getLastPrompt() {
 
 function getEffectiveApiConfig() {
     let config = getApiConfig();
+    const runtime = getApiRuntimeStorage();
     let { maxTokens, contextSize } = config;
 
-    // Fallback if contextSize is not returned by getApiConfig
-    if (!contextSize) contextSize = parseInt(localStorage.getItem('api-context')) || 32000;
+    if (!contextSize) contextSize = runtime.contextSize || 32000;
     if (maxTokens === undefined || maxTokens === null) {
-        const mt = parseInt(localStorage.getItem('api-max-tokens'));
-        maxTokens = isNaN(mt) ? 8000 : mt;
+        maxTokens = runtime.maxTokens || 8000;
     }
 
     return { ...config, maxTokens, contextSize };
@@ -133,8 +132,9 @@ export async function generateChatResponse({
     const activePreset = loadActivePreset(char, char?.sessionId);
 
     // Reasoning Tags from Preset
-    const tagStart = activePreset?.reasoningStart || localStorage.getItem('gz_api_reasoning_start');
-    const tagEnd = activePreset?.reasoningEnd || localStorage.getItem('gz_api_reasoning_end');
+    const reasoningTags = getApiReasoningTags();
+    const tagStart = activePreset?.reasoningStart || reasoningTags.start;
+    const tagEnd = activePreset?.reasoningEnd || reasoningTags.end;
 
     // Merge Settings from Preset
     const mergePrompts = activePreset?.mergePrompts || false;

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -233,11 +233,14 @@ export async function generateChatResponse({
         const vectorResults = await vectorSearchLorebooks(safeHistory || history, text, char, char?.sessionId);
         if (vectorResults.length > 0 && result.loreEntries) {
             const keywordIds = new Set(result.loreEntries.map(e => e.id));
-            newVectorEntries = vectorResults.filter(e => !keywordIds.has(e.id));
-            newVectorEntries.forEach(e => { e._source = 'vector'; });
             result.loreEntries.forEach(e => { if (!e._source) e._source = 'keyword'; });
             const keywordEntries = result.loreEntries.filter(e => e._source === 'keyword');
-            const vectorOnly = newVectorEntries.sort((a, b) => (b.vectorScore || 0) - (a.vectorScore || 0));
+            newVectorEntries = limitVectorLoreEntries(
+                vectorResults.filter(e => !keywordIds.has(e.id)),
+                keywordEntries
+            );
+            newVectorEntries.forEach(e => { e._source = 'vector'; });
+            const vectorOnly = [...newVectorEntries];
             result.loreEntries = [...keywordEntries, ...vectorOnly];
         }
     } catch (e) {
@@ -505,7 +508,13 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             const vectorResults = await vectorSearchLorebooks(safeHistory || history, '', char, char?.sessionId);
             if (vectorResults.length > 0) {
                 const keywordIds = result.loreEntries ? new Set(result.loreEntries.map(e => e.id)) : new Set();
-                const newVectorEntries = vectorResults.filter(e => !keywordIds.has(e.id));
+                const keywordEntries = Array.isArray(result.loreEntries)
+                    ? result.loreEntries.filter(e => (e?._source || 'keyword') === 'keyword')
+                    : [];
+                const newVectorEntries = limitVectorLoreEntries(
+                    vectorResults.filter(e => !keywordIds.has(e.id)),
+                    keywordEntries
+                );
                 vectorLoreTokens = newVectorEntries.reduce((sum, entry) => {
                     const content = entry.content || '';
                     const tokens = estimateTokens(content);
@@ -948,6 +957,16 @@ function combineLoreSources(messages = []) {
         sourceMap.set(item.source, (sourceMap.get(item.source) || 0) + (item.tokens || 0));
     }
     return [...sourceMap.entries()].map(([source, tokens]) => ({ source, tokens }));
+}
+
+function limitVectorLoreEntries(vectorEntries = [], keywordEntries = []) {
+    const maxInjectedEntries = Math.max(1, Math.min(100, Number(lorebookState.globalSettings?.maxInjectedEntries || 5)));
+    const remainingSlots = Math.max(0, maxInjectedEntries - keywordEntries.length);
+    if (remainingSlots <= 0) return [];
+
+    return [...vectorEntries]
+        .sort((a, b) => (b.vectorScore || 0) - (a.vectorScore || 0))
+        .slice(0, remainingSlots);
 }
 
 function buildVectorLoreBlock(entries, position) {

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -1,10 +1,10 @@
-import { Capacitor, CapacitorHttp } from '@capacitor/core';
 import { cleanText } from '@/utils/textFormatter.js';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import { startNetworkTrace, updateNetworkTrace, appendNetworkTraceLine, finishNetworkTrace } from '@/core/services/networkDebugService.js';
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
 import { completeStructuredResponse, finalizeStreamResponse, handleAbortOutcome, handleRequestFailure } from '@/core/llm/transport/requestOutcome.js';
+import { executeFetchRequest, executeNativeNonStreamingRequest, shouldUseNativeNonStreamingRequest, validateFetchResponse } from '@/core/llm/transport/requestExecution.js';
 import { setupRequestRuntimePolicy } from '@/core/llm/transport/requestRuntimePolicy.js';
 import { createStreamAccumulator } from '@/core/llm/transport/streamAccumulator.js';
 import { consumeSseDataLines, getTrailingSseDataLine } from '@/core/llm/transport/sseParser.js';
@@ -83,39 +83,28 @@ export async function executeRequest({
         // Bypass Mixed Content/Cleartext restrictions on Native for local HTTP
         // Use CapacitorHttp only for non-streaming requests.
         // For streaming, we fall through to standard fetch (requires android:usesCleartextTraffic="true")
-        if (Capacitor.isNativePlatform() && apiUrl.startsWith('http:') && !apiUrl.includes('https:') && !stream) {
-            const response = await CapacitorHttp.post({
-                url: requestUrl,
-                headers: headers,
-                data: requestBody,
-                responseType: 'json',
+        if (shouldUseNativeNonStreamingRequest({ apiUrl, stream })) {
+            const data = await executeNativeNonStreamingRequest({
+                requestUrl,
+                headers,
+                requestBody,
                 connectTimeout: CONNECT_TIMEOUT,
-                readTimeout: STREAM_TIMEOUT
+                streamTimeout: STREAM_TIMEOUT
             });
-
-            if (response.status >= 400) {
-                const errorData = typeof response.data === 'object' ? JSON.stringify(response.data) : String(response.data || '');
-                updateNetworkTrace({ responseStatus: response.status });
-                finishNetworkTrace({ rawResponse: response.data, error: `API Error: ${response.status} ${errorData}` });
-                throw new Error(`API Error: ${response.status} ${errorData}`);
-            }
-
-            const data = response.data;
-            updateNetworkTrace({ responseStatus: response.status });
             throwIfAborted();
 
-                completeStructuredResponse({
-                    data,
-                    contextLabel: 'API response structure (Native)',
-                    logLabel: 'LLM Response (Native):',
-                    requestReasoning,
-                    hasInlineTags,
-                    tagStart,
-                    tagEnd,
-                    headerModel,
-                    headerInline,
-                    onComplete
-                });
+            completeStructuredResponse({
+                data,
+                contextLabel: 'API response structure (Native)',
+                logLabel: 'LLM Response (Native):',
+                requestReasoning,
+                hasInlineTags,
+                tagStart,
+                tagEnd,
+                headerModel,
+                headerInline,
+                onComplete
+            });
 
             // Exit function, finally block will still run for cleanup
             return;
@@ -124,11 +113,11 @@ export async function executeRequest({
         // Connection timeout — abort if server doesn't respond
         connectTimer = setTimeout(() => { timedOut = true; if (controller) controller.abort(); }, CONNECT_TIMEOUT);
 
-        const response = await fetch(requestUrl, {
-            method: 'POST',
-            headers: headers,
-            body: JSON.stringify(requestBody),
-            signal: controller ? controller.signal : undefined
+        const response = await executeFetchRequest({
+            requestUrl,
+            headers,
+            requestBody,
+            controller
         });
 
         throwIfAborted();
@@ -136,18 +125,7 @@ export async function executeRequest({
         clearTimeout(connectTimer);
         connectTimer = null;
 
-        if (!response.ok) {
-            let errText = "";
-            try { errText = await response.text(); } catch (e) { }
-            updateNetworkTrace({ responseStatus: response.status, responseHeaders: Object.fromEntries(response.headers.entries()) });
-            finishNetworkTrace({ rawResponse: errText, error: `API Error: ${response.status} ${errText}` });
-            throw new Error(`API Error: ${response.status} ${errText}`);
-        }
-
-        updateNetworkTrace({
-            responseStatus: response.status,
-            responseHeaders: Object.fromEntries(response.headers.entries())
-        });
+        await validateFetchResponse(response);
 
         if (stream) {
             const contentType = (response.headers.get('content-type') || '').toLowerCase();

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -7,6 +7,7 @@ import { currentLang } from '@/core/config/APPSettings.js';
 import { startNetworkTrace, updateNetworkTrace, appendNetworkTraceLine, finishNetworkTrace } from '@/core/services/networkDebugService.js';
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
 import { extractOpenAiMessage, normalizeReasoningOutput } from '@/core/llm/transport/responseNormalizer.js';
+import { createStreamAccumulator } from '@/core/llm/transport/streamAccumulator.js';
 import { consumeSseDataLines, getTrailingSseDataLine } from '@/core/llm/transport/sseParser.js';
 import { logger } from '../../utils/logger.js';
 
@@ -66,9 +67,14 @@ export async function executeRequest({
         }
     }
 
-    let fullText = "";
-    let rawAccumulated = "";
-    let accumulatedReasoning = "";
+    const streamAccumulator = createStreamAccumulator({
+        requestReasoning,
+        tagStart,
+        tagEnd,
+        hasInlineTags,
+        headerModel,
+        headerInline
+    });
 
     const createAbortError = () => {
         const error = new Error('Generation aborted');
@@ -207,7 +213,6 @@ export async function executeRequest({
 
             const reader = response.body.getReader();
             const decoder = new TextDecoder("utf-8");
-            let previousEffectiveText = "";
             let pendingLineBuffer = '';
 
             const resetStreamTimer = () => {
@@ -247,56 +252,10 @@ export async function executeRequest({
 
                             if (content) logger.debug(content);
 
-                            fullText += content;
-                            rawAccumulated += content;
-                            if (reasoning) accumulatedReasoning += reasoning;
-
-                            // Process Outer CoT (Reasoning Tags)
-                            let effectiveText = rawAccumulated;
-                            let effectiveReasoning = "";
-
-                            if (requestReasoning) {
-                                effectiveReasoning = accumulatedReasoning || "";
-                            }
-
-                            let inlineReasoning = "";
-                            if (hasInlineTags && rawAccumulated.includes(tagStart)) {
-                                const startIndex = rawAccumulated.indexOf(tagStart);
-                                const endIndex = rawAccumulated.indexOf(tagEnd, startIndex);
-                                if (endIndex !== -1) {
-                                    inlineReasoning = rawAccumulated.substring(startIndex + tagStart.length, endIndex);
-                                    effectiveText = rawAccumulated.substring(0, startIndex) + rawAccumulated.substring(endIndex + tagEnd.length);
-                                } else {
-                                    inlineReasoning = rawAccumulated.substring(startIndex + tagStart.length);
-                                    effectiveText = rawAccumulated.substring(0, startIndex);
-                                }
-                            }
-
-                            if (effectiveReasoning && inlineReasoning) {
-                                effectiveReasoning = `${headerModel}\n${effectiveReasoning}\n\n---\n\n${headerInline}\n${inlineReasoning}`;
-                            } else if (inlineReasoning) {
-                                effectiveReasoning = inlineReasoning;
-                            }
-
-                            // Strip leading whitespace and decode HTML entities
-                            effectiveText = effectiveText.replace(/^\s+/, '')
-                                .replace(/&amp;/g, '&')
-                                .replace(/&gt;/g, '>')
-                                .replace(/&lt;/g, '<')
-                                .replace(/&quot;/g, '"')
-                                .replace(/&apos;/g, "'");
-
-                            // Buffer text ending in an incomplete HTML entity, flush it in the next delta
-                            const incompleteEntity = effectiveText.match(/&[a-zA-Z0-9#]*$/);
-                            if (incompleteEntity) {
-                                effectiveText = effectiveText.substring(0, incompleteEntity.index);
-                            }
-
-                            let textDelta = null;
-                            if (effectiveText.startsWith(previousEffectiveText)) {
-                                textDelta = effectiveText.substring(previousEffectiveText.length);
-                            }
-                            previousEffectiveText = effectiveText;
+                            const { effectiveText, effectiveReasoning, textDelta } = streamAccumulator.consumeDelta({
+                                content,
+                                reasoning
+                            });
 
                             if (onUpdate) onUpdate(content, reasoning, effectiveText, effectiveReasoning, textDelta);
                         }
@@ -318,24 +277,9 @@ export async function executeRequest({
             throwIfAborted();
 
             // Final processing for onComplete
-            let finalReasoning = requestReasoning ? accumulatedReasoning : "";
-            let finalText = fullText;
-            let inlineReasoning = "";
-
-            if (hasInlineTags && fullText.includes(tagStart)) {
-                const startIndex = fullText.indexOf(tagStart);
-                const endIndex = fullText.indexOf(tagEnd, startIndex);
-                if (endIndex !== -1) {
-                    inlineReasoning = fullText.substring(startIndex + tagStart.length, endIndex);
-                    finalText = fullText.substring(0, startIndex) + fullText.substring(endIndex + tagEnd.length);
-                }
-            }
-
-            if (finalReasoning && inlineReasoning) {
-                finalReasoning = `${headerModel}\n${finalReasoning}\n\n---\n\n${headerInline}\n${inlineReasoning}`;
-            } else if (inlineReasoning) {
-                finalReasoning = inlineReasoning;
-            }
+            const finalResult = streamAccumulator.finalize();
+            const finalText = finalResult.text;
+            const finalReasoning = finalResult.reasoning;
 
             logger.debug("Stream finished:", finalText);
 
@@ -345,10 +289,10 @@ export async function executeRequest({
                     eventCount: null
                 },
                 text: cleanText(finalText),
-                reasoning: finalReasoning || null
+                reasoning: finalReasoning
             });
 
-            if (onComplete) onComplete(cleanText(finalText), finalReasoning || null);
+            if (onComplete) onComplete(cleanText(finalText), finalReasoning);
 
         } else {
             const data = await response.json();
@@ -375,9 +319,10 @@ export async function executeRequest({
         if (e.name === 'AbortError') {
             if (timedOut) {
                 // Timeout-induced abort — treat as error, not user cancellation
-                if (fullText.length > 0) {
-                    finishNetworkTrace({ text: cleanText(fullText), reasoning: requestReasoning ? accumulatedReasoning : null, error: 'Generation timed out' });
-                    if (onComplete) onComplete(cleanText(fullText), requestReasoning ? accumulatedReasoning : null, { partialError: "Generation timed out" });
+                const partial = streamAccumulator.getPartial();
+                if (partial.text.length > 0) {
+                    finishNetworkTrace({ text: cleanText(partial.text), reasoning: partial.reasoning, error: 'Generation timed out' });
+                    if (onComplete) onComplete(cleanText(partial.text), partial.reasoning, { partialError: "Generation timed out" });
                 } else {
                     finishNetworkTrace({ error: 'Generation timed out — no response from server' });
                     if (onError) onError(new Error("Generation timed out — no response from server"));
@@ -386,9 +331,10 @@ export async function executeRequest({
             }
 
             // User-initiated abort — save partial text if available
-            if (fullText.length > 0) {
-                finishNetworkTrace({ text: cleanText(fullText), reasoning: requestReasoning ? accumulatedReasoning : null, error: 'Generation aborted' });
-                if (onComplete) onComplete(cleanText(fullText), requestReasoning ? accumulatedReasoning : null);
+            const partial = streamAccumulator.getPartial();
+            if (partial.text.length > 0) {
+                finishNetworkTrace({ text: cleanText(partial.text), reasoning: partial.reasoning, error: 'Generation aborted' });
+                if (onComplete) onComplete(cleanText(partial.text), partial.reasoning);
             } else {
                 finishNetworkTrace({ error: e });
                 if (onError) onError(e);
@@ -397,11 +343,12 @@ export async function executeRequest({
         }
 
         // Network error (connection abort, DNS failure, etc.) — save partial text cleanly
-        if (fullText.length > 0) {
+        const partial = streamAccumulator.getPartial();
+        if (partial.text.length > 0) {
             console.warn("Network error during stream, saving partial response:", e);
             const errorMsg = e.message || "Stream Error";
-            finishNetworkTrace({ text: cleanText(fullText), reasoning: requestReasoning ? accumulatedReasoning : null, error: errorMsg });
-            if (onComplete) onComplete(cleanText(fullText), requestReasoning ? accumulatedReasoning : null, { partialError: errorMsg });
+            finishNetworkTrace({ text: cleanText(partial.text), reasoning: partial.reasoning, error: errorMsg });
+            if (onComplete) onComplete(cleanText(partial.text), partial.reasoning, { partialError: errorMsg });
             return;
         }
 

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -69,6 +69,26 @@ export async function executeRequest({
     };
     Object.assign(headers, provider.buildAuthHeaders(apiKey));
 
+    const completeStructuredResponse = ({ data, contextLabel, logLabel }) => {
+        logger.debug(logLabel, data);
+
+        const { content, reasoningContent } = extractOpenAiMessage(data, contextLabel);
+        const normalized = normalizeReasoningOutput({
+            content,
+            requestReasoning,
+            rawReasoning: reasoningContent,
+            hasInlineTags,
+            tagStart,
+            tagEnd,
+            headerModel,
+            headerInline
+        });
+
+        const cleanedText = cleanText(normalized.text);
+        finishNetworkTrace({ rawResponse: data, text: cleanedText, reasoning: normalized.reasoning });
+        if (onComplete) onComplete(cleanedText, normalized.reasoning);
+    };
+
     startNetworkTrace({
         requestType,
         apiUrl,
@@ -101,25 +121,14 @@ export async function executeRequest({
             }
 
             const data = response.data;
-            logger.debug("LLM Response (Native):", data);
             updateNetworkTrace({ responseStatus: response.status });
             throwIfAborted();
-            
-            const { content, reasoningContent } = extractOpenAiMessage(data, 'API response structure (Native)');
-            const normalized = normalizeReasoningOutput({
-                content,
-                requestReasoning,
-                rawReasoning: reasoningContent,
-                hasInlineTags,
-                tagStart,
-                tagEnd,
-                headerModel,
-                headerInline
+
+            completeStructuredResponse({
+                data,
+                contextLabel: 'API response structure (Native)',
+                logLabel: 'LLM Response (Native):'
             });
-
-            finishNetworkTrace({ rawResponse: data, text: cleanText(normalized.text), reasoning: normalized.reasoning });
-
-            if (onComplete) onComplete(cleanText(normalized.text), normalized.reasoning);
 
             // Exit function, finally block will still run for cleanup
             return;
@@ -166,24 +175,13 @@ export async function executeRequest({
                 }
 
                 const data = await response.json();
-                logger.debug('LLM Response (stream fallback):', data);
                 throwIfAborted();
 
-                const { content, reasoningContent } = extractOpenAiMessage(data, 'API response structure (stream fallback)');
-                const normalized = normalizeReasoningOutput({
-                    content,
-                    requestReasoning,
-                    rawReasoning: reasoningContent,
-                    hasInlineTags,
-                    tagStart,
-                    tagEnd,
-                    headerModel,
-                    headerInline
+                completeStructuredResponse({
+                    data,
+                    contextLabel: 'API response structure (stream fallback)',
+                    logLabel: 'LLM Response (stream fallback):'
                 });
-
-                finishNetworkTrace({ rawResponse: data, text: cleanText(normalized.text), reasoning: normalized.reasoning });
-
-                if (onComplete) onComplete(cleanText(normalized.text), normalized.reasoning);
                 return;
             }
 
@@ -272,24 +270,13 @@ export async function executeRequest({
 
         } else {
             const data = await response.json();
-            logger.debug("LLM Response:", data);
             throwIfAborted();
-            
-            const { content, reasoningContent } = extractOpenAiMessage(data, 'API response structure');
-            const normalized = normalizeReasoningOutput({
-                content,
-                requestReasoning,
-                rawReasoning: reasoningContent,
-                hasInlineTags,
-                tagStart,
-                tagEnd,
-                headerModel,
-                headerInline
+
+            completeStructuredResponse({
+                data,
+                contextLabel: 'API response structure',
+                logLabel: 'LLM Response:'
             });
-
-            finishNetworkTrace({ rawResponse: data, text: cleanText(normalized.text), reasoning: normalized.reasoning });
-
-            if (onComplete) onComplete(cleanText(normalized.text), normalized.reasoning);
         }
     } catch (e) {
         if (e.name === 'AbortError') {

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -1,13 +1,13 @@
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
-import { completeStructuredResponse, finalizeStreamResponse, handleAbortOutcome, handleRequestFailure } from '@/core/llm/transport/requestOutcome.js';
-import { executeFetchRequest, executeNativeNonStreamingRequest, shouldUseNativeNonStreamingRequest, validateFetchResponse } from '@/core/llm/transport/requestExecution.js';
+import { completeStructuredResponse, handleAbortOutcome, handleRequestFailure } from '@/core/llm/transport/requestOutcome.js';
+import { executeNativeNonStreamingRequest, shouldUseNativeNonStreamingRequest } from '@/core/llm/transport/requestExecution.js';
+import { executeFetchChatCompletions } from '@/core/llm/transport/chatCompletionsClient.js';
 import { createRequestLifecycle } from '@/core/llm/transport/requestLifecycle.js';
-import { completeJsonResponse, getStreamingResponseMode } from '@/core/llm/transport/responseHandling.js';
+import { completeJsonResponse } from '@/core/llm/transport/responseHandling.js';
 import { setupRequestRuntimePolicy } from '@/core/llm/transport/requestRuntimePolicy.js';
 import { createStreamAccumulator } from '@/core/llm/transport/streamAccumulator.js';
-import { consumeStreamingSseResponse } from '@/core/llm/transport/streamingSse.js';
 import { logger } from '../../utils/logger.js';
 
 export async function executeRequest({
@@ -89,78 +89,22 @@ export async function executeRequest({
             return;
         }
 
-        // Connection timeout — abort if server doesn't respond
-        requestLifecycle.startConnectTimeout();
-
-        const response = await executeFetchRequest({
+        await executeFetchChatCompletions({
             requestUrl,
-            headers: requestLifecycle.headers,
             requestBody,
-            controller
+            controller,
+            requestLifecycle,
+            stream,
+            requestReasoning,
+            hasInlineTags,
+            tagStart,
+            tagEnd,
+            headerModel,
+            headerInline,
+            streamAccumulator,
+            onUpdate,
+            onComplete
         });
-
-        requestLifecycle.throwIfAborted();
-
-        requestLifecycle.clearConnectTimeout();
-
-        await validateFetchResponse(response);
-
-        if (stream) {
-            const { contentType, supportsStreamingBody, canStreamSse } = getStreamingResponseMode(response);
-
-            if (!canStreamSse) {
-                if (!supportsStreamingBody) {
-                    console.warn('[llmApi] Streaming body is unavailable on this platform/runtime, falling back to non-streaming response handling.');
-                } else {
-                    console.warn('[llmApi] Stream requested but provider returned a non-SSE response, falling back to non-streaming handling.', { contentType });
-                }
-
-                await completeJsonResponse({
-                    response,
-                    throwIfAborted: requestLifecycle.throwIfAborted,
-                    contextLabel: 'API response structure (stream fallback)',
-                    logLabel: 'LLM Response (stream fallback):',
-                    requestReasoning,
-                    hasInlineTags,
-                    tagStart,
-                    tagEnd,
-                    headerModel,
-                    headerInline,
-                    onComplete
-                });
-                return;
-            }
-
-            await consumeStreamingSseResponse({
-                responseBody: response.body,
-                controller: requestLifecycle.createStreamingTimeoutController(),
-                streamTimeout: requestLifecycle.streamTimeout,
-                throwIfAborted: requestLifecycle.throwIfAborted,
-                requestReasoning,
-                streamAccumulator,
-                onUpdate
-            });
-
-            finalizeStreamResponse({
-                streamAccumulator,
-                onComplete
-            });
-
-        } else {
-            await completeJsonResponse({
-                response,
-                throwIfAborted: requestLifecycle.throwIfAborted,
-                contextLabel: 'API response structure',
-                logLabel: 'LLM Response:',
-                requestReasoning,
-                hasInlineTags,
-                tagStart,
-                tagEnd,
-                headerModel,
-                headerInline,
-                onComplete
-            });
-        }
     } catch (e) {
         if (e.name === 'AbortError') {
             handleAbortOutcome({

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -7,6 +7,7 @@ import { currentLang } from '@/core/config/APPSettings.js';
 import { startNetworkTrace, updateNetworkTrace, appendNetworkTraceLine, finishNetworkTrace } from '@/core/services/networkDebugService.js';
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
 import { extractOpenAiMessage, normalizeReasoningOutput } from '@/core/llm/transport/responseNormalizer.js';
+import { consumeSseDataLines, getTrailingSseDataLine } from '@/core/llm/transport/sseParser.js';
 import { logger } from '../../utils/logger.js';
 
 export async function executeRequest({
@@ -223,16 +224,10 @@ export async function executeRequest({
                 throwIfAborted();
 
                 const chunk = decoder.decode(value, { stream: true });
-                pendingLineBuffer += chunk;
-                const lines = pendingLineBuffer.split('\n');
-                pendingLineBuffer = lines.pop() || '';
+                const parsedChunk = consumeSseDataLines(pendingLineBuffer, chunk);
+                pendingLineBuffer = parsedChunk.remaining;
 
-                for (const line of lines) {
-                    const trimmed = line.trim();
-                    if (!trimmed || !trimmed.startsWith('data: ')) continue;
-
-                    const dataStr = trimmed.substring(6);
-                    if (dataStr === '[DONE]') continue;
+                for (const dataStr of parsedChunk.dataLines) {
                     appendNetworkTraceLine(dataStr);
                     throwIfAborted();
 
@@ -314,12 +309,9 @@ export async function executeRequest({
                 }
             }
 
-            const trailingLine = pendingLineBuffer.trim();
-            if (trailingLine.startsWith('data: ')) {
-                const dataStr = trailingLine.substring(6);
-                if (dataStr && dataStr !== '[DONE]') {
-                    appendNetworkTraceLine(dataStr);
-                }
+            const trailingDataLine = getTrailingSseDataLine(pendingLineBuffer);
+            if (trailingDataLine) {
+                appendNetworkTraceLine(trailingDataLine);
             }
 
             if (streamTimer) { clearTimeout(streamTimer); streamTimer = null; }

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -1,11 +1,10 @@
-import { BackgroundMode } from '@anuradev/capacitor-background-mode';
 import { Capacitor, CapacitorHttp } from '@capacitor/core';
-import { startGenerationNotification, stopGenerationNotification } from '@/core/services/notificationService.js';
 import { cleanText } from '@/utils/textFormatter.js';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import { startNetworkTrace, updateNetworkTrace, appendNetworkTraceLine, finishNetworkTrace } from '@/core/services/networkDebugService.js';
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
+import { setupRequestRuntimePolicy } from '@/core/llm/transport/requestRuntimePolicy.js';
 import { extractOpenAiMessage, normalizeReasoningOutput } from '@/core/llm/transport/responseNormalizer.js';
 import { createStreamAccumulator } from '@/core/llm/transport/streamAccumulator.js';
 import { consumeSseDataLines, getTrailingSseDataLine } from '@/core/llm/transport/sseParser.js';
@@ -39,33 +38,10 @@ export async function executeRequest({
     let connectTimer = null;
     let streamTimer = null;
     let timedOut = false;
-
-    // Keep screen on during generation to prevent OS suspension
-    let wakeLock = null;
-    const requestWakeLock = async () => {
-        if ('wakeLock' in navigator && document.visibilityState === 'visible') {
-            try { wakeLock = await navigator.wakeLock.request('screen'); } catch (e) { console.warn("WakeLock error:", e); }
-        }
-    };
-    await requestWakeLock();
-
-    // Re-acquire lock if app comes back to foreground while generating
-    const handleVisibilityChange = () => { if (document.visibilityState === 'visible') requestWakeLock(); };
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    // Keep app alive when backgrounded during generation
-    const isAndroid = Capacitor.getPlatform() === 'android';
-    const isIos = Capacitor.getPlatform() === 'ios';
-
-    if (isAndroid) {
-        await startGenerationNotification('Glaze', translations[currentLang.value]['model_typing'] || 'Generating...');
-    } else if (isIos) {
-        try {
-            await BackgroundMode.enable();
-        } catch (e) {
-            console.warn("BackgroundMode enable failed:", e);
-        }
-    }
+    const runtimePolicy = await setupRequestRuntimePolicy({
+        notificationTitle: 'Glaze',
+        notificationBody: translations[currentLang.value]['model_typing'] || 'Generating...'
+    });
 
     const streamAccumulator = createStreamAccumulator({
         requestReasoning,
@@ -357,17 +333,6 @@ export async function executeRequest({
     } finally {
         if (connectTimer) clearTimeout(connectTimer);
         if (streamTimer) clearTimeout(streamTimer);
-        document.removeEventListener('visibilitychange', handleVisibilityChange);
-        if (wakeLock) {
-            try { wakeLock.release(); } catch (e) { }
-        }
-
-        if (isAndroid) {
-            await stopGenerationNotification();
-        } else if (isIos) {
-            try {
-                await BackgroundMode.disable();
-            } catch (e) { }
-        }
+        await runtimePolicy.cleanup();
     }
 }

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -1,10 +1,10 @@
-import { cleanText } from '@/utils/textFormatter.js';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import { startNetworkTrace } from '@/core/services/networkDebugService.js';
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
 import { completeStructuredResponse, finalizeStreamResponse, handleAbortOutcome, handleRequestFailure } from '@/core/llm/transport/requestOutcome.js';
 import { executeFetchRequest, executeNativeNonStreamingRequest, shouldUseNativeNonStreamingRequest, validateFetchResponse } from '@/core/llm/transport/requestExecution.js';
+import { completeJsonResponse, getStreamingResponseMode } from '@/core/llm/transport/responseHandling.js';
 import { setupRequestRuntimePolicy } from '@/core/llm/transport/requestRuntimePolicy.js';
 import { createStreamAccumulator } from '@/core/llm/transport/streamAccumulator.js';
 import { consumeStreamingSseResponse } from '@/core/llm/transport/streamingSse.js';
@@ -92,8 +92,9 @@ export async function executeRequest({
             });
             throwIfAborted();
 
-            completeStructuredResponse({
+            await completeJsonResponse({
                 data,
+                throwIfAborted,
                 contextLabel: 'API response structure (Native)',
                 logLabel: 'LLM Response (Native):',
                 requestReasoning,
@@ -127,22 +128,18 @@ export async function executeRequest({
         await validateFetchResponse(response);
 
         if (stream) {
-            const contentType = (response.headers.get('content-type') || '').toLowerCase();
-            const supportsStreamingBody = !!response.body && typeof response.body.getReader === 'function';
-            const isSseResponse = contentType.includes('text/event-stream');
+            const { contentType, supportsStreamingBody, canStreamSse } = getStreamingResponseMode(response);
 
-            if (!supportsStreamingBody || !isSseResponse) {
+            if (!canStreamSse) {
                 if (!supportsStreamingBody) {
                     console.warn('[llmApi] Streaming body is unavailable on this platform/runtime, falling back to non-streaming response handling.');
                 } else {
                     console.warn('[llmApi] Stream requested but provider returned a non-SSE response, falling back to non-streaming handling.', { contentType });
                 }
 
-                const data = await response.json();
-                throwIfAborted();
-
-                completeStructuredResponse({
-                    data,
+                await completeJsonResponse({
+                    response,
+                    throwIfAborted,
                     contextLabel: 'API response structure (stream fallback)',
                     logLabel: 'LLM Response (stream fallback):',
                     requestReasoning,
@@ -177,11 +174,9 @@ export async function executeRequest({
             });
 
         } else {
-            const data = await response.json();
-            throwIfAborted();
-
-            completeStructuredResponse({
-                data,
+            await completeJsonResponse({
+                response,
+                throwIfAborted,
                 contextLabel: 'API response structure',
                 logLabel: 'LLM Response:',
                 requestReasoning,

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -5,9 +5,12 @@ import { cleanText } from '@/utils/textFormatter.js';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import { startNetworkTrace, updateNetworkTrace, appendNetworkTraceLine, finishNetworkTrace } from '@/core/services/networkDebugService.js';
+import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
+import { extractOpenAiMessage, normalizeReasoningOutput } from '@/core/llm/transport/responseNormalizer.js';
 import { logger } from '../../utils/logger.js';
 
 export async function executeRequest({
+    providerId,
     apiUrl,
     apiKey,
     requestBody,
@@ -23,6 +26,8 @@ export async function executeRequest({
     const t = (key) => translations[currentLang.value]?.[key] || key;
     const headerModel = `<span style="color: var(--vk-blue); font-weight: 700; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.5px;">${t('reasoning_model')}</span>`;
     const headerInline = `<span style="color: var(--vk-blue); font-weight: 700; font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.5px;">${t('reasoning_inline')}</span>`;
+    const provider = getProviderById(providerId);
+    const requestUrl = provider.buildChatCompletionsUrl(apiUrl);
 
     const hasInlineTags = !!tagStart && !!tagEnd;
 
@@ -79,7 +84,7 @@ export async function executeRequest({
     const headers = {
         'Content-Type': 'application/json'
     };
-    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+    Object.assign(headers, provider.buildAuthHeaders(apiKey));
 
     startNetworkTrace({
         requestType,
@@ -97,7 +102,7 @@ export async function executeRequest({
         // For streaming, we fall through to standard fetch (requires android:usesCleartextTraffic="true")
         if (Capacitor.isNativePlatform() && apiUrl.startsWith('http:') && !apiUrl.includes('https:') && !stream) {
             const response = await CapacitorHttp.post({
-                url: `${apiUrl}/chat/completions`,
+                url: requestUrl,
                 headers: headers,
                 data: requestBody,
                 responseType: 'json',
@@ -117,36 +122,21 @@ export async function executeRequest({
             updateNetworkTrace({ responseStatus: response.status });
             throwIfAborted();
             
-            // Defensive check: ensure API returned valid structure
-            if (!data || !data.choices || !data.choices.length || !data.choices[0] || !data.choices[0].message) {
-                throw new Error("Invalid API response structure (Native): " + JSON.stringify(data));
-            }
-            
-            const content = data.choices[0].message.content;
-            const rawReasoning = data.choices[0].message.reasoning_content;
+            const { content, reasoningContent } = extractOpenAiMessage(data, 'API response structure (Native)');
+            const normalized = normalizeReasoningOutput({
+                content,
+                requestReasoning,
+                rawReasoning: reasoningContent,
+                hasInlineTags,
+                tagStart,
+                tagEnd,
+                headerModel,
+                headerInline
+            });
 
-            let finalText = content || "";
-            let finalReasoning = requestReasoning ? (rawReasoning || "") : "";
-            let inlineReasoning = "";
+            finishNetworkTrace({ rawResponse: data, text: cleanText(normalized.text), reasoning: normalized.reasoning });
 
-            if (hasInlineTags && content && content.includes(tagStart)) {
-                const startIndex = content.indexOf(tagStart);
-                const endIndex = content.indexOf(tagEnd, startIndex);
-                if (endIndex !== -1) {
-                    inlineReasoning = content.substring(startIndex + tagStart.length, endIndex);
-                    finalText = content.substring(0, startIndex) + content.substring(endIndex + tagEnd.length);
-                }
-            }
-
-            if (finalReasoning && inlineReasoning) {
-                finalReasoning = `${headerModel}\n${finalReasoning}\n\n---\n\n${headerInline}\n${inlineReasoning}`;
-            } else if (inlineReasoning) {
-                finalReasoning = inlineReasoning;
-            }
-
-            finishNetworkTrace({ rawResponse: data, text: cleanText(finalText), reasoning: finalReasoning || null });
-
-            if (onComplete) onComplete(cleanText(finalText), finalReasoning || null);
+            if (onComplete) onComplete(cleanText(normalized.text), normalized.reasoning);
 
             // Exit function, finally block will still run for cleanup
             return;
@@ -155,7 +145,7 @@ export async function executeRequest({
         // Connection timeout — abort if server doesn't respond
         connectTimer = setTimeout(() => { timedOut = true; if (controller) controller.abort(); }, CONNECT_TIMEOUT);
 
-        const response = await fetch(`${apiUrl}/chat/completions`, {
+        const response = await fetch(requestUrl, {
             method: 'POST',
             headers: headers,
             body: JSON.stringify(requestBody),
@@ -196,35 +186,21 @@ export async function executeRequest({
                 logger.debug('LLM Response (stream fallback):', data);
                 throwIfAborted();
 
-                if (!data || !data.choices || !data.choices.length || !data.choices[0] || !data.choices[0].message) {
-                    throw new Error('Invalid API response structure (stream fallback): ' + JSON.stringify(data));
-                }
+                const { content, reasoningContent } = extractOpenAiMessage(data, 'API response structure (stream fallback)');
+                const normalized = normalizeReasoningOutput({
+                    content,
+                    requestReasoning,
+                    rawReasoning: reasoningContent,
+                    hasInlineTags,
+                    tagStart,
+                    tagEnd,
+                    headerModel,
+                    headerInline
+                });
 
-                const content = data.choices[0].message.content;
-                const rawReasoning = data.choices[0].message.reasoning_content;
+                finishNetworkTrace({ rawResponse: data, text: cleanText(normalized.text), reasoning: normalized.reasoning });
 
-                let finalText = content || '';
-                let finalReasoning = requestReasoning ? (rawReasoning || '') : '';
-                let inlineReasoning = '';
-
-                if (hasInlineTags && content && content.includes(tagStart)) {
-                    const startIndex = content.indexOf(tagStart);
-                    const endIndex = content.indexOf(tagEnd, startIndex);
-                    if (endIndex !== -1) {
-                        inlineReasoning = content.substring(startIndex + tagStart.length, endIndex);
-                        finalText = content.substring(0, startIndex) + content.substring(endIndex + tagEnd.length);
-                    }
-                }
-
-                if (finalReasoning && inlineReasoning) {
-                    finalReasoning = `${headerModel}\n${finalReasoning}\n\n---\n\n${headerInline}\n${inlineReasoning}`;
-                } else if (inlineReasoning) {
-                    finalReasoning = inlineReasoning;
-                }
-
-                finishNetworkTrace({ rawResponse: data, text: cleanText(finalText), reasoning: finalReasoning || null });
-
-                if (onComplete) onComplete(cleanText(finalText), finalReasoning || null);
+                if (onComplete) onComplete(cleanText(normalized.text), normalized.reasoning);
                 return;
             }
 
@@ -387,36 +363,21 @@ export async function executeRequest({
             logger.debug("LLM Response:", data);
             throwIfAborted();
             
-            // Defensive check: ensure API returned valid structure
-            if (!data || !data.choices || !data.choices.length || !data.choices[0] || !data.choices[0].message) {
-                throw new Error("Invalid API response structure: " + JSON.stringify(data));
-            }
-            
-            const content = data.choices[0].message.content;
-            const rawReasoning = data.choices[0].message.reasoning_content;
+            const { content, reasoningContent } = extractOpenAiMessage(data, 'API response structure');
+            const normalized = normalizeReasoningOutput({
+                content,
+                requestReasoning,
+                rawReasoning: reasoningContent,
+                hasInlineTags,
+                tagStart,
+                tagEnd,
+                headerModel,
+                headerInline
+            });
 
-            let finalText = content || "";
-            let finalReasoning = requestReasoning ? (rawReasoning || "") : "";
-            let inlineReasoning = "";
+            finishNetworkTrace({ rawResponse: data, text: cleanText(normalized.text), reasoning: normalized.reasoning });
 
-            if (hasInlineTags && content && content.includes(tagStart)) {
-                const startIndex = content.indexOf(tagStart);
-                const endIndex = content.indexOf(tagEnd, startIndex);
-                if (endIndex !== -1) {
-                    inlineReasoning = content.substring(startIndex + tagStart.length, endIndex);
-                    finalText = content.substring(0, startIndex) + content.substring(endIndex + tagEnd.length);
-                }
-            }
-
-            if (finalReasoning && inlineReasoning) {
-                finalReasoning = `${headerModel}\n${finalReasoning}\n\n---\n\n${headerInline}\n${inlineReasoning}`;
-            } else if (inlineReasoning) {
-                finalReasoning = inlineReasoning;
-            }
-
-            finishNetworkTrace({ rawResponse: data, text: cleanText(finalText), reasoning: finalReasoning || null });
-
-            if (onComplete) onComplete(cleanText(finalText), finalReasoning || null);
+            if (onComplete) onComplete(cleanText(normalized.text), normalized.reasoning);
         }
     } catch (e) {
         if (e.name === 'AbortError') {

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -1,13 +1,13 @@
 import { cleanText } from '@/utils/textFormatter.js';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
-import { startNetworkTrace, updateNetworkTrace, appendNetworkTraceLine, finishNetworkTrace } from '@/core/services/networkDebugService.js';
+import { startNetworkTrace } from '@/core/services/networkDebugService.js';
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
 import { completeStructuredResponse, finalizeStreamResponse, handleAbortOutcome, handleRequestFailure } from '@/core/llm/transport/requestOutcome.js';
 import { executeFetchRequest, executeNativeNonStreamingRequest, shouldUseNativeNonStreamingRequest, validateFetchResponse } from '@/core/llm/transport/requestExecution.js';
 import { setupRequestRuntimePolicy } from '@/core/llm/transport/requestRuntimePolicy.js';
 import { createStreamAccumulator } from '@/core/llm/transport/streamAccumulator.js';
-import { consumeSseDataLines, getTrailingSseDataLine } from '@/core/llm/transport/sseParser.js';
+import { consumeStreamingSseResponse } from '@/core/llm/transport/streamingSse.js';
 import { logger } from '../../utils/logger.js';
 
 export async function executeRequest({
@@ -36,7 +36,6 @@ export async function executeRequest({
     const CONNECT_TIMEOUT = parseInt(localStorage.getItem('gz_api_connect_timeout')) || 90000;
     const STREAM_TIMEOUT = parseInt(localStorage.getItem('gz_api_stream_timeout')) || 120000;
     let connectTimer = null;
-    let streamTimer = null;
     let timedOut = false;
     const runtimePolicy = await setupRequestRuntimePolicy({
         notificationTitle: 'Glaze',
@@ -157,70 +156,20 @@ export async function executeRequest({
                 return;
             }
 
-            const reader = response.body.getReader();
-            const decoder = new TextDecoder("utf-8");
-            let pendingLineBuffer = '';
-
-            const resetStreamTimer = () => {
-                if (streamTimer) clearTimeout(streamTimer);
-                streamTimer = setTimeout(() => { timedOut = true; if (controller) controller.abort(); }, STREAM_TIMEOUT);
-            };
-            resetStreamTimer();
-
-            while (true) {
-                throwIfAborted();
-                const { done, value } = await reader.read();
-                if (done) break;
-                resetStreamTimer();
-                throwIfAborted();
-
-                const chunk = decoder.decode(value, { stream: true });
-                const parsedChunk = consumeSseDataLines(pendingLineBuffer, chunk);
-                pendingLineBuffer = parsedChunk.remaining;
-
-                for (const dataStr of parsedChunk.dataLines) {
-                    appendNetworkTraceLine(dataStr);
-                    throwIfAborted();
-
-                    try {
-                        const json = JSON.parse(dataStr);
-
-                        if (json.error) {
-                            throw new Error("API Stream Error: " + (json.error.message || JSON.stringify(json.error)));
-                        }
-
-                        if (!json.choices || !json.choices.length) continue;
-
-                        const delta = json.choices[0].delta;
-                        if (delta && (delta.content || delta.reasoning_content)) {
-                            const content = delta.content || "";
-                            const reasoning = (requestReasoning && delta.reasoning_content) || null;
-
-                            if (content) logger.debug(content);
-
-                            const { effectiveText, effectiveReasoning, textDelta } = streamAccumulator.consumeDelta({
-                                content,
-                                reasoning
-                            });
-
-                            if (onUpdate) onUpdate(content, reasoning, effectiveText, effectiveReasoning, textDelta);
-                        }
-                    } catch (e) {
-                        if (e.message && e.message.startsWith("API Stream Error")) {
-                            throw e;
-                        }
-                        console.warn("Error parsing stream chunk", e);
+            await consumeStreamingSseResponse({
+                responseBody: response.body,
+                controller: controller && {
+                    abort() {
+                        timedOut = true;
+                        controller.abort();
                     }
-                }
-            }
-
-            const trailingDataLine = getTrailingSseDataLine(pendingLineBuffer);
-            if (trailingDataLine) {
-                appendNetworkTraceLine(trailingDataLine);
-            }
-
-            if (streamTimer) { clearTimeout(streamTimer); streamTimer = null; }
-            throwIfAborted();
+                },
+                streamTimeout: STREAM_TIMEOUT,
+                throwIfAborted,
+                requestReasoning,
+                streamAccumulator,
+                onUpdate
+            });
 
             finalizeStreamResponse({
                 streamAccumulator,
@@ -264,7 +213,6 @@ export async function executeRequest({
         });
     } finally {
         if (connectTimer) clearTimeout(connectTimer);
-        if (streamTimer) clearTimeout(streamTimer);
         await runtimePolicy.cleanup();
     }
 }

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -1,9 +1,9 @@
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
-import { startNetworkTrace } from '@/core/services/networkDebugService.js';
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
 import { completeStructuredResponse, finalizeStreamResponse, handleAbortOutcome, handleRequestFailure } from '@/core/llm/transport/requestOutcome.js';
 import { executeFetchRequest, executeNativeNonStreamingRequest, shouldUseNativeNonStreamingRequest, validateFetchResponse } from '@/core/llm/transport/requestExecution.js';
+import { createRequestLifecycle } from '@/core/llm/transport/requestLifecycle.js';
 import { completeJsonResponse, getStreamingResponseMode } from '@/core/llm/transport/responseHandling.js';
 import { setupRequestRuntimePolicy } from '@/core/llm/transport/requestRuntimePolicy.js';
 import { createStreamAccumulator } from '@/core/llm/transport/streamAccumulator.js';
@@ -31,12 +31,6 @@ export async function executeRequest({
     const requestUrl = provider.buildChatCompletionsUrl(apiUrl);
 
     const hasInlineTags = !!tagStart && !!tagEnd;
-
-    // Timeout configuration (configurable via localStorage for future settings UI)
-    const CONNECT_TIMEOUT = parseInt(localStorage.getItem('gz_api_connect_timeout')) || 90000;
-    const STREAM_TIMEOUT = parseInt(localStorage.getItem('gz_api_stream_timeout')) || 120000;
-    let connectTimer = null;
-    let timedOut = false;
     const runtimePolicy = await setupRequestRuntimePolicy({
         notificationTitle: 'Glaze',
         notificationBody: translations[currentLang.value]['model_typing'] || 'Generating...'
@@ -51,29 +45,14 @@ export async function executeRequest({
         headerInline
     });
 
-    const createAbortError = () => {
-        const error = new Error('Generation aborted');
-        error.name = 'AbortError';
-        return error;
-    };
-
-    const throwIfAborted = () => {
-        if (controller?.signal?.aborted) {
-            throw createAbortError();
-        }
-    };
-
-    const headers = {
-        'Content-Type': 'application/json'
-    };
-    Object.assign(headers, provider.buildAuthHeaders(apiKey));
-
-    startNetworkTrace({
+    const requestLifecycle = createRequestLifecycle({
+        provider,
+        apiKey,
+        controller,
         requestType,
         apiUrl,
         stream,
-        requestBody,
-        headers
+        requestBody
     });
 
     try {
@@ -85,16 +64,16 @@ export async function executeRequest({
         if (shouldUseNativeNonStreamingRequest({ apiUrl, stream })) {
             const data = await executeNativeNonStreamingRequest({
                 requestUrl,
-                headers,
+                headers: requestLifecycle.headers,
                 requestBody,
-                connectTimeout: CONNECT_TIMEOUT,
-                streamTimeout: STREAM_TIMEOUT
+                connectTimeout: requestLifecycle.connectTimeout,
+                streamTimeout: requestLifecycle.streamTimeout
             });
-            throwIfAborted();
+            requestLifecycle.throwIfAborted();
 
             await completeJsonResponse({
                 data,
-                throwIfAborted,
+                throwIfAborted: requestLifecycle.throwIfAborted,
                 contextLabel: 'API response structure (Native)',
                 logLabel: 'LLM Response (Native):',
                 requestReasoning,
@@ -111,19 +90,18 @@ export async function executeRequest({
         }
 
         // Connection timeout — abort if server doesn't respond
-        connectTimer = setTimeout(() => { timedOut = true; if (controller) controller.abort(); }, CONNECT_TIMEOUT);
+        requestLifecycle.startConnectTimeout();
 
         const response = await executeFetchRequest({
             requestUrl,
-            headers,
+            headers: requestLifecycle.headers,
             requestBody,
             controller
         });
 
-        throwIfAborted();
+        requestLifecycle.throwIfAborted();
 
-        clearTimeout(connectTimer);
-        connectTimer = null;
+        requestLifecycle.clearConnectTimeout();
 
         await validateFetchResponse(response);
 
@@ -139,7 +117,7 @@ export async function executeRequest({
 
                 await completeJsonResponse({
                     response,
-                    throwIfAborted,
+                    throwIfAborted: requestLifecycle.throwIfAborted,
                     contextLabel: 'API response structure (stream fallback)',
                     logLabel: 'LLM Response (stream fallback):',
                     requestReasoning,
@@ -155,14 +133,9 @@ export async function executeRequest({
 
             await consumeStreamingSseResponse({
                 responseBody: response.body,
-                controller: controller && {
-                    abort() {
-                        timedOut = true;
-                        controller.abort();
-                    }
-                },
-                streamTimeout: STREAM_TIMEOUT,
-                throwIfAborted,
+                controller: requestLifecycle.createStreamingTimeoutController(),
+                streamTimeout: requestLifecycle.streamTimeout,
+                throwIfAborted: requestLifecycle.throwIfAborted,
                 requestReasoning,
                 streamAccumulator,
                 onUpdate
@@ -176,7 +149,7 @@ export async function executeRequest({
         } else {
             await completeJsonResponse({
                 response,
-                throwIfAborted,
+                throwIfAborted: requestLifecycle.throwIfAborted,
                 contextLabel: 'API response structure',
                 logLabel: 'LLM Response:',
                 requestReasoning,
@@ -191,7 +164,7 @@ export async function executeRequest({
     } catch (e) {
         if (e.name === 'AbortError') {
             handleAbortOutcome({
-                timedOut,
+                timedOut: requestLifecycle.timedOut,
                 streamAccumulator,
                 onComplete,
                 onError,
@@ -207,7 +180,7 @@ export async function executeRequest({
             onError
         });
     } finally {
-        if (connectTimer) clearTimeout(connectTimer);
+        requestLifecycle.clearConnectTimeout();
         await runtimePolicy.cleanup();
     }
 }

--- a/src/core/services/llmApi.js
+++ b/src/core/services/llmApi.js
@@ -4,8 +4,8 @@ import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import { startNetworkTrace, updateNetworkTrace, appendNetworkTraceLine, finishNetworkTrace } from '@/core/services/networkDebugService.js';
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
+import { completeStructuredResponse, finalizeStreamResponse, handleAbortOutcome, handleRequestFailure } from '@/core/llm/transport/requestOutcome.js';
 import { setupRequestRuntimePolicy } from '@/core/llm/transport/requestRuntimePolicy.js';
-import { extractOpenAiMessage, normalizeReasoningOutput } from '@/core/llm/transport/responseNormalizer.js';
 import { createStreamAccumulator } from '@/core/llm/transport/streamAccumulator.js';
 import { consumeSseDataLines, getTrailingSseDataLine } from '@/core/llm/transport/sseParser.js';
 import { logger } from '../../utils/logger.js';
@@ -69,26 +69,6 @@ export async function executeRequest({
     };
     Object.assign(headers, provider.buildAuthHeaders(apiKey));
 
-    const completeStructuredResponse = ({ data, contextLabel, logLabel }) => {
-        logger.debug(logLabel, data);
-
-        const { content, reasoningContent } = extractOpenAiMessage(data, contextLabel);
-        const normalized = normalizeReasoningOutput({
-            content,
-            requestReasoning,
-            rawReasoning: reasoningContent,
-            hasInlineTags,
-            tagStart,
-            tagEnd,
-            headerModel,
-            headerInline
-        });
-
-        const cleanedText = cleanText(normalized.text);
-        finishNetworkTrace({ rawResponse: data, text: cleanedText, reasoning: normalized.reasoning });
-        if (onComplete) onComplete(cleanedText, normalized.reasoning);
-    };
-
     startNetworkTrace({
         requestType,
         apiUrl,
@@ -124,11 +104,18 @@ export async function executeRequest({
             updateNetworkTrace({ responseStatus: response.status });
             throwIfAborted();
 
-            completeStructuredResponse({
-                data,
-                contextLabel: 'API response structure (Native)',
-                logLabel: 'LLM Response (Native):'
-            });
+                completeStructuredResponse({
+                    data,
+                    contextLabel: 'API response structure (Native)',
+                    logLabel: 'LLM Response (Native):',
+                    requestReasoning,
+                    hasInlineTags,
+                    tagStart,
+                    tagEnd,
+                    headerModel,
+                    headerInline,
+                    onComplete
+                });
 
             // Exit function, finally block will still run for cleanup
             return;
@@ -180,7 +167,14 @@ export async function executeRequest({
                 completeStructuredResponse({
                     data,
                     contextLabel: 'API response structure (stream fallback)',
-                    logLabel: 'LLM Response (stream fallback):'
+                    logLabel: 'LLM Response (stream fallback):',
+                    requestReasoning,
+                    hasInlineTags,
+                    tagStart,
+                    tagEnd,
+                    headerModel,
+                    headerInline,
+                    onComplete
                 });
                 return;
             }
@@ -250,23 +244,10 @@ export async function executeRequest({
             if (streamTimer) { clearTimeout(streamTimer); streamTimer = null; }
             throwIfAborted();
 
-            // Final processing for onComplete
-            const finalResult = streamAccumulator.finalize();
-            const finalText = finalResult.text;
-            const finalReasoning = finalResult.reasoning;
-
-            logger.debug("Stream finished:", finalText);
-
-            finishNetworkTrace({
-                rawResponse: {
-                    mode: 'sse',
-                    eventCount: null
-                },
-                text: cleanText(finalText),
-                reasoning: finalReasoning
+            finalizeStreamResponse({
+                streamAccumulator,
+                onComplete
             });
-
-            if (onComplete) onComplete(cleanText(finalText), finalReasoning);
 
         } else {
             const data = await response.json();
@@ -275,48 +256,34 @@ export async function executeRequest({
             completeStructuredResponse({
                 data,
                 contextLabel: 'API response structure',
-                logLabel: 'LLM Response:'
+                logLabel: 'LLM Response:',
+                requestReasoning,
+                hasInlineTags,
+                tagStart,
+                tagEnd,
+                headerModel,
+                headerInline,
+                onComplete
             });
         }
     } catch (e) {
         if (e.name === 'AbortError') {
-            if (timedOut) {
-                // Timeout-induced abort — treat as error, not user cancellation
-                const partial = streamAccumulator.getPartial();
-                if (partial.text.length > 0) {
-                    finishNetworkTrace({ text: cleanText(partial.text), reasoning: partial.reasoning, error: 'Generation timed out' });
-                    if (onComplete) onComplete(cleanText(partial.text), partial.reasoning, { partialError: "Generation timed out" });
-                } else {
-                    finishNetworkTrace({ error: 'Generation timed out — no response from server' });
-                    if (onError) onError(new Error("Generation timed out — no response from server"));
-                }
-                return;
-            }
-
-            // User-initiated abort — save partial text if available
-            const partial = streamAccumulator.getPartial();
-            if (partial.text.length > 0) {
-                finishNetworkTrace({ text: cleanText(partial.text), reasoning: partial.reasoning, error: 'Generation aborted' });
-                if (onComplete) onComplete(cleanText(partial.text), partial.reasoning);
-            } else {
-                finishNetworkTrace({ error: e });
-                if (onError) onError(e);
-            }
+            handleAbortOutcome({
+                timedOut,
+                streamAccumulator,
+                onComplete,
+                onError,
+                abortError: e
+            });
             return;
         }
 
-        // Network error (connection abort, DNS failure, etc.) — save partial text cleanly
-        const partial = streamAccumulator.getPartial();
-        if (partial.text.length > 0) {
-            console.warn("Network error during stream, saving partial response:", e);
-            const errorMsg = e.message || "Stream Error";
-            finishNetworkTrace({ text: cleanText(partial.text), reasoning: partial.reasoning, error: errorMsg });
-            if (onComplete) onComplete(cleanText(partial.text), partial.reasoning, { partialError: errorMsg });
-            return;
-        }
-
-        finishNetworkTrace({ error: e });
-        if (onError) onError(e);
+        handleRequestFailure({
+            error: e,
+            streamAccumulator,
+            onComplete,
+            onError
+        });
     } finally {
         if (connectTimer) clearTimeout(connectTimer);
         if (streamTimer) clearTimeout(streamTimer);

--- a/src/utils/macroEngine.js
+++ b/src/utils/macroEngine.js
@@ -1,3 +1,7 @@
+import { getApiReasoningTags } from '@/core/config/APISettings.js';
+
+let pickCount = 0;
+
 export function replaceMacros(text, char, persona, sessionVarsIn = null, notifyObj = null) {
     if (!text) return "";
 
@@ -75,7 +79,6 @@ export function replaceMacros(text, char, persona, sessionVarsIn = null, notifyO
     });
 
     // {{pick::a::b::c}}
-    let pickCount = 0;
     result = result.replace(/{{pick::(.*?)}}/gi, (match, optionsStr) => {
         const options = optionsStr.split("::");
         const version = sessionVars.__pick_version || 0;
@@ -97,10 +100,10 @@ export function replaceMacros(text, char, persona, sessionVarsIn = null, notifyO
 
     // {{reasoningPrefix}} / {{reasoningSuffix}} - reasoning tags from sessionVars or localStorage
     result = result.replace(/\{\{reasoningPrefix\}\}/gi, () => {
-        return sessionVars.reasoningPrefix || localStorage.getItem('gz_api_reasoning_start') || '<think>';
+        return sessionVars.reasoningPrefix || getApiReasoningTags().start;
     });
     result = result.replace(/\{\{reasoningSuffix\}\}/gi, () => {
-        return sessionVars.reasoningSuffix || localStorage.getItem('gz_api_reasoning_end') || '';
+        return sessionVars.reasoningSuffix || getApiReasoningTags().end;
     });
 
     // --- Escaping: \{\{ → {{ and \}\} → }} ---

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -12,7 +12,7 @@ function handleBack() {
         sheet.value?.close();
     }
 }
-import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getBlacklistedProvider } from '@/core/config/APISettings.js';
+import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getApiRuntimeStorage, saveApiRuntimeSetting, applyApiRuntimeConfig, getBlacklistedProvider } from '@/core/config/APISettings.js';
 import { getEmbeddingConfig, saveEmbeddingSetting, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
 import { testEmbeddingConnection } from '@/core/services/embeddingService.js';
 import { updateLanguage, translations } from '@/utils/i18n.js';
@@ -150,31 +150,24 @@ function showBlacklistWarning(providerName) {
 }
 
 function loadApiSettings() {
-    apiSettings.endpoint = localStorage.getItem('api-endpoint') || '';
-    apiSettings.key = localStorage.getItem('api-key') || '';
-    apiSettings.model = localStorage.getItem('api-model') || '';
-    const mt = parseInt(localStorage.getItem('api-max-tokens'));
-    apiSettings.maxTokens = isNaN(mt) ? 8000 : mt;
-    apiSettings.contextSize = parseInt(localStorage.getItem('api-context')) || 32000;
-    apiSettings.temp = parseFloat(localStorage.getItem('gz_api_temp')) || 0.7;
-    apiSettings.topP = parseFloat(localStorage.getItem('gz_api_topp')) || 0.9;
-    apiSettings.stream = localStorage.getItem('gz_api_stream') === 'true';
-    apiSettings.autoHideImages = localStorage.getItem('gz_api_auto_hide_images') === 'true';
-    apiSettings.autoHideImagesN = parseInt(localStorage.getItem('gz_api_auto_hide_images_n') || '1', 10);
-    apiSettings.reasoningEnabled = localStorage.getItem('gz_api_request_reasoning') === 'true';
-    apiSettings.reasoningEffort = localStorage.getItem('gz_api_reasoning_effort') || 'medium';
+    const runtime = getApiRuntimeStorage();
+    apiSettings.endpoint = runtime.endpoint;
+    apiSettings.key = runtime.key;
+    apiSettings.model = runtime.model;
+    apiSettings.maxTokens = runtime.maxTokens;
+    apiSettings.contextSize = runtime.contextSize;
+    apiSettings.temp = runtime.temp;
+    apiSettings.topP = runtime.topP;
+    apiSettings.stream = runtime.stream;
+    apiSettings.autoHideImages = runtime.autoHideImages;
+    apiSettings.autoHideImagesN = runtime.autoHideImagesN;
+    apiSettings.reasoningEnabled = runtime.requestReasoning;
+    apiSettings.reasoningEffort = runtime.reasoningEffort;
     loadEmbeddingSettings();
 }
 
 function saveApiSetting(key, value) {
-    if (key === 'api-endpoint') {
-        const normalized = normalizeEndpoint(value);
-        localStorage.setItem('gz_api_endpoint_normalized', normalized);
-    }
-    localStorage.setItem(key, value);
-    if (key === 'api-context' || key === 'api-max-tokens') {
-        window.dispatchEvent(new CustomEvent('api-context-settings-changed'));
-    }
+    saveApiRuntimeSetting(key, value);
     
     // Update current preset
     if (activeApiPreset.value) {
@@ -206,7 +199,7 @@ function onApiInput(key, value) {
         if (debounceTimer) clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => {
             if (key === 'api-endpoint') {
-                const endpoint = localStorage.getItem('gz_api_endpoint_normalized') || value;
+                const endpoint = getApiRuntimeStorage().normalizedEndpoint || value;
                 const blacklisted = getBlacklistedProvider(endpoint);
                 if (blacklisted) showBlacklistWarning(blacklisted.name);
             }
@@ -224,7 +217,7 @@ function flushApiDebounce() {
 }
 
 async function checkConnection() {
-    const endpoint = localStorage.getItem('gz_api_endpoint_normalized') || apiSettings.endpoint;
+    const endpoint = getApiRuntimeStorage().normalizedEndpoint || apiSettings.endpoint;
 
     if (!endpoint) {
         apiStatus.value = 'failed';
@@ -320,7 +313,21 @@ function createNewApiPreset() {
 function applyApiPreset(p) {
     activeApiPresetId.value = p.id;
     localStorage.setItem('gz_active_api_preset_id', p.id);
-    localStorage.setItem('gz_api_provider', p.providerId || getApiProviderId());
+    applyApiRuntimeConfig({
+        providerId: p.providerId || getApiProviderId(),
+        endpoint: p.endpoint,
+        apiKey: p.key,
+        model: p.model,
+        maxTokens: p.max_tokens,
+        contextSize: p.context,
+        temp: p.temp,
+        topP: p.topp,
+        stream: p.stream,
+        autoHideImages: (p.auto_hide_images === true || p.auto_hide_images === 'true'),
+        autoHideImagesN: parseInt(p.auto_hide_images_n || '1', 10),
+        requestReasoning: (p.reasoning_enabled === true || p.reasoning_enabled === 'true'),
+        reasoningEffort: p.reasoning_effort || 'medium'
+    });
     
     apiSettings.endpoint = p.endpoint;
     apiSettings.key = p.key;
@@ -335,19 +342,6 @@ function applyApiPreset(p) {
     apiSettings.autoHideImagesN = parseInt(p.auto_hide_images_n || '1', 10);
     apiSettings.reasoningEnabled = (p.reasoning_enabled === true || p.reasoning_enabled === 'true');
     apiSettings.reasoningEffort = p.reasoning_effort || 'medium';
-    
-    saveApiSetting('api-endpoint', p.endpoint);
-    saveApiSetting('api-key', p.key);
-    saveApiSetting('api-model', p.model);
-    saveApiSetting('api-max-tokens', p.max_tokens);
-    saveApiSetting('api-context', p.context);
-    saveApiSetting('gz_api_temp', p.temp);
-    saveApiSetting('gz_api_topp', p.topp);
-    saveApiSetting('gz_api_stream', p.stream);
-    saveApiSetting('gz_api_auto_hide_images', apiSettings.autoHideImages.toString());
-    saveApiSetting('gz_api_auto_hide_images_n', apiSettings.autoHideImagesN.toString());
-    saveApiSetting('gz_api_request_reasoning', apiSettings.reasoningEnabled.toString());
-    saveApiSetting('gz_api_reasoning_effort', apiSettings.reasoningEffort);
     
     checkConnection();
 }

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -12,7 +12,7 @@ function handleBack() {
         sheet.value?.close();
     }
 }
-import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getBlacklistedProvider } from '@/core/config/APISettings.js';
+import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getBlacklistedProvider } from '@/core/config/APISettings.js';
 import { getEmbeddingConfig, saveEmbeddingSetting, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
 import { testEmbeddingConnection } from '@/core/services/embeddingService.js';
 import { updateLanguage, translations } from '@/utils/i18n.js';
@@ -291,6 +291,7 @@ function createNewApiPreset() {
                 const newPreset = {
                     id: Date.now().toString(36),
                     name: name,
+                    providerId: getApiProviderId(),
                     endpoint: apiSettings.endpoint,
                     key: apiSettings.key,
                     model: apiSettings.model,
@@ -319,6 +320,7 @@ function createNewApiPreset() {
 function applyApiPreset(p) {
     activeApiPresetId.value = p.id;
     localStorage.setItem('gz_active_api_preset_id', p.id);
+    localStorage.setItem('gz_api_provider', p.providerId || getApiProviderId());
     
     apiSettings.endpoint = p.endpoint;
     apiSettings.key = p.key;

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -1,8 +1,6 @@
 <script>
 // --- Module Level State (Persists across component mounts) ---
 let activeChatChar = null;
-const generatingStates = {}; // { charId: state }
-let genIdCounter = 0;
 let _cleanupScroll = null;
 let _msgIdCounter = 0;
 function genMsgId() {
@@ -68,6 +66,7 @@ import { createNewSession as dbCreateSession, deleteSession as dbDeleteSession, 
 import { lorebookState, getActiveLorebooksForContext } from '@/core/states/lorebookState.js';
 import { presetState, getEffectivePreset, getEffectivePresetId } from '@/core/states/presetState.js';
 import { useVirtualScroll } from '@/composables/chat/useVirtualScroll.js';
+import { useGenerationRegistry } from '@/composables/chat/useGenerationRegistry.js';
 import { useSidebarResizer } from '@/composables/ui/useSidebarResizer.js';
 import { sendMessageNotification, clearMessageNotifications, startGenerationNotification, stopGenerationNotification } from '@/core/services/notificationService.js';
 import { addNotification } from '@/core/states/notificationsState.js';
@@ -177,6 +176,16 @@ async function openMemoryEntryEditor(entryId) {
 }
 
 const isAndroid = Capacitor.getPlatform() === 'android';
+const {
+    nextGenerationId,
+    listGeneratingCharIds,
+    getGenerationState,
+    hasGenerationState,
+    setGenerationState,
+    clearGenerationState,
+    markGenerationPersisted,
+    clearPersistedGeneration
+} = useGenerationRegistry();
 
 // --- Component State ---
 const chatViewRoot = ref(null);
@@ -721,7 +730,7 @@ async function generateMemoryDraftForMessages(selectedMessages, { openSheet = fa
     if (!activeChatChar || !Array.isArray(selectedMessages) || !selectedMessages.length) return false;
     console.debug('[MemoryBooks] generateMemoryDraftForMessages:start', { source, existingDraftId, inputCount: selectedMessages.length });
 
-    const activeGeneration = generatingStates[activeChatChar.id];
+    const activeGeneration = getGenerationState(activeChatChar.id);
     if (activeGeneration && activeGeneration.type !== 'impersonation') {
         showToast('Stop the current response generation before starting a memory draft');
         return false;
@@ -2170,11 +2179,11 @@ const onChatSearch = (e) => {
 
 async function loadChats() {
     // Preserve in-memory data for ANY character currently generating
-    for (const charId of Object.keys(generatingStates)) {
+    for (const charId of listGeneratingCharIds()) {
         const memData = await getChatData(charId);
         if (!memData) continue;
 
-        const state = generatingStates[charId];
+        const state = getGenerationState(charId);
 
         let foundMsg = null;
         let foundSessionId = memData.currentId;
@@ -2218,7 +2227,7 @@ async function loadChats() {
 }
 
 async function abortActiveChatGeneration(charId, { restore = true } = {}) {
-    const state = generatingStates[charId];
+    const state = getGenerationState(charId);
     if (!state || state.type === 'impersonation') return false;
 
     if (state.controller) {
@@ -2237,9 +2246,7 @@ async function abortActiveChatGeneration(charId, { restore = true } = {}) {
         }
     }
 
-    if (generatingStates[charId]?.genId === state.genId) {
-        delete generatingStates[charId];
-    }
+    clearGenerationState(charId, state.genId);
 
     if (activeChatChar && activeChatChar.id === charId) {
         isGenerating.value = false;
@@ -2608,7 +2615,7 @@ async function openChat(char, onBack, force = false) {
     delete activeChatChar.summary;
 
     activeChar.value = activeChatChar;
-    isGenerating.value = !!generatingStates[char.id];
+    isGenerating.value = hasGenerationState(char.id);
 
     // Clear unread
     let unread = (await db.get('gz_unread')) || {};
@@ -2696,7 +2703,7 @@ async function openChat(char, onBack, force = false) {
     let dirty = false;
     while (msgs.length > 0) {
         const lastMsg = msgs[msgs.length - 1];
-        const isPhantomTyping = lastMsg.isTyping && !generatingStates[char.id];
+        const isPhantomTyping = lastMsg.isTyping && !hasGenerationState(char.id);
 
         if (isPhantomTyping) {
             if (lastMsg.swipes && lastMsg.swipes.length > 1) {
@@ -2841,8 +2848,8 @@ async function openChat(char, onBack, force = false) {
         // updateInputPreview(); // Handled by ChatInput component
 
         // Restore generation state if active
-        if (generatingStates[char.id]) {
-            const state = generatingStates[char.id];
+        if (hasGenerationState(char.id)) {
+            const state = getGenerationState(char.id);
             
             // Clear previous timer if exists (from previous mount)
             if (state.timerId) clearInterval(state.timerId);
@@ -3007,10 +3014,10 @@ function smartScroll() {
 async function sendMessage(attachedImage = null, guidanceText = null) {
     if (isGenerating.value && activeChatChar) {
         // Stop Generation
-        const state = generatingStates[activeChatChar.id];
+        const state = getGenerationState(activeChatChar.id);
         if (state?.type === 'impersonation') {
             if (state.controller) state.controller.abort();
-            delete generatingStates[activeChatChar.id];
+            clearGenerationState(activeChatChar.id);
             isGenerating.value = false;
             isImpersonating.value = false;
         } else if (state) {
@@ -3089,7 +3096,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
     const runtime = getApiRuntimeStorage();
     const model = runtime.model;
     const endpoint = runtime.normalizedEndpoint;
-    const existingState = generatingStates[char.id];
+    const existingState = getGenerationState(char.id);
 
     if (existingState && existingState.type !== 'impersonation') {
         console.warn('[generation] Ignoring overlapping startGeneration call for active chat request', {
@@ -3114,7 +3121,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         return;
     }
 
-    const genId = ++genIdCounter;
+    const genId = nextGenerationId();
     const controller = new AbortController();
     const startTime = Date.now();
     // Capture session ID at start
@@ -3248,7 +3255,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
     };
 
     // Save generation status for DialogList
-    localStorage.setItem(`gz_generating_${char.id}_${sessionId}`, 'true');
+    markGenerationPersisted(char.id, sessionId);
 
     // Initialize state
     // Setup initial UI updater inline to avoid null gap between state creation and assignment (#8)
@@ -3268,16 +3275,16 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         }
     };
 
-    generatingStates[char.id] = { 
+    setGenerationState(char.id, { 
         genId, 
         controller, 
         startTime, 
         msgId,
         timerId: null,
         onUIUpdate: initialUIUpdate
-    };
+    });
 
-    generatingStates[char.id].timerId = setInterval(() => {
+    getGenerationState(char.id).timerId = setInterval(() => {
         if (activeChatChar && activeChatChar.id === char.id) {
             const idx = currentMessages.value.findIndex(m => m.id === msgId);
             if (idx !== -1) {
@@ -3309,8 +3316,8 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
 
     const restoreState = async (isError = false) => {
         if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
-        if (generatingStates[char.id]?.timerId) clearInterval(generatingStates[char.id].timerId);
-        localStorage.removeItem(`gz_generating_${char.id}_${sessionId}`);
+        if (getGenerationState(char.id)?.timerId) clearInterval(getGenerationState(char.id).timerId);
+        clearPersistedGeneration(char.id, sessionId);
         
         const idx = currentMessages.value.findIndex(m => m.id === msgId);
         if (idx !== -1) {
@@ -3383,10 +3390,10 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         if (onAbort) onAbort(isError);
     };
 
-    generatingStates[char.id].restoreState = restoreState;
+    getGenerationState(char.id).restoreState = restoreState;
 
     const onError = async (e) => {
-        const state = generatingStates[char.id];
+        const state = getGenerationState(char.id);
         if (!state || state.genId !== genId) return;
         if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
 
@@ -3415,14 +3422,14 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             // Handle Context Limit gracefully (Bottom Sheet already shown by llmApi)
             if (e.message === "Context limit exceeded") {
                 await restoreState(false); // Treat as abort/cancel (removes typing indicator)
-                delete generatingStates[char.id];
+                clearGenerationState(char.id);
                 if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
                 window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
                 return;
             }
 
             await restoreState(true);
-            delete generatingStates[char.id];
+            clearGenerationState(char.id);
             if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
 
             sendMessageNotification(
@@ -3463,7 +3470,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             console.error('[onError] Error handler failed:', handlerErr);
             // Fallback: ensure typing is cleared even if main handler fails
             await ensureTypingCleared();
-            delete generatingStates[char.id];
+            clearGenerationState(char.id);
             if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
             window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
         }
@@ -3491,7 +3498,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         rawStreamText = effectiveText || (rawStreamText + (chunk || ""));
         
         // Update via dynamic updater (handles re-mounts)
-        const state = generatingStates[char.id];
+        const state = getGenerationState(char.id);
         if (state && state.genId === genId && state.onUIUpdate) {
             state.onUIUpdate(effectiveText, effectiveReasoning, true, textDelta);
         } else if (!state || state.genId !== genId) {
@@ -3504,7 +3511,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
                 _bgUpdateTimer = setTimeout(async () => {
                     _bgUpdateTimer = null;
                     if (_bgPendingText === null) return;
-                    const latestState = generatingStates[char.id];
+                    const latestState = getGenerationState(char.id);
                     if (!latestState || latestState.genId !== genId) return;
                     const data = await getChatData(char.id);
                     if (data && data.sessions[sessionId]) {
@@ -3586,21 +3593,21 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             onComplete: async (response, finalReasoning, meta) => {
         // CRITICAL: Ensure cleanup happens even if handler fails
         const ensureCleanup = () => {
-            const currentState = generatingStates[char.id];
+            const currentState = getGenerationState(char.id);
             if (currentState && currentState.timerId) clearInterval(currentState.timerId);
             if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
-            localStorage.removeItem(`gz_generating_${char.id}_${sessionId}`);
-            delete generatingStates[char.id];
+            clearPersistedGeneration(char.id, sessionId);
+            clearGenerationState(char.id);
             if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
         };
 
         const ensureStaleCleanup = () => {
             if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
-            localStorage.removeItem(`gz_generating_${char.id}_${sessionId}`);
+            clearPersistedGeneration(char.id, sessionId);
         };
 
         try {
-            const currentState = generatingStates[char.id];
+            const currentState = getGenerationState(char.id);
             if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
 
             if (!currentState || currentState.genId !== genId) {
@@ -3611,7 +3618,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             }
 
             if (currentState.timerId) clearInterval(currentState.timerId);
-            localStorage.removeItem(`gz_generating_${char.id}_${sessionId}`);
+            clearPersistedGeneration(char.id, sessionId);
             
             // Guard against race with abort
             const hasCompletionPayload = !!(response || finalReasoning || meta?.partialError);
@@ -3633,7 +3640,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             }
         }
 
-        delete generatingStates[char.id];
+        clearGenerationState(char.id);
         if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
 
         const now = new Date();
@@ -3926,11 +3933,11 @@ function regenerateMessage(msgIndex, mode = 'normal', guidanceText = null) {
 async function branchSession(msgIndex) {
     if (!activeChatChar) return;
 
-    if (isGenerating.value && generatingStates[activeChatChar.id]) {
-        const state = generatingStates[activeChatChar.id];
+    if (isGenerating.value && hasGenerationState(activeChatChar.id)) {
+        const state = getGenerationState(activeChatChar.id);
         if (state?.type === 'impersonation') {
             if (state.controller) state.controller.abort();
-            delete generatingStates[activeChatChar.id];
+            clearGenerationState(activeChatChar.id);
             isGenerating.value = false;
         } else {
             await abortActiveChatGeneration(activeChatChar.id);
@@ -4102,11 +4109,11 @@ function openMessageActions(msg, index) {
                 icon: '<svg viewBox="0 0 24 24"><path d="M6 6h12v12H6z"/></svg>',
                 iconColor: '#ff4444',
                 onClick: () => {
-                    if (activeChatChar && generatingStates[activeChatChar.id]) {
-                        const state = generatingStates[activeChatChar.id];
+                    if (activeChatChar && hasGenerationState(activeChatChar.id)) {
+                        const state = getGenerationState(activeChatChar.id);
                         if (state?.type === 'impersonation') {
                             if (state.controller) state.controller.abort();
-                            delete generatingStates[activeChatChar.id];
+                            clearGenerationState(activeChatChar.id);
                             isGenerating.value = false;
                         } else {
                             abortActiveChatGeneration(activeChatChar.id);
@@ -4514,7 +4521,7 @@ async function startImpersonation(guidanceText = null) {
     isImpersonating.value = true;
     isGenerating.value = true;
     const controller = new AbortController();
-    generatingStates[charId] = { genId: ++genIdCounter, controller, type: 'impersonation' };
+    setGenerationState(charId, { genId: nextGenerationId(), controller, type: 'impersonation' });
 
     // Prepare history
     const history = currentMessages.value
@@ -4537,14 +4544,14 @@ async function startImpersonation(guidanceText = null) {
         inputValue.value = cleanText(response);
         isImpersonating.value = false;
         isGenerating.value = false;
-        delete generatingStates[charId];
+        clearGenerationState(charId);
         window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: charId } }));
             },
             onError: (err) => {
         console.error(err);
         isImpersonating.value = false;
         isGenerating.value = false;
-        delete generatingStates[charId];
+        clearGenerationState(charId);
         window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: charId } }));
             }
         }
@@ -4595,11 +4602,11 @@ function openAvatar(msg) {
 async function deleteSession(sessionId, targetChar) {
     const char = targetChar || activeChatChar;
 
-    if (char && generatingStates[char.id]) {
-        const state = generatingStates[char.id];
+    if (char && hasGenerationState(char.id)) {
+        const state = getGenerationState(char.id);
         if (state?.type === 'impersonation') {
             if (state.controller) state.controller.abort();
-            delete generatingStates[char.id];
+            clearGenerationState(char.id);
             if (activeChatChar && activeChatChar.id === char.id) {
                 isGenerating.value = false;
             }
@@ -5108,8 +5115,8 @@ onUnmounted(() => {
     stopMemoryDraftProgress();
     // Cleanup UI timers AND abort active generations for ALL generating states
     // This prevents leaked intervals, closures referencing unmounted reactive state, and stuck isTyping flags
-    for (const charId of Object.keys(generatingStates)) {
-        const state = generatingStates[charId];
+    for (const charId of listGeneratingCharIds()) {
+        const state = getGenerationState(charId);
         // Abort controller to stop ongoing API requests
         if (state.controller) {
             try {
@@ -5128,7 +5135,7 @@ onUnmounted(() => {
         // Clean localStorage flag
         const sessionId = activeChatChar?.sessionId;
         if (sessionId) {
-            localStorage.removeItem(`gz_generating_${charId}_${sessionId}`);
+            clearPersistedGeneration(charId, sessionId);
         }
     }
     window.removeEventListener('character-updated', onCharacterUpdated);

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -69,7 +69,7 @@ import { useVirtualScroll } from '@/composables/chat/useVirtualScroll.js';
 import { useGenerationRegistry } from '@/composables/chat/useGenerationRegistry.js';
 import { handleGenerationComplete } from '@/composables/chat/useGenerationCompleteHandler.js';
 import { handleGenerationError } from '@/composables/chat/useGenerationErrorHandler.js';
-import { buildGenerationAuthorsNote, buildGenerationHistory, ensureGenerationPlaceholderMessage } from '@/composables/chat/useGenerationPreparation.js';
+import { buildGenerationAuthorsNote, buildGenerationHistory, ensureGenerationPlaceholderMessage, resolveGenerationSessionContext } from '@/composables/chat/useGenerationPreparation.js';
 import { handleGenerationPromptReady } from '@/composables/chat/useGenerationPromptReady.js';
 import { createPromptMetadataSnapshots } from '@/composables/chat/usePromptMetadataSnapshots.js';
 import { restoreGenerationState } from '@/composables/chat/useGenerationStateRestore.js';
@@ -3134,34 +3134,15 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
     const genId = nextGenerationId();
     const controller = new AbortController();
     const startTime = Date.now();
-    // Capture session ID at start
     let rawStreamText = text || "";
-    let chatData = null;
-    let sessionId = null;
-    let summary = char.summary !== undefined ? char.summary : null;
-    let anContent = char.authors_note !== undefined ? char.authors_note : null;
+    resolveGenerationSessionContext({ char, db }).then(context => {
+        continueGeneration(context);
+    }).catch(e => {
+        console.error('Failed to load chat for generation:', e);
+        isGenerating.value = false;
+    });
 
-    if (!char.sessionId) {
-        // Fallback for missing sessionId (e.g. from background task without activeChatChar)
-        db.getChat(char.id).then(d => {
-            chatData = d;
-            sessionId = chatData?.currentId;
-            if (summary === null) summary = chatData?.summaries?.[sessionId];
-            if (typeof summary === 'object' && summary !== null) summary = summary.content;
-            if (anContent === null) anContent = chatData?.authorsNotes?.[sessionId];
-            if (typeof anContent === 'object' && anContent !== null) anContent = anContent.content;
-            continueGeneration();
-        }).catch(e => {
-            console.error('Failed to load chat for generation:', e);
-            isGenerating.value = false;
-        });
-        return; // wait for async db to finish
-    } else {
-        sessionId = char.sessionId;
-        continueGeneration();
-    }
-
-    async function continueGeneration() {
+    async function continueGeneration({ sessionId, summary, anContent }) {
 
     // Notify application about generation start
     window.dispatchEvent(new CustomEvent('chat-generation-started', { detail: { charId: char.id, sessionId: sessionId } }));

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -68,6 +68,7 @@ import { presetState, getEffectivePreset, getEffectivePresetId } from '@/core/st
 import { useVirtualScroll } from '@/composables/chat/useVirtualScroll.js';
 import { useGenerationRegistry } from '@/composables/chat/useGenerationRegistry.js';
 import { createPromptMetadataSnapshots } from '@/composables/chat/usePromptMetadataSnapshots.js';
+import { useTypingStateCleanup } from '@/composables/chat/useTypingStateCleanup.js';
 import { useSidebarResizer } from '@/composables/ui/useSidebarResizer.js';
 import { sendMessageNotification, clearMessageNotifications, startGenerationNotification, stopGenerationNotification } from '@/core/services/notificationService.js';
 import { addNotification } from '@/core/states/notificationsState.js';
@@ -187,6 +188,7 @@ const {
     markGenerationPersisted,
     clearPersistedGeneration
 } = useGenerationRegistry();
+const { clearTypingStateForMessage } = useTypingStateCleanup({ currentMessages, getChatData, db });
 
 // --- Component State ---
 const chatViewRoot = ref(null);
@@ -3258,26 +3260,6 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         }
     }, 100);
 
-    const clearTypingStateForMessage = async () => {
-        const idx = currentMessages.value.findIndex(m => m.id === msgId);
-        if (idx !== -1) {
-            currentMessages.value[idx].isTyping = false;
-        }
-
-        try {
-            const data = await getChatData(char.id);
-            if (data && data.sessions[sessionId]) {
-                const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
-                if (dbIdx !== -1) {
-                    data.sessions[sessionId][dbIdx].isTyping = false;
-                    await db.saveChat(char.id, data);
-                }
-            }
-        } catch (dbErr) {
-            console.error('[generation] Failed to clear typing state:', dbErr);
-        }
-    };
-
     const restoreState = async (isError = false) => {
         if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
         if (getGenerationState(char.id)?.timerId) clearInterval(getGenerationState(char.id).timerId);
@@ -3363,23 +3345,12 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
 
         // CRITICAL: Ensure isTyping is ALWAYS cleared, even if DB operations fail
         const ensureTypingCleared = async () => {
-            const idx = currentMessages.value.findIndex(m => m.id === msgId);
-            if (idx !== -1) {
-                currentMessages.value[idx].isTyping = false;
-            }
-            // Also clear in DB to prevent phantom typing on reload
-            try {
-                const data = await getChatData(char.id);
-                if (data && data.sessions[sessionId]) {
-                    const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
-                    if (dbIdx !== -1) {
-                        data.sessions[sessionId][dbIdx].isTyping = false;
-                        await db.saveChat(char.id, data);
-                    }
-                }
-            } catch (dbErr) {
-                console.error('[onError] Failed to clear isTyping in DB:', dbErr);
-            }
+            await clearTypingStateForMessage({
+                charId: char.id,
+                sessionId,
+                msgId,
+                errorLabel: '[onError]'
+            });
         };
 
         try {
@@ -3575,7 +3546,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
 
             if (!currentState || currentState.genId !== genId) {
-                await clearTypingStateForMessage();
+                await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
                 ensureStaleCleanup();
                 window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
                 return;
@@ -3587,7 +3558,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             // Guard against race with abort
             const hasCompletionPayload = !!(response || finalReasoning || meta?.partialError);
             if (controller.signal.aborted && !hasCompletionPayload) {
-                await clearTypingStateForMessage();
+                await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
                 ensureCleanup();
                 window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
                 return;
@@ -3764,23 +3735,12 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             console.error('[onComplete] Completion handler failed:', completeErr);
             // Ensure cleanup and isTyping cleared even if handler fails
             ensureCleanup();
-            // Clear isTyping in both reactive state and DB
-            const idx = currentMessages.value.findIndex(m => m.id === msgId);
-            if (idx !== -1) {
-                currentMessages.value[idx].isTyping = false;
-            }
-            try {
-                const data = await getChatData(char.id);
-                if (data && data.sessions[sessionId]) {
-                    const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
-                    if (dbIdx !== -1) {
-                        data.sessions[sessionId][dbIdx].isTyping = false;
-                        await db.saveChat(char.id, data);
-                    }
-                }
-            } catch (dbErr) {
-                console.error('[onComplete] Failed to clear isTyping in DB:', dbErr);
-            }
+            await clearTypingStateForMessage({
+                charId: char.id,
+                sessionId,
+                msgId,
+                errorLabel: '[onComplete]'
+            });
             window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
         }
             },

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -185,6 +185,7 @@ async function openMemoryEntryEditor(entryId) {
 }
 
 const isAndroid = Capacitor.getPlatform() === 'android';
+const currentMessages = ref([]);
 const {
     nextGenerationId,
     listGeneratingCharIds,
@@ -223,7 +224,6 @@ watch(rightPaddingRef, (val) => {
 const chatInputRef = ref(null);
 const inputValue = ref('');
 const isImpersonating = ref(false);
-const currentMessages = ref([]);
 const isGenerating = ref(false);
 const showScrollButton = ref(false);
 const isLoading = ref(false);

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -73,6 +73,7 @@ import { buildGenerationAuthorsNote, buildGenerationHistory, ensureGenerationPla
 import { handleGenerationPromptReady } from '@/composables/chat/useGenerationPromptReady.js';
 import { createPromptMetadataSnapshots } from '@/composables/chat/usePromptMetadataSnapshots.js';
 import { restoreGenerationState } from '@/composables/chat/useGenerationStateRestore.js';
+import { applyGenerationGuidanceState, setupGenerationState } from '@/composables/chat/useGenerationStateSetup.js';
 import { createGenerationStreamUpdater } from '@/composables/chat/useGenerationStreamUpdate.js';
 import { useTypingStateCleanup } from '@/composables/chat/useTypingStateCleanup.js';
 import { useSidebarResizer } from '@/composables/ui/useSidebarResizer.js';
@@ -3189,59 +3190,31 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         scrollToBottom
     });
 
-    // Get unique ID to identify message across re-mounts
-    if (msgIndex !== -1 && currentMessages.value[msgIndex]) {
-        const msg = currentMessages.value[msgIndex];
-        msg.guidanceText = guidanceText;
-        msg.guidanceType = guidanceType;
-        // Force fallback to message-level guidance by clearing current swipe's metadata if it exists
-        if (msg.swipesMeta && msg.swipesMeta[msg.swipeId || 0]) {
-            msg.swipesMeta[msg.swipeId || 0].guidanceText = null;
-            msg.swipesMeta[msg.swipeId || 0].guidanceType = null;
-        }
-    }
+    applyGenerationGuidanceState({
+        currentMessages,
+        msgIndex,
+        guidanceText,
+        guidanceType
+    });
+
     const msgId = currentMessages.value[msgIndex]?.id || genMsgId();
     const { snapshotPromptMeta, restorePromptMetaOnMessages } = createPromptMetadataSnapshots();
 
     // Save generation status for DialogList
     markGenerationPersisted(char.id, sessionId);
 
-    // Initialize state
-    // Setup initial UI updater inline to avoid null gap between state creation and assignment (#8)
-    const initialUIUpdate = (text, reasoning, isTyping, textDelta) => {
-        const idx = currentMessages.value.findIndex(m => m.id === msgId);
-        if (idx !== -1) {
-            const m = currentMessages.value[idx];
-            if (textDelta) {
-                m.text = m.text.replace(/class="stream-char"/g, 'class="stream-char-done"');
-                m.text += `<span class="stream-char">${textDelta}</span>`;
-            } else {
-                m.text = text;
-            }
-            m.reasoning = reasoning;
-            m.isTyping = isTyping;
-            smartScroll();
-        }
-    };
-
-    setGenerationState(char.id, { 
-        genId, 
-        controller, 
-        startTime, 
+    setupGenerationState({
+        char,
         msgId,
-        timerId: null,
-        onUIUpdate: initialUIUpdate
+        genId,
+        controller,
+        startTime,
+        currentMessages,
+        activeChatChar,
+        setGenerationState,
+        getGenerationState,
+        smartScroll
     });
-
-    getGenerationState(char.id).timerId = setInterval(() => {
-        if (activeChatChar && activeChatChar.id === char.id) {
-            const idx = currentMessages.value.findIndex(m => m.id === msgId);
-            if (idx !== -1) {
-                const elapsed = ((Date.now() - startTime) / 1000).toFixed(1) + 's';
-                currentMessages.value[idx].genTime = elapsed;
-            }
-        }
-    }, 100);
 
     const { onUpdate, clearBackgroundUpdateTimer } = createGenerationStreamUpdater({
         char,

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -3206,6 +3206,44 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         }
     }
     const msgId = currentMessages.value[msgIndex]?.id || genMsgId();
+    const promptMetaSnapshots = new Map();
+
+    const clonePromptMetaList = (items) => Array.isArray(items)
+        ? items.map(item => ({ ...item }))
+        : [];
+
+    const snapshotPromptMeta = (message) => {
+        if (!message?.id || promptMetaSnapshots.has(message.id)) return;
+        promptMetaSnapshots.set(message.id, {
+            hasTriggeredLorebooks: Object.prototype.hasOwnProperty.call(message, 'triggeredLorebooks'),
+            hasTriggeredMemories: Object.prototype.hasOwnProperty.call(message, 'triggeredMemories'),
+            hasContextRefs: Object.prototype.hasOwnProperty.call(message, 'contextRefs'),
+            triggeredLorebooks: clonePromptMetaList(message.triggeredLorebooks),
+            triggeredMemories: clonePromptMetaList(message.triggeredMemories),
+            contextRefs: clonePromptMetaList(message.contextRefs)
+        });
+    };
+
+    const restorePromptMetaOnMessages = (messages) => {
+        if (!Array.isArray(messages) || promptMetaSnapshots.size === 0) return false;
+        let changed = false;
+        messages.forEach(message => {
+            const snapshot = message?.id ? promptMetaSnapshots.get(message.id) : null;
+            if (!snapshot) return;
+
+            if (snapshot.hasTriggeredLorebooks) message.triggeredLorebooks = clonePromptMetaList(snapshot.triggeredLorebooks);
+            else delete message.triggeredLorebooks;
+
+            if (snapshot.hasTriggeredMemories) message.triggeredMemories = clonePromptMetaList(snapshot.triggeredMemories);
+            else delete message.triggeredMemories;
+
+            if (snapshot.hasContextRefs) message.contextRefs = clonePromptMetaList(snapshot.contextRefs);
+            else delete message.contextRefs;
+
+            changed = true;
+        });
+        return changed;
+    };
 
     // Save generation status for DialogList
     localStorage.setItem(`gz_generating_${char.id}_${sessionId}`, 'true');
@@ -3275,6 +3313,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         const idx = currentMessages.value.findIndex(m => m.id === msgId);
         if (idx !== -1) {
             // User is still viewing this chat — update reactive state
+            restorePromptMetaOnMessages(currentMessages.value);
             currentMessages.value[idx].isTyping = false;
 
             if (!isError) {
@@ -3317,6 +3356,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             // User navigated away — clean up directly in DB
             const data = await getChatData(char.id);
             if (data && data.sessions[sessionId]) {
+                restorePromptMetaOnMessages(data.sessions[sessionId]);
                 const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
                 if (dbIdx !== -1) {
                     data.sessions[sessionId][dbIdx].isTyping = false;
@@ -3521,6 +3561,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
                 ];
 
                 const assignRefs = (m) => {
+                    snapshotPromptMeta(m);
                     m.triggeredLorebooks = triggeredLorebooks;
                     m.triggeredMemories = triggeredMemories;
                     m.contextRefs = contextRefs;

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -69,6 +69,7 @@ import { useVirtualScroll } from '@/composables/chat/useVirtualScroll.js';
 import { useGenerationRegistry } from '@/composables/chat/useGenerationRegistry.js';
 import { handleGenerationComplete } from '@/composables/chat/useGenerationCompleteHandler.js';
 import { handleGenerationError } from '@/composables/chat/useGenerationErrorHandler.js';
+import { buildGenerationAuthorsNote, buildGenerationHistory, ensureGenerationPlaceholderMessage } from '@/composables/chat/useGenerationPreparation.js';
 import { handleGenerationPromptReady } from '@/composables/chat/useGenerationPromptReady.js';
 import { createPromptMetadataSnapshots } from '@/composables/chat/usePromptMetadataSnapshots.js';
 import { restoreGenerationState } from '@/composables/chat/useGenerationStateRestore.js';
@@ -3166,50 +3167,27 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
 
     isGenerating.value = true;
     let msgIndex = existingMsgIndex;
+    const authorsNote = buildGenerationAuthorsNote({
+        getEffectivePreset,
+        charId: char.id,
+        sessionId,
+        anContent
+    });
 
-    // Get Authors Note combined object for current session and preset
-    const effectivePreset = getEffectivePreset(char.id, sessionId ? `${char.id}_${sessionId}` : null);
-    const anBlock = effectivePreset?.blocks?.find(b => b.id === 'authors_note');
-    let authorsNote = null;
-    
-    if (typeof anContent === 'object' && anContent !== null) anContent = anContent.content;
-
-    if (anBlock && anBlock.enabled && anContent) {
-        authorsNote = {
-            content: anContent,
-            role: anBlock.role || 'system',
-            enabled: true,
-            depth: anBlock.depth !== undefined ? anBlock.depth : 0,
-            insertion_mode: anBlock.insertion_mode || 'relative'
-        };
-    }
-
-    if (msgIndex === -1 && !text) {
-        const now = new Date();
-        const time = now.getHours() + ':' + String(now.getMinutes()).padStart(2, '0');
-
-        const msg = { 
-            id: genMsgId(),
-            role: 'char', 
-            text: "", 
-            time: time, 
-            timestamp: Date.now(),
-            swipes: [""],
-            swipeId: 0,
-            isTyping: true, // Custom flag for UI
-            guidanceText,
-            guidanceType,
-            ...createBaseMessageMeta()
-        };
-        currentMessages.value.push(msg);
-        msgIndex = currentMessages.value.length - 1;
-        const data = await getChatData(char.id);
-        if (data) {
-            data.sessions[sessionId] = currentMessages.value;
-            await db.saveChat(char.id, data);
-        }
-        scrollToBottom();
-    }
+    msgIndex = await ensureGenerationPlaceholderMessage({
+        msgIndex,
+        text,
+        guidanceText,
+        guidanceType,
+        currentMessages,
+        createBaseMessageMeta,
+        genMsgId,
+        charId: char.id,
+        sessionId,
+        getChatData,
+        db,
+        scrollToBottom
+    });
 
     // Get unique ID to identify message across re-mounts
     if (msgIndex !== -1 && currentMessages.value[msgIndex]) {
@@ -3321,19 +3299,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         });
     };
 
-    // Prepare history for LLM
-    const history = currentMessages.value
-        .map((m, i) => ({ ...m, originalIndex: i }))
-        .filter(m => !m.isTyping && !m.isHidden)
-        .map(m => ({ 
-            role: m.role === 'user' ? 'user' : 'assistant', 
-            content: m.text || "", 
-            text: m.text || "", 
-            image: (m.image && !m.imageHidden) ? m.image : null,
-            chatId: m.originalIndex,
-            messageId: m.id || null,
-            contextRefs: Array.isArray(m.contextRefs) ? m.contextRefs : []
-        }));
+    const history = buildGenerationHistory(currentMessages);
 
     generateChatResponse({
         text,

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -59,7 +59,7 @@ import { currentLang, chatPaddingLR, setChatPaddingLR } from '@/core/config/APPS
 import { translations } from '@/utils/i18n.js';
 import { generateChatResponse, calculateContext, generateMemoryDraft } from '@/core/services/generationService.js';
 import { executeRequest } from '@/core/services/llmApi.js';
-import { getApiConfig } from '@/core/config/APISettings.js';
+import { getApiConfig, getApiRuntimeStorage, getApiReasoningTags } from '@/core/config/APISettings.js';
 import { getEmbeddingConfig, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
 import { animateTextChange, updateAppColors, initHeaderScroll, initRipple } from '@/core/services/ui.js';
 import { showBottomSheet, closeBottomSheet, bottomSheetState } from '@/core/states/bottomSheetState.js';
@@ -2275,8 +2275,9 @@ async function updateContextCutoff() {
         const sessionId = cutoffChatData.currentId;
 
         // Cache key includes context settings so changes to context size bust the cache
-        const contextSize = localStorage.getItem('api-context') || '32000';
-        const maxTokens = localStorage.getItem('api-max-tokens') || '8000';
+        const runtime = getApiRuntimeStorage();
+        const contextSize = String(runtime.contextSize || 32000);
+        const maxTokens = String(runtime.maxTokens || 8000);
         const cacheKey = `${currentCharId}_${sessionId}_${messageCount}_${contextSize}_${maxTokens}`;
 
         if (contextCutoffCache && contextCutoffCache.hash === cacheKey) {
@@ -3085,8 +3086,9 @@ async function sendMessage(attachedImage = null, guidanceText = null) {
 
 function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guidanceText = null, guidanceType = 'GENERATION') {
     // Check API Configuration
-    const model = localStorage.getItem('api-model');
-    const endpoint = localStorage.getItem('gz_api_endpoint_normalized') || localStorage.getItem('api-endpoint');
+    const runtime = getApiRuntimeStorage();
+    const model = runtime.model;
+    const endpoint = runtime.normalizedEndpoint;
     const existingState = generatingStates[char.id];
 
     if (existingState && existingState.type !== 'impersonation') {
@@ -4076,8 +4078,7 @@ function changeGreeting(msgIndex, dir, fromSwipe = false) {
 }
 
 function getReasoningTags() {
-    let start = localStorage.getItem('gz_api_reasoning_start') || '<think>';
-    let end = localStorage.getItem('gz_api_reasoning_end') || '</think>';
+    let { start, end } = getApiReasoningTags();
 
     try {
         const charId = activeChatChar?.id;

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -67,7 +67,12 @@ import { lorebookState, getActiveLorebooksForContext } from '@/core/states/loreb
 import { presetState, getEffectivePreset, getEffectivePresetId } from '@/core/states/presetState.js';
 import { useVirtualScroll } from '@/composables/chat/useVirtualScroll.js';
 import { useGenerationRegistry } from '@/composables/chat/useGenerationRegistry.js';
+import { handleGenerationComplete } from '@/composables/chat/useGenerationCompleteHandler.js';
+import { handleGenerationError } from '@/composables/chat/useGenerationErrorHandler.js';
+import { handleGenerationPromptReady } from '@/composables/chat/useGenerationPromptReady.js';
 import { createPromptMetadataSnapshots } from '@/composables/chat/usePromptMetadataSnapshots.js';
+import { restoreGenerationState } from '@/composables/chat/useGenerationStateRestore.js';
+import { createGenerationStreamUpdater } from '@/composables/chat/useGenerationStreamUpdate.js';
 import { useTypingStateCleanup } from '@/composables/chat/useTypingStateCleanup.js';
 import { useSidebarResizer } from '@/composables/ui/useSidebarResizer.js';
 import { sendMessageNotification, clearMessageNotifications, startGenerationNotification, stopGenerationNotification } from '@/core/services/notificationService.js';
@@ -3260,155 +3265,60 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         }
     }, 100);
 
-    const restoreState = async (isError = false) => {
-        if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
-        if (getGenerationState(char.id)?.timerId) clearInterval(getGenerationState(char.id).timerId);
-        clearPersistedGeneration(char.id, sessionId);
-        
-        const idx = currentMessages.value.findIndex(m => m.id === msgId);
-        if (idx !== -1) {
-            // User is still viewing this chat — update reactive state
-            restorePromptMetaOnMessages(currentMessages.value);
-            currentMessages.value[idx].isTyping = false;
-
-            if (!isError) {
-                const msg = currentMessages.value[idx];
-                if (msg.swipes && msg.swipes.length > 1) {
-                    const currentSwipeId = msg.swipeId || 0;
-                    msg.swipes.splice(currentSwipeId, 1);
-                    if (msg.swipesMeta) msg.swipesMeta.splice(currentSwipeId, 1);
-                    
-                    let newSwipeId = currentSwipeId - 1;
-                    if (newSwipeId < 0) newSwipeId = 0;
-                    
-                    msg.swipeId = newSwipeId;
-                    msg.text = msg.swipes[newSwipeId] || "";
-                    
-                    // Restore guidance from the reverted swipe's meta
-                    if (msg.swipesMeta && msg.swipesMeta[newSwipeId]) {
-                        msg.guidanceText = msg.swipesMeta[newSwipeId].guidanceText || null;
-                        msg.guidanceType = msg.swipesMeta[newSwipeId].guidanceType || 'GENERATION';
-                    } else {
-                        msg.guidanceText = null;
-                        msg.guidanceType = 'GENERATION';
-                    }
-                    
-                    if (msg.swipesMeta && msg.swipesMeta[newSwipeId]) {
-                        msg.reasoning = msg.swipesMeta[newSwipeId].reasoning;
-                        msg.genTime = msg.swipesMeta[newSwipeId].genTime;
-                    }
-                    updateSessionMessage(char, idx, msg);
-                } else {
-                    currentMessages.value.splice(idx, 1);
-                    const data = await getChatData(char.id);
-                    if (data && sessionId && data.sessions[sessionId]) {
-                        data.sessions[sessionId] = currentMessages.value;
-                        await db.saveChat(char.id, data);
-                    }
-                }
-            }
-        } else {
-            // User navigated away — clean up directly in DB
-            const data = await getChatData(char.id);
-            if (data && data.sessions[sessionId]) {
-                restorePromptMetaOnMessages(data.sessions[sessionId]);
-                const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
-                if (dbIdx !== -1) {
-                    data.sessions[sessionId][dbIdx].isTyping = false;
-                    if (!isError) {
-                        const msg = data.sessions[sessionId][dbIdx];
-                        if (msg.swipes && msg.swipes.length > 1) {
-                            const currentSwipeId = msg.swipeId || 0;
-                            msg.swipes.splice(currentSwipeId, 1);
-                            if (msg.swipesMeta) msg.swipesMeta.splice(currentSwipeId, 1);
-                            let newSwipeId = currentSwipeId - 1;
-                            if (newSwipeId < 0) newSwipeId = 0;
-                            msg.swipeId = newSwipeId;
-                            msg.text = msg.swipes[newSwipeId] || "";
-                        } else {
-                            data.sessions[sessionId].splice(dbIdx, 1);
-                        }
-                    }
-                    await db.saveChat(char.id, data);
-                }
-            }
+    const { onUpdate, clearBackgroundUpdateTimer } = createGenerationStreamUpdater({
+        char,
+        sessionId,
+        msgId,
+        genId,
+        getGenerationState,
+        getChatData,
+        db,
+        onRawText: (effectiveText, chunk) => {
+            rawStreamText = effectiveText || (rawStreamText + (chunk || ''));
         }
-        if (onAbort) onAbort(isError);
+    });
+
+    const restoreState = async (isError = false) => {
+        await restoreGenerationState({
+            currentMessages,
+            getChatData,
+            db,
+            getGenerationState,
+            clearPersistedGeneration,
+            char,
+            sessionId,
+            msgId,
+            isError,
+            onAbort,
+            restorePromptMetaOnMessages,
+            clearBackgroundUpdateTimer,
+            updateSessionMessage
+        });
     };
 
     getGenerationState(char.id).restoreState = restoreState;
 
     const onError = async (e) => {
-        const state = getGenerationState(char.id);
-        if (!state || state.genId !== genId) return;
-        if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
-
-        // CRITICAL: Ensure isTyping is ALWAYS cleared, even if DB operations fail
-        const ensureTypingCleared = async () => {
-            await clearTypingStateForMessage({
-                charId: char.id,
-                sessionId,
-                msgId,
-                errorLabel: '[onError]'
-            });
-        };
-
-        try {
-            // Handle Context Limit gracefully (Bottom Sheet already shown by llmApi)
-            if (e.message === "Context limit exceeded") {
-                await restoreState(false); // Treat as abort/cancel (removes typing indicator)
-                clearGenerationState(char.id);
-                if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
-                window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
-                return;
-            }
-
-            await restoreState(true);
-            clearGenerationState(char.id);
-            if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
-
-            sendMessageNotification(
-                `Error — ${char.name}`,
-                e.message || 'Generation failed',
-                char.avatar, char.id, sessionId, msgId
-            );
-
-            const idx = currentMessages.value.findIndex(m => m.id === msgId);
-            if (idx !== -1) {
-                // User is still viewing this chat
-                const msg = currentMessages.value[idx];
-                msg.text = formatError(e, rawStreamText);
-                msg.isError = true;
-                if (msg.swipes && msg.swipes.length > 0) {
-                    msg.swipes[msg.swipeId || 0] = msg.text;
-                }
-                updateSessionMessage(char, idx, msg);
-            } else {
-                // User navigated away — write error directly to DB
-                const data = await getChatData(char.id);
-                if (data && data.sessions[sessionId]) {
-                    const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
-                    if (dbIdx !== -1) {
-                        const msg = data.sessions[sessionId][dbIdx];
-                        msg.text = formatError(e, rawStreamText);
-                        msg.isError = true;
-                        msg.isTyping = false;
-                        if (msg.swipes && msg.swipes.length > 0) {
-                            msg.swipes[msg.swipeId || 0] = msg.text;
-                        }
-                        await db.saveChat(char.id, data);
-                    }
-                }
-            }
-            window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
-        } catch (handlerErr) {
-            console.error('[onError] Error handler failed:', handlerErr);
-            // Fallback: ensure typing is cleared even if main handler fails
-            await ensureTypingCleared();
-            clearGenerationState(char.id);
-            if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
-            window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
-        }
+        await handleGenerationError({
+            error: e,
+            char,
+            sessionId,
+            msgId,
+            genId,
+            rawStreamText,
+            activeChatChar,
+            isGenerating,
+            currentMessages,
+            getGenerationState,
+            clearGenerationState,
+            restoreState,
+            clearBackgroundUpdateTimer,
+            clearTypingStateForMessage,
+            getChatData,
+            db,
+            formatError,
+            sendMessageNotification
+        });
     };
 
     // Prepare history for LLM
@@ -3425,43 +3335,6 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
             contextRefs: Array.isArray(m.contextRefs) ? m.contextRefs : []
         }));
 
-    let _bgUpdateTimer = null;
-    let _bgPendingText = null;
-    let _bgPendingReasoning = null;
-
-    const onUpdate = async (chunk, reasoningChunk, effectiveText, effectiveReasoning, textDelta) => {
-        rawStreamText = effectiveText || (rawStreamText + (chunk || ""));
-        
-        // Update via dynamic updater (handles re-mounts)
-        const state = getGenerationState(char.id);
-        if (state && state.genId === genId && state.onUIUpdate) {
-            state.onUIUpdate(effectiveText, effectiveReasoning, true, textDelta);
-        } else if (!state || state.genId !== genId) {
-            return;
-        } else {
-            // Background update — throttle DB writes to once per 2s (#7)
-            _bgPendingText = effectiveText;
-            _bgPendingReasoning = effectiveReasoning;
-            if (!_bgUpdateTimer) {
-                _bgUpdateTimer = setTimeout(async () => {
-                    _bgUpdateTimer = null;
-                    if (_bgPendingText === null) return;
-                    const latestState = getGenerationState(char.id);
-                    if (!latestState || latestState.genId !== genId) return;
-                    const data = await getChatData(char.id);
-                    if (data && data.sessions[sessionId]) {
-                        const dbMsg = data.sessions[sessionId].find(m => m.id === msgId);
-                        if (dbMsg) {
-                            dbMsg.text = _bgPendingText;
-                            dbMsg.reasoning = _bgPendingReasoning;
-                            await db.saveChat(char.id, data);
-                        }
-                    }
-                }, 2000);
-            }
-        }
-    };
-
     generateChatResponse({
         text,
         char,
@@ -3473,276 +3346,57 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         controller,
         callbacks: {
             onPromptReady: async ({ loreEntries, memoryEntries }) => {
-                const triggeredLorebooks = loreEntries.map(e => ({
-                    id: e.id,
-                    name: e.comment || e.name || e.keys?.[0] || 'Entry',
-                    content: e.content,
-                    lorebookName: e.lorebookName,
-                    lorebookId: e.lorebookId,
-                    _source: e._source || 'keyword' // 'keyword' or 'vector'
-                }));
-                const triggeredMemories = (memoryEntries || []).map(entry => ({
-                    id: entry.id,
-                    name: entry.title || 'Memory',
-                    content: entry.content || '',
-                    messageIds: Array.isArray(entry.messageIds) ? entry.messageIds : []
-                }));
-                const contextRefs = [
-                    ...triggeredLorebooks.map(entry => ({
-                        id: entry.id,
-                        type: 'lorebook',
-                        label: entry.name,
-                        sourceId: entry.lorebookId || null,
-                        sourceName: entry.lorebookName || null
-                    })),
-                    ...triggeredMemories.map(entry => ({
-                        id: entry.id,
-                        type: 'memory',
-                        label: entry.name,
-                        sourceId: sessionId,
-                        sourceName: 'Memory Book'
-                    }))
-                ];
-
-                const assignRefs = (m) => {
-                    snapshotPromptMeta(m);
-                    m.triggeredLorebooks = triggeredLorebooks;
-                    m.triggeredMemories = triggeredMemories;
-                    m.contextRefs = contextRefs;
-                };
-
-                if (msgIndex !== -1 && currentMessages.value[msgIndex]) {
-                    assignRefs(currentMessages.value[msgIndex]);
-                }
-                if (msgIndex > 0 && currentMessages.value[msgIndex - 1]?.role === 'user') {
-                    assignRefs(currentMessages.value[msgIndex - 1]);
-                }
-
-                const data = await getChatData(char.id);
-                if (data) {
-                    data.sessions[sessionId] = currentMessages.value;
-                    await db.saveChat(char.id, data);
-                }
+                await handleGenerationPromptReady({
+                    loreEntries,
+                    memoryEntries,
+                    currentMessages,
+                    msgIndex,
+                    char,
+                    sessionId,
+                    getChatData,
+                    db,
+                    snapshotPromptMeta
+                });
             },
             onUpdate,
             onComplete: async (response, finalReasoning, meta) => {
-        // CRITICAL: Ensure cleanup happens even if handler fails
-        const ensureCleanup = () => {
-            const currentState = getGenerationState(char.id);
-            if (currentState && currentState.timerId) clearInterval(currentState.timerId);
-            if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
-            clearPersistedGeneration(char.id, sessionId);
-            clearGenerationState(char.id);
-            if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
-        };
-
-        const ensureStaleCleanup = () => {
-            if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
-            clearPersistedGeneration(char.id, sessionId);
-        };
-
-        try {
-            const currentState = getGenerationState(char.id);
-            if (_bgUpdateTimer) { clearTimeout(_bgUpdateTimer); _bgUpdateTimer = null; }
-
-            if (!currentState || currentState.genId !== genId) {
-                await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
-                ensureStaleCleanup();
-                window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
-                return;
-            }
-
-            if (currentState.timerId) clearInterval(currentState.timerId);
-            clearPersistedGeneration(char.id, sessionId);
-            
-            // Guard against race with abort
-            const hasCompletionPayload = !!(response || finalReasoning || meta?.partialError);
-            if (controller.signal.aborted && !hasCompletionPayload) {
-                await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
-                ensureCleanup();
-                window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
-                return;
-            }
-
-        let wasVisible = false;
-        let displayIndex = -1;
-        const foundIndex = currentMessages.value.findIndex(m => m.id === currentState.msgId);
-        
-        if (foundIndex !== -1) {
-            displayIndex = displayMessages.value.findIndex(m => m.type === 'message' && m.originalIndex === foundIndex);
-            if (displayIndex !== -1) {
-                wasVisible = isItemVisible(displayIndex);
-            }
-        }
-
-        clearGenerationState(char.id);
-        if (activeChatChar && activeChatChar.id === char.id) isGenerating.value = false;
-
-        const now = new Date();
-        response = cleanText(response);
-        const time = now.getHours() + ':' + String(now.getMinutes()).padStart(2, '0');
-        const duration = ((Date.now() - startTime) / 1000).toFixed(2) + 's';
-
-        // Try to find message in current view by timestamp, fallback to index if same instance
-        if (activeChatChar && activeChatChar.id === char.id && foundIndex !== -1) {
-            const msg = currentMessages.value[foundIndex];
-            msg.text = response;
-            msg.reasoning = finalReasoning;
-            msg.time = time;
-            msg.genTime = duration;
-            msg.tokens = estimateTokens(response);
-            msg.isTyping = false;
-            if (meta?.partialError) {
-                msg.isPartial = true;
-                msg.partialErrorMsg = meta.partialError;
-            }
-
-            // Update swipes
-            if (!msg.swipes) msg.swipes = [];
-            if (!msg.swipesMeta) msg.swipesMeta = [];
-            
-            // If this was a new generation (not a swipe add), it's the first swipe
-            if (msg.swipes.length === 1 && msg.swipes[0] === "") {
-                msg.swipes[0] = response;
-                msg.swipesMeta[0] = { 
-                    genTime: duration, 
-                    reasoning: finalReasoning, 
-                    tokens: msg.tokens,
-                    guidanceText: msg.guidanceText,
-                    guidanceType: msg.guidanceType
-                };
-                addMessageStats(char.id, sessionId, msg.tokens, response.length, msg.timestamp);
-                triggerAutoSyncCheck();
-            } else {
-                msg.swipes[msg.swipeId || 0] = response;
-                if (!msg.swipesMeta[msg.swipeId || 0]) msg.swipesMeta[msg.swipeId || 0] = {};
-                msg.swipesMeta[msg.swipeId || 0].genTime = duration;
-                msg.swipesMeta[msg.swipeId || 0].reasoning = finalReasoning;
-                msg.swipesMeta[msg.swipeId || 0].tokens = msg.tokens;
-                msg.swipesMeta[msg.swipeId || 0].guidanceText = guidanceText;
-                msg.swipesMeta[msg.swipeId || 0].guidanceType = guidanceType;
-                addRegenerationStats(char.id, sessionId, msg.tokens, response.length);
-            }
-            
-            updateSessionMessage(char, foundIndex, msg);
-
-            // Process image generation tags async (non-blocking)
-            processMessageImages(msg.text, (updatedText) => {
-                msg.text = updatedText;
-                msg.swipes[msg.swipeId || 0] = updatedText;
-                // Only persist to DB once all images are resolved (no loading states remain)
-                if (!updatedText.includes('imggen-loading')) {
-                    updateSessionMessage(char, foundIndex, msg);
-                }
-            }, { charAvatar: char.avatar || null, userAvatar: activePersona.value?.avatar || null, messages: currentMessages.value, currentMsgIndex: foundIndex }).then(finalText => {
-                if (finalText !== msg.text) {
-                    msg.text = finalText;
-                    msg.swipes[msg.swipeId || 0] = finalText;
-                    updateSessionMessage(char, foundIndex, msg);
-                }
-            }).catch(e => console.error('[ImageGen] processMessageImages failed:', e));
-
-            if (wasVisible) {
-                scrollToIndex(displayIndex, 'smooth', 'top');
-            } else {
-                smartScroll();
-            }
-
-            sendMessageNotification(char.name, response, char.avatar, char.id, sessionId, msgId);
-
-            if (guidanceType === 'GENERATION') {
-                const autoData = await getChatData(char.id);
-                if (autoData) {
-                    const autoSessionId = char.sessionId || autoData.currentId;
-                    autoData.sessions[autoSessionId] = currentMessages.value;
-                    await runMemoryAutomationAfterStableTurn(autoData, autoSessionId, currentMessages.value, { allowImmediate: true });
-                }
-            }
-
-            // Notify application about generation end (after update)
-            window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
-        } else {
-            // Background completion — write directly to DB, NOT currentMessages.value
-            const bgData = await getChatData(char.id);
-            if (bgData && bgData.sessions[sessionId]) {
-                const bIdx = bgData.sessions[sessionId].findIndex(m => m.id === msgId);
-                if (bIdx !== -1) {
-                    const msg = bgData.sessions[sessionId][bIdx];
-                    msg.text = response;
-                    msg.reasoning = finalReasoning;
-                    msg.time = time;
-                    msg.genTime = duration;
-                    msg.tokens = estimateTokens(response);
-                    msg.isTyping = false;
-                    if (meta?.partialError) {
-                        msg.isPartial = true;
-                        msg.partialErrorMsg = meta.partialError;
-                    }
-
-                    if (!msg.swipes) msg.swipes = [];
-                    if (!msg.swipesMeta) msg.swipesMeta = [];
-                    
-                    if (msg.swipes.length === 1 && msg.swipes[0] === "") {
-                        msg.swipes[0] = response;
-                        msg.swipesMeta[0] = { genTime: duration, reasoning: finalReasoning, tokens: msg.tokens };
-                        addMessageStats(char.id, sessionId, msg.tokens, response.length, msg.timestamp);
-                        triggerAutoSyncCheck();
-                    } else {
-                        msg.swipes[msg.swipeId || 0] = response;
-                        if (!msg.swipesMeta[msg.swipeId || 0]) msg.swipesMeta[msg.swipeId || 0] = {};
-                        msg.swipesMeta[msg.swipeId || 0].genTime = duration;
-                        msg.swipesMeta[msg.swipeId || 0].reasoning = finalReasoning;
-                        msg.swipesMeta[msg.swipeId || 0].tokens = msg.tokens;
-                        addRegenerationStats(char.id, sessionId, msg.tokens, response.length);
-                    }
-                    
-                    processMessageImages(response, (updatedText) => {
-                        msg.text = updatedText;
-                        msg.swipes[msg.swipeId || 0] = updatedText;
-                        // Only persist to DB once all images are resolved (no loading states remain)
-                        if (!updatedText.includes('imggen-loading')) {
-                            db.saveChat(char.id, bgData);
-                        }
-                    }, { charAvatar: char.avatar || null, userAvatar: activePersona.value?.avatar || null, messages: bgData.sessions[sessionId], currentMsgIndex: bIdx }).then(finalText => {
-                        if (finalText !== msg.text) {
-                            msg.text = finalText;
-                            msg.swipes[msg.swipeId || 0] = finalText;
-                            db.saveChat(char.id, bgData);
-                        }
-                    }).catch(e => console.error('[ImageGen] background processMessageImages failed:', e));
-                    
-                    await db.saveChat(char.id, bgData);
-
-                    if (guidanceType === 'GENERATION') {
-                        await runMemoryAutomationAfterStableTurn(bgData, sessionId, bgData.sessions[sessionId], { allowImmediate: true });
-                    }
-
-                    sendMessageNotification(char.name, response, char.avatar, char.id, sessionId, msgId);
-                    
-                    // Mark unread
-                    db.get('gz_unread').then(unread => {
-                        const newUnread = unread || {};
-                        newUnread[char.id] = true;
-                        db.set('gz_unread', newUnread);
-                        window.dispatchEvent(new CustomEvent('chat-updated'));
-                    });
-
-                    window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
-                }
-            }
-        }
-        } catch (completeErr) {
-            console.error('[onComplete] Completion handler failed:', completeErr);
-            // Ensure cleanup and isTyping cleared even if handler fails
-            ensureCleanup();
-            await clearTypingStateForMessage({
-                charId: char.id,
-                sessionId,
-                msgId,
-                errorLabel: '[onComplete]'
-            });
-            window.dispatchEvent(new CustomEvent('chat-generation-ended', { detail: { charId: char.id, sessionId: sessionId } }));
-        }
+                await handleGenerationComplete({
+                    response,
+                    finalReasoning,
+                    meta,
+                    char,
+                    sessionId,
+                    msgId,
+                    genId,
+                    startTime,
+                    controller,
+                    guidanceText,
+                    guidanceType,
+                    activeChatChar,
+                    isGenerating,
+                    currentMessages,
+                    displayMessages,
+                    getGenerationState,
+                    clearGenerationState,
+                    clearPersistedGeneration,
+                    clearBackgroundUpdateTimer,
+                    clearTypingStateForMessage,
+                    getChatData,
+                    db,
+                    cleanText,
+                    estimateTokens,
+                    updateSessionMessage,
+                    processMessageImages,
+                    userAvatar: activePersona.value?.avatar || null,
+                    isItemVisible,
+                    scrollToIndex,
+                    smartScroll,
+                    sendMessageNotification,
+                    runMemoryAutomationAfterStableTurn,
+                    addMessageStats,
+                    addRegenerationStats,
+                    triggerAutoSyncCheck
+                });
             },
             onError
         }

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -447,25 +447,27 @@ function getMemoryPromptLabelByKey(settings = {}, promptPreset = 'detailed_beats
 function restoreVisibleSwipeState(messages = []) {
     if (!Array.isArray(messages)) return [];
 
-    for (const msg of messages) {
-        if (!msg || !Array.isArray(msg.swipesMeta)) continue;
+    return messages.map(msg => {
+        if (!msg || !Array.isArray(msg.swipesMeta)) return msg;
 
         const swipeIndex = msg.swipeId || 0;
         const swipeMeta = msg.swipesMeta[swipeIndex];
-        if (!swipeMeta) continue;
+        if (!swipeMeta) return msg;
+
+        let nextMsg = msg;
 
         if (msg.reasoning == null && swipeMeta.reasoning != null) {
-            msg.reasoning = swipeMeta.reasoning;
+            nextMsg = { ...nextMsg, reasoning: swipeMeta.reasoning };
         }
-        if (msg.genTime == null && swipeMeta.genTime != null) {
-            msg.genTime = swipeMeta.genTime;
+        if (nextMsg.genTime == null && swipeMeta.genTime != null) {
+            nextMsg = { ...nextMsg, genTime: swipeMeta.genTime };
         }
-        if ((msg.tokens == null || msg.tokens === 0) && swipeMeta.tokens != null) {
-            msg.tokens = swipeMeta.tokens;
+        if ((nextMsg.tokens == null || nextMsg.tokens === 0) && swipeMeta.tokens != null) {
+            nextMsg = { ...nextMsg, tokens: swipeMeta.tokens };
         }
-    }
 
-    return messages;
+        return nextMsg;
+    });
 }
 
 function getNormalizedMemoryGenerationState(settings = {}, overrides = {}) {

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -444,6 +444,30 @@ function getMemoryPromptLabelByKey(settings = {}, promptPreset = 'detailed_beats
     return options.find(item => item.key === promptPreset)?.label || builtInMemoryPrompts[0].label;
 }
 
+function restoreVisibleSwipeState(messages = []) {
+    if (!Array.isArray(messages)) return [];
+
+    for (const msg of messages) {
+        if (!msg || !Array.isArray(msg.swipesMeta)) continue;
+
+        const swipeIndex = msg.swipeId || 0;
+        const swipeMeta = msg.swipesMeta[swipeIndex];
+        if (!swipeMeta) continue;
+
+        if (msg.reasoning == null && swipeMeta.reasoning != null) {
+            msg.reasoning = swipeMeta.reasoning;
+        }
+        if (msg.genTime == null && swipeMeta.genTime != null) {
+            msg.genTime = swipeMeta.genTime;
+        }
+        if ((msg.tokens == null || msg.tokens === 0) && swipeMeta.tokens != null) {
+            msg.tokens = swipeMeta.tokens;
+        }
+    }
+
+    return messages;
+}
+
 function getNormalizedMemoryGenerationState(settings = {}, overrides = {}) {
     return {
         source: settings.generationSource || 'current',
@@ -2229,7 +2253,7 @@ async function loadChats() {
         const data = await getChatData(activeChatChar.id);
         const sessionId = activeChatChar.sessionId || data.currentId;
         if (data && data.sessions && data.sessions[sessionId]) {
-            currentMessages.value = data.sessions[sessionId];
+            currentMessages.value = restoreVisibleSwipeState(data.sessions[sessionId]);
         } else {
             currentMessages.value = [];
         }

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -67,6 +67,7 @@ import { lorebookState, getActiveLorebooksForContext } from '@/core/states/loreb
 import { presetState, getEffectivePreset, getEffectivePresetId } from '@/core/states/presetState.js';
 import { useVirtualScroll } from '@/composables/chat/useVirtualScroll.js';
 import { useGenerationRegistry } from '@/composables/chat/useGenerationRegistry.js';
+import { createPromptMetadataSnapshots } from '@/composables/chat/usePromptMetadataSnapshots.js';
 import { useSidebarResizer } from '@/composables/ui/useSidebarResizer.js';
 import { sendMessageNotification, clearMessageNotifications, startGenerationNotification, stopGenerationNotification } from '@/core/services/notificationService.js';
 import { addNotification } from '@/core/states/notificationsState.js';
@@ -3215,44 +3216,7 @@ function startGeneration(char, text, existingMsgIndex = -1, onAbort = null, guid
         }
     }
     const msgId = currentMessages.value[msgIndex]?.id || genMsgId();
-    const promptMetaSnapshots = new Map();
-
-    const clonePromptMetaList = (items) => Array.isArray(items)
-        ? items.map(item => ({ ...item }))
-        : [];
-
-    const snapshotPromptMeta = (message) => {
-        if (!message?.id || promptMetaSnapshots.has(message.id)) return;
-        promptMetaSnapshots.set(message.id, {
-            hasTriggeredLorebooks: Object.prototype.hasOwnProperty.call(message, 'triggeredLorebooks'),
-            hasTriggeredMemories: Object.prototype.hasOwnProperty.call(message, 'triggeredMemories'),
-            hasContextRefs: Object.prototype.hasOwnProperty.call(message, 'contextRefs'),
-            triggeredLorebooks: clonePromptMetaList(message.triggeredLorebooks),
-            triggeredMemories: clonePromptMetaList(message.triggeredMemories),
-            contextRefs: clonePromptMetaList(message.contextRefs)
-        });
-    };
-
-    const restorePromptMetaOnMessages = (messages) => {
-        if (!Array.isArray(messages) || promptMetaSnapshots.size === 0) return false;
-        let changed = false;
-        messages.forEach(message => {
-            const snapshot = message?.id ? promptMetaSnapshots.get(message.id) : null;
-            if (!snapshot) return;
-
-            if (snapshot.hasTriggeredLorebooks) message.triggeredLorebooks = clonePromptMetaList(snapshot.triggeredLorebooks);
-            else delete message.triggeredLorebooks;
-
-            if (snapshot.hasTriggeredMemories) message.triggeredMemories = clonePromptMetaList(snapshot.triggeredMemories);
-            else delete message.triggeredMemories;
-
-            if (snapshot.hasContextRefs) message.contextRefs = clonePromptMetaList(snapshot.contextRefs);
-            else delete message.contextRefs;
-
-            changed = true;
-        });
-        return changed;
-    };
+    const { snapshotPromptMeta, restorePromptMetaOnMessages } = createPromptMetadataSnapshots();
 
     // Save generation status for DialogList
     markGenerationPersisted(char.id, sessionId);

--- a/src/views/OnboardingView.vue
+++ b/src/views/OnboardingView.vue
@@ -2,7 +2,7 @@
 import { ref, computed, reactive, onMounted } from 'vue';
 import { importFullBackupAsync } from '@/core/services/backupService.js';
 import { addPersona, allPersonas, deletePersona } from '@/core/states/personaState.js';
-import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets } from '@/core/config/APISettings.js';
+import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiProviderId } from '@/core/config/APISettings.js';
 import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetState.js';
 import BackupSheet from '@/components/sheets/BackupSheet.vue';
 import { translations } from '@/utils/i18n.js';
@@ -258,6 +258,7 @@ async function savePreset() {
     const newPreset = {
         id: Date.now().toString(36),
         name: 'Onboarding Setup',
+        providerId: getApiProviderId(),
         endpoint: normalized,
         key: apiSettings.key,
         model: apiSettings.model,
@@ -271,6 +272,7 @@ async function savePreset() {
     presets.push(newPreset);
     await saveApiPresets(presets);
     localStorage.setItem('gz_active_api_preset_id', newPreset.id);
+    localStorage.setItem('gz_api_provider', newPreset.providerId);
 
     // Also save legacy globals for immediate use
     localStorage.setItem('api-endpoint', normalized);

--- a/src/views/OnboardingView.vue
+++ b/src/views/OnboardingView.vue
@@ -2,7 +2,7 @@
 import { ref, computed, reactive, onMounted } from 'vue';
 import { importFullBackupAsync } from '@/core/services/backupService.js';
 import { addPersona, allPersonas, deletePersona } from '@/core/states/personaState.js';
-import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiProviderId } from '@/core/config/APISettings.js';
+import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiProviderId, applyApiRuntimeConfig } from '@/core/config/APISettings.js';
 import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetState.js';
 import BackupSheet from '@/components/sheets/BackupSheet.vue';
 import { translations } from '@/utils/i18n.js';
@@ -272,13 +272,12 @@ async function savePreset() {
     presets.push(newPreset);
     await saveApiPresets(presets);
     localStorage.setItem('gz_active_api_preset_id', newPreset.id);
-    localStorage.setItem('gz_api_provider', newPreset.providerId);
-
-    // Also save legacy globals for immediate use
-    localStorage.setItem('api-endpoint', normalized);
-    localStorage.setItem('gz_api_endpoint_normalized', normalized);
-    if (apiSettings.key) localStorage.setItem('api-key', apiSettings.key);
-    if (apiSettings.model) localStorage.setItem('api-model', apiSettings.model);
+    applyApiRuntimeConfig({
+        providerId: newPreset.providerId,
+        endpoint: normalized,
+        apiKey: apiSettings.key,
+        model: apiSettings.model
+    });
 }
 
 function triggerPresetImport() {

--- a/src/views/ToolsView.vue
+++ b/src/views/ToolsView.vue
@@ -3,7 +3,7 @@ import { onMounted, ref, computed } from 'vue';
 import { t, updateLanguage } from '@/utils/i18n.js';
 import { initRipple } from '@/core/services/ui.js';
 
-import { getApiPresets, fetchRemoteModels } from '@/core/config/APISettings.js';
+import { getApiPresets, fetchRemoteModels, getApiRuntimeStorage } from '@/core/config/APISettings.js';
 import { presetState, DEFAULT_PRESETS } from '@/core/states/presetState.js';
 import { lorebookState } from '@/core/states/lorebookState.js';
 import { activePersona } from '@/core/states/personaState.js';
@@ -67,14 +67,15 @@ onMounted(async () => {
 });
 
 async function checkConnection() {
-    const endpoint = localStorage.getItem('gz_api_endpoint_normalized') || localStorage.getItem('api-endpoint');
+    const runtime = getApiRuntimeStorage();
+    const endpoint = runtime.normalizedEndpoint;
     if (!endpoint) {
         apiStatus.value = 'failed';
         return;
     }
     apiStatus.value = 'connecting';
     try {
-        await fetchRemoteModels(endpoint, localStorage.getItem('api-key'));
+        await fetchRemoteModels(endpoint, runtime.key, runtime.providerId);
         apiStatus.value = 'connected';
     } catch (e) {
         apiStatus.value = 'failed';


### PR DESCRIPTION
## Summary
- refactor chat generation handling and network request flow into focused composables and transport modules while preserving existing runtime behavior
- carry forward recent upstream generation and lorebook regression fixes, including prompt metadata rollback and late vector lore injection safeguards
- fix post-refactor regressions around chat reopen setup order and restoring visible swipe reasoning on load

## Testing
- npm test -- --run
- npm run build