### PR TITLE
fix: hide memory selection buttons, document persistence races

### DIFF
--- a/BUGFIX_TODO.md
+++ b/BUGFIX_TODO.md
@@ -1,0 +1,92 @@
+# Bug Fix Todo
+
+## Critical
+
+### BUG-1: DB read-modify-write race — settings lost on close
+**Status:** not fixed  
+**Symptom:** Memory book custom prompts, model settings, generation config disappear after closing/opening app.  
+**Root cause:** `asyncSaveCurrentSessionState` and `onBeforeUnmount` both do `getChatData()` → modify → `db.saveChat()` as fire-and-forget. If the memory sheet saved settings between the read and the write-back, the stale chatData overwrites the new settings.  
+**Fix:**
+1. Switch `db.saveChat` to use `db.queuedSet` (write queue already exists at db.js:146 but `saveChat` bypasses it)
+2. In `asyncSaveCurrentSessionState` and `onBeforeUnmount`, merge only the fields they actually change (scrollAnchor, draft, authorsNotes, summaries) into the DB record instead of overwriting the entire chatData object
+3. Alternatively: make all `saveChat` callers go through a single `persistChatDelta(charId, patch)` function that does read-modify-write-merge atomically
+
+**Files:** `src/utils/db.js`, `src/views/ChatView.vue`
+
+---
+
+### BUG-2: No save on app background — DB reverts to last launch on crash
+**Status:** not fixed  
+**Symptom:** App freeze during memory draft → kill → chat reverts hours back (to last app launch).  
+**Root cause:**
+- No `visibilitychange` or Capacitor `appStateChange` handler saves chat state when going to background
+- `onBeforeUnmount` is fire-and-forget, only saves scrollAnchor + draft (NOT currentMessages)
+- No periodic auto-save of `currentMessages.value` to DB
+- `db.set` resolves on `req.onsuccess` (not `tx.oncomplete`) — data may not be durable when process is killed
+
+**Fix:**
+1. Add `document.addEventListener('visibilitychange', ...)` that saves `currentMessages.value` when `visibilityState === 'hidden'`
+2. Add Capacitor `App.addListener('appStateChange', ...)` that saves on `isActive === false`
+3. Add debounced auto-save watcher on `currentMessages` (e.g. every 30s of inactivity)
+4. Switch `db.set` to resolve on `tx.oncomplete` instead of `req.onsuccess` for durability
+5. Make `onBeforeUnmount` await the save and include `currentMessages.value`
+
+**Files:** `src/views/ChatView.vue`, `src/utils/db.js`
+
+---
+
+### BUG-3: App freeze on memory draft generation
+**Status:** not fixed  
+**Symptom:** App hangs during memory draft, no recovery except kill.  
+**Likely cause:**
+- Memory draft generation may block the main thread (worker communication issue, unhandled promise, or infinite loop in draft parsing)
+- Possible memory leak: closures may hold references to old reactive state after component updates
+- `isGeneratingDraft` flag may get stuck if the generation abort path doesn't clear it
+
+**Investigation needed:**
+1. Check if `generateMemoryDraft` has proper abort/cleanup on error
+2. Check if draft parsing (`parseMemoryDraftResponse`) can hang on malformed model output
+3. Profile for memory leaks — check if reactive refs hold stale references
+4. Verify `stopMemoryDraftProgress` is called on all error paths
+
+**Files:** `src/views/ChatView.vue`, `src/core/services/memoryBooksService.js`
+
+---
+
+## Medium
+
+### BUG-4: Tokenizer cutoff index mismatch with hidden messages
+**Status:** not fixed  
+**Symptom:** Tokenizer cutoff line appears at wrong position when hidden messages exist.  
+**Root cause:** `cutoffIndex` is calculated against a filtered list (`!m.isHidden`) but `displayMessages` inserts the cutoff marker while iterating the full unfiltered `currentMessages`. The index doesn't map correctly.  
+**Fix:** In `displayMessages`, track the visible-message index separately from the raw index, and compare the visible index against `cutoffIndex.value`. Or: include hidden messages in the cutoff index calculation but mark them accordingly.
+
+**Files:** `src/views/ChatView.vue`
+
+---
+
+### BUG-5: Memory tokens not factored into cutoff calculation
+**Status:** not fixed  
+**Symptom:** Context breakdown may report more remaining space than actually available when memory injection is active.  
+**Root cause:** `updateContextCutoff` calculates cutoff before memory is injected. The post-hoc `buildMergedContextBreakdown` only adjusts `remaining` retroactively, but `cutoffIndex` and `availableForHistory` were already set by the worker without knowing about memory overhead.  
+**Fix:** Reserve memory budget upfront in the worker payload (pass estimated memory tokens as a `reservedContext` parameter) so the worker's cutoff accounts for memory space before calculating the history window.
+
+**Files:** `src/core/llm/usecases/chatContextCalculation.js`, `src/workers/generationWorker.js`, `src/core/services/generationService.js`
+
+---
+
+### BUG-6: `updateSessionMessage` uses `data.currentId` instead of actual sessionId
+**Status:** not fixed  
+**Symptom:** Message updates may be written to wrong session after session switch.  
+**Root cause:** `updateSessionMessage` reads `data.currentId` from DB, but if user navigated to a different session, `currentId` may not match `activeChatChar.sessionId`.  
+**Fix:** Pass the actual `activeChatChar.sessionId` explicitly to `updateSessionMessage` instead of relying on `data.currentId`.
+
+**Files:** `src/views/ChatView.vue`
+
+---
+
+## Done
+
+### BUG-0: Memory selection buttons clutter in selection mode
+**Status:** fixed  
+**Fix:** Hidden 4 memory-related selection buttons (config, draft, create, remove) in ChatInput.vue. Will be re-added after UX polish.

