### PR TITLE
fix: reasoning macro expansion order and API tag settings UI

### DIFF
--- a/src/core/config/APISettings.js
+++ b/src/core/config/APISettings.js
@@ -88,7 +88,9 @@ export function applyApiRuntimeConfig({
     autoHideImages,
     autoHideImagesN,
     requestReasoning,
-    reasoningEffort
+    reasoningEffort,
+    reasoningStart,
+    reasoningEnd
 } = {}) {
     if (providerId !== undefined) localStorage.setItem('gz_api_provider', providerId);
     if (endpoint !== undefined) saveApiRuntimeSetting('api-endpoint', endpoint);
@@ -103,6 +105,8 @@ export function applyApiRuntimeConfig({
     if (autoHideImagesN !== undefined) saveApiRuntimeSetting('gz_api_auto_hide_images_n', String(autoHideImagesN));
     if (requestReasoning !== undefined) saveApiRuntimeSetting('gz_api_request_reasoning', String(requestReasoning));
     if (reasoningEffort !== undefined) saveApiRuntimeSetting('gz_api_reasoning_effort', String(reasoningEffort));
+    if (reasoningStart !== undefined) saveApiRuntimeSetting('gz_api_reasoning_start', String(reasoningStart));
+    if (reasoningEnd !== undefined) saveApiRuntimeSetting('gz_api_reasoning_end', String(reasoningEnd));
 }
 
 export function getApiConfig() {

--- a/src/utils/macroEngine.js
+++ b/src/utils/macroEngine.js
@@ -41,6 +41,15 @@ export function replaceMacros(text, char, persona, sessionVarsIn = null, notifyO
     const sessionVars = ownVars ? _getSessionVars(charId, sessionId) : sessionVarsIn;
     let varsChanged = false;
 
+    // {{reasoningPrefix}} / {{reasoningSuffix}} - expand BEFORE setvar/setglobalvar
+    // so that nested {{reasoningPrefix}} inside {{setvar::...}} doesn't break the regex
+    result = result.replace(/\{\{reasoningPrefix\}\}/gi, () => {
+        return sessionVars.reasoningPrefix || getApiReasoningTags().start;
+    });
+    result = result.replace(/\{\{reasoningSuffix\}\}/gi, () => {
+        return sessionVars.reasoningSuffix || getApiReasoningTags().end;
+    });
+
     // {{setvar::name::value}}
     result = result.replace(/{{setvar::([\s\S]*?)::([\s\S]*?)}}/gi, (match, name, value) => {
         sessionVars[name] = value;
@@ -98,13 +107,7 @@ export function replaceMacros(text, char, persona, sessionVarsIn = null, notifyO
     result = result.replace(/\{\{time\}\}/gi, () => now.toLocaleTimeString());
     result = result.replace(/\{\{weekday\}\}/gi, () => now.toLocaleDateString('en-US', { weekday: 'long' }));
 
-    // {{reasoningPrefix}} / {{reasoningSuffix}} - reasoning tags from sessionVars or localStorage
-    result = result.replace(/\{\{reasoningPrefix\}\}/gi, () => {
-        return sessionVars.reasoningPrefix || getApiReasoningTags().start;
-    });
-    result = result.replace(/\{\{reasoningSuffix\}\}/gi, () => {
-        return sessionVars.reasoningSuffix || getApiReasoningTags().end;
-    });
+
 
     // --- Escaping: \{\{ → {{ and \}\} → }} ---
     result = result.replace(/\\\{/g, '{').replace(/\\\}/g, '}');

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -12,7 +12,7 @@ function handleBack() {
         sheet.value?.close();
     }
 }
-import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getApiRuntimeStorage, saveApiRuntimeSetting, applyApiRuntimeConfig, getBlacklistedProvider } from '@/core/config/APISettings.js';
+import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getApiRuntimeStorage, saveApiRuntimeSetting, applyApiRuntimeConfig, getBlacklistedProvider, getApiReasoningTags } from '@/core/config/APISettings.js';
 import { getEmbeddingConfig, saveEmbeddingSetting, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
 import { testEmbeddingConnection } from '@/core/services/embeddingService.js';
 import { getImageGenSettings, saveImageGenSettings } from '@/core/services/imageGenService.js';

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -12,7 +12,7 @@ function handleBack() {
         sheet.value?.close();
     }
 }
-import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getApiRuntimeStorage, saveApiRuntimeSetting, applyApiRuntimeConfig, getBlacklistedProvider, getApiReasoningTags } from '@/core/config/APISettings.js';
+import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getApiRuntimeStorage, saveApiRuntimeSetting, applyApiRuntimeConfig, getBlacklistedProvider } from '@/core/config/APISettings.js';
 import { getEmbeddingConfig, saveEmbeddingSetting, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
 import { testEmbeddingConnection } from '@/core/services/embeddingService.js';
 import { getImageGenSettings, saveImageGenSettings } from '@/core/services/imageGenService.js';

--- a/src/views/ApiView.vue
+++ b/src/views/ApiView.vue
@@ -12,7 +12,7 @@ function handleBack() {
         sheet.value?.close();
     }
 }
-import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getApiRuntimeStorage, saveApiRuntimeSetting, applyApiRuntimeConfig, getBlacklistedProvider } from '@/core/config/APISettings.js';
+import { normalizeEndpoint, fetchRemoteModels, getApiPresets, saveApiPresets, getApiConfig, getApiProviderId, getApiRuntimeStorage, saveApiRuntimeSetting, applyApiRuntimeConfig, getBlacklistedProvider, getApiReasoningTags } from '@/core/config/APISettings.js';
 import { getEmbeddingConfig, saveEmbeddingSetting, isEmbeddingConfigured } from '@/core/config/embeddingSettings.js';
 import { testEmbeddingConnection } from '@/core/services/embeddingService.js';
 import { getImageGenSettings, saveImageGenSettings } from '@/core/services/imageGenService.js';
@@ -71,7 +71,9 @@ const apiSettings = reactive({
     autoHideImages: false,
     autoHideImagesN: 1,
     reasoningEnabled: false,
-    reasoningEffort: 'medium'
+    reasoningEffort: 'medium',
+    reasoningStart: '',
+    reasoningEnd: ''
 });
 
 const showApiKey = ref(false);
@@ -223,6 +225,9 @@ const activeApiPreset = computed(() => {
     return apiPresets.value.find(p => p.id === activeApiPresetId.value) || apiPresets.value[0];
 });
 
+const startTagPlaceholder = computed(() => getApiReasoningTags().start);
+const endTagPlaceholder = computed(() => getApiReasoningTags().end);
+
 // --- Blacklist Warning ---
 let blacklistCountdownTimer = null;
 
@@ -270,6 +275,8 @@ function loadApiSettings() {
     apiSettings.autoHideImagesN = runtime.autoHideImagesN;
     apiSettings.reasoningEnabled = runtime.requestReasoning;
     apiSettings.reasoningEffort = runtime.reasoningEffort;
+    apiSettings.reasoningStart = runtime.reasoningTags.start;
+    apiSettings.reasoningEnd = runtime.reasoningTags.end;
     loadEmbeddingSettings();
     loadImageGenSettings();
     loadMemoryProviderSettings();
@@ -292,7 +299,9 @@ function saveApiSetting(key, value) {
             'gz_api_auto_hide_images': 'auto_hide_images',
             'gz_api_auto_hide_images_n': 'auto_hide_images_n',
             'gz_api_request_reasoning': 'reasoning_enabled',
-            'gz_api_reasoning_effort': 'reasoning_effort'
+            'gz_api_reasoning_effort': 'reasoning_effort',
+            'gz_api_reasoning_start': 'reasoning_start',
+            'gz_api_reasoning_end': 'reasoning_end'
         };
         if (map[key]) {
             activeApiPreset.value[map[key]] = value;
@@ -405,7 +414,9 @@ function createNewApiPreset() {
                     auto_hide_images: apiSettings.autoHideImages,
                     auto_hide_images_n: apiSettings.autoHideImagesN,
                     reasoning_enabled: apiSettings.reasoningEnabled,
-                    reasoning_effort: apiSettings.reasoningEffort
+                    reasoning_effort: apiSettings.reasoningEffort,
+                    reasoning_start: apiSettings.reasoningStart,
+                    reasoning_end: apiSettings.reasoningEnd
                 };
 
                 apiPresets.value.push(newPreset);
@@ -435,7 +446,9 @@ function applyApiPreset(p) {
         autoHideImages: (p.auto_hide_images === true || p.auto_hide_images === 'true'),
         autoHideImagesN: parseInt(p.auto_hide_images_n || '1', 10),
         requestReasoning: (p.reasoning_enabled === true || p.reasoning_enabled === 'true'),
-        reasoningEffort: p.reasoning_effort || 'medium'
+        reasoningEffort: p.reasoning_effort || 'medium',
+        reasoningStart: p.reasoning_start || '',
+        reasoningEnd: p.reasoning_end || ''
     });
     
     apiSettings.endpoint = p.endpoint;
@@ -451,6 +464,8 @@ function applyApiPreset(p) {
     apiSettings.autoHideImagesN = parseInt(p.auto_hide_images_n || '1', 10);
     apiSettings.reasoningEnabled = (p.reasoning_enabled === true || p.reasoning_enabled === 'true');
     apiSettings.reasoningEffort = p.reasoning_effort || 'medium';
+    apiSettings.reasoningStart = p.reasoning_start || '';
+    apiSettings.reasoningEnd = p.reasoning_end || '';
     
     checkConnection();
 }
@@ -755,6 +770,12 @@ onBeforeUnmount(() => {
                             <span>{{ t('reasoning_effort_' + apiSettings.reasoningEffort) || apiSettings.reasoningEffort }}</span>
                             <svg viewBox="0 0 24 24"><path d="M7 10l5 5 5-5z"/></svg>
                         </div>
+                    </div>
+                    <div class="settings-item">
+                        <label>{{ t('label_reasoning_tags') || 'Reasoning Tags' }}</label>
+                        <div class="settings-desc">{{ t('desc_reasoning_tags') || 'Used by reasoning macros and inline reasoning parsing' }}</div>
+                        <input type="text" v-model="apiSettings.reasoningStart" @input="onApiInput('gz_api_reasoning_start', $event.target.value)" :placeholder="startTagPlaceholder" style="margin-bottom: 5px;">
+                        <input type="text" v-model="apiSettings.reasoningEnd" @input="onApiInput('gz_api_reasoning_end', $event.target.value)" :placeholder="endTagPlaceholder">
                     </div>
                 </div>
                 </template>


### PR DESCRIPTION
## Summary
- **Fix macro engine**: `{{reasoningPrefix}}`/`{{reasoningSuffix}}` now expand **before** `{{setvar::}}`/`{{setglobalvar::}}` processing, preventing the lazy regex from breaking on nested `}}` inside setvar values (e.g. presets like Lucid Loom that embed `{{reasoningPrefix}}` inside `{{setvar::startthink::...}}`)
- **Add reasoning tag inputs to API settings**: After the reasoning settings were moved from PresetView to ApiView, the `gz_api_reasoning_start`/`gz_api_reasoning_end` fields had no UI and weren't persisted through API presets. Now they have dedicated inputs in the Reasoning section, and are saved/restored with API connection presets.

## Changes
- `macroEngine.js`: Move reasoningPrefix/Suffix expansion before setvar, after sessionVars load
- `ApiView.vue`: Add `reasoningStart`/`reasoningEnd` to reactive state, load/save/apply/create flows, and UI inputs
- `APISettings.js`: Add `reasoningStart`/`reasoningEnd` params to `applyApiRuntimeConfig`
