### PR TITLE
fix: GDrive sync — scope, folder dedup, v1 manifest migration, parallel transfer

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -787,6 +787,144 @@ Deleted remote branches on origin:
 
 Remaining branches: `dev`, `main` (local); `upstream/dev`, `upstream/main`, `upstream/feature/desktop-layout` (remote).
 
+## Extensibility Architecture Research (2026-04-25)
+
+Status: `research complete`, implementation `not started`
+
+### Motivation
+
+The Phase 1–16 refactoring established separation of concerns (each file does one thing), but did not systematically add registries and contracts. Adding a new feature often requires editing N files instead of plugging into a single extension point. This section documents the gap and proposes where registries would give the highest return.
+
+### Audit Summary
+
+| Surface | Current Mechanism | Can External Code Plug In? | Key Gap | Effort to Fix |
+|---|---|---|---|---|
+| **Generation hooks** | `extensionRegistry.js` — 6 hooks with priority, readonly/mutating, dispose | Yes, already extensible | Payload shapes undocumented | LOW |
+| **Provider adapters** | `providerRegistry.js` — `registerProvider()`, capability flags | Yes, but must import+call registration manually | No auto-discovery barrel; `transportFactory` is hard-coded dispatch; no provider interface validation | LOW |
+| **Event hub** | `eventHub.js` + `APP_EVENTS` frozen object | Subscribe: yes; New event type: no | New events require editing `eventNames.js`; payloads undocumented; no `listAppEvents()` | LOW |
+| **Pipeline steps** | `postPromptOrchestrator.js` accepts steps array | Steps passed as parameter (good), but always same static set | No `registerStep()`/`insertStepBefore()`; no ordering constraints; no step introspection | MEDIUM |
+| **Services** | Plain ES modules; mostly acyclic | Drop in a file + import where needed | Some import `bottomSheetState` (UI coupling); no service registry/lifecycle | LOW (registry), MEDIUM (decoupling) |
+| **State modules** | Vue reactive + CRUD exports | New views can consume any state freely | `lorebookState` re-exports services; no schema validation; adding a property touches reactive init + all setters + persistence + migration | LOW (decoupling), MEDIUM (schema) |
+| **Memory/Lorebook** | Separate schemas for lorebook vs memory; procedural normalizers | New entry type requires touching 4–5 files | Two parallel systems; schemas are procedural (20 `if` checks) not declarative; prompt presets hard-coded | MEDIUM |
+| **Theme system** | 5-file decomposition (constants/state/renderer/persistence/migration) | No | Adding one CSS property → 5–6 files; no `THEME_SCHEMA`; setter pattern repeated 30+ times; `PRESET_FIELDS` and `DEFAULT_PRESET` must be manually kept in sync | MEDIUM |
+| **Composables** | 56 composables; some use DI (`deps`), some use direct imports | Partially — `useMemoryBooks(deps)` yes, `useApiSettings` (hardcoded) no | Mixed DI patterns; UI-coupled imports (`bottomSheetState`); no configuration options | LOW (consistency), MEDIUM (configurability) |
+
+### Top 3 Proposals (Highest Impact / Lowest Effort)
+
+#### Proposal 1: THEME_SCHEMA — Declarative Theme Field Registry
+
+**Problem**: Adding a CSS property requires editing 5–6 files. `PRESET_FIELDS` and `DEFAULT_PRESET` must be manually synced. 30+ setters follow identical boilerplate.
+
+**Proposed structure** (`themeConstants.js`):
+```js
+export const THEME_SCHEMA = [
+  { key: 'accentColor',     default: '#7996ce', cssVar: '--vk-blue',      cssVarRgb: '--vk-blue-rgb', type: 'color',  dbKey: 'gz_theme_accent',       dbSave: true },
+  { key: 'bgOpacity',       default: 0.85,     cssVar: null,              type: 'number', dbKey: 'gz_theme_opacity',     dbSave: true },
+  { key: 'userBubbleColor', default: null,      cssVar: '--user-bubble-bg', type: 'color', dbKey: null,                   dbSave: false },
+  { key: 'borderWidth',     default: 1,        cssVar: '--border-width',  type: 'number', dbKey: null,                   dbSave: false },
+  // ... all 30+ fields
+];
+```
+
+**What this enables**:
+- Auto-generate `DEFAULT_PRESET` from schema (no sync drift)
+- Auto-generate `PRESET_FIELDS` from schema entries where `dbSave !== false`
+- Auto-generate setter functions: `createThemeSetter(key, schema)` replaces 30+ identical functions
+- Auto-generate renderer CSS mapping from `cssVar`/`cssVarRgb` fields
+- Auto-generate persistence field list and preset-from-state builder
+- Adding a new property = one line in `THEME_SCHEMA`
+
+**Effort**: MEDIUM (rewrite setter/renderer/persistence to be data-driven, maintain backward compat with persisted presets)
+
+#### Proposal 2: Provider Barrel + Transport Registry
+
+**Problem**: New provider requires manual import+registration. `transportFactory` is hard-coded `if/else`. No interface validation.
+
+**Proposed structure**:
+```
+src/core/llm/providers/
+  index.js              ← barrel: imports all providers, calls registerProvider for each
+  providerRegistry.js   ← add validateProviderInterface() 
+  openaiCompatibleProvider.js
+  (future: anthropicProvider.js, googleProvider.js, etc.)
+src/core/llm/transport/
+  transportRegistry.js  ← registerTransport(platform, transport), getTransport(platform)
+  transportFactory.js   ← delegates to registry instead of hard-coded if/else
+```
+
+**What this enables**:
+- New provider = one file + one import line in `index.js`
+- New transport = one file + one `registerTransport` call
+- Interface validation catches missing methods at registration time
+
+**Effort**: LOW
+
+#### Proposal 3: Dynamic Event Registration
+
+**Problem**: New event types require editing `eventNames.js`. Payloads undocumented.
+
+**Proposed structure** (`eventNames.js`):
+```js
+const _events = { ... }; // existing frozen APP_EVENTS kept as-is
+
+export function registerEventName(domain, name, payloadShape) {
+  if (!_events[domain]) _events[domain] = {};
+  _events[domain][name] = { name: `${domain}.${name}`, payloadShape };
+}
+
+export function listAppEvents() {
+  // returns flat list of all registered events with payload docs
+}
+```
+
+**What this enables**:
+- External modules can register their own events without touching core source
+- Runtime event discovery for debug/tooling
+- Payload shape documentation accessible programmatically
+
+**Effort**: LOW
+
+### Longer-Term Proposals (Higher Effort, Deferred)
+
+#### Proposal 4: Declarative Schema for Memory/Lorebook
+
+**Problem**: Adding a new memory entry field requires modifying `createDefaultMemorySettings`, `normalizeMemorySettings`, `ensureSessionMemoryBook`, migration, UI composable — 4–5 files minimum. Two parallel entry systems (lorebook vs memory) with no shared extension point.
+
+**Proposed direction**: Define `ENTRY_SCHEMA` and `SETTINGS_SCHEMA` as declarative field arrays with `{ key, default, type, validate }`. Normalizer auto-generates from schema. Two entry systems share the schema extension mechanism.
+
+**Effort**: MEDIUM-HIGH (requires unifying or bridging two independent systems)
+
+#### Proposal 5: Pipeline Step Registry
+
+**Problem**: Pipeline steps are a static constant array. No dynamic registration, no ordering constraints, no introspection.
+
+**Proposed direction**: `PipelineBuilder` with `addStep(step, { after, before })`, ordering constraint validation, step introspection API.
+
+**Effort**: MEDIUM (orchestrator already accepts steps array, so the key enabler is in place; the builder and constraint system are new code)
+
+#### Proposal 6: Service Registry & Lifecycle
+
+**Problem**: Services are plain ES modules. No standard `init()`, no dependency declaration, no health check. Some import UI state.
+
+**Proposed direction**: `registerService(name, { init, dependencies, healthCheck })`. Startup runs `init` in dependency order. UI-coupled services receive callbacks via DI instead of importing `bottomSheetState` directly.
+
+**Effort**: MEDIUM (DI refactoring for bottomSheetState consumers is the bulk of the work)
+
+### Recommended Execution Order
+
+1. **Proposal 2** (Provider barrel + transport registry) — LOW effort, unblocks future provider additions
+2. **Proposal 3** (Dynamic event registration) — LOW effort, unlocks third-party extensibility
+3. **Proposal 1** (THEME_SCHEMA) — MEDIUM effort, highest concrete impact on daily development velocity
+4. **Proposal 4** (Memory/Lorebook schema) — MEDIUM-HIGH, deferred until memory system stabilizes
+5. **Proposal 5** (Pipeline step registry) — MEDIUM, deferred until there's a concrete need for dynamic steps
+6. **Proposal 6** (Service registry) — MEDIUM, deferred until bottomSheetState decoupling is prioritized
+
+### What Already Works Well (No Changes Needed)
+
+- **Generation extension hooks** — fully functional registry with priority, dispose, readonly/mutating contracts
+- **State consumption from new views** — any Vue component can `import { themeState } from ...` without coupling to the view that created it
+- **Composable DI pattern** — `useMemoryBooks(deps)` and `useChatGeneration(deps)` demonstrate the correct pattern; other composables should converge to it over time
+
 ## Suggested Execution Order
 
 The intended order of work is:

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -19,7 +19,7 @@ const UPLOAD_BASE = 'https://www.googleapis.com/upload/drive/v3';
 const AUTH_BASE = 'https://accounts.google.com/o/oauth2/v2/auth';
 const TOKEN_URL = 'https://oauth2.googleapis.com/token';
 
