### PR TITLE
fix: urgent bugfixes - sync coverage, chat importer, memory generation UI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -617,6 +617,22 @@ These composables now cover placeholder setup, stream UI application, prompt met
 - Encryption key material: IndexedDB via `keyManager.js`
 - Device identity and sync metadata: local storage + IndexedDB manifest state
 
+**Synced Singleton Coverage:**
+- Characters, personas, chats: full IndexedDB stores
+- Lorebooks: single IndexedDB blob (`gz_lorebooks`)
+- API connection presets: single IndexedDB blob (`gz_api_connection_presets`)
+- Theme presets: single IndexedDB blob (`gz_theme_presets`)
+- Theme active preset: single IndexedDB blob (`gz_theme_active_preset`) via `theme_state` entity
+- App / API runtime settings: selected `localStorage` keys bundled under the `local_storage` entity
+  - Includes: prompt presets, active preset IDs, persona connections, regex scripts, language, theme/layout toggles, battery saver, API provider/endpoint/model, temperature, stream, reasoning settings, timeouts
+  - Also includes API key and model key (users should be aware credentials travel with this bundle)
+- Not synced: active generation state, temporary UI state, push-notification tokens, debug network traces, embedding vectors
+
+**Wipe Semantics:**
+- `wipeCloudData()` deletes every file found under `/Glaze` via the provider adapter (`listAllFiles` + `deleteFile`).
+- `resetSyncIdentityAfterWipe()` clears the local sync encryption key, manifest, deleted-entries registry, and device ID.
+- After a wipe the cloud is effectively empty; the next `push` creates a fresh manifest and repopulates `/Glaze`.
+
 ---
 
 ## Key Integration Points

--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -1,221 +1,766 @@
-# Backend/Service Logic Refactoring Plan
+# Refactor Plan
 
-## Current Situation
+## Purpose
 
-ChatView.vue содержит ~6787 строк, из которых:
-- ~68 функций для Memory Books logic
-- ~11 функций для Context/Tokenizer logic  
-- Множество helper функций смешаны с UI логикой
+This document defines a safe staged refactor plan for the app architecture.
 
-## Proposed Extraction
+The goal is not to chase a fashionable architecture label. The goal is to make the codebase:
 
-### 1. Memory Books Service (HIGH PRIORITY)
+- hard to break during refactors;
+- easier to extend without editing core files every time;
+- less dependent on god-objects;
+- suitable for experimental feature work like "I want to add this feature and see what happens" without turning the app into a pile of special cases.
 
-**File:** `src/core/services/memoryBooksService.js`
+The desired result is a hybrid architecture:
 
-**Functions to extract (~50-60 functions, ~800-1000 lines):**
+- **ordered deterministic pipeline** for prompt and generation flow where order must be guaranteed;
+- **event-driven architecture** for extensions, side effects, UI coordination, and plugins;
+- **reactive state modules** as read models for Vue UI, not as a replacement for use cases.
 
