### PR TITLE
fix: cutoff index with hidden messages, memory reserve, session ID (BUG-4,5,6)

### DIFF
--- a/BUGFIX_TODO.md
+++ b/BUGFIX_TODO.md
@@ -55,30 +55,35 @@
 ## Medium
 
 ### BUG-4: Tokenizer cutoff index mismatch with hidden messages
-**Status:** not fixed  
+**Status:** fixed  
 **Symptom:** Tokenizer cutoff line appears at wrong position when hidden messages exist.  
-**Root cause:** `cutoffIndex` is calculated against a filtered list (`!m.isHidden`) but `displayMessages` inserts the cutoff marker while iterating the full unfiltered `currentMessages`. The index doesn't map correctly.  
-**Fix:** In `displayMessages`, track the visible-message index separately from the raw index, and compare the visible index against `cutoffIndex.value`. Or: include hidden messages in the cutoff index calculation but mark them accordingly.
+**Root cause:** `cutoffIndex` is calculated against a filtered list (`!m.isHidden`) but `displayMessages` was comparing raw index `i` against it.  
+**Fix applied:** `displayMessages` now tracks a separate `visibleIndex` counter that increments only for non-hidden messages, and compares `visibleIndex` against `cutoffIndex.value`.
 
 **Files:** `src/views/ChatView.vue`
 
 ---
 
 ### BUG-5: Memory tokens not factored into cutoff calculation
-**Status:** not fixed  
+**Status:** fixed  
 **Symptom:** Context breakdown may report more remaining space than actually available when memory injection is active.  
-**Root cause:** `updateContextCutoff` calculates cutoff before memory is injected. The post-hoc `buildMergedContextBreakdown` only adjusts `remaining` retroactively, but `cutoffIndex` and `availableForHistory` were already set by the worker without knowing about memory overhead.  
-**Fix:** Reserve memory budget upfront in the worker payload (pass estimated memory tokens as a `reservedContext` parameter) so the worker's cutoff accounts for memory space before calculating the history window.
+**Root cause:** `calculateContext` ran the worker first, then added memory tokens post-hoc. The worker's `availableForHistory` and `cutoffIndex` didn't account for memory overhead.  
+**Fix applied:**
+1. Added `getMemoryReserveEstimate()` — reads active memory entries from DB, estimates token cost, caps at 35% of safeContext
+2. Memory reserve passed to `buildPromptWorkerPayload` as `memoryReserve`
+3. Worker adds `memoryReserve` to `fixedTotal` alongside `lorebookReserve`, reducing `availableForHistory` upfront
+4. `buildMergedContextBreakdown` and `buildContextCalculationResult` include `memoryReserve` in breakdown
+5. Both `calculateContext` and `generateChatResponse` compute memory reserve before calling worker
 
-**Files:** `src/core/llm/usecases/chatContextCalculation.js`, `src/workers/generationWorker.js`, `src/core/services/generationService.js`
+**Files:** `src/core/services/generationService.js`, `src/workers/generationWorker.js`
 
 ---
 
 ### BUG-6: `updateSessionMessage` uses `data.currentId` instead of actual sessionId
-**Status:** not fixed  
+**Status:** fixed  
 **Symptom:** Message updates may be written to wrong session after session switch.  
 **Root cause:** `updateSessionMessage` reads `data.currentId` from DB, but if user navigated to a different session, `currentId` may not match `activeChatChar.sessionId`.  
-**Fix:** Pass the actual `activeChatChar.sessionId` explicitly to `updateSessionMessage` instead of relying on `data.currentId`.
+**Fix applied:** Uses `char.sessionId || data.currentId` — prefers the actual active session.
 
 **Files:** `src/views/ChatView.vue`
 

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -110,19 +110,22 @@ function trimHistoryForContextWindow(history, safeContextLimit) {
     return history;
 }
 