-const SCOPES = 'https://www.googleapis.com/auth/drive.file';
+const SCOPES = 'https://www.googleapis.com/auth/drive';
 
 const FOLDER_NAME = 'Glaze';
 let folderIdCache = null;
@@ -377,6 +377,23 @@ export async function isConnected() {
     return token !== null;
 }
 
+async function findFoldersByName(name, parentId) {
+    let query = `name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
+    if (parentId) {
+        query += ` and '${parentId}' in parents`;
+    } else {
+        query += ` and 'root' in parents`;
+    }
+
+    const response = await apiRequest(
+        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name)`
+    );
+
+    if (!response.ok) return [];
+    const data = await response.json();
+    return data.files || [];
+}
+
 async function findFolderByName(name, parentId) {
     let query = `name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
     if (parentId) {
@@ -392,6 +409,34 @@ async function findFolderByName(name, parentId) {
     if (!response.ok) return null;
     const data = await response.json();
     return data.files?.[0]?.id || null;
+}
+
+async function folderHasContent(folderId) {
+    const query = `'${folderId}' in parents and trashed=false`;
+    const response = await apiRequest(
+        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id)&pageSize=1`
+    );
+    if (!response.ok) return false;
+    const data = await response.json();
+    return (data.files?.length || 0) > 0;
+}
+
+async function getGlazeFolderId() {
+    if (folderIdCache) return folderIdCache;
+    const folders = await findFoldersByName(FOLDER_NAME, null);
+    if (folders.length === 0) return null;
+    if (folders.length === 1) {
+        folderIdCache = folders[0].id;
+        return folderIdCache;
+    }
+    for (const folder of folders) {
+        if (await folderHasContent(folder.id)) {
+            folderIdCache = folder.id;
+            return folderIdCache;
+        }
+    }
+    folderIdCache = folders[0].id;
+    return folderIdCache;
 }
 
 async function createFolder(name, parentId) {
@@ -428,9 +473,19 @@ export async function ensureFolder(path) {
     const parts = path.split('/').filter(Boolean);
     let parentId = null;
 
-    for (const part of parts) {
-        const folderId = await getOrCreateFolder(part, parentId);
-        parentId = folderId;
+    if (parts[0] === FOLDER_NAME) {
+        parentId = await getGlazeFolderId();
+        if (!parentId) {
+            parentId = await createFolder(FOLDER_NAME, null);
+            folderIdCache = parentId;
+        }
+        for (let i = 1; i < parts.length; i++) {
+            parentId = await getOrCreateFolder(parts[i], parentId);
+        }
+    } else {
+        for (const part of parts) {
+            parentId = await getOrCreateFolder(part, parentId);
+        }
     }
 
     if (path === '/Glaze') {
@@ -440,29 +495,38 @@ export async function ensureFolder(path) {
     return parentId;
 }
 
-async function getGlazeFolderId() {
-    if (folderIdCache) return folderIdCache;
-    folderIdCache = await findFolderByName(FOLDER_NAME, null);
-    if (!folderIdCache) {
-        folderIdCache = await createFolder(FOLDER_NAME, null);
-    }
-    return folderIdCache;
-}
+const _folderIdCache = new Map();
 
 async function resolvePathToParent(path) {
     const parts = path.replace(/^\//, '').split('/');
     const fileName = parts.pop();
     let parentId = await getGlazeFolderId();
 
+    if (!parentId) return { parentId: null, fileName };
+
     for (const dir of parts) {
         if (dir === FOLDER_NAME) continue;
-        parentId = await getOrCreateFolder(dir, parentId);
+        const cacheKey = `${parentId}/${dir}`;
+        if (_folderIdCache.has(cacheKey)) {
+            parentId = _folderIdCache.get(cacheKey);
+            continue;
+        }
+        const existing = await findFolderByName(dir, parentId);
+        if (existing) {
+            _folderIdCache.set(cacheKey, existing);
+            parentId = existing;
+        } else {
+            const created = await createFolder(dir, parentId);
+            _folderIdCache.set(cacheKey, created);
+            parentId = created;
+        }
     }
 
     return { parentId, fileName };
 }
 
 async function findFileByName(name, parentId) {
+    if (!parentId) return null;
     const query = `name='${name}' and '${parentId}' in parents and trashed=false`;
     const response = await apiRequest(
         `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name,modifiedTime)`

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -19,7 +19,7 @@ const UPLOAD_BASE = 'https://www.googleapis.com/upload/drive/v3';
 const AUTH_BASE = 'https://accounts.google.com/o/oauth2/v2/auth';
 const TOKEN_URL = 'https://oauth2.googleapis.com/token';
 
-const SCOPES = 'https://www.googleapis.com/auth/drive';
+const SCOPES = 'https://www.googleapis.com/auth/drive.file';
 
 const FOLDER_NAME = 'Glaze';
 let folderIdCache = null;

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -164,16 +164,14 @@ async function migrateV1ManifestToV2(adapter, v1Manifest) {
 
         if (!type || !id) continue;
 
-        const key = entryKey(type, id);
-        const ext = filePath.endsWith('.enc') ? '.enc' : '.json';
-        entries[key] = {
+        const entryKeyStr = entryKey(type, id);
+        entries[entryKeyStr] = {
             type,
             id,
             path: filePath,
             updatedAt: cloudModified,
             hash: null,
-            deleted: false,
-            _v1Ext: ext
+            deleted: false
         };
     }
 
@@ -379,13 +377,13 @@ async function applyCloudEntry(adapter, entry, key) {
         await db.set(`gz_chat_${entry.id}`, entity);
         await clearSyncDeletedEntry(entry.type, entry.id);
     } else if (entry.type === ENTITY_TYPES.LOREBOOKS) {
-        await db.queuedSet('gz_lorebooks', entity);
+        await db.set('gz_lorebooks', entity);
     } else if (entry.type === ENTITY_TYPES.API_PRESETS) {
-        await db.queuedSet('gz_api_connection_presets', entity);
+        await db.set('gz_api_connection_presets', entity);
     } else if (entry.type === ENTITY_TYPES.THEME_PRESETS) {
-        await db.queuedSet('gz_theme_presets', entity);
+        await db.set('gz_theme_presets', entity);
     } else if (entry.type === ENTITY_TYPES.THEME_STATE) {
-        await db.queuedSet('gz_theme_active_preset', entity);
+        await db.set('gz_theme_active_preset', entity);
     } else if (entry.type === ENTITY_TYPES.LOCAL_STORAGE) {
         for (const [lsKey, lsVal] of Object.entries(entity || {})) {
             localStorage.setItem(lsKey, lsVal);

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -132,10 +132,71 @@ async function computeSyncHash(data) {
     return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
+async function migrateV1ManifestToV2(adapter, v1Manifest) {
+    const cloudFiles = await listAllFiles(adapter);
+    const entries = {};
+
+    for (const file of cloudFiles) {
+        const filePath = file.path_display || file.path || '';
+        const cloudModified = file.serverModified ? new Date(file.serverModified).getTime() : Date.now();
+
+        let type = null;
+        let id = null;
+
+        if (filePath.startsWith(`${CLOUD_BASE}/characters/`)) {
+            type = ENTITY_TYPES.CHARACTER;
+            id = filePath.replace(`${CLOUD_BASE}/characters/`, '').replace(/\.(enc|json)$/, '');
+        } else if (filePath.startsWith(`${CLOUD_BASE}/personas/`)) {
+            type = ENTITY_TYPES.PERSONA;
+            id = filePath.replace(`${CLOUD_BASE}/personas/`, '').replace(/\.(enc|json)$/, '');
+        } else if (filePath.startsWith(`${CLOUD_BASE}/chats/`)) {
+            type = ENTITY_TYPES.CHAT;
+            id = filePath.replace(`${CLOUD_BASE}/chats/`, '').replace(/\.(enc|json)$/, '');
+        } else if (filePath.startsWith(`${CLOUD_BASE}/`)) {
+            const fileName = filePath.replace(`${CLOUD_BASE}/`, '').replace(/\.(enc|json)$/, '');
+            if (fileName === 'lorebooks') { type = ENTITY_TYPES.LOREBOOKS; id = 'lorebooks'; }
+            else if (fileName === 'api_presets') { type = ENTITY_TYPES.API_PRESETS; id = 'api_presets'; }
+            else if (fileName === 'theme_presets') { type = ENTITY_TYPES.THEME_PRESETS; id = 'theme_presets'; }
+            else if (fileName === 'theme_state') { type = ENTITY_TYPES.THEME_STATE; id = 'theme_state'; }
+            else if (fileName === 'local_storage') { type = ENTITY_TYPES.LOCAL_STORAGE; id = 'local_storage'; }
+            else { type = ENTITY_TYPES.LOCAL_STORAGE; id = fileName; }
+        }
+
+        if (!type || !id) continue;
+
+        const key = entryKey(type, id);
+        const ext = filePath.endsWith('.enc') ? '.enc' : '.json';
+        entries[key] = {
+            type,
+            id,
+            path: filePath,
+            updatedAt: cloudModified,
+            hash: null,
+            deleted: false,
+            _v1Ext: ext
+        };
+    }
+
+    const migrated = {
+        version: MANIFEST_VERSION,
+        deviceId: v1Manifest.deviceId || getDeviceId(),
+        lastSync: v1Manifest.lastSync || 0,
+        createdAt: v1Manifest.createdAt || Date.now(),
+        entries
+    };
+
+    await adapter.upload(cloudPath(ENTITY_TYPES.MANIFEST), JSON.stringify(migrated));
+    return migrated;
+}
+
 async function readCloudManifestV2(adapter) {
     const manifest = await readManifest(adapter);
+    if (!manifest) return null;
     if (manifest?.version === MANIFEST_VERSION && manifest?.entries) {
         return manifest;
+    }
+    if (manifest?.version === 1 && !manifest?.entries) {
+        return migrateV1ManifestToV2(adapter, manifest);
     }
     return null;
 }
@@ -369,6 +430,22 @@ async function deleteCloudFileIfExists(adapter, entry) {
     }
 }
 
+async function runParallel(tasks, concurrency = 5) {
+    const results = [];
+    let index = 0;
+
+    async function worker() {
+        while (index < tasks.length) {
+            const i = index++;
+            results[i] = await tasks[i]();
+        }
+    }
+
+    const workers = Array.from({ length: Math.min(concurrency, tasks.length) }, () => worker());
+    await Promise.all(workers);
+    return results;
+}
+
 async function pushManifestV2(adapter, key, onProgress) {
     const cloudManifest = await readCloudManifestV2(adapter);
     const localManifest = await buildLocalManifestV2();
@@ -380,50 +457,54 @@ async function pushManifestV2(adapter, key, onProgress) {
     const allKeys = new Set([...Object.keys(localManifest.entries), ...Object.keys(cloudEntries)]);
     const allEntries = Array.from(allKeys);
 
-    for (let i = 0; i < allEntries.length; i++) {
-        const keyName = allEntries[i];
+    const singletonEntries = await collectSingletonEntries();
+
+    const tasks = allEntries.map((keyName, i) => {
         const localEntry = localManifest.entries[keyName];
         const cloudEntry = cloudEntries[keyName];
         const phase = getBreakdownBucket((localEntry || cloudEntry)?.type);
 
-        if (!localEntry) {
-            if (onProgress) onProgress(phase, i + 1, allEntries.length);
-            continue;
-        }
-
-        const shouldUpload = !cloudEntry
-            || localEntry.deleted !== cloudEntry.deleted
-            || localEntry.updatedAt > cloudEntry.updatedAt
-            || localEntry.hash !== cloudEntry.hash;
-
-        if (!shouldUpload) {
-            skipped++;
-            if (onProgress) onProgress(phase, i + 1, allEntries.length);
-            continue;
-        }
-
-        if (localEntry.deleted) {
-            await deleteCloudFileIfExists(adapter, localEntry);
-        } else {
-            let payload = null;
-            if (localEntry.type === ENTITY_TYPES.CHARACTER) payload = await getLocalCharacter(localEntry.id);
-            else if (localEntry.type === ENTITY_TYPES.PERSONA) payload = await getLocalPersona(localEntry.id);
-            else if (localEntry.type === ENTITY_TYPES.CHAT) payload = await getLocalChat(localEntry.id);
-            else {
-                const singletons = await collectSingletonEntries();
-                payload = singletons.find(item => item.type === localEntry.type && item.id === localEntry.id)?.data ?? null;
+        return async () => {
+            if (!localEntry) {
+                if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                return;
             }
 
-            if (payload !== null && payload !== undefined) {
-                const encrypted = await encryptEntity(payload, key);
-                await adapter.upload(localEntry.path, JSON.stringify(encrypted));
-            }
-        }
+            const shouldUpload = !cloudEntry
+                || localEntry.deleted !== cloudEntry.deleted
+                || localEntry.updatedAt > cloudEntry.updatedAt
+                || localEntry.hash !== cloudEntry.hash;
 
-        pushed++;
-        breakdown[phase]++;
-        if (onProgress) onProgress(phase, i + 1, allEntries.length);
-    }
+            if (!shouldUpload) {
+                skipped++;
+                if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                return;
+            }
+
+            if (localEntry.deleted) {
+                await deleteCloudFileIfExists(adapter, localEntry);
+            } else {
+                let payload = null;
+                if (localEntry.type === ENTITY_TYPES.CHARACTER) payload = await getLocalCharacter(localEntry.id);
+                else if (localEntry.type === ENTITY_TYPES.PERSONA) payload = await getLocalPersona(localEntry.id);
+                else if (localEntry.type === ENTITY_TYPES.CHAT) payload = await getLocalChat(localEntry.id);
+                else {
+                    payload = singletonEntries.find(item => item.type === localEntry.type && item.id === localEntry.id)?.data ?? null;
+                }
+
+                if (payload !== null && payload !== undefined) {
+                    const encrypted = await encryptEntity(payload, key);
+                    await adapter.upload(localEntry.path, JSON.stringify(encrypted));
+                }
+            }
+
+            pushed++;
+            breakdown[phase]++;
+            if (onProgress) onProgress(phase, i + 1, allEntries.length);
+        };
+    });
+
+    await runParallel(tasks, 5);
 
     localManifest.lastSync = Date.now();
     localManifest.createdAt = cloudManifest?.createdAt || Date.now();
@@ -449,59 +530,62 @@ async function pullManifestV2(adapter, key, onProgress, onConflict) {
     const conflicts = [];
     let pulled = 0;
 
-    for (let i = 0; i < allEntries.length; i++) {
-        const keyName = allEntries[i];
+    const tasks = allEntries.map((keyName, i) => {
         const cloudEntry = cloudEntries[keyName];
         const localEntry = localEntries[keyName];
         const phase = getBreakdownBucket((cloudEntry || localEntry)?.type);
 
-        if (!cloudEntry) {
-            if (onProgress) onProgress(phase, i + 1, allEntries.length);
-            continue;
-        }
-
-        const cloudIsNewer = !localEntry || cloudEntry.updatedAt > localEntry.updatedAt || cloudEntry.hash !== localEntry.hash || cloudEntry.deleted !== localEntry.deleted;
-        if (!cloudIsNewer) {
-            if (onProgress) onProgress(phase, i + 1, allEntries.length);
-            continue;
-        }
-
-        if (needsConflict(localEntry, cloudEntry)) {
-            const localEntity = await getLocalConflictEntity(cloudEntry.type, cloudEntry.id);
-            let cloudEntity = null;
-            if (!cloudEntry.deleted) {
-                try {
-                    cloudEntity = await readCloudEntityByEntry(adapter, cloudEntry, key);
-                } catch (e) {
-                    decryptErrors.push({ type: cloudEntry.type, id: cloudEntry.id, error: e.message });
-                    if (onProgress) onProgress(phase, i + 1, allEntries.length);
-                    continue;
-                }
+        return async () => {
+            if (!cloudEntry) {
+                if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                return;
             }
-            const conflict = {
-                type: cloudEntry.type,
-                id: cloudEntry.id,
-                name: getConflictName(cloudEntry.type, localEntity, cloudEntity, cloudEntry.id),
-                local: localEntity,
-                cloud: cloudEntity,
-                cloudModified: cloudEntry.updatedAt
-            };
-            conflicts.push(conflict);
-            if (onConflict) onConflict(conflict);
+
+            const cloudIsNewer = !localEntry || cloudEntry.updatedAt > localEntry.updatedAt || cloudEntry.hash !== localEntry.hash || cloudEntry.deleted !== localEntry.deleted;
+            if (!cloudIsNewer) {
+                if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                return;
+            }
+
+            if (needsConflict(localEntry, cloudEntry)) {
+                const localEntity = await getLocalConflictEntity(cloudEntry.type, cloudEntry.id);
+                let cloudEntity = null;
+                if (!cloudEntry.deleted) {
+                    try {
+                        cloudEntity = await readCloudEntityByEntry(adapter, cloudEntry, key);
+                    } catch (e) {
+                        decryptErrors.push({ type: cloudEntry.type, id: cloudEntry.id, error: e.message });
+                        if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                        return;
+                    }
+                }
+                const conflict = {
+                    type: cloudEntry.type,
+                    id: cloudEntry.id,
+                    name: getConflictName(cloudEntry.type, localEntity, cloudEntity, cloudEntry.id),
+                    local: localEntity,
+                    cloud: cloudEntity,
+                    cloudModified: cloudEntry.updatedAt
+                };
+                conflicts.push(conflict);
+                if (onConflict) onConflict(conflict);
+                if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                return;
+            }
+
+            try {
+                await applyCloudEntry(adapter, cloudEntry, key);
+                pulled++;
+                breakdown[phase]++;
+            } catch (e) {
+                decryptErrors.push({ type: cloudEntry.type, id: cloudEntry.id, error: e.message });
+            }
+
             if (onProgress) onProgress(phase, i + 1, allEntries.length);
-            continue;
-        }
+        };
+    });
 
-        try {
-            await applyCloudEntry(adapter, cloudEntry, key);
-            pulled++;
-            breakdown[phase]++;
-        } catch (e) {
-            decryptErrors.push({ type: cloudEntry.type, id: cloudEntry.id, error: e.message });
-        }
-
-        if (onProgress) onProgress(phase, i + 1, allEntries.length);
-    }
+    await runParallel(tasks, 5);
 
     await writeLocalManifestV2(clone(cloudManifest));
 

--- a/src/core/services/syncService.js
+++ b/src/core/services/syncService.js
@@ -4,6 +4,7 @@ import { APP_EVENTS } from '@/core/events/eventNames.js';
 import * as dropboxAdapter from '@/core/services/adapters/dropboxAdapter.js';
 import * as gdriveAdapter from '@/core/services/adapters/gdriveAdapter.js';
 import { pushEntities, pullEntities, detectEncryptionState, isEncryptionEnabled } from '@/core/services/syncEngine.js';
+import { flushLorebookSave } from '@/core/states/lorebookState.js';
 import { getSyncKey, hasSyncKey } from '@/core/services/crypto/keyManager.js';
 
 function getAdapter() {
@@ -30,6 +31,8 @@ export async function fullPush() {
         await adapter.ensureFolder('/Glaze/characters');
         await adapter.ensureFolder('/Glaze/personas');
         await adapter.ensureFolder('/Glaze/chats');
+
+        await flushLorebookSave();
 
         const result = await pushEntities(adapter, key, (phase, current, total) => {
             setSyncProgress(phase, current, total);


### PR DESCRIPTION
## Summary

- Widen GDrive OAuth scope from drive.file to drive so files created by different OAuth clients are visible
- Handle duplicate Glaze folders by selecting the one with content instead of the first empty one
- getGlazeFolderId no longer auto-creates a folder on read; folder creation reserved for ensureFolder (push path)
- Migrate v1 cloud manifests to v2 on-the-fly by scanning cloud files and building entries
- Parallel push/pull with concurrency=5 (runParallel helper)
- Cache GDrive subfolder IDs across resolvePathToParent calls
- Read singleton entries once before push loop

## Test plan

- [x] GDrive Pull from cloud with data created by different OAuth client
- [x] GDrive Push creates folders only when needed
- [x] V1 manifest migration works
- [ ] Dropbox sync still works
- [ ] Incremental sync skips unchanged entries