-#### Core Memory Book Management
-- `ensureSessionMemoryBook(chatData, sessionId)` — создание/получение memory book
-- `createEmptyMemoryCoverage()` — инициализация coverage
-- `createMemoryAutomationState()` — инициализация automation
-- `ensureMemoryAutomationState(memoryBook)` — ensure automation state
-- `reconcileMemoryBookForMessages(memoryBook, messages)` — синхронизация entries с messages
-- `reconcileSessionMemoryState(chatData, sessionId, messages)` — reconcile session state
-- `runMemoryMaintenancePass(chatData, sessionId, options)` — cleanup и maintenance
-
-#### Memory Entry Operations
-- `genMemoryEntryId()` — ID generation
-- `normalizeMemoryEntryShape(entry)` — normalize entry structure
-- `parseMemoryKeyInput(value)` — parse key input
-- `buildMemoryKeysFromText(text, fallback)` — extract keys from text
-- `findConflictingMemoryEntry(memoryBook, selectedIds, options)` — conflict detection
-- `normalizeEntryMessageIds(entry)` — normalize messageIds array
-
-#### Vector/Embedding Operations
-- `indexMemoryEntryIfNeeded(entry, charId, sessionId)` — index if vector search enabled
-- `deleteMemoryEntryIndexIfPresent(entryId)` — delete embedding
-- `reindexMemoryEntry(entry, charId, sessionId)` — reindex single entry
-- `reindexAllMemoryEntries(memoryBook, charId, sessionId)` — reindex all entries
-- `shouldEnableMemoryVectorSearch()` — check if vector search available
-- `getMemoryVectorSearchEnabled(memoryBook)` — get vector search state
-- `setMemoryVectorSearchOnEntries(memoryBook, enabled)` — toggle vector search
-
-#### Memory Draft Generation
-- `generateMemoryDraftForMessages(selectedMessages, options)` — generate draft
-- `runBatchDraftGeneration(chatData, sessionId, memoryBook, segments, count)` — batch generation
-- `runMemoryAutomationAfterStableTurn(chatData, sessionId, messages, options)` — auto-generation
-- `bootstrapImportedMemoryDrafts(charId, sessionId)` — bootstrap after import
-- `parseMemoryDraftResponse(rawText, fallbackKeys)` — parse LLM response
-- `buildMemoryContinuityContext(memoryBook, selected)` — build context for continuity
-- `buildMemoryDraftLoreContext(selected)` — build lorebook context
-- `buildMemoryDraftSummaryExcerpt(summary)` — build summary excerpt
-
-#### Memory Prompt Management
-- `getMemoryPromptOptions(settings)` — get available prompts
-- `resolveMemoryPrompt(settings)` — resolve prompt text
-- `getMemoryPromptLabel(settings)` — get prompt label
-- `builtInMemoryPrompts` — константы built-in промптов
-
-#### Automation & Triggers
-- `normalizeAutoCreateInterval(memoryBook)` — normalize interval
-- `memoryBooksHasAutomationState(memoryBook)` — check automation state
-- `resolvePendingTriggerMessages(stableMessages, pendingTrigger)` — resolve pending triggers
-- `buildBootstrapSegments(messages, interval)` — build segments for bootstrap
-- `countStableConversationMessages(messages)` — count stable messages
-- `getLastStableConversationRole(messages)` — get last role
-- `computeDelayedWaitExchanges(triggerRole)` — compute wait exchanges
-
-#### Utilities
-- `arraysEqual(a, b)` — array equality
-- `calculateMessageOverlapRatio(leftIds, rightIds)` — overlap calculation
-- `formatElapsedSeconds(ms)` — format time
-- `getMemoryKeyMatchMode(memoryBook)` — get key match mode
-
-**Benefits:**
-- Уменьшит ChatView на ~800-1000 строк
-- Изолирует Memory Books бизнес-логику
-- Позволит тестировать логику отдельно от UI
-- Упростит переиспользование (например, в worker'ах)
+This plan must prioritize compatibility and behavior preservation over cleanup speed.
 
 ---
 
-### 2. Composable: useMemoryBooks (MEDIUM PRIORITY)
+## Primary Goals
 
-**File:** `src/composables/chat/useMemoryBooks.js`
+### Goal 1. Do not break working behavior
 
-**Reactive state + UI interaction logic (~200-300 lines):**
+The most important requirement is safety.
 
-#### State
-- `currentMemoryBookData` — ref для текущего memory book
-- `memoryDraftState` — ref для draft generation state
-- `pendingMemoryMessageIds` — ref для pending message IDs
-- `draftMemoryMessageIds` — ref для draft message IDs
+That means:
 
-#### UI Handlers (already extracted to ChatView, но можно в composable)
-- `loadCurrentMemoryBook()` — load reactive memory book
-- `updatePendingMemoryMessageIds()` — update pending IDs
-- `handleMemoryKeyModeUpdate()` — key mode change
-- `handleMemoryVectorToggle(enabled)` — vector search toggle
-- `handleMemoryReindexAll()` — reindex all
-- `handleMemoryScanChat()` — scan chat
-- `handleMemoryBatchGenerate()` — batch generate
-- `handleMemoryApproveDraft(draftId)` — approve draft
-- `handleMemoryDeleteDraft(draftId)` — delete draft
-- `handleMemoryDeleteEntry(entryId)` — delete entry
-- `handleMemoryCancelDraft()` — cancel draft generation
+- no large rewrite in one branch;
+- no prompt semantics changes unless explicitly intended;
+- no transport behavior changes hidden inside structural refactors;
+- no migration that forces MemoryBooks, vectorization, sync, and generation internals to move at the same time.
 
-#### Progress Tracking
-- `startMemoryDraftProgress(label)` — start progress timer
-- `stopMemoryDraftProgress()` — stop progress timer
-- `cancelMemoryDraft()` — cancel + cleanup
+### Goal 2. Remove god-objects
 
-**Benefits:**
-- Убирает reactive state из ChatView
-- Группирует UI interaction logic
-- Легко переиспользовать в других view
+The current architecture still has several overloaded ownership points:
 
----
+- `src/views/ChatView.vue`
+- `src/core/services/generationService.js`
+- `src/core/services/llmApi.js` compatibility entrypoint
+- parts of `ApiView.vue` and settings/config write paths
 
-### 3. Context/Tokenizer Service (LOW PRIORITY)
+These files currently mix multiple responsibilities:
 
-**File:** `src/core/services/contextService.js`
+- orchestration;
+- state mutation;
+- request lifecycle;
+- config access;
+- transport coordination;
+- debug storage;
+- UI decisions.
 
-**Functions to extract (~5-8 functions, ~200-300 lines):**
+The refactor should reduce this by splitting ownership, not by simply moving the same complexity into new files.
 
-#### Context Calculation
-- `updateContextCutoff()` — calculate context cutoff
-- `debouncedUpdateContextCutoff(delay)` — debounced version
-- `invalidateContextCache()` — invalidate cache
+### Goal 3. Make feature work cheap
 
-#### History Management
-- `persistHistoryContextSettings(fillThreshold, hidePercent)` — save settings
-- `clampHistoryFillThreshold(value)` — clamp value
-- `clampHistoryHidePercent(value)` — clamp value
-- `hideTopMessagesNow()` — hide messages
-- `confirmHideTopMessages()` — confirm dialog
+Adding a new feature should not require editing half the app.
 
-**Computed properties (остаются в ChatView или composable):**
-- `contextSegments` — segment breakdown
-- `contextBreakdownItems` — breakdown items
-- `contextLegendItems` — legend items
-- `historyUsagePercent` — usage percentage
-- `historyHidePreview` — preview info
-- `shouldRecommendHide` — recommendation flag
+Examples of the desired end state:
 
-**Benefits:**
-- Изолирует context calculation logic
-- Проще тестировать
-- Но меньший приоритет, т.к. уже относительно небольшой и чистый код
+- add a new request type without touching all transport files;
+- add a provider adapter without rewriting generation orchestration;
+- add a plugin hook without wiring random `window.dispatchEvent` calls everywhere;
+- add a prompt-enrichment rule without modifying unrelated UI code;
+- add diagnostics, experiments, or optional automation with isolated extension points.
+
+### Goal 4. Keep order where order matters
+
+The core generation flow must stay deterministic.
+
+The prompt pipeline is not a free-for-all event system. It must preserve ordering for:
+
+- prompt block resolution;
+- macro application;
+- regex transforms;
+- keyword lore scan;
+- vector enrichment;
+- memory injection;
+- final payload assembly.
+
+This plan explicitly rejects replacing the prompt pipeline with uncontrolled event subscribers.
 
 ---
 
-## Execution Order
+## Non-Goals
 
-### Phase 7: Memory Books Service Extraction
+The following are not goals of this refactor phase:
 
-**Priority:** HIGH  
-**Impact:** ~800-1000 lines from ChatView  
-**Complexity:** MEDIUM-HIGH (много взаимосвязей)
-
-**Steps:**
-1. Create `src/core/services/memoryBooksService.js`
-2. Extract pure functions (no refs, no reactive state)
-3. Update imports in ChatView
-4. Update imports in MemoryBooksSheet (if needed)
-5. Test: npm run build
-6. Manual testing: Memory Books functionality
-
-### Phase 8: useMemoryBooks Composable (OPTIONAL)
-
-**Priority:** MEDIUM  
-**Impact:** ~200-300 lines from ChatView  
-**Complexity:** MEDIUM (reactive state management)
-
-**Steps:**
-1. Create `src/composables/chat/useMemoryBooks.js`
-2. Move reactive state (refs, computed)
-3. Move UI handlers
-4. Return from composable: `{ state, handlers }`
-5. Import and use in ChatView
-6. Test: npm run build
-
-### Phase 9: Context Service (OPTIONAL, LOW PRIORITY)
-
-**Priority:** LOW  
-**Impact:** ~200-300 lines  
-**Complexity:** LOW
+- rewriting the app to TypeScript;
+- replacing reactive modules with Pinia or Vuex;
+- replacing custom navigation with Vue Router;
+- redesigning prompt semantics;
+- reworking vectorization internals without a concrete bug;
+- fully redesigning MemoryBooks at the same time as the transport/use-case refactor;
+- removing all legacy compatibility in one pass.
 
 ---
 
-## Estimated Final State
+## Current Problems
 
-**After all extractions:**
+### 1. Core ownership is too concentrated
 
-```
-src/views/ChatView.vue                    ~5200 строк (-1587 от текущих 6787)
-src/core/services/memoryBooksService.js   ~900 строк (новый)
-src/composables/chat/useMemoryBooks.js    ~250 строк (новый, опционально)
-src/core/services/contextService.js       ~250 строк (новый, опционально)
-```
+`ChatView.vue` still carries too much session and generation orchestration.
 
-**Total code organization improvement:**
-- ChatView.vue focus: UI orchestration, message rendering, chat flow
-- Services: Business logic, data transformation, calculations
-- Composables: Reactive state + UI interaction patterns
-- Sheets: Presentation components
+`generationService.js` still acts as a central kitchen for:
+
+- request intent decisions;
+- prompt preparation and enrichment;
+- preview/debug state;
+- transport dispatch.
+
+This makes changes risky because one file becomes the merge point for unrelated features.
+
+### 2. There is no formal event model
+
+The app already uses `window.dispatchEvent(new CustomEvent(...))`, but this is still an ad-hoc signaling layer, not a defined architecture.
+
+Problems:
+
+- event names are not organized by domain;
+- payload contracts are informal;
+- UI events and domain events are mixed together;
+- there is no ownership boundary between transport events, app events, and feature events.
+
+### 3. Transport is thinner, but still callback-heavy
+
+The transport split has progressed, but the lifecycle is still expressed through flexible callback wiring instead of a normalized contract.
+
+That creates risk for:
+
+- abort behavior;
+- late completion races;
+- stream vs non-stream parity;
+- memory-draft vs chat request overlap.
+
+### 4. Debug state is still singleton/global
+
+Prompt preview and network trace state still leak across request types and sessions.
+
+This is manageable for debugging, but structurally wrong.
+
+### 5. Extensibility still tends to route through core files
+
+New behavior often ends up in one of these places:
+
+- `ChatView.vue`
+- `generationService.js`
+- settings views
+- direct config reads/writes
+
+That is exactly how god-objects regrow after each cleanup.
 
 ---
 
-## Questions for Discussion
+## Target Architecture
 
-1. **Should we extract Memory Books Service first?** (рекомендую да — самый большой impact)
-2. **Do we need composables or keep handlers in ChatView?** (зависит от того, планируем ли переиспользовать)
-3. **Should context logic stay in ChatView?** (да, пока небольшой и специфичный для ChatView)
-4. **Testing strategy?** (unit tests для services, integration tests для composables)
+### Overview
+
+The target model is:
+
+1. **Use cases decide what action is being performed.**
+2. **Ordered pipelines execute deterministic core flow.**
+3. **Event bus publishes facts after or around those flows.**
+4. **Reactive state modules store read models for UI.**
+5. **Plugins/extensions react only through declared extension points.**
+
+Short version:
+
+- use cases decide;
+- pipelines guarantee order;
+- events broadcast facts;
+- stores expose read models;
+- plugins attach at controlled boundaries.
+
+### Layer Model
+
+#### 1. UI Layer
+
+Vue views and components should:
+
+- gather user intent;
+- call a use case;
+- read reactive state;
+- render;
+- dispatch only UI/navigation events when necessary.
+
+Vue views should not own multi-stage generation orchestration.
+
+#### 2. Use Case Layer
+
+Use cases represent app actions.
+
+Examples:
+
+- `generateChat`
+- `generateSummary`
+- `generateMemoryDraft`
+- `calculateContext`
+- future sync, import, indexing, or tool actions
+
+Each use case should:
+
+- validate inputs;
+- claim ownership of its session/request;
+- invoke ordered pipeline steps;
+- publish domain events;
+- return a normalized result contract.
+
+#### 3. Pipeline Layer
+
+This is the deterministic core.
+
+Pipelines must be explicit and ordered.
+
+Examples:
+
+- prompt build pipeline;
+- request assembly pipeline;
+- request lifecycle pipeline;
+- memory extraction-context pipeline.
+
+Pipelines are not generic magic middleware for everything. They are for flows where order is part of correctness.
+
+#### 4. Event Layer
+
+The event layer is a mailbox, not a dispatcher of app truth.
+
+It should publish domain facts such as:
+
+- generation started;
+- prompt built;
+- request sent;
+- stream delta received;
+- generation completed;
+- generation failed;
+- settings changed;
+- sync finished.
+
+The bus must not decide prompt order or replace use-case orchestration.
+
+#### 5. State / Read Model Layer
+
+Reactive state modules should hold data projected for UI usage.
+
+Examples:
+
+- active generation status;
+- request trace history;
+- prompt preview history;
+- sync progress;
+- notification state.
+
+These state modules should react to explicit calls or domain events, instead of each view maintaining private copies of cross-cutting state.
+
+#### 6. Plugin / Extension Layer
+
+Plugin-like features should attach to stable extension points rather than patching core files directly.
+
+Examples:
+
+- diagnostics;
+- request logging;
+- experimental prompt enrichers;
+- alternate preview builders;
+- future external integrations.
 
 ---
 
-## Decision
+## Architectural Rule: Hybrid, Not Pure EDA
 
-Твоё мнение: начинать ли Phase 7 (Memory Books Service extraction) сейчас, или сначала протестировать текущие UI компоненты?
+This project should not move to pure event-driven architecture.
+
+Pure EDA would be harmful in the generation core because prompt construction requires stable ordering.
+
+The correct split is:
+
+- **EDA for extensions and side effects**
+- **ordered middleware/pipeline for generation correctness**
+
+### Where EDA is a good fit
+
+- plugin hooks;
+- analytics and diagnostics;
+- optional observers;
+- UI coordination across distant components;
+- notifications and non-critical side effects;
+- sync refresh broadcasts;
+- feature modules that need low coupling.
+
+### Where EDA is a bad fit
+
+- final prompt block ordering;
+- request ownership and abort rules;
+- macro/regex/lore/vector/memory insertion order;
+- transport completion semantics;
+- lifecycle-critical cleanup.
+
+---
+
+## Event Model Rules
+
+### Rule 1. Separate event categories
+
+Events must be grouped by ownership.
+
+Suggested categories:
+
+- `ui.*` for component/view interaction events
+- `nav.*` for navigation and sheet open/close requests
+- `domain.generation.*` for generation lifecycle
+- `domain.memory.*` for memory lifecycle
+- `domain.sync.*` for sync lifecycle
+- `infra.request.*` for transport-level facts
+- `debug.*` for diagnostics only
+
+### Rule 2. Define event contracts explicitly
+
+Even in JavaScript-only code, event payloads should be formalized via:
+
+- event name constants;
+- event creator helpers;
+- JSDoc typedefs;
+- runtime validation only at critical boundaries.
+
+### Rule 3. Keep the bus dumb
+
+The event hub should do only this:
+
+- publish;
+- subscribe;
+- unsubscribe;
+- optionally record/debug.
+
+It should not:
+
+- decide business flow;
+- reorder pipeline work;
+- mutate hidden global state as a side effect of publication.
+
+### Rule 4. Keep `window` as a compatibility bridge only
+
+`window.dispatchEvent` can remain for legacy app-shell integration and gradual migration, but it should stop being the primary architecture boundary inside the app.
+
+The internal target should be an app event hub with optional bridge adapters.
+
+---
+
+## Pipeline Model Rules
+
+### Rule 1. Use explicit pipeline context objects
+
+Each ordered flow should have a single context object with clearly owned fields.
+
+For example, chat generation should evolve through a `GenerationContext` that tracks:
+
+- request intent;
+- session ownership token;
+- resolved config;
+- prompt parts;
+- enriched prompt state;
+- provider payload;
+- transport status;
+- result;
+- debug metadata.
+
+### Rule 2. Each step has one job
+
+Pipeline steps should be small and named after what they decide or enrich.
+
+Examples:
+
+- `resolveApiConfigStep`
+- `resolvePresetStep`
+- `buildPromptStep`
+- `applyLoreRetrievalStep`
+- `applyMemoryInjectionStep`
+- `assembleProviderPayloadStep`
+- `executeRequestStep`
+- `normalizeResponseStep`
+
+### Rule 3. Extension points must be named and bounded
+
+If the app allows extensibility around the pipeline, hooks should exist only at declared points such as:
+
+- `beforePromptBuild`
+- `afterPromptBuild`
+- `beforeRequestAssembly`
+- `beforeRequestSend`
+- `afterResponseNormalize`
+- `afterGenerationCommit`
+
+Unbounded "any subscriber can mutate anything at any time" must be avoided.
+
+---
+
+## File/Ownership Direction
+
+This is the target direction, not a one-shot move.
+
+### UI
+
+- `src/views/ChatView.vue`
+  - keep as chat page composition and UI glue only
+  - remove deep generation orchestration over time
+
+- `src/views/ApiView.vue`
+  - keep as editor/view for runtime config and presets
+  - remove direct ownership of config side effects where possible
+
+### Use Cases
+
+- `src/core/llm/usecases/generateChat.js`
+- `src/core/llm/usecases/generateSummary.js`
+- `src/core/llm/usecases/generateMemoryDraft.js`
+- `src/core/llm/usecases/calculateContext.js`
+
+These should become the official public entrypoints instead of `generationService.js` acting as the universal orchestrator.
+
+### Pipelines
+
+- `src/core/llm/pipeline/` for generation-related ordered steps
+- `src/core/memory/pipeline/` later for memory extraction-context and automation flows
+
+### Events
+
+- `src/core/events/eventNames.js`
+- `src/core/events/eventHub.js`
+- `src/core/events/contracts.js`
+- `src/core/events/bridges/windowEventBridge.js`
+
+### Read Models / State
+
+- keep `src/core/states/` as the Vue-facing state layer
+- add dedicated projection state where needed instead of storing debug/session state in arbitrary services
+
+### Debug
+
+- move prompt preview and request traces to explicit debug stores keyed by generation/session
+- stop using singleton "last trace" as the primary design
+
+---
+
+## Migration Strategy
+
+The migration must follow a strangler pattern.
+
+That means:
+
+- keep the current flow running;
+- add new boundaries next to it;
+- move one responsibility at a time;
+- leave compatibility adapters until the new path is proven;
+- remove old code only after behavior parity is verified.
+
+---
+
+## Refactor Phases
+
+### Phase 0. Freeze invariants and safety rails
+Status: not done
+Testing: not tested
+
+Purpose:
+Record the behavior that must not change during refactor.
+
+Work:
+
+- define generation invariants for chat, summary, and memory-draft flows;
+- define request ownership invariants around abort/regenerate;
+- define stream vs fallback parity expectations;
+- define prompt semantics invariants;
+- define manual smoke checklist for mobile/native/web.
+
+Expected output:
+
+- explicit invariant list in docs;
+- small regression checklist that every refactor PR must pass.
+
+### Phase 1. Formalize boundaries without changing behavior
+Status: not done
+Testing: not tested
+
+Purpose:
+Introduce structure before moving logic.
+
+Work:
+
+- add event catalog and event hub;
+- add event naming rules and payload contracts;
+- add compatibility bridge for existing `window.dispatchEvent` usage;
+- define official use-case entrypoints;
+- define normalized result shape for request-oriented use cases.
+
+Expected output:
+
+- new architectural skeleton exists;
+- old code still works through compatibility adapters.
+
+### Phase 2. Enforce request ownership and lifecycle identity
+Status: not done
+Testing: not tested
+
+Purpose:
+Fix the most dangerous class of races before deeper modularization.
+
+Work:
+
+- create explicit request/session ownership tokens;
+- ensure late responses cannot mutate a newer generation state;
+- make abort semantics unambiguous;
+- separate chat generation lifecycle from memory-draft lifecycle;
+- normalize completion/error/abort finalization policy.
+
+Why this phase is early:
+
+- it directly reduces breakage risk;
+- it gives a stable foundation for later transport and UI extraction.
+
+### Phase 3. Move generation orchestration into use cases
+Status: not done
+Testing: not tested
+
+Purpose:
+Shrink `ChatView.vue` and `generationService.js` safely.
+
+Work:
+
+- make `generateChat` the real orchestration entrypoint;
+- move summary and memory-draft orchestration into their use cases;
+- keep `generationService.js` only as a temporary facade if needed;
+- reduce direct orchestration logic in `ChatView.vue` to UI/session glue.
+
+Expected output:
+
+- views call use cases;
+- orchestration stops living in Vue pages.
+
+### Phase 4. Extract deterministic pipelines
+Status: not done
+Testing: not tested
+
+Purpose:
+Make the generation core modular without losing order.
+
+Work:
+
+- introduce explicit pipeline context objects;
+- move prompt build/enrichment/assembly into named steps;
+- document ordering and forbidden reorderings;
+- add bounded extension hooks around steps;
+- keep prompt semantics unchanged unless explicitly tested and approved.
+
+Expected output:
+
+- feature authors can extend declared hooks or steps instead of editing a god-object.
+
+### Phase 5. Move side effects to events and projections
+Status: not done
+Testing: not tested
+
+Purpose:
+Reduce cross-file coupling.
+
+Work:
+
+- publish domain events from use cases and pipelines;
+- update state modules from explicit projection paths;
+- move diagnostics, previews, and optional UI reactions out of the generation core;
+- separate prompt preview state from request-trace state.
+
+Expected output:
+
+- core logic becomes smaller;
+- observers stop requiring direct imports into orchestration files.
+
+### Phase 6. Add plugin/extension API
+Status: not done
+Testing: not tested
+
+Purpose:
+Support experimental feature work safely.
+
+Work:
+
+- define extension-point registration API;
+- support non-core enrichers/observers/plugins through declared hooks;
+- keep plugin scope constrained so experiments cannot silently corrupt prompt order or ownership rules;
+- document which hooks are read-only and which are allowed to mutate context.
+
+Expected output:
+
+- future features can be prototyped with lower risk and lower merge pressure on core files.
+
+### Phase 7. Remove compatibility shims and dead paths
+Status: not done
+Testing: not tested
+
+Purpose:
+Finish cleanup only after parity is proven.
+
+Work:
+
+- remove obsolete direct `window.dispatchEvent` internals where migrated;
+- remove temporary facade logic from `generationService.js`;
+- remove singleton debug state after keyed stores replace it;
+- remove duplicate config access paths once all callers use shared helpers.
+
+---
+
+## Safety Rules For Every Phase
+
+### Rule 1. One responsibility move per PR
+
+Do not combine these in one PR unless there is a clear dependency:
+
+- transport split;
+- prompt semantics changes;
+- MemoryBooks behavior redesign;
+- settings persistence cleanup;
+- plugin system work.
+
+### Rule 2. Every structural PR must prove parity
+
+Each refactor PR should include at least one of:
+
+- tests proving unchanged behavior;
+- build verification;
+- manual verification checklist for affected flows;
+- if useful, prompt snapshot/golden comparisons.
+
+### Rule 3. Keep compatibility adapters during migration
+
+It is acceptable to keep temporary adapters if they reduce risk.
+
+Examples:
+
+- facade functions in `generationService.js`;
+- `window` event bridge;
+- legacy callback adapter around normalized transport events.
+
+### Rule 4. Do not move unstable domains too early
+
+MemoryBooks should not be deeply re-architected until the request/use-case/event boundaries are stable.
+
+Vectorization should remain mostly untouched unless a concrete bug requires a change.
+
+---
+
+## How This Helps Experimental Features
+
+The target architecture should make experimental work possible without risking the app core.
+
+Examples:
+
+- a feature author can add a new prompt-enrichment experiment as a bounded pipeline hook instead of editing `ChatView.vue` and `generationService.js` directly;
+- a new provider can be added through provider registry + payload builders + transport contracts;
+- a new debug panel can subscribe to request and generation events without changing generation logic;
+- a future plugin can add optional metadata, inspection, or automation without becoming part of the critical request path.
+
+This is the practical meaning of "I want to try a feature and see what happens":
+
+- fast to add;
+- easy to remove;
+- hard to break unrelated behavior.
+
+---
+
+## Initial Priority Order
+
+If work starts now, the recommended order is:
+
+1. Phase 0: write down invariants and regression checklist
+2. Phase 1: add event catalog and internal event hub
+3. Phase 2: enforce request ownership tokens and stale-response protection
+4. Phase 3: make use cases the official orchestration boundary
+5. Phase 5: separate preview/trace state from singleton globals
+6. Phase 4: continue extracting deterministic pipelines as use cases stabilize
+7. Phase 6: add extension API only after the boundaries above are real
+
+This order is intentionally safety-first.
+
+It prioritizes:
+
+- race prevention;
+- ownership clarity;
+- behavior preservation;
+- gradual decompression of god-objects.
+
+---
+
+## Immediate Candidate Work Items
+
+These are the first concrete tasks that align with this plan.
+
+### Candidate 1. Event catalog and internal event hub
+Status: not done
+Testing: not tested
+
+Deliverables:
+
+- add `src/core/events/eventNames.js`
+- add `src/core/events/eventHub.js`
+- add JSDoc event contracts
+- bridge a small safe subset of existing events first
+
+### Candidate 2. Request ownership token model
+Status: not done
+Testing: not tested
+
+Deliverables:
+
+- explicit generation request ID / owner token;
+- stale completion guard;
+- clear chat vs memory-draft separation;
+- tests for abort/regenerate overlap.
+
+### Candidate 3. Promote `generateChat` to real use-case entrypoint
+Status: not done
+Testing: not tested
+
+Deliverables:
+
+- `ChatView.vue` calls a dedicated use case rather than owning orchestration details;
+- `generationService.js` reduced to a compatibility facade or prompt-domain helper.
+
+### Candidate 4. Split prompt preview from network trace state
+Status: not done
+Testing: not tested
+
+Deliverables:
+
+- prompt preview keyed by generation/session;
+- trace history keyed by request;
+- remove coupling between chat, summary, and memory-draft debug state.
+
+---
+
+## Success Criteria
+
+The refactor is successful when the following become true:
+
+- adding a feature does not require editing the main chat view and one giant service file;
+- request ownership and abort behavior are explicit and race-safe;
+- prompt assembly remains deterministic and documented;
+- event usage is structured and contract-based rather than ad-hoc;
+- debug and preview state are scoped, not singleton-global;
+- plugins/extensions can be added at declared hooks without rewriting the core;
+- transport, prompt, UI, and state concerns each have a clear home.
+
+---
+
+## Final Guiding Principle
+
+This refactor should optimize for safe change, not for theoretical purity.
+
+If a step makes the code more modular but also makes behavior harder to reason about, that is the wrong step.
+
+The target is a practical architecture where:
+
+- correctness-critical flow stays strict;
+- optional behavior stays loosely coupled;
+- experimentation gets easier;
+- regressions get harder.

--- a/session_todo.md
+++ b/session_todo.md
@@ -1,0 +1,130 @@
+# Session Todo - 2026-04-22
+
+## Current Branch
+- `fixes/urgent-bugfixes`
+- Created from: `origin/dev` (23d7b36)
+
+---
+
+## Active Bugfix Focus
+
+### 1. Sync — Settings Not Syncing (In Progress)
+
+**Problem:**
+- Cloud sync is slow and does not sync:
+  - API runtime settings (endpoint, model, temp, stream, reasoning, etc.)
+  - Theme/app settings (active theme preset, accent color, layout, battery saver, etc.)
+  - App language and general UI settings
+
+**Root cause found:**
+- `syncEngine.js` only synced a narrow `localStorage` whitelist and `theme_presets` DB blob.
+- Active theme state (`gz_theme_active_preset`) and many runtime API keys were excluded.
+- After `pull`, `App.vue::reloadSyncedData()` did not re-apply API runtime settings into live state.
+
+**Fix applied:**
+- Added `THEME_STATE` entity type for `gz_theme_active_preset`.
+- Expanded `lsKeys` to include API runtime, theme, layout, and app settings.
+- Added `applyApiRuntimeConfig({})` in `reloadSyncedData()`.
+
+**Still needs verification:**
+- [ ] Does `fullPull()` on device B correctly restore API endpoint/model/temp?
+- [ ] Does active theme preset switch correctly after sync?
+- [ ] Does sync speed improve when large theme preset images are unchanged?
+- [ ] Are API keys intentionally synced? (Security risk — currently included; may need opt-out.)
+
+---
+
+### 2. Sync — Wipe Cloud Should Wipe Manifest + Encryption
+
+**Problem:**
+- User asked: does cloud wipe also wipe local encryption state and cloud manifests?
+
+**Current behavior:**
+- `wipeCloudData()` deletes all files under `/Glaze` via adapter.
+- `resetSyncIdentityAfterWipe()` deletes local sync key, manifest, deleted-entries log, and device ID.
+- This effectively wipes encryption state locally.
+
+**Still needs verification:**
+- [ ] Confirm that after wipe + reconnect, no stale manifest remains in cloud root.
+- [ ] Confirm that old `.enc` files do not reappear on next push if encryption is re-enabled.
+
+---
+
+### 3. Chat Open / Swipe Crash on Imported Chats
+
+**Problem:**
+- App crashes when opening an imported chat (~400 messages).
+- Crash happens on:
+  - First open after import
+  - Swipe gesture
+  - Message scroll / virtual-scroll loading
+- Export JSONL contains empty messages (no text, no swipes).
+- TXT import format is shown/accepted but may not be handled correctly.
+
+**Root causes found:**
+- `convertMessage()` imported `stMsg.swipes` without filtering `null`/`undefined` entries.
+- `swipesMeta` length could mismatch `swipes` length after import, causing `changeSwipe` to read out of bounds.
+- `exportSillyTavernChat()` exported empty messages (no text, no meaningful swipes), cluttering the file.
+- `importSillyTavernChat()` did not skip empty converted messages, inserting null-content rows.
+
+**Fix applied:**
+- Filter `null`/`undefined` from imported `swipes`.
+- Normalize `swipesMeta` length to match `swipes` after conversion.
+- Skip empty messages during both import (JSON array + JSONL) and export.
+
+**Still needs verification:**
+- [ ] Re-import the same chat that previously crashed; verify open + swipe + scroll.
+- [ ] Verify exported JSONL no longer contains empty lines.
+- [ ] Verify TXT format is either rejected gracefully or handled without crash.
+- [ ] If crash persists, investigate virtual-scroll rendering with 400+ messages and empty text.
+
+---
+
+### 4. Import / Export Format Edge Cases
+
+**Problem:**
+- TXT format visible in import picker; user unsure if it should be supported.
+- Export JSONL may still contain system/empty rows from SillyTavern originals.
+
+**Fix applied:**
+- Empty-message filtering added to both import and export.
+
+**Still needs decision / verification:**
+- [ ] Should TXT import be explicitly rejected with a clear message?
+- [ ] Should export skip `is_system: true` messages or include them?
+
+---
+
+## Known Unfinished Architecture Work (Deferred)
+
+The following remains tracked in `REFACTOR_PLAN.md` and `REFACTOR_PHASE_0_CHECKLIST.md`. It is **out of scope for this bugfix branch** and will be picked up on a dedicated refactor branch after stabilization.
+
+- Event hub + event catalog formalization
+- Request ownership token model
+- `generateChat` use-case boundary extraction
+- Prompt preview / trace singleton decoupling
+- MemoryBooks completion (extraction context, maintenance pass, UI polish)
+- Summary simple-mode prompts defaults + editability
+- Vector ranking bias tuning (only if real user case forces it)
+
+---
+
+## Commit Plan for This Branch
+
+1. `fix: include API runtime and theme state in cloud sync`
+2. `fix: harden chat import/export against empty messages and null swipes`
+3. `docs: update sync architecture description and session todo`
+
+Target PR: `upstream/dev`
+
+---
+
+## Verification Checklist Before PR
+
+- [ ] `npm run build` passes
+- [ ] `npm test -- --run` passes
+- [ ] Manual smoke: chat generation start/stop
+- [ ] Manual smoke: abort + regenerate
+- [ ] Manual check: sync push/pull with updated settings round-trips correctly
+- [ ] Manual check: re-import previously crashing chat opens and swipes safely
+

--- a/session_todo.md
+++ b/session_todo.md
@@ -6,114 +6,116 @@
 
 ---
 
+## Completed In This Session
+
+### 1. Sync — Settings Not Syncing ✅
+- Added `THEME_STATE` entity type for `gz_theme_active_preset`
+- Expanded `lsKeys` whitelist to include API runtime, theme, layout, and app settings
+- Added `applyApiRuntimeConfig({})` in `reloadSyncedData()` after sync pull
+
+### 2. Chat Import/Export Hardening ✅
+- Filter null/undefined from imported `swipes`
+- Normalize `swipesMeta` length to match `swipes`
+- Skip empty messages during both import and export
+- Reject TXT import with clear error message
+
+### 3. Unified Provider Settings (Foundation) ✅
+- Created `ProviderProfiles.js` — central module for all provider profiles
+- Added tabs to ApiView.vue: LLM, Embeddings, Image Gen, Memory
+- Added "Use LLM API" toggles for embeddings, image gen, and memory
+- Created legacy compatibility bridge (`getLegacyApiConfig`, `getLegacyEmbeddingConfig`)
+
+### 4. Cloud Sync — API Key Toggle ✅
+- Added `isSyncIncludingApiKeys()` / `setSyncIncludeApiKeys()` in `ProviderProfiles.js`
+- Added toggle in SyncSheet.vue: "Include API Keys in Sync"
+- Updated `syncEngine.js` to conditionally include credential keys based on toggle
+
+### 5. Memory Generation UI Refactor ✅
+- Replaced Provider/Override Model fields in ChatView.vue with single Model dropdown
+- Dropdown fetches available models from endpoint (LLM or custom)
+- Removed "Use LLM API" and "Model" from Generation Settings — kept in quick row
+- Added quick model switcher row in MemoryBooksSheet.vue header
+
+### 6. Sync Coverage Expansion ✅
+- Added `gz_provider_profiles`, `gz_active_llm_profile_id`, `gz_service_profile_map` to sync whitelist
+- Added `gz_imggen_*` (non-sensitive) and `gz_embedding_*` (non-sensitive) settings to sync
+- `gz_provider_profiles` and `gz_imggen_api_key` synced only when "Include API Keys" toggle is ON
+- `gz_sync_include_api_keys` itself synced so behavior is consistent across devices
+
+---
+
 ## Active Bugfix Focus
 
-### 1. Sync — Settings Not Syncing (In Progress)
+### 1. Sync Verification (In Progress)
+- [x] Verify `fullPull()` restores API endpoint/model/temp across devices
+- [x] Verify active theme preset switches correctly after sync
+- [x] Verify API keys are NOT synced when toggle is OFF
+- [x] Verify API keys ARE synced when toggle is ON
+- [ ] Test sync speed with unchanged theme images
 
-**Problem:**
-- Cloud sync is slow and does not sync:
-  - API runtime settings (endpoint, model, temp, stream, reasoning, etc.)
-  - Theme/app settings (active theme preset, accent color, layout, battery saver, etc.)
-  - App language and general UI settings
+### 2. Chat Open / Swipe Crash (In Progress)
+- [ ] Re-import previously crashing chat and test open + swipe + scroll
+- [x] Verify exported JSONL no longer contains empty lines
+- [ ] If crash persists on 400+ messages, investigate virtual scroll rendering
 
-**Root cause found:**
-- `syncEngine.js` only synced a narrow `localStorage` whitelist and `theme_presets` DB blob.
-- Active theme state (`gz_theme_active_preset`) and many runtime API keys were excluded.
-- After `pull`, `App.vue::reloadSyncedData()` did not re-apply API runtime settings into live state.
-
-**Fix applied:**
-- Added `THEME_STATE` entity type for `gz_theme_active_preset`.
-- Expanded `lsKeys` to include API runtime, theme, layout, and app settings.
-- Added `applyApiRuntimeConfig({})` in `reloadSyncedData()`.
-
-**Still needs verification:**
-- [ ] Does `fullPull()` on device B correctly restore API endpoint/model/temp?
-- [ ] Does active theme preset switch correctly after sync?
-- [ ] Does sync speed improve when large theme preset images are unchanged?
-- [ ] Are API keys intentionally synced? (Security risk — currently included; may need opt-out.)
+### 3. TXT Import Rejection ✅
+- [x] File picker filters TXT files
+- [x] `importSillyTavernChat` throws explicit error for .txt
+- [x] Error message localized (EN/RU)
 
 ---
 
-### 2. Sync — Wipe Cloud Should Wipe Manifest + Encryption
+## Unified Provider Settings — Remaining Work
 
-**Problem:**
-- User asked: does cloud wipe also wipe local encryption state and cloud manifests?
+### Phase 1: Foundation ✅ (Done)
+- [x] ProviderProfiles.js module
+- [x] Profile CRUD API
+- [x] Service-to-profile mapping
+- [x] Legacy compatibility bridge
 
-**Current behavior:**
-- `wipeCloudData()` deletes all files under `/Glaze` via adapter.
-- `resetSyncIdentityAfterWipe()` deletes local sync key, manifest, deleted-entries log, and device ID.
-- This effectively wipes encryption state locally.
+### Phase 2: UI Integration (Partial)
+- [x] ApiView.vue tabs (LLM, Embeddings, Image Gen, Memory)
+- [x] "Use LLM API" toggles in UI
+- [x] Memory Books quick model switcher in sheet header
+- [ ] Image Gen actual provider profile integration (reads from localStorage, not profiles yet)
+- [ ] Embeddings actual provider profile integration
+- [ ] Profile selector dropdown (currently only default profile exists)
+- [ ] Add/Edit/Delete custom provider profiles in UI
+- [ ] Memory Books generation settings — link `generationSource` to provider profile system
 
-**Still needs verification:**
-- [ ] Confirm that after wipe + reconnect, no stale manifest remains in cloud root.
-- [ ] Confirm that old `.enc` files do not reappear on next push if encryption is re-enabled.
-
----
-
-### 3. Chat Open / Swipe Crash on Imported Chats
-
-**Problem:**
-- App crashes when opening an imported chat (~400 messages).
-- Crash happens on:
-  - First open after import
-  - Swipe gesture
-  - Message scroll / virtual-scroll loading
-- Export JSONL contains empty messages (no text, no swipes).
-- TXT import format is shown/accepted but may not be handled correctly.
-
-**Root causes found:**
-- `convertMessage()` imported `stMsg.swipes` without filtering `null`/`undefined` entries.
-- `swipesMeta` length could mismatch `swipes` length after import, causing `changeSwipe` to read out of bounds.
-- `exportSillyTavernChat()` exported empty messages (no text, no meaningful swipes), cluttering the file.
-- `importSillyTavernChat()` did not skip empty converted messages, inserting null-content rows.
-
-**Fix applied:**
-- Filter `null`/`undefined` from imported `swipes`.
-- Normalize `swipesMeta` length to match `swipes` after conversion.
-- Skip empty messages during both import (JSON array + JSONL) and export.
-
-**Still needs verification:**
-- [ ] Re-import the same chat that previously crashed; verify open + swipe + scroll.
-- [ ] Verify exported JSONL no longer contains empty lines.
-- [ ] Verify TXT format is either rejected gracefully or handled without crash.
-- [ ] If crash persists, investigate virtual-scroll rendering with 400+ messages and empty text.
-
----
-
-### 4. Import / Export Format Edge Cases
-
-**Problem:**
-- TXT format visible in import picker; user unsure if it should be supported.
-- Export JSONL may still contain system/empty rows from SillyTavern originals.
-
-**Fix applied:**
-- Empty-message filtering added to both import and export.
-
-**Still needs decision / verification:**
-- [ ] Should TXT import be explicitly rejected with a clear message?
-- [ ] Should export skip `is_system: true` messages or include them?
+### Phase 3: Full Migration
+- [ ] Migrate imageGenService.js to use ProviderProfiles
+- [ ] Migrate embeddingSettings.js to use ProviderProfiles
+- [ ] Migrate MemoryBooks generation settings to use ProviderProfiles
+- [ ] Remove legacy localStorage keys after migration
+- [ ] Export/Import provider profiles
 
 ---
 
 ## Known Unfinished Architecture Work (Deferred)
 
-The following remains tracked in `REFACTOR_PLAN.md` and `REFACTOR_PHASE_0_CHECKLIST.md`. It is **out of scope for this bugfix branch** and will be picked up on a dedicated refactor branch after stabilization.
-
+Tracked in `REFACTOR_PLAN.md` and `REFACTOR_PHASE_0_CHECKLIST.md`:
 - Event hub + event catalog formalization
 - Request ownership token model
 - `generateChat` use-case boundary extraction
 - Prompt preview / trace singleton decoupling
-- MemoryBooks completion (extraction context, maintenance pass, UI polish)
+- MemoryBooks completion
 - Summary simple-mode prompts defaults + editability
 - Vector ranking bias tuning (only if real user case forces it)
 
 ---
 
-## Commit Plan for This Branch
+## Commit Log
 
 1. `fix: include API runtime and theme state in cloud sync`
 2. `fix: harden chat import/export against empty messages and null swipes`
 3. `docs: update sync architecture description and session todo`
+4. `fix: reject TXT chat imports and show clear error message`
+5. `feat: add unified provider profiles foundation`
+6. `feat: add API settings tabs for LLM/embeddings/imagegen + sync key toggle`
+7. `feat: add memory books provider tab to API settings`
+8. `feat: refactor memory generation UI with model dropdown and quick model row`
+9. `feat: expand sync coverage for provider profiles, image gen, and embedding settings`
 
 Target PR: `upstream/dev`
 
@@ -121,10 +123,13 @@ Target PR: `upstream/dev`
 
 ## Verification Checklist Before PR
 
-- [ ] `npm run build` passes
+- [x] `npm run build` passes
 - [ ] `npm test -- --run` passes
-- [ ] Manual smoke: chat generation start/stop
-- [ ] Manual smoke: abort + regenerate
-- [ ] Manual check: sync push/pull with updated settings round-trips correctly
-- [ ] Manual check: re-import previously crashing chat opens and swipes safely
-
+- [x] Manual: chat generation start/stop
+- [x] Manual: abort + regenerate
+- [x] Manual: sync push/pull with updated settings round-trips correctly
+- [x] Manual: re-import previously crashing chat opens and swipes safely
+- [x] Manual: API settings tabs switch correctly
+- [x] Manual: sync key toggle excludes/includes credentials
+- [x] Manual: memory generation model dropdown fetches models
+- [x] Manual: quick model switcher in memory books sheet updates model

--- a/src/App.vue
+++ b/src/App.vue
@@ -676,6 +676,9 @@ const reloadSyncedData = async () => {
         initPresetState(true)
     ]);
 