-function buildMergedContextBreakdown(contextBreakdown, { vectorLoreTokens = 0, memoryTokens = 0 } = {}) {
+function buildMergedContextBreakdown(contextBreakdown, { vectorLoreTokens = 0, memoryTokens = 0, memoryReserve = 0 } = {}) {
     if (!contextBreakdown) return null;
+
+    const actualMemory = memoryTokens || memoryReserve;
 
     return {
         ...contextBreakdown,
         memory: memoryTokens,
+        memoryReserve,
         vectorLore: (contextBreakdown.vectorLore || 0) + vectorLoreTokens,
         summaryBase: contextBreakdown.summary || 0,
-        summary: (contextBreakdown.summary || 0) + memoryTokens,
-        fixedBase: (contextBreakdown.fixedBase || 0) + memoryTokens,
-        fixedTotal: (contextBreakdown.fixedTotal || 0) + memoryTokens,
-        totalUsed: (contextBreakdown.totalUsed || 0) + memoryTokens,
-        remaining: Math.max(0, (contextBreakdown.remaining || 0) - memoryTokens)
+        summary: (contextBreakdown.summary || 0) + actualMemory,
+        fixedBase: (contextBreakdown.fixedBase || 0) + actualMemory,
+        fixedTotal: (contextBreakdown.fixedTotal || 0),
+        totalUsed: (contextBreakdown.totalUsed || 0),
+        remaining: Math.max(0, (contextBreakdown.remaining || 0))
     };
 }
 
@@ -168,7 +171,8 @@ function buildPromptWorkerPayload({
     guidanceType,
     globalRegexes,
     sessionVars,
-    apiConfig
+    apiConfig,
+    memoryReserve = 0
 }) {
     return JSON.parse(JSON.stringify({
         char,
@@ -190,8 +194,32 @@ function buildPromptWorkerPayload({
         activations: lorebookState.activations,
         globalRegexes,
         sessionVars,
-        apiConfig
+        apiConfig,
+        memoryReserve
     }));
+}
+
+async function getMemoryReserveEstimate(char, safeContext) {
+    const charId = char?.id;
+    const sessionId = char?.sessionId;
+    if (!charId || !sessionId) return 0;
+    try {
+        const chatData = await db.getChat(charId);
+        const memoryBook = chatData?.memoryBooks?.[sessionId];
+        const settings = memoryBook?.settings || {};
+        const activeEntries = (Array.isArray(memoryBook?.entries) ? memoryBook.entries : [])
+            .filter(e => e && (e.status || 'active') === 'active' && (e.content || '').trim());
+        if (!settings.enabled || !activeEntries.length) return 0;
+        const maxInjected = Math.max(1, Math.min(20, settings.maxInjectedEntries || 3));
+        let totalContentLen = 0;
+        for (const entry of activeEntries.slice(0, maxInjected)) {
+            totalContentLen += (entry.content || '').trim().length;
+        }
+        const estimatedTokens = estimateTokens('M'.repeat(totalContentLen));
+        return Math.min(estimatedTokens, Math.floor(safeContext * 0.35));
+    } catch (e) {
+        return 0;
+    }
 }
 
 function resolvePromptCutoffIndex(result) {
@@ -243,12 +271,13 @@ function estimateVectorLoreTokens(entries = []) {
     return entries.reduce((sum, entry) => sum + estimateTokens(entry?.content || ''), 0);
 }
 
-function buildContextCalculationResult(result, { vectorLoreTokens = 0, memoryTokens = 0 } = {}) {
+function buildContextCalculationResult(result, { vectorLoreTokens = 0, memoryTokens = 0, memoryReserve = 0 } = {}) {
     return {
         cutoffIndex: resolvePromptCutoffIndex(result),
         contextBreakdown: buildMergedContextBreakdown(result?.contextBreakdown, {
             vectorLoreTokens,
-            memoryTokens
+            memoryTokens,
+            memoryReserve
         })
     };
 }
@@ -324,6 +353,8 @@ export async function generateChatResponse({
         const safeContextLimit = getSafeContextLimit(contextSize, maxTokens);
         safeHistory = trimHistoryForContextWindow(history, safeContextLimit);
 
+        const memoryReserve = await getMemoryReserveEstimate(char, safeContextLimit);
+
         const payload = buildPromptWorkerPayload({
             char,
             history: safeHistory,
@@ -335,7 +366,8 @@ export async function generateChatResponse({
             guidanceType: type,
             globalRegexes,
             sessionVars,
-            apiConfig
+            apiConfig,
+            memoryReserve
         });
 
         result = await processPromptAsync(payload);
@@ -544,6 +576,8 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
         const safeContextLimit = getSafeContextLimit(apiConfig.contextSize, apiConfig.maxTokens);
         const safeHistory = trimHistoryForContextWindow(history, safeContextLimit);
 
+        const memoryReserve = await getMemoryReserveEstimate(char, safeContextLimit);
+
         const payload = buildPromptWorkerPayload({
             char,
             history: safeHistory,
@@ -553,7 +587,8 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
             authorsNote: anData,
             globalRegexes,
             sessionVars,
-            apiConfig
+            apiConfig,
+            memoryReserve
         });
 
         const result = await processPromptAsync(payload);
@@ -579,7 +614,8 @@ export async function calculateContext({ char, history, authorsNote, summary }) 
 
         return buildContextCalculationResult(result, {
             vectorLoreTokens,
-            memoryTokens: memoryInjection.tokens || 0
+            memoryTokens: memoryInjection.tokens || 0,
+            memoryReserve
         });
     } catch (e) {
         console.error("Calculate context worker error", e);

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -1917,6 +1917,7 @@ const displayMessages = computed(() => {
     
     const res = [];
     let lastDateKey = null;
+    let visibleIndex = 0;
     
     for (let i = 0; i < msgs.length; i++) {
         const msg = msgs[i];
@@ -1929,14 +1930,17 @@ const displayMessages = computed(() => {
             lastDateKey = dateKey;
         }
         
-        if (i === cutoffIndex.value && i > 0) {
-            res.push({ type: 'cutoff', id: 'context-cutoff' });
+        if (!msg.isHidden) {
+            if (visibleIndex === cutoffIndex.value && visibleIndex > 0) {
+                res.push({ type: 'cutoff', id: 'context-cutoff' });
+            }
+            visibleIndex++;
         }
         
         res.push({ type: 'message', data: msg, originalIndex: i, id: `msg_${msg.timestamp}_${i}` });
     }
     
-    if (cutoffIndex.value >= msgs.length && msgs.length > 0) {
+    if (cutoffIndex.value >= visibleIndex && visibleIndex > 0) {
         res.push({ type: 'cutoff', id: 'context-cutoff-end' });
     }
     
@@ -2371,8 +2375,9 @@ function invalidateContextCache() {
 
 async function updateSessionMessage(char, msgIndex, newMsgData) {
     let data = await getChatData(char.id);
-    if (data && data.sessions[data.currentId]) {
-        data.sessions[data.currentId][msgIndex] = newMsgData;
+    const sessionId = char.sessionId || data.currentId;
+    if (data && data.sessions[sessionId]) {
+        data.sessions[sessionId][msgIndex] = newMsgData;
         await db.saveChat(char.id, data);
     }
 }

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -818,6 +818,7 @@ self.onmessage = async function (e) {
             const staticMessages = messages.filter(m => !m.isHistory);
             const historyMessages = messages.filter(m => m.isHistory);
             const loreReserveTokens = getLorebookReserve(payload.globalSettings, safeContext);
+            const memoryReserveTokens = Math.max(0, Math.floor(payload.memoryReserve || 0));
 
             const sourceKeys = ['character', 'preset', 'summary', 'authorsNote', 'lorebook', 'vectorLore', 'history'];
             const sourceTotals = {};
@@ -847,6 +848,7 @@ self.onmessage = async function (e) {
                 lorebook: sourceTotals.lorebook,
                 vectorLore: sourceTotals.vectorLore,
                 lorebookReserve: loreReserveTokens,
+                memoryReserve: memoryReserveTokens,
                 history: 0,
                 fixedBase: 0,
                 fixedTotal: 0,
@@ -860,7 +862,7 @@ self.onmessage = async function (e) {
 
             // Lorebook and vectorLore are inside reserve, not in fixedBase
             breakdown.fixedBase = breakdown.character + breakdown.preset + breakdown.summary + breakdown.authorsNote;
-            breakdown.fixedTotal = breakdown.fixedBase + breakdown.lorebookReserve;
+            breakdown.fixedTotal = breakdown.fixedBase + breakdown.lorebookReserve + breakdown.memoryReserve;
 
             let availableForHistory = safeContext - breakdown.fixedTotal;
             breakdown.availableForHistory = Math.max(0, availableForHistory);
@@ -904,7 +906,7 @@ self.onmessage = async function (e) {
                 }
             }
 
-            breakdown.totalUsed = breakdown.fixedBase + breakdown.lorebookReserve + breakdown.history;
+            breakdown.totalUsed = breakdown.fixedBase + breakdown.lorebookReserve + breakdown.memoryReserve + breakdown.history;
             breakdown.remaining = Math.max(0, contextSize - breakdown.totalUsed);
 
             self.postMessage({


### PR DESCRIPTION
## Summary
- BUG-4: displayMessages tracks visibleIndex separately so cutoff marker aligns correctly when hidden messages exist
- BUG-5: getMemoryReserveEstimate reads active memory entries from DB, estimates token cost, passes to worker as memoryReserve — worker reserves this budget in fixedTotal before calculating history window
- BUG-6: updateSessionMessage uses char.sessionId instead of data.currentId — fixes writes to wrong session after session switch

## Test plan
- Hide some messages → verify cutoff line appears at correct position
- Enable memory book with entries → verify context breakdown accounts for memory reserve
- Switch sessions → edit a message → verify it saves to the active session