--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -503,18 +503,7 @@ defineExpose({
                             {{ selectedCount }} {{ t('selected_count') || 'Selected' }}
                         </div>
                         <div class="selection-actions-group">
-                            <div class="selection-circle-btn btn-memory-config-selection" @click="emit('configure-memory-selected')" :title="t('Memory settings') || 'Memory settings'">
-                                <svg viewBox="0 0 24 24"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.04.24.24.41.48.41h3.84c.24 0 .43-.17.47-.41l.36-2.54c.59-.24 1.13-.57 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg>
-                            </div>
-                            <div class="selection-circle-btn btn-memory-draft-selection" :class="{ disabled: selectedCount === 0 }" @click="emit('generate-memory-draft-selected')" :title="t('Generate memory draft') || 'Generate memory draft'">
-                                <svg viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-2 .9-2 2v16l4-4h10c1.1 0 2-.9 2-2V8l-6-6zm1 7V3.5L19.5 9H15zm-5 8H8v-2h2v2zm0-4H8V7h2v6z"/></svg>
-                            </div>
-                            <div class="selection-circle-btn btn-memory-selection" :class="{ disabled: selectedCount === 0 }" @click="emit('create-memory-selected')" :title="t('Create memory') || 'Create memory'">
-                                <svg viewBox="0 0 24 24"><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-1 10h-5v5h-2v-5H6v-2h5V6h2v5h5v2z"/></svg>
-                            </div>
-                            <div class="selection-circle-btn btn-memory-remove-selection" :class="{ disabled: selectedCount === 0 }" @click="emit('remove-memory-selected')" :title="t('Remove memory') || 'Remove memory'">
-                                <svg viewBox="0 0 24 24"><path d="M19 13H5v-2h14v2z"/></svg>
-                            </div>
+                            <!-- Memory selection buttons temporarily hidden — pending UX polish -->
                             <div class="selection-circle-btn btn-hide-selection" :class="{ disabled: selectedCount === 0 }" @click="emit('hide-selected')">
                                 <svg viewBox="0 0 24 24"><path d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46C3.08 8.3 1.78 10.02 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"/></svg>
                             </div>


### PR DESCRIPTION
## Summary
- Hide 4 memory-related selection buttons (config, draft, create, remove) in ChatInput selection mode - pending UX polish
- Add BUGFIX_TODO.md documenting 6 discovered bugs with root cause analysis (DB race, no background save, memory draft freeze, tokenizer cutoff mismatch, memory token budget, session ID bug)

## Test plan
- Open chat, select messages, verify only hide/delete buttons visible (no memory buttons)
- Memory books sheet still works normally via magic drawer