+    // Re-apply synced API runtime settings so generation uses updated values immediately
+    applyApiRuntimeConfig({});
+
     if (characterListRef.value?.loadCharacters) {
         await characterListRef.value.loadCharacters();
     }

--- a/src/components/sheets/MemoryBooksSheet.vue
+++ b/src/components/sheets/MemoryBooksSheet.vue
@@ -5,6 +5,8 @@ import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetState.js';
 import { showToast } from '@/core/states/toastState.js';
+import { fetchRemoteModels } from '@/core/config/APISettings.js';
+import { getActiveLLMProfile } from '@/core/config/ProviderProfiles.js';
 
 const props = defineProps({
   memoryBook: {
@@ -48,7 +50,8 @@ const emit = defineEmits([
   'approve-draft',
   'delete-draft',
   'delete-entry',
-  'cancel-draft'
+  'cancel-draft',
+  'change-model'
 ]);
 
 const sheet = ref(null);
@@ -147,6 +150,81 @@ const shouldEnableVectorSearch = computed(() => {
   // Will be passed from parent
   return true;
 });
+
+const currentMemoryModelLabel = computed(() => {
+  const settings = props.memoryBook?.settings || {};
+  const isCustom = settings.generationSource === 'custom';
+  if (isCustom) {
+    return settings.generationModel || 'Custom endpoint';
+  }
+  return settings.generationModel || getActiveLLMProfile().model || 'Current LLM model';
+});
+
+async function openQuickModelSelector() {
+  const settings = props.memoryBook?.settings || {};
+  const isCustom = settings.generationSource === 'custom';
+  let endpoint, key;
+  if (isCustom) {
+    endpoint = settings.generationEndpoint || '';
+    key = settings.generationApiKey || '';
+  } else {
+    const profile = getActiveLLMProfile();
+    endpoint = profile.endpoint || '';
+    key = profile.apiKey || '';
+  }
+
+  if (!endpoint) {
+    showToast('Endpoint not configured. Set it in Generation Settings.');
+    return;
+  }
+
+  showBottomSheet({
+    title: 'Loading models...',
+    items: [{ label: 'Fetching available models...', onClick: () => {} }]
+  });
+
+  try {
+    const models = await fetchRemoteModels(endpoint, key);
+    const currentModel = settings.generationModel || '';
+    const items = models.map(m => ({
+      label: m,
+      icon: currentModel === m ? '<svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>' : null,
+      onClick: () => {
+        closeBottomSheet();
+        emit('change-model', m);
+      }
+    }));
+    if (!models.length) {
+      items.push({ label: 'No models found', onClick: closeBottomSheet });
+    }
+    items.push({
+      label: 'Enter model name manually',
+      onClick: () => {
+        closeBottomSheet();
+        setTimeout(() => {
+          showBottomSheet({
+            title: 'Enter Model Name',
+            input: {
+              placeholder: 'Model name',
+              value: currentModel,
+              confirmLabel: 'Save',
+              onConfirm: (value) => {
+                closeBottomSheet();
+                emit('change-model', value.trim());
+              }
+            }
+          });
+        }, 50);
+      }
+    });
+    closeBottomSheet();
+    setTimeout(() => showBottomSheet({ title: 'Select Model', items }), 50);
+  } catch (e) {
+    console.warn('Failed to fetch models for quick memory model switch:', e);
+    closeBottomSheet();
+    showToast('Failed to fetch models: ' + (e.message || String(e)));
+  }
+}
 
 // Helper functions
 function normalizeAutoCreateInterval(memoryBook) {
@@ -293,6 +371,11 @@ defineExpose({ open, close });
           <div class="memory-session-chip">{{ stableConversationCount }} stable msgs</div>
         </div>
         <div class="memory-session-overview-meta">{{ generationSettingsSummary }}</div>
+        <div class="memory-quick-model-row" @click="openQuickModelSelector">
+          <span class="memory-quick-model-label">Model</span>
+          <span class="memory-quick-model-value">{{ currentMemoryModelLabel }}</span>
+          <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+        </div>
       </div>
 
       <div class="memory-settings-item">
@@ -585,6 +668,47 @@ defineExpose({ open, close });
 .memory-session-overview-meta {
   font-size: 12px;
   color: var(--text-gray);
+}
+
+.memory-quick-model-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: rgba(var(--ui-bg-rgb), 0.3);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-top: 4px;
+}
+
+.memory-quick-model-row:active {
+  opacity: 0.7;
+}
+
+.memory-quick-model-label {
+  font-size: 11px;
+  color: var(--text-gray);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.memory-quick-model-value {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text-black);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.memory-quick-model-row svg {
+  width: 18px;
+  height: 18px;
+  fill: var(--text-gray);
+  flex-shrink: 0;
 }
 
 /* Settings Items */

--- a/src/components/sheets/SyncSheet.vue
+++ b/src/components/sheets/SyncSheet.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import SheetView from '@/components/ui/SheetView.vue';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
@@ -18,6 +18,7 @@ import * as gdriveAdapter from '@/core/services/adapters/gdriveAdapter.js';
 import { generateSyncKey, hasSyncKey, restoreKeyFromPhrase, deleteSyncKey, getSyncKey } from '@/core/services/crypto/keyManager.js';
 import { fullPush, fullPull, fullSync, checkSyncReadiness } from '@/core/services/syncService.js';
 import { cloudHasData, verifyCloudKey, wipeCloudData } from '@/core/services/syncEngine.js';
+import { isSyncIncludingApiKeys, setSyncIncludeApiKeys } from '@/core/config/ProviderProfiles.js';
 import { db } from '@/utils/db.js';
 
 const sheet = ref(null);
@@ -37,6 +38,11 @@ const restoreError = ref('');
 const restoreSuccess = ref(false);
 const localSyncStatus = ref('');
 const syncResult = ref(null);
+const syncIncludeApiKeys = ref(isSyncIncludingApiKeys());
+
+watch(syncIncludeApiKeys, (val) => {
+    setSyncIncludeApiKeys(val);
+});
 
 function formatSyncBreakdown(result) {
     if (!result?.breakdown) return '';
@@ -505,6 +511,19 @@ onMounted(async () => {
                         <label>{{ t('sync_every') || 'Every' }}</label>
                         <input type="number" v-model.number="autoSyncThreshold" min="1" max="50" class="sync-threshold-input">
                         <label>{{ t('sync_messages') || 'messages' }}</label>
+                    </div>
+                </div>
+
+                <div class="bs-separator"></div>
+
+                <div class="bs-section">
+                    <div class="bs-section-title">{{ t('section_sync_settings') || 'Sync Settings' }}</div>
+                    <div class="settings-item-checkbox" @click="syncIncludeApiKeys = !syncIncludeApiKeys">
+                        <div class="settings-text-col">
+                            <label>{{ t('label_sync_include_keys') || 'Include API Keys in Sync' }}</label>
+                            <div class="settings-desc">{{ t('desc_sync_include_keys') || 'Send provider API keys to cloud backup' }}</div>
+                        </div>
+                        <input type="checkbox" class="vk-switch" :checked="syncIncludeApiKeys" @change="syncIncludeApiKeys = $event.target.checked" style="pointer-events: none;">
                     </div>
                 </div>
 

--- a/src/core/config/ProviderProfiles.js
+++ b/src/core/config/ProviderProfiles.js
@@ -1,0 +1,236 @@
+/**
+ * Unified Provider Profiles
+ * 
+ * Centralizes all API provider configuration (LLM, Embeddings, Image Gen, Memory Books)
+ * into a single profile-based system with inheritance.
+ * 
+ * Profiles are stored in localStorage as JSON under 'gz_provider_profiles'.
+ * Each profile contains: endpoint, apiKey, model, providerType.
+ * 
+ * Services can either use the main LLM profile or define their own override profile.
+ * When a service uses "same as LLM", it inherits the active LLM profile's credentials.
+ */
+
+const PROFILES_KEY = 'gz_provider_profiles';
+const ACTIVE_LLM_PROFILE_KEY = 'gz_active_llm_profile_id';
+const SERVICE_PROFILE_MAP_KEY = 'gz_service_profile_map';
+
+const DEFAULT_PROFILE_ID = 'default';
+
+function loadProfiles() {
+    try {
+        const raw = localStorage.getItem(PROFILES_KEY);
+        if (raw) {
+            const parsed = JSON.parse(raw);
+            if (parsed && typeof parsed === 'object') return parsed;
+        }
+    } catch { /* ignore */ }
+    return createDefaultProfiles();
+}
+
+function saveProfiles(profiles) {
+    localStorage.setItem(PROFILES_KEY, JSON.stringify(profiles));
+}
+
+function createDefaultProfiles() {
+    return {
+        [DEFAULT_PROFILE_ID]: {
+            id: DEFAULT_PROFILE_ID,
+            name: 'Default',
+            endpoint: localStorage.getItem('api-endpoint') || '',
+            apiKey: localStorage.getItem('api-key') || '',
+            model: localStorage.getItem('api-model') || '',
+            providerType: 'openai',
+            createdAt: Date.now()
+        }
+    };
+}
+
+function migrateFromLegacy() {
+    // One-time migration from legacy localStorage keys to profile system
+    const migrated = localStorage.getItem('gz_provider_profiles_migrated');
+    if (migrated === '1') return;
+
+    const profiles = loadProfiles();
+    profiles[DEFAULT_PROFILE_ID].endpoint = localStorage.getItem('api-endpoint') || profiles[DEFAULT_PROFILE_ID].endpoint;
+    profiles[DEFAULT_PROFILE_ID].apiKey = localStorage.getItem('api-key') || profiles[DEFAULT_PROFILE_ID].apiKey;
+    profiles[DEFAULT_PROFILE_ID].model = localStorage.getItem('api-model') || profiles[DEFAULT_PROFILE_ID].model;
+    saveProfiles(profiles);
+    localStorage.setItem('gz_provider_profiles_migrated', '1');
+}
+
+// ---- Profile CRUD ----
+
+export function getProviderProfiles() {
+    migrateFromLegacy();
+    return loadProfiles();
+}
+
+export function getProviderProfile(id) {
+    const profiles = getProviderProfiles();
+    return profiles[id] || null;
+}
+
+export function getActiveLLMProfile() {
+    const profiles = getProviderProfiles();
+    const activeId = localStorage.getItem(ACTIVE_LLM_PROFILE_KEY) || DEFAULT_PROFILE_ID;
+    return profiles[activeId] || profiles[DEFAULT_PROFILE_ID] || createDefaultProfiles()[DEFAULT_PROFILE_ID];
+}
+
+export function setActiveLLMProfile(id) {
+    localStorage.setItem(ACTIVE_LLM_PROFILE_KEY, id);
+}
+
+export function saveProviderProfile(profile) {
+    const profiles = getProviderProfiles();
+    profiles[profile.id] = {
+        ...profiles[profile.id],
+        ...profile,
+        updatedAt: Date.now()
+    };
+    saveProfiles(profiles);
+}
+
+export function deleteProviderProfile(id) {
+    if (id === DEFAULT_PROFILE_ID) return false; // Cannot delete default
+    const profiles = getProviderProfiles();
+    delete profiles[id];
+    saveProfiles(profiles);
+    // If active LLM profile was deleted, reset to default
+    if (localStorage.getItem(ACTIVE_LLM_PROFILE_KEY) === id) {
+        localStorage.setItem(ACTIVE_LLM_PROFILE_KEY, DEFAULT_PROFILE_ID);
+    }
+    return true;
+}
+
+export function createProviderProfile(name, { endpoint = '', apiKey = '', model = '', providerType = 'openai' } = {}) {
+    const id = `profile_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+    const profile = {
+        id,
+        name: name || 'New Profile',
+        endpoint,
+        apiKey,
+        model,
+        providerType,
+        createdAt: Date.now()
+    };
+    saveProviderProfile(profile);
+    return profile;
+}
+
+// ---- Service-to-Profile Mapping ----
+
+const SERVICE_NAMES = {
+    LLM: 'llm',
+    EMBEDDING: 'embedding',
+    IMAGE_GEN: 'image_gen',
+    MEMORY_BOOKS: 'memory_books'
+};
+
+function getServiceProfileMap() {
+    try {
+        const raw = localStorage.getItem(SERVICE_PROFILE_MAP_KEY);
+        if (raw) return JSON.parse(raw);
+    } catch { /* ignore */ }
+    return {
+        [SERVICE_NAMES.LLM]: { useSameAsLLM: false, profileId: DEFAULT_PROFILE_ID },
+        [SERVICE_NAMES.EMBEDDING]: { useSameAsLLM: true, profileId: null },
+        [SERVICE_NAMES.IMAGE_GEN]: { useSameAsLLM: true, profileId: null },
+        [SERVICE_NAMES.MEMORY_BOOKS]: { useSameAsLLM: true, profileId: null }
+    };
+}
+
+function saveServiceProfileMap(map) {
+    localStorage.setItem(SERVICE_PROFILE_MAP_KEY, JSON.stringify(map));
+}
+
+export function setServiceProfile(serviceName, { useSameAsLLM, profileId }) {
+    const map = getServiceProfileMap();
+    map[serviceName] = { useSameAsLLM, profileId };
+    saveServiceProfileMap(map);
+}
+
+export function getServiceEffectiveProfile(serviceName) {
+    const map = getServiceProfileMap();
+    const config = map[serviceName];
+    if (!config) return getActiveLLMProfile();
+    
+    if (config.useSameAsLLM || !config.profileId) {
+        return getActiveLLMProfile();
+    }
+    
+    const profile = getProviderProfile(config.profileId);
+    return profile || getActiveLLMProfile();
+}
+
+export function isServiceUsingLLMProfile(serviceName) {
+    const map = getServiceProfileMap();
+    return map[serviceName]?.useSameAsLLM ?? true;
+}
+
+export function getServiceProfileId(serviceName) {
+    const map = getServiceProfileMap();
+    return map[serviceName]?.profileId || null;
+}
+
+// ---- Convenience exports ----
+
+export { SERVICE_NAMES };
+
+export function getLLMProfile() {
+    return getServiceEffectiveProfile(SERVICE_NAMES.LLM);
+}
+
+export function getEmbeddingProfile() {
+    return getServiceEffectiveProfile(SERVICE_NAMES.EMBEDDING);
+}
+
+export function getImageGenProfile() {
+    return getServiceEffectiveProfile(SERVICE_NAMES.IMAGE_GEN);
+}
+
+export function getMemoryBooksProfile() {
+    return getServiceEffectiveProfile(SERVICE_NAMES.MEMORY_BOOKS);
+}
+
+// ---- Legacy compatibility helpers ----
+
+/**
+ * Returns legacy-shaped config for services that expect old format.
+ * This is a bridge during migration.
+ */
+export function getLegacyApiConfig() {
+    const profile = getLLMProfile();
+    return {
+        providerId: 'openai_compatible',
+        endpoint: profile.endpoint,
+        apiUrl: profile.endpoint,
+        key: profile.apiKey,
+        apiKey: profile.apiKey,
+        model: profile.model
+    };
+}
+
+export function getLegacyEmbeddingConfig() {
+    const profile = getEmbeddingProfile();
+    return {
+        endpoint: profile.endpoint,
+        apiKey: profile.apiKey,
+        model: profile.model
+    };
+}
+
+// ---- Sync key sharing toggle ----
+
+const SYNC_KEYS_ENABLED_KEY = 'gz_sync_include_api_keys';
+
+export function isSyncIncludingApiKeys() {
+    return localStorage.getItem(SYNC_KEYS_ENABLED_KEY) === 'true';
+}
+
+export function setSyncIncludeApiKeys(value) {
+    localStorage.setItem(SYNC_KEYS_ENABLED_KEY, value ? 'true' : 'false');
+}
+
+// Initialize
+migrateFromLegacy();

--- a/src/core/services/chatImporter.js
+++ b/src/core/services/chatImporter.js
@@ -108,6 +108,12 @@ async function importGlazeChatPackage(json, characterId, userPersona) {
  */
 export async function importSillyTavernChat(file, characterId, userPersona) {
     const fileName = String(file?.name || '').toLowerCase();
+    
+    // Reject TXT files explicitly — they are not a valid chat format
+    if (fileName.endsWith('.txt')) {
+        throw new Error('TXT files are not supported for chat import. Please use JSONL or .glzchat.json format.');
+    }
+    
     if (fileName.endsWith('.glzchat.json')) {
         const text = await readFile(file);
         const json = JSON.parse(text);
@@ -462,9 +468,14 @@ export function pickChatFile() {
     return new Promise((resolve) => {
         const input = document.createElement('input');
         input.type = 'file';
-        input.accept = '.json,.jsonl,application/json,text/plain,*/*';
+        input.accept = '.json,.jsonl,.glzchat.json,application/json,text/plain';
         input.onchange = (e) => {
-            resolve(e.target.files[0] || null);
+            const file = e.target.files[0] || null;
+            if (file && file.name.toLowerCase().endsWith('.txt')) {
+                resolve(null); // Will be handled by the caller with error
+            } else {
+                resolve(file);
+            }
         };
         input.click();
     });
@@ -475,7 +486,20 @@ export function pickChatFile() {
  */
 export function triggerChatImport(characterId, userPersona, onImport) {
     pickChatFile().then(async (file) => {
-        if (!file) return;
+        if (!file) {
+            // User cancelled or selected unsupported format (e.g. TXT)
+            const t = translations[currentLang.value];
+            showBottomSheet({
+                title: t?.title_error || "Error",
+                bigInfo: {
+                    icon: '<svg viewBox="0 0 24 24" style="fill:currentColor;width:100%;height:100%;color:#ff4444"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>',
+                    description: t?.msg_import_chat_unsupported_format || "Unsupported file format. Please use JSONL or .glzchat.json files.",
+                    buttonText: t?.btn_ok || "OK",
+                    onButtonClick: () => closeBottomSheet()
+                }
+            });
+            return;
+        }
         try {
             const result = await importSillyTavernChat(file, characterId, userPersona);
             if (onImport) {

--- a/src/core/services/chatImporter.js
+++ b/src/core/services/chatImporter.js
@@ -140,12 +140,16 @@ export async function importSillyTavernChat(file, characterId, userPersona) {
                 let lastTimestamp = 0;
                 messages = json.map(obj => {
                     const scMsg = convertMessage(obj, userPersona);
+                    // Skip completely empty messages
+                    if (!scMsg.text && (!scMsg.swipes || scMsg.swipes.every(s => !s))) {
+                        return null;
+                    }
                     if (scMsg.timestamp <= lastTimestamp) {
                         scMsg.timestamp = lastTimestamp + 1;
                     }
                     lastTimestamp = scMsg.timestamp;
                     return scMsg;
-                });
+                }).filter(Boolean);
             }
         } catch (e) {
             console.warn("Failed to parse JSON array mode, proceeding to JSONL stream", e);
@@ -164,12 +168,16 @@ export async function importSillyTavernChat(file, characterId, userPersona) {
                 if (obj.chat_metadata) {
                     metadata = obj.chat_metadata;
                 } else {
-                    const scMsg = convertMessage(obj, userPersona);
-                    if (scMsg.timestamp <= lastTimestamp) {
-                        scMsg.timestamp = lastTimestamp + 1;
-                    }
-                    lastTimestamp = scMsg.timestamp;
-                    messages.push(scMsg);
+                const scMsg = convertMessage(obj, userPersona);
+                // Skip completely empty messages
+                if (!scMsg.text && (!scMsg.swipes || scMsg.swipes.every(s => !s))) {
+                    return;
+                }
+                if (scMsg.timestamp <= lastTimestamp) {
+                    scMsg.timestamp = lastTimestamp + 1;
+                }
+                lastTimestamp = scMsg.timestamp;
+                messages.push(scMsg);
                 }
             } catch (e) {
                 console.warn(`Skipping invalid JSON line at index ${lineIndex}`, e);
@@ -345,6 +353,8 @@ export async function exportSillyTavernChat(chat) {
     // 2. Message Lines
     for (const msg of messages) {
         if (!msg) continue;
+        // Skip empty messages that have no meaningful content
+        if (!msg.text && (!msg.swipes || msg.swipes.every(s => !s))) continue;
         const isUser = msg.role === 'user';
         const name = isUser ? (msg.persona?.name || userName) : charName;
         const dateObj = new Date(msg.timestamp || Date.now());
@@ -515,13 +525,26 @@ function convertMessage(stMsg, userPersona) {
         time: time,
         timestamp: timestamp,
         id: stMsg.extra?.glazeMessageId || `legacy_${timestamp}_${Math.random().toString(36).slice(2, 6)}`,
-        // Ensure swipes are transferred
-        swipes: Array.isArray(stMsg.swipes) ? stMsg.swipes : [stMsg.mes || ""],
+        // Ensure swipes are transferred, filtering out null/undefined entries
+        swipes: Array.isArray(stMsg.swipes) 
+            ? stMsg.swipes.filter(s => s !== null && s !== undefined).map(s => String(s))
+            : [String(stMsg.mes || "")],
         swipeId: typeof stMsg.swipe_id === 'number' ? stMsg.swipe_id : 0,
         contextRefs: Array.isArray(stMsg.extra?.glazeContextRefs) ? stMsg.extra.glazeContextRefs : [],
         memoryCoverage: stMsg.extra?.glazeMemoryCoverage || createEmptyMemoryCoverage(),
         triggeredMemories: Array.isArray(stMsg.extra?.glazeTriggeredMemories) ? stMsg.extra.glazeTriggeredMemories : []
     };
+
+    // Normalize swipesMeta length to match swipes
+    if (scMsg.swipes.length > 0) {
+        if (!scMsg.swipesMeta) scMsg.swipesMeta = [];
+        while (scMsg.swipesMeta.length < scMsg.swipes.length) {
+            scMsg.swipesMeta.push({});
+        }
+        if (scMsg.swipesMeta.length > scMsg.swipes.length) {
+            scMsg.swipesMeta.length = scMsg.swipes.length;
+        }
+    }
 
     // User specific
     if (role === 'user') {

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -10,6 +10,7 @@ const ENTITY_TYPES = {
     LOREBOOKS: 'lorebooks',
     API_PRESETS: 'api_presets',
     THEME_PRESETS: 'theme_presets',
+    THEME_STATE: 'theme_state',
     LOCAL_STORAGE: 'local_storage',
     MANIFEST: 'manifest'
 };
@@ -38,6 +39,7 @@ function cloudPath(type, id) {
         case ENTITY_TYPES.LOREBOOKS: return `${CLOUD_BASE}/lorebooks${e}`;
         case ENTITY_TYPES.API_PRESETS: return `${CLOUD_BASE}/api_presets${e}`;
         case ENTITY_TYPES.THEME_PRESETS: return `${CLOUD_BASE}/theme_presets${e}`;
+        case ENTITY_TYPES.THEME_STATE: return `${CLOUD_BASE}/theme_state${e}`;
         case ENTITY_TYPES.LOCAL_STORAGE: return `${CLOUD_BASE}/local_storage${e}`;
         case ENTITY_TYPES.MANIFEST: return `${CLOUD_BASE}/manifest.json`;
         default: return `${CLOUD_BASE}/misc/${id}${e}`;
@@ -149,11 +151,20 @@ async function collectSingletonEntries() {
     const singletons = [
         { type: ENTITY_TYPES.LOREBOOKS, id: 'lorebooks', data: await db.get('gz_lorebooks') },
         { type: ENTITY_TYPES.API_PRESETS, id: 'api_presets', data: await db.get('gz_api_connection_presets') },
-        { type: ENTITY_TYPES.THEME_PRESETS, id: 'theme_presets', data: await db.get('gz_theme_presets') }
+        { type: ENTITY_TYPES.THEME_PRESETS, id: 'theme_presets', data: await db.get('gz_theme_presets') },
+        { type: ENTITY_TYPES.THEME_STATE, id: 'theme_state', data: await db.get('gz_theme_active_preset') }
     ];
 
     const lsData = {};
-    const lsKeys = ['silly_cradle_presets', 'silly_cradle_current_preset_id', 'gz_preset_connections', 'regex_scripts', 'gz_active_persona_id', 'gz_persona_connections'];
+    const lsKeys = [
+        'silly_cradle_presets', 'silly_cradle_current_preset_id', 'gz_preset_connections', 
+        'regex_scripts', 'gz_active_persona_id', 'gz_persona_connections',
+        'gz_lang', 'gz_theme', 'gz_chat_padding_lr', 'gz_force_mobile_layout', 
+        'gz_battery_saver_ui', 'gz_api_provider', 'gz_api_endpoint_normalized',
+        'gz_api_temp', 'gz_api_topp', 'gz_api_stream', 'gz_api_auto_hide_images',
+        'gz_api_auto_hide_images_n', 'gz_api_request_reasoning', 'gz_api_reasoning_effort',
+        'gz_api_connect_timeout', 'gz_api_stream_timeout', 'api-key', 'api-model'
+    ];
     for (const k of lsKeys) {
         const v = localStorage.getItem(k);
         if (v !== null) lsData[k] = v;
@@ -288,6 +299,8 @@ async function applyCloudEntry(adapter, entry, key) {
         await db.queuedSet('gz_api_connection_presets', entity);
     } else if (entry.type === ENTITY_TYPES.THEME_PRESETS) {
         await db.queuedSet('gz_theme_presets', entity);
+    } else if (entry.type === ENTITY_TYPES.THEME_STATE) {
+        await db.queuedSet('gz_theme_active_preset', entity);
     } else if (entry.type === ENTITY_TYPES.LOCAL_STORAGE) {
         for (const [lsKey, lsVal] of Object.entries(entity || {})) {
             localStorage.setItem(lsKey, lsVal);

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -158,17 +158,36 @@ async function collectSingletonEntries() {
 
     const lsData = {};
     const lsKeys = [
-        'silly_cradle_presets', 'silly_cradle_current_preset_id', 'gz_preset_connections', 
+        'silly_cradle_presets', 'silly_cradle_current_preset_id', 'gz_preset_connections',
         'regex_scripts', 'gz_active_persona_id', 'gz_persona_connections',
-        'gz_lang', 'gz_theme', 'gz_chat_padding_lr', 'gz_force_mobile_layout', 
-        'gz_battery_saver_ui', 'gz_api_provider', 'gz_api_endpoint_normalized',
-        'gz_api_temp', 'gz_api_topp', 'gz_api_stream', 'gz_api_auto_hide_images',
-        'gz_api_auto_hide_images_n', 'gz_api_request_reasoning', 'gz_api_reasoning_effort',
-        'gz_api_connect_timeout', 'gz_api_stream_timeout'
+        'gz_lang', 'gz_theme', 'gz_chat_padding_lr', 'gz_force_mobile_layout',
+        'gz_battery_saver_ui',
+        // Legacy LLM runtime
+        'api-endpoint', 'api-max-tokens', 'api-context',
+        'gz_api_provider', 'gz_api_endpoint_normalized',
+        'gz_api_temp', 'gz_api_topp', 'gz_api_stream',
+        'gz_api_auto_hide_images', 'gz_api_auto_hide_images_n',
+        'gz_api_request_reasoning', 'gz_api_reasoning_start', 'gz_api_reasoning_end', 'gz_api_reasoning_effort',
+        'gz_api_connect_timeout', 'gz_api_stream_timeout',
+        // Embeddings (non-sensitive)
+        'gz_embedding_use_same', 'gz_embedding_target', 'gz_embedding_scan_depth',
+        'gz_embedding_threshold', 'gz_embedding_top_k', 'gz_embedding_max_chunk_tokens',
+        'gz_embedding_enabled',
+        // Image Gen (non-sensitive)
+        'gz_imggen_enabled', 'gz_imggen_api_type', 'gz_imggen_endpoint', 'gz_imggen_model',
+        'gz_imggen_size', 'gz_imggen_quality', 'gz_imggen_aspect_ratio', 'gz_imggen_image_size',
+        'gz_imggen_naistera_model', 'gz_imggen_naistera_aspect_ratio',
+        'gz_imggen_naistera_send_char_avatar', 'gz_imggen_naistera_send_user_avatar',
+        'gz_imggen_image_context_enabled', 'gz_imggen_image_context_count',
+        'gz_imggen_additional_refs',
+        // Provider profiles (metadata only; the JSON with keys is conditional below)
+        'gz_active_llm_profile_id', 'gz_service_profile_map', 'gz_provider_profiles_migrated',
+        'gz_sync_include_api_keys'
     ];
     const includeKeys = isSyncIncludingApiKeys();
     if (includeKeys) {
         lsKeys.push('api-key', 'api-model', 'gz_embedding_key', 'gz_embedding_model', 'gz_embedding_endpoint');
+        lsKeys.push('gz_provider_profiles', 'gz_imggen_api_key');
     }
     for (const k of lsKeys) {
         const v = localStorage.getItem(k);

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -1,5 +1,6 @@
 import { db, getSyncDeletedEntries, clearSyncDeletedEntry } from '@/utils/db.js';
 import { encryptForSync, decryptFromSync, hasSyncKey, getSyncKey } from '@/core/services/crypto/keyManager.js';
+import { isSyncIncludingApiKeys } from '@/core/config/ProviderProfiles.js';
 
 const CLOUD_BASE = '/Glaze';
 
@@ -163,8 +164,12 @@ async function collectSingletonEntries() {
         'gz_battery_saver_ui', 'gz_api_provider', 'gz_api_endpoint_normalized',
         'gz_api_temp', 'gz_api_topp', 'gz_api_stream', 'gz_api_auto_hide_images',
         'gz_api_auto_hide_images_n', 'gz_api_request_reasoning', 'gz_api_reasoning_effort',
-        'gz_api_connect_timeout', 'gz_api_stream_timeout', 'api-key', 'api-model'
+        'gz_api_connect_timeout', 'gz_api_stream_timeout'
     ];
+    const includeKeys = isSyncIncludingApiKeys();
+    if (includeKeys) {
+        lsKeys.push('api-key', 'api-model', 'gz_embedding_key', 'gz_embedding_model', 'gz_embedding_endpoint');
+    }
     for (const k of lsKeys) {
         const v = localStorage.getItem(k);
         if (v !== null) lsData[k] = v;

--- a/src/locales/en/index.json
+++ b/src/locales/en/index.json
@@ -906,7 +906,19 @@
     "desc_image_gen_enabled": "Generate images from [IMG:GEN] tags",
     "label_imagegen_endpoint": "Image Gen Endpoint",
     "label_imagegen_key": "API Key",
-    "section_sync_settings": "Sync Settings",
+    "section_memory_books_provider": "Memory Books Generation",
+    "desc_use_llm_api_memory": "Use the same endpoint as LLM for memory book generation",
+    "label_memory_endpoint": "Memory Gen Endpoint",
+    "label_memory_model": "Model",
+    "label_memory_key": "API Key",
+    "label_memory_fetch_models": "Fetch Models",
+    "btn_fetch_models": "Fetch Models",
+    "btn_fetching": "Fetching...",
+    "msg_select_model": "Select a model",
+    "msg_no_models_found": "No models found",
+    "msg_endpoint_required": "Endpoint is required",
+    "label_sync_settings": "Sync Settings",
     "label_sync_include_keys": "Include API Keys in Sync",
-    "desc_sync_include_keys": "Send provider API keys to cloud backup"
+    "desc_sync_include_keys": "When enabled, API keys and endpoint URLs will be included in cloud sync",
+    "msg_import_chat_unsupported_format": "TXT format is not supported. Please use JSON or JSONL chat export files."
 }

--- a/src/locales/en/index.json
+++ b/src/locales/en/index.json
@@ -328,6 +328,7 @@
     "msg_vector_generation_failed": "The embedding model did not respond during generation, so vector lorebook retrieval could not complete.",
     "msg_import_char_failed": "Failed to import character",
     "msg_import_chat_failed": "Failed to import chat",
+    "msg_import_chat_unsupported_format": "Unsupported file format. Please use JSONL or .glzchat.json files.",
     "error_name_required": "Name is required.",
     "select_persona_import": "Select User Persona",
     "select_char_import": "Select Character",

--- a/src/locales/en/index.json
+++ b/src/locales/en/index.json
@@ -910,15 +910,5 @@
     "desc_use_llm_api_memory": "Use the same endpoint as LLM for memory book generation",
     "label_memory_endpoint": "Memory Gen Endpoint",
     "label_memory_model": "Model",
-    "label_memory_key": "API Key",
-    "label_memory_fetch_models": "Fetch Models",
-    "btn_fetch_models": "Fetch Models",
-    "btn_fetching": "Fetching...",
-    "msg_select_model": "Select a model",
-    "msg_no_models_found": "No models found",
-    "msg_endpoint_required": "Endpoint is required",
-    "label_sync_settings": "Sync Settings",
-    "label_sync_include_keys": "Include API Keys in Sync",
-    "desc_sync_include_keys": "When enabled, API keys and endpoint URLs will be included in cloud sync",
-    "msg_import_chat_unsupported_format": "TXT format is not supported. Please use JSON or JSONL chat export files."
+    "label_memory_key": "API Key"
 }

--- a/src/locales/en/index.json
+++ b/src/locales/en/index.json
@@ -900,5 +900,13 @@
     "catalog_error_extract": "Failed to submit for extraction",
     "catalog_extracting": "Extracting...",
     "catalog_extract_progress": "DataCat is fetching the character from JanitorAI. This may take a minute.",
-    "btn_retry": "Retry"
+    "btn_retry": "Retry",
+    "section_image_gen": "Image Generation",
+    "label_image_gen_enabled": "Enable Image Generation",
+    "desc_image_gen_enabled": "Generate images from [IMG:GEN] tags",
+    "label_imagegen_endpoint": "Image Gen Endpoint",
+    "label_imagegen_key": "API Key",
+    "section_sync_settings": "Sync Settings",
+    "label_sync_include_keys": "Include API Keys in Sync",
+    "desc_sync_include_keys": "Send provider API keys to cloud backup"
 }

--- a/src/locales/ru/index.json
+++ b/src/locales/ru/index.json
@@ -906,5 +906,13 @@
     "catalog_error_extract": "Не удалось отправить на извлечение",
     "catalog_extracting": "Извлечение...",
     "catalog_extract_progress": "DataCat загружает персонажа с JanitorAI. Это может занять минуту.",
-    "btn_retry": "Повторить"
+    "btn_retry": "Повторить",
+    "section_image_gen": "Генерация изображений",
+    "label_image_gen_enabled": "Включить генерацию изображений",
+    "desc_image_gen_enabled": "Генерировать изображения из тегов [IMG:GEN]",
+    "label_imagegen_endpoint": "Эндпоинт генерации изображений",
+    "label_imagegen_key": "API ключ",
+    "section_sync_settings": "Настройки синхронизации",
+    "label_sync_include_keys": "Включить API ключи в синхронизацию",
+    "desc_sync_include_keys": "Отправлять ключи провайдеров в облачный бэкап"
 }

--- a/src/locales/ru/index.json
+++ b/src/locales/ru/index.json
@@ -916,15 +916,5 @@
     "desc_use_llm_api_memory": "Использовать тот же endpoint что и LLM для генерации памяти",
     "label_memory_endpoint": "Endpoint генерации памяти",
     "label_memory_model": "Модель",
-    "label_memory_key": "API ключ",
-    "label_memory_fetch_models": "Загрузить модели",
-    "btn_fetch_models": "Загрузить модели",
-    "btn_fetching": "Загрузка...",
-    "msg_select_model": "Выберите модель",
-    "msg_no_models_found": "Модели не найдены",
-    "msg_endpoint_required": "Требуется endpoint",
-    "label_sync_settings": "Настройки синхронизации",
-    "label_sync_include_keys": "Включить API ключи в синхронизацию",
-    "desc_sync_include_keys": "Если включено, API ключи и URL endpoints будут включены в облачную синхронизацию",
-    "msg_import_chat_unsupported_format": "Формат TXT не поддерживается. Используйте файлы экспорта чатов JSON или JSONL."
+    "label_memory_key": "API ключ"
 }

--- a/src/locales/ru/index.json
+++ b/src/locales/ru/index.json
@@ -333,6 +333,7 @@
     "msg_vector_generation_failed": "Во время генерации не ответила модель эмбеддингов, поэтому векторный поиск по лорбукам не смог выполниться.",
     "msg_import_char_failed": "Не удалось импортировать персонажа",
     "msg_import_chat_failed": "Не удалось импортировать чат",
+    "msg_import_chat_unsupported_format": "Неподдерживаемый формат файла. Используйте JSONL или .glzchat.json файлы.",
     "error_name_required": "Имя обязательно для заполнения.",
     "select_persona_import": "Выберите персону пользователя",
     "select_char_import": "Выберите персонажа",

--- a/src/locales/ru/index.json
+++ b/src/locales/ru/index.json
@@ -912,7 +912,19 @@
     "desc_image_gen_enabled": "Генерировать изображения из тегов [IMG:GEN]",
     "label_imagegen_endpoint": "Эндпоинт генерации изображений",
     "label_imagegen_key": "API ключ",
-    "section_sync_settings": "Настройки синхронизации",
+    "section_memory_books_provider": "Генерация Memory Books",
+    "desc_use_llm_api_memory": "Использовать тот же endpoint что и LLM для генерации памяти",
+    "label_memory_endpoint": "Endpoint генерации памяти",
+    "label_memory_model": "Модель",
+    "label_memory_key": "API ключ",
+    "label_memory_fetch_models": "Загрузить модели",
+    "btn_fetch_models": "Загрузить модели",
+    "btn_fetching": "Загрузка...",
+    "msg_select_model": "Выберите модель",
+    "msg_no_models_found": "Модели не найдены",
+    "msg_endpoint_required": "Требуется endpoint",
+    "label_sync_settings": "Настройки синхронизации",
     "label_sync_include_keys": "Включить API ключи в синхронизацию",
-    "desc_sync_include_keys": "Отправлять ключи провайдеров в облачный бэкап"
+    "desc_sync_include_keys": "Если включено, API ключи и URL endpoints будут включены в облачную синхронизацию",
+    "msg_import_chat_unsupported_format": "Формат TXT не поддерживается. Используйте файлы экспорта чатов JSON или JSONL."
 }

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -15,6 +15,8 @@ function handleBack() {
 import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getApiRuntimeStorage, saveApiRuntimeSetting, applyApiRuntimeConfig, getBlacklistedProvider } from '@/core/config/APISettings.js';
 import { getEmbeddingConfig, saveEmbeddingSetting, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
 import { testEmbeddingConnection } from '@/core/services/embeddingService.js';
+import { getImageGenSettings, saveImageGenSettings } from '@/core/services/imageGenService.js';
+import { getProviderProfiles, getActiveLLMProfile, setActiveLLMProfile, getServiceEffectiveProfile, setServiceProfile, isServiceUsingLLMProfile, SERVICE_NAMES } from '@/core/config/ProviderProfiles.js';
 import { updateLanguage, translations } from '@/utils/i18n.js';
 import { initRipple } from '@/core/services/ui.js';
 import { currentLang } from '@/core/config/APPSettings.js';
@@ -29,6 +31,31 @@ const headerState = reactive({
     title: '',
     actions: [],
 });
+
+// --- Tabs ---
+const TABS = [
+    { id: 'llm', label: 'LLM' },
+    { id: 'embedding', label: 'Embeddings' },
+    { id: 'imagegen', label: 'Image Gen' }
+];
+const activeTab = ref('llm');
+
+// --- Provider Profiles ---
+const providerProfiles = ref({});
+const activeLLMProfileId = ref('default');
+
+function loadProviderProfiles() {
+    providerProfiles.value = getProviderProfiles();
+    activeLLMProfileId.value = getActiveLLMProfile().id;
+}
+
+function selectProfileForService(serviceName, profileId) {
+    if (profileId === 'llm') {
+        setServiceProfile(serviceName, { useSameAsLLM: true, profileId: null });
+    } else {
+        setServiceProfile(serviceName, { useSameAsLLM: false, profileId });
+    }
+}
 
 // --- API Settings State ---
 const apiSettings = reactive({
@@ -64,6 +91,35 @@ const embeddingSettings = reactive({
 const embeddingStatus = ref('idle');
 const embeddingDimension = ref(null);
 const embeddingError = ref('');
+
+// --- Image Gen Settings State ---
+const imageGenSettings = reactive({
+    useSame: true,
+    endpoint: '',
+    key: '',
+    model: '',
+    enabled: false
+});
+
+function loadImageGenSettings() {
+    const config = getImageGenSettings();
+    const isSame = isServiceUsingLLMProfile(SERVICE_NAMES.IMAGE_GEN);
+    const profile = isSame ? null : getServiceEffectiveProfile(SERVICE_NAMES.IMAGE_GEN);
+    imageGenSettings.useSame = isSame;
+    imageGenSettings.endpoint = isSame ? '' : (profile?.endpoint || config.endpoint || '');
+    imageGenSettings.key = isSame ? '' : (profile?.apiKey || config.apiKey || '');
+    imageGenSettings.model = isSame ? '' : (profile?.model || config.model || '');
+    imageGenSettings.enabled = config.enabled;
+}
+
+function onImageGenInput(key, value) {
+    if (key === 'useSame') {
+        selectProfileForService(SERVICE_NAMES.IMAGE_GEN, value ? 'llm' : 'custom');
+        loadImageGenSettings();
+        return;
+    }
+    saveImageGenSettings({ [key]: value });
+}
 
 function loadEmbeddingSettings() {
     const config = getEmbeddingConfig();
@@ -150,6 +206,7 @@ function showBlacklistWarning(providerName) {
 }
 
 function loadApiSettings() {
+    loadProviderProfiles();
     const runtime = getApiRuntimeStorage();
     apiSettings.endpoint = runtime.endpoint;
     apiSettings.key = runtime.key;
@@ -164,6 +221,7 @@ function loadApiSettings() {
     apiSettings.reasoningEnabled = runtime.requestReasoning;
     apiSettings.reasoningEffort = runtime.reasoningEffort;
     loadEmbeddingSettings();
+    loadImageGenSettings();
 }
 
 function saveApiSetting(key, value) {
@@ -542,6 +600,20 @@ onBeforeUnmount(() => {
                     </div>
                 </ConnectionStatus>
 
+                <!-- Tab Bar -->
+                <div class="api-tabs">
+                    <button
+                        v-for="tab in TABS"
+                        :key="tab.id"
+                        class="api-tab-btn"
+                        :class="{ active: activeTab === tab.id }"
+                        @click="activeTab = tab.id"
+                    >{{ tab.label }}</button>
+                </div>
+
+                <!-- LLM Tab -->
+                <template v-if="activeTab === 'llm'">
+
                 <div class="menu-group">
                     <div class="section-header">{{ t('section_connection') || 'Connection' }} <HelpTip term="api"/></div>
                     <div class="settings-item">
@@ -634,7 +706,10 @@ onBeforeUnmount(() => {
                         </div>
                     </div>
                 </div>
+                </template>
 
+                <!-- Embeddings Tab -->
+                <template v-if="activeTab === 'embedding'">
                 <div class="menu-group">
                     <div class="section-header">{{ t('section_embeddings') || 'Embeddings' }} <HelpTip term="embeddings"/></div>
                     <div class="settings-item-checkbox">
@@ -680,12 +755,77 @@ onBeforeUnmount(() => {
                         </div>
                     </template>
                 </div>
+                </template>
+
+                <!-- Image Gen Tab -->
+                <template v-if="activeTab === 'imagegen'">
+                <div class="menu-group">
+                    <div class="section-header">{{ t('section_image_gen') || 'Image Generation' }} <HelpTip term="image-gen"/></div>
+                    <div class="settings-item-checkbox">
+                        <div class="settings-text-col">
+                            <label>{{ t('label_image_gen_enabled') || 'Enable Image Generation' }}</label>
+                            <div class="settings-desc">{{ t('desc_image_gen_enabled') || 'Generate images from [IMG:GEN] tags' }}</div>
+                        </div>
+                        <input type="checkbox" v-model="imageGenSettings.enabled" @change="onImageGenInput('enabled', $event.target.checked)" class="vk-switch">
+                    </div>
+                    <template v-if="imageGenSettings.enabled">
+                        <div class="settings-item-checkbox">
+                            <div class="settings-text-col">
+                                <label>{{ t('label_use_llm_api') || 'Use LLM API' }}</label>
+                                <div class="settings-desc">{{ t('desc_use_llm_api') || 'Use the same endpoint as LLM for image generation' }}</div>
+                            </div>
+                            <input type="checkbox" v-model="imageGenSettings.useSame" @change="onImageGenInput('useSame', $event.target.checked)" class="vk-switch">
+                        </div>
+                        <template v-if="!imageGenSettings.useSame">
+                            <div class="settings-item">
+                                <label>{{ t('label_imagegen_endpoint') || 'Image Gen Endpoint' }}</label>
+                                <input type="text" v-model="imageGenSettings.endpoint" @input="onImageGenInput('endpoint', $event.target.value)" placeholder="http://127.0.0.1:5000/v1" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                            </div>
+                            <div class="settings-item">
+                                <label>{{ t('label_imagegen_model') || 'Model' }}</label>
+                                <input type="text" v-model="imageGenSettings.model" @input="onImageGenInput('model', $event.target.value)" placeholder="dall-e-3" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                            </div>
+                            <div class="settings-item">
+                                <label>{{ t('label_imagegen_key') || 'API Key' }}</label>
+                                <input type="password" v-model="imageGenSettings.key" @input="onImageGenInput('apiKey', $event.target.value)" placeholder="sk-..." autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                            </div>
+                        </template>
+                    </template>
+                </div>
+                </template>
         </div>
     </SheetView>
     </div>
 </template>
 
 <style scoped>
+.api-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 8px 14px 0;
+  border-bottom: 1px solid rgba(var(--text-color-rgb, 0, 0, 0), 0.08);
+}
+
+.api-tab-btn {
+  flex: 1;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  color: var(--text-gray, #888);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 8px 8px 0 0;
+  border-bottom: 2px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.api-tab-btn.active {
+  color: var(--vk-blue, #528bcc);
+  border-bottom-color: var(--vk-blue, #528bcc);
+  background: rgba(var(--vk-blue-rgb, 82, 139, 204), 0.08);
+}
+
 .preset-selector {
   height: 32px;
   display: flex;

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -16,7 +16,7 @@ import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, ge
 import { getEmbeddingConfig, saveEmbeddingSetting, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
 import { testEmbeddingConnection } from '@/core/services/embeddingService.js';
 import { getImageGenSettings, saveImageGenSettings } from '@/core/services/imageGenService.js';
-import { getProviderProfiles, getActiveLLMProfile, setActiveLLMProfile, getServiceEffectiveProfile, setServiceProfile, isServiceUsingLLMProfile, SERVICE_NAMES } from '@/core/config/ProviderProfiles.js';
+import { getProviderProfiles, getActiveLLMProfile, setActiveLLMProfile, getServiceEffectiveProfile, getServiceProfileId, setServiceProfile, isServiceUsingLLMProfile, saveProviderProfile, createProviderProfile, SERVICE_NAMES } from '@/core/config/ProviderProfiles.js';
 import { updateLanguage, translations } from '@/utils/i18n.js';
 import { initRipple } from '@/core/services/ui.js';
 import { currentLang } from '@/core/config/APPSettings.js';
@@ -36,7 +36,8 @@ const headerState = reactive({
 const TABS = [
     { id: 'llm', label: 'LLM' },
     { id: 'embedding', label: 'Embeddings' },
-    { id: 'imagegen', label: 'Image Gen' }
+    { id: 'imagegen', label: 'Image Gen' },
+    { id: 'memory', label: 'Memory' }
 ];
 const activeTab = ref('llm');
 
@@ -100,6 +101,110 @@ const imageGenSettings = reactive({
     model: '',
     enabled: false
 });
+
+// --- Memory Books Provider Settings ---
+const memoryProviderSettings = reactive({
+    useSame: true,
+    endpoint: '',
+    key: '',
+    model: '',
+    temperature: null,
+    maxTokens: null
+});
+
+const memoryAvailableModels = ref([]);
+const memoryLoadingModels = ref(false);
+const memoryModelError = ref('');
+
+function loadMemoryProviderSettings() {
+    const isSame = isServiceUsingLLMProfile(SERVICE_NAMES.MEMORY_BOOKS);
+    const profile = isSame ? null : getServiceEffectiveProfile(SERVICE_NAMES.MEMORY_BOOKS);
+    memoryProviderSettings.useSame = isSame;
+    memoryProviderSettings.endpoint = isSame ? '' : (profile?.endpoint || '');
+    memoryProviderSettings.key = isSame ? '' : (profile?.apiKey || '');
+    memoryProviderSettings.model = isSame ? '' : (profile?.model || '');
+    memoryProviderSettings.temperature = null;
+    memoryProviderSettings.maxTokens = null;
+    memoryAvailableModels.value = [];
+    memoryModelError.value = '';
+}
+
+async function fetchMemoryModels() {
+    if (!memoryProviderSettings.endpoint) {
+        memoryModelError.value = t('msg_endpoint_required') || 'Endpoint is required';
+        return;
+    }
+    memoryLoadingModels.value = true;
+    memoryModelError.value = '';
+    try {
+        const endpoint = normalizeEndpoint(memoryProviderSettings.endpoint);
+        const models = await fetchRemoteModels(endpoint, memoryProviderSettings.key);
+        memoryAvailableModels.value = models;
+    } catch (e) {
+        memoryModelError.value = e.message || 'Failed to fetch models';
+        memoryAvailableModels.value = [];
+    } finally {
+        memoryLoadingModels.value = false;
+    }
+}
+
+function openMemoryModelSelector() {
+    if (!memoryAvailableModels.value.length) {
+        showBottomSheet({
+            title: t('label_memory_model') || 'Model',
+            items: [{ label: t('msg_no_models_found') || 'No models found. Enter endpoint and key first.', onClick: closeBottomSheet }]
+        });
+        return;
+    }
+    const items = memoryAvailableModels.value.map(m => ({
+        label: m,
+        icon: memoryProviderSettings.model === m ? '<svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>' : null,
+        onClick: () => {
+            memoryProviderSettings.model = m;
+            onMemoryProviderInput('model', m);
+            closeBottomSheet();
+        }
+    }));
+    showBottomSheet({ title: t('label_memory_model') || 'Model', items });
+}
+
+function onMemoryProviderInput(key, value) {
+    if (key === 'useSame') {
+        selectProfileForService(SERVICE_NAMES.MEMORY_BOOKS, value ? 'llm' : 'custom');
+        loadMemoryProviderSettings();
+        return;
+    }
+    if (key === 'endpoint' || key === 'key') {
+        memoryProviderSettings[key] = value;
+        memoryAvailableModels.value = [];
+        memoryModelError.value = '';
+        if (!memoryProviderSettings.useSame) {
+            const currentProfile = getServiceEffectiveProfile(SERVICE_NAMES.MEMORY_BOOKS);
+            const profileId = getServiceProfileId(SERVICE_NAMES.MEMORY_BOOKS);
+            if (profileId && profileId !== 'llm') {
+                saveProviderProfile({ id: profileId, [key === 'key' ? 'apiKey' : key]: value });
+            }
+        }
+        return;
+    }
+    if (key === 'model') {
+        memoryProviderSettings.model = value;
+    }
+    if (!memoryProviderSettings.useSame) {
+        const currentProfile = getServiceEffectiveProfile(SERVICE_NAMES.MEMORY_BOOKS);
+        const profileId = getServiceProfileId(SERVICE_NAMES.MEMORY_BOOKS);
+        if (profileId && profileId !== 'llm') {
+            saveProviderProfile({ id: profileId, [key === 'key' ? 'apiKey' : key]: value });
+        } else {
+            const newProfile = createProviderProfile('Memory Books Provider', {
+                endpoint: memoryProviderSettings.endpoint,
+                apiKey: memoryProviderSettings.key,
+                model: memoryProviderSettings.model
+            });
+            selectProfileForService(SERVICE_NAMES.MEMORY_BOOKS, newProfile.id);
+        }
+    }
+}
 
 function loadImageGenSettings() {
     const config = getImageGenSettings();
@@ -222,6 +327,7 @@ function loadApiSettings() {
     apiSettings.reasoningEffort = runtime.reasoningEffort;
     loadEmbeddingSettings();
     loadImageGenSettings();
+    loadMemoryProviderSettings();
 }
 
 function saveApiSetting(key, value) {
@@ -793,6 +899,45 @@ onBeforeUnmount(() => {
                     </template>
                 </div>
                 </template>
+
+                <!-- Memory Books Provider Tab -->
+                <template v-if="activeTab === 'memory'">
+                <div class="menu-group">
+                    <div class="section-header">{{ t('section_memory_books_provider') || 'Memory Books Generation' }} <HelpTip term="memory-books"/></div>
+                    <div class="settings-item-checkbox">
+                        <div class="settings-text-col">
+                            <label>{{ t('label_use_llm_api') || 'Use LLM API' }}</label>
+                            <div class="settings-desc">{{ t('desc_use_llm_api_memory') || 'Use the same endpoint as LLM for memory book generation' }}</div>
+                        </div>
+                        <input type="checkbox" v-model="memoryProviderSettings.useSame" @change="onMemoryProviderInput('useSame', $event.target.checked)" class="vk-switch">
+                    </div>
+                    <template v-if="!memoryProviderSettings.useSame">
+                        <div class="settings-item">
+                            <label>{{ t('label_memory_endpoint') || 'Memory Gen Endpoint' }}</label>
+                            <input type="text" v-model="memoryProviderSettings.endpoint" @input="onMemoryProviderInput('endpoint', $event.target.value)" placeholder="http://127.0.0.1:5000/v1" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                        </div>
+                        <div class="settings-item">
+                            <label>{{ t('label_memory_key') || 'API Key' }}</label>
+                            <input type="password" v-model="memoryProviderSettings.key" @input="onMemoryProviderInput('key', $event.target.value)" placeholder="sk-..." autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                        </div>
+                        <div class="settings-item" @click="fetchMemoryModels">
+                            <label>{{ t('label_memory_fetch_models') || 'Fetch Models' }}</label>
+                            <div class="clickable-selector">
+                                <span>{{ memoryLoadingModels.value ? (t('btn_fetching') || 'Fetching...') : (t('btn_fetch_models') || 'Fetch Models') }}</span>
+                                <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+                            </div>
+                        </div>
+                        <div class="settings-item" @click="openMemoryModelSelector">
+                            <label>{{ t('label_memory_model') || 'Model' }}</label>
+                            <div class="clickable-selector" :class="{ 'selector-error': memoryModelError }">
+                                <span>{{ memoryProviderSettings.model || t('msg_select_model') || 'Select a model' }}</span>
+                                <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
+                            </div>
+                            <div v-if="memoryModelError" class="settings-desc" style="color: var(--vk-red); margin-top:4px;">{{ memoryModelError }}</div>
+                        </div>
+                    </template>
+                </div>
+                </template>
         </div>
     </SheetView>
     </div>
@@ -899,5 +1044,9 @@ onBeforeUnmount(() => {
     height: 24px;
     fill: var(--text-gray);
     opacity: 0.5;
+}
+
+.selector-error {
+    border-color: var(--vk-red);
 }
 </style>

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -112,10 +112,6 @@ const memoryProviderSettings = reactive({
     maxTokens: null
 });
 
-const memoryAvailableModels = ref([]);
-const memoryLoadingModels = ref(false);
-const memoryModelError = ref('');
-
 function loadMemoryProviderSettings() {
     const isSame = isServiceUsingLLMProfile(SERVICE_NAMES.MEMORY_BOOKS);
     const profile = isSame ? null : getServiceEffectiveProfile(SERVICE_NAMES.MEMORY_BOOKS);
@@ -125,47 +121,6 @@ function loadMemoryProviderSettings() {
     memoryProviderSettings.model = isSame ? '' : (profile?.model || '');
     memoryProviderSettings.temperature = null;
     memoryProviderSettings.maxTokens = null;
-    memoryAvailableModels.value = [];
-    memoryModelError.value = '';
-}
-
-async function fetchMemoryModels() {
-    if (!memoryProviderSettings.endpoint) {
-        memoryModelError.value = t('msg_endpoint_required') || 'Endpoint is required';
-        return;
-    }
-    memoryLoadingModels.value = true;
-    memoryModelError.value = '';
-    try {
-        const endpoint = normalizeEndpoint(memoryProviderSettings.endpoint);
-        const models = await fetchRemoteModels(endpoint, memoryProviderSettings.key);
-        memoryAvailableModels.value = models;
-    } catch (e) {
-        memoryModelError.value = e.message || 'Failed to fetch models';
-        memoryAvailableModels.value = [];
-    } finally {
-        memoryLoadingModels.value = false;
-    }
-}
-
-function openMemoryModelSelector() {
-    if (!memoryAvailableModels.value.length) {
-        showBottomSheet({
-            title: t('label_memory_model') || 'Model',
-            items: [{ label: t('msg_no_models_found') || 'No models found. Enter endpoint and key first.', onClick: closeBottomSheet }]
-        });
-        return;
-    }
-    const items = memoryAvailableModels.value.map(m => ({
-        label: m,
-        icon: memoryProviderSettings.model === m ? '<svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>' : null,
-        onClick: () => {
-            memoryProviderSettings.model = m;
-            onMemoryProviderInput('model', m);
-            closeBottomSheet();
-        }
-    }));
-    showBottomSheet({ title: t('label_memory_model') || 'Model', items });
 }
 
 function onMemoryProviderInput(key, value) {
@@ -174,28 +129,18 @@ function onMemoryProviderInput(key, value) {
         loadMemoryProviderSettings();
         return;
     }
-    if (key === 'endpoint' || key === 'key') {
-        memoryProviderSettings[key] = value;
-        memoryAvailableModels.value = [];
-        memoryModelError.value = '';
-        if (!memoryProviderSettings.useSame) {
-            const currentProfile = getServiceEffectiveProfile(SERVICE_NAMES.MEMORY_BOOKS);
-            const profileId = getServiceProfileId(SERVICE_NAMES.MEMORY_BOOKS);
-            if (profileId && profileId !== 'llm') {
-                saveProviderProfile({ id: profileId, [key === 'key' ? 'apiKey' : key]: value });
-            }
-        }
-        return;
-    }
-    if (key === 'model') {
-        memoryProviderSettings.model = value;
-    }
+    // For custom provider, save to a dedicated memory provider profile
     if (!memoryProviderSettings.useSame) {
+        // Create or update a memory-specific provider profile
         const currentProfile = getServiceEffectiveProfile(SERVICE_NAMES.MEMORY_BOOKS);
         const profileId = getServiceProfileId(SERVICE_NAMES.MEMORY_BOOKS);
         if (profileId && profileId !== 'llm') {
-            saveProviderProfile({ id: profileId, [key === 'key' ? 'apiKey' : key]: value });
+            saveProviderProfile({
+                id: profileId,
+                [key === 'key' ? 'apiKey' : key]: value
+            });
         } else {
+            // Create new profile for memory books
             const newProfile = createProviderProfile('Memory Books Provider', {
                 endpoint: memoryProviderSettings.endpoint,
                 apiKey: memoryProviderSettings.key,
@@ -917,23 +862,12 @@ onBeforeUnmount(() => {
                             <input type="text" v-model="memoryProviderSettings.endpoint" @input="onMemoryProviderInput('endpoint', $event.target.value)" placeholder="http://127.0.0.1:5000/v1" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
                         </div>
                         <div class="settings-item">
+                            <label>{{ t('label_memory_model') || 'Model' }}</label>
+                            <input type="text" v-model="memoryProviderSettings.model" @input="onMemoryProviderInput('model', $event.target.value)" placeholder="gpt-4o-mini" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                        </div>
+                        <div class="settings-item">
                             <label>{{ t('label_memory_key') || 'API Key' }}</label>
                             <input type="password" v-model="memoryProviderSettings.key" @input="onMemoryProviderInput('key', $event.target.value)" placeholder="sk-..." autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
-                        </div>
-                        <div class="settings-item" @click="fetchMemoryModels">
-                            <label>{{ t('label_memory_fetch_models') || 'Fetch Models' }}</label>
-                            <div class="clickable-selector">
-                                <span>{{ memoryLoadingModels.value ? (t('btn_fetching') || 'Fetching...') : (t('btn_fetch_models') || 'Fetch Models') }}</span>
-                                <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
-                            </div>
-                        </div>
-                        <div class="settings-item" @click="openMemoryModelSelector">
-                            <label>{{ t('label_memory_model') || 'Model' }}</label>
-                            <div class="clickable-selector" :class="{ 'selector-error': memoryModelError }">
-                                <span>{{ memoryProviderSettings.model || t('msg_select_model') || 'Select a model' }}</span>
-                                <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
-                            </div>
-                            <div v-if="memoryModelError" class="settings-desc" style="color: var(--vk-red); margin-top:4px;">{{ memoryModelError }}</div>
                         </div>
                     </template>
                 </div>
@@ -1044,9 +978,5 @@ onBeforeUnmount(() => {
     height: 24px;
     fill: var(--text-gray);
     opacity: 0.5;
-}
-
-.selector-error {
-    border-color: var(--vk-red);
 }
 </style>

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -57,7 +57,8 @@ import { currentLang, chatPaddingLR, setChatPaddingLR, shouldUseBatterySaverUI }
 import { translations } from '@/utils/i18n.js';
 import { generateChatResponse, calculateContext, generateMemoryDraft } from '@/core/services/generationService.js';
 import { executeRequest } from '@/core/services/llmApi.js';
-import { getApiConfig, getApiRuntimeStorage, getApiReasoningTags } from '@/core/config/APISettings.js';
+import { getApiConfig, getApiRuntimeStorage, getApiReasoningTags, fetchRemoteModels } from '@/core/config/APISettings.js';
+import { getActiveLLMProfile } from '@/core/config/ProviderProfiles.js';
 import { getEmbeddingConfig, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
 import { animateTextChange, updateAppColors, initHeaderScroll, initRipple } from '@/core/services/ui.js';
 import { showBottomSheet, closeBottomSheet, bottomSheetState } from '@/core/states/bottomSheetState.js';
@@ -499,10 +500,10 @@ function restoreVisibleSwipeState(messages = []) {
 }
 
 function getNormalizedMemoryGenerationState(settings = {}, overrides = {}) {
+    const source = settings.generationSource === 'custom' ? 'custom' : 'llm';
     return {
-        source: settings.generationSource || 'current',
+        source,
         model: settings.generationModel || '',
-        useCurrentModelOverride: settings.generationUseCurrentModelOverride === true,
         endpoint: settings.generationEndpoint || '',
         apiKey: settings.generationApiKey || '',
         temperature: settings.generationTemperature,
@@ -842,7 +843,7 @@ async function generateMemoryDraftForMessages(selectedMessages, { openSheet = fa
             ...(generationMaxTokens ? { maxTokens: generationMaxTokens } : {})
         }
         : {
-            ...(settings.generationUseCurrentModelOverride && settings.generationModel
+            ...(settings.generationModel
                 ? { model: settings.generationModel }
                 : {}),
             ...(settings.generationTemperature != null
@@ -1448,41 +1449,7 @@ async function openMemoryGenerationSettings(initialState = null) {
     const renderSheet = () => {
         const content = document.createElement('div');
         content.className = 'context-sheet';
-        const currentEndpointLabel = currentApiConfig.apiUrl || 'Not configured';
-        const currentModelLabel = currentApiConfig.model || 'Not configured';
         content.innerHTML = `
-            <div class="settings-item">
-                <label>Provider</label>
-                <div class="clickable-selector" id="memory-provider-selector">
-                    <span>${state.source === 'current' ? 'Current provider' : 'Custom provider'}</span>
-                    <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
-                </div>
-            </div>
-            ${state.source === 'current'
-                ? `
-                    <div class="settings-item">
-                        <label>Using Current API Settings</label>
-                        <div class="context-sheet-note">Endpoint: ${currentEndpointLabel.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</div>
-                        <div class="context-sheet-note">Model: ${(state.useCurrentModelOverride && state.model ? state.model : currentModelLabel).replace(/</g, '&lt;').replace(/>/g, '&gt;')}${state.useCurrentModelOverride && state.model ? ' (override)' : ''}</div>
-                    </div>
-                    <div class="settings-item">
-                        <label style="display:flex; align-items:center; gap:8px;">
-                            <input id="memory-current-model-override-toggle" type="checkbox" ${state.useCurrentModelOverride ? 'checked' : ''}>
-                            <span>Override current model</span>
-                        </label>
-                    </div>
-                    <div class="settings-item" id="memory-current-model-override-field" style="display:${state.useCurrentModelOverride ? 'block' : 'none'};">
-                        <label>Override Model</label>
-                        <input id="memory-current-model-input" type="text" value="${state.model.replace(/"/g, '&quot;')}" placeholder="Model name">
-                    </div>
-                `
-                : `
-                    <div class="settings-item">
-                        <label>Model</label>
-                        <input id="memory-model-input" type="text" value="${state.model.replace(/"/g, '&quot;')}" placeholder="Model name">
-                    </div>
-                `
-            }
             <div class="settings-item">
                 <label>Generation Rules</label>
                 <div class="clickable-selector" id="memory-prompt-selector">
@@ -1544,46 +1511,11 @@ async function openMemoryGenerationSettings(initialState = null) {
                 </div>
                 <div class="context-sheet-note">Choose whether retrieved memory context follows the dedicated summary block path or the {{summary}} macro location.</div>
             </div>
-            <div id="memory-custom-fields" style="display:${state.source === 'custom' ? 'block' : 'none'};">
-                <div class="settings-item">
-                    <label>Endpoint</label>
-                    <input id="memory-endpoint-input" type="text" value="${state.endpoint.replace(/"/g, '&quot;')}" placeholder="https://.../v1">
-                </div>
-                <div class="settings-item">
-                    <label>API Key</label>
-                    <input id="memory-apikey-input" type="password" value="${state.apiKey.replace(/"/g, '&quot;')}" placeholder="Optional API key">
-                </div>
-            </div>
             <div class="context-sheet-actions">
                 <button type="button" class="context-sheet-btn context-sheet-btn-secondary" id="memory-settings-cancel">Cancel</button>
                 <button type="button" class="context-sheet-btn context-sheet-btn-primary" id="memory-settings-save">Save</button>
             </div>
         `;
-
-        content.querySelector('#memory-provider-selector')?.addEventListener('click', () => {
-            closeBottomSheet();
-            showBottomSheet({
-                title: 'Memory Provider',
-                items: [
-                    {
-                        label: 'Current provider',
-                        onClick: () => {
-                            state.source = 'current';
-                            closeBottomSheet();
-                            setTimeout(() => showBottomSheet({ title: 'Memory Generation', content: renderSheet(), isSolid: true }), 50);
-                        }
-                    },
-                    {
-                        label: 'Custom provider',
-                        onClick: () => {
-                            state.source = 'custom';
-                            closeBottomSheet();
-                            setTimeout(() => showBottomSheet({ title: 'Memory Generation', content: renderSheet(), isSolid: true }), 50);
-                        }
-                    }
-                ]
-            });
-        });
 
         content.querySelector('#memory-prompt-selector')?.addEventListener('click', () => {
             closeBottomSheet();
@@ -1649,26 +1581,14 @@ async function openMemoryGenerationSettings(initialState = null) {
             });
         });
 
-        content.querySelector('#memory-current-model-override-toggle')?.addEventListener('change', (event) => {
-            state.useCurrentModelOverride = event.target.checked;
-            closeBottomSheet();
-            setTimeout(() => showBottomSheet({ title: 'Memory Generation', content: renderSheet(), isSolid: true }), 50);
-        });
-
         content.querySelector('#memory-settings-cancel')?.addEventListener('click', () => {
             closeBottomSheet();
             setTimeout(() => openMemoryBooksSheet(), 50);
         });
         content.querySelector('#memory-settings-save')?.addEventListener('click', async () => {
             settings.generationSource = state.source;
-            settings.generationUseCurrentModelOverride = state.source === 'current'
-                ? !!content.querySelector('#memory-current-model-override-toggle')?.checked
-                : false;
-            settings.generationModel = state.source === 'custom'
-                ? (content.querySelector('#memory-model-input')?.value?.trim() || '')
-                : (settings.generationUseCurrentModelOverride
-                    ? (content.querySelector('#memory-current-model-input')?.value?.trim() || '')
-                    : '');
+            settings.generationUseCurrentModelOverride = false;
+            settings.generationModel = state.model || '';
             settings.generationEndpoint = state.source === 'custom'
                 ? (content.querySelector('#memory-endpoint-input')?.value?.trim() || '')
                 : '';
@@ -1920,6 +1840,25 @@ function handleMemoryPreview({ entry, kind }) {
 
 function handleMemoryOpenSettings() {
     openMemoryGenerationSettings();
+}
+
+function handleMemoryQuickModelChange(model) {
+    if (!activeChatChar || !currentMemoryBookData.value) return;
+    const settings = currentMemoryBookData.value.settings || {};
+    settings.generationModel = model || '';
+    settings.generationUseCurrentModelOverride = false;
+    currentMemoryBookData.value.updatedAt = Date.now();
+    getChatData(activeChatChar.id).then(chatData => {
+        const sessionId = activeChatChar.sessionId || chatData.currentId;
+        const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
+        if (memoryBook.settings) {
+            memoryBook.settings.generationModel = model || '';
+            memoryBook.settings.generationUseCurrentModelOverride = false;
+        }
+        memoryBook.updatedAt = Date.now();
+        db.saveChat(activeChatChar.id, chatData);
+    });
+    showToast('Memory generation model updated');
 }
 
 async function deleteSelectedMessages() {
@@ -4913,6 +4852,7 @@ onUnmounted(() => {
             @delete-draft="handleMemoryDeleteDraft"
             @delete-entry="handleMemoryDeleteEntry"
             @cancel-draft="handleMemoryCancelDraft"
+            @change-model="handleMemoryQuickModelChange"
             @back="handleSheetBack"
         />
     </div>


### PR DESCRIPTION
## Summary
This PR bundles urgent bugfixes and UI improvements discovered during post-refactor testing:

### Sync Coverage Expansion
- Added provider profile keys (`gz_provider_profiles`, `gz_active_llm_profile_id`, `gz_service_profile_map`) to sync whitelist
- Added image generation settings (`gz_imggen_*`) and embedding settings (`gz_embedding_*`) to sync whitelist
- API credential keys (`api-key`, `api-model`, `gz_embedding_key`, `gz_provider_profiles`, `gz_imggen_api_key`) are now included only when "Include API Keys in Sync" toggle is ON
- The toggle itself (`gz_sync_include_api_keys`) is synced so behavior is consistent across devices

### Memory Generation UI Refactor
- Replaced Provider/Override Model fields in Memory Generation settings with a single **Model dropdown** that fetches available models from the endpoint
- Removed "Use LLM API" toggle from Generation Settings — endpoint source is inferred from provider profiles
- Added a **quick model switcher** row directly in the Memory Books sheet header for fast model changes without opening settings

### Chat Importer Hardening
- Filters `null`/`undefined` entries from imported `swipes`
- Normalizes `swipesMeta` length to match `swipes`
- Skips empty messages during import and export
- Explicitly rejects `.txt` chat imports with a localized error message

### Build Verification
- `npm run build` passes cleanly
