### PR TITLE
fix: preserve custom prompt order in request assembly

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1066,6 +1066,30 @@ These rules prevent the gradual re-accumulation of responsibilities that motivat
 
 7. **Template is not logic** — 1000+ lines of template is acceptable for complex UI. The decomposition target is script logic, not HTML structure. Never extract a sub-component solely to reduce line count if it requires excessive prop-drilling.
 
+## Deferred Refactoring Items
+
+These files exceed the 400-line guard rail but are intentionally left as-is. Each entry explains why refactoring is deferred.
+
+### `ChatView.vue` — `openChat()` extraction (~400 lines inline)
+
+- **Status:** Deferred
+- **Reason:** `openChat()` has ~30+ dependency injections. Extracting it into a composable would create a massive parameter list and prop-drilling surface with no architectural gain — ChatView is already a composable-wiring shell. Accepted as permanent exception (see Guard Rail #1).
+- **Revisit if:** A new feature requires testing `openChat()` in isolation, or the function grows significantly beyond its current scope.
+
+### `themeState.js` (639 lines) — State ≠ service violation
+
+- **Status:** Deferred (next refactor pass)
+- **Problem:** Violates Guard Rail #3. File mixes reactive state + simple setters (~300 lines, correct) with preset CRUD orchestration (`initTheme`, `applyPreset`, `createPreset/switchPreset/deletePreset/updatePresetMeta/exportThemePreset/importThemePreset`, ~340 lines, should be a service).
+- **Proposed fix:** Extract preset orchestration into `themePresetService.js`. `themeState.js` would retain only `themeState` reactive + setter functions (~300 lines).
+- **Risk:** Low — preset functions already delegate to `themePersistence.js`, `themeMigration.js`, `themeRenderer.js`. The extraction boundary is clear.
+
+### `useMemorySheetUI.js` (844 lines) — imperative DOM anti-pattern
+
+- **Status:** Do not refactor
+- **Reason:** ~600 of 844 lines are `document.createElement('div')` + `innerHTML` + `querySelector` + `addEventListener`. This is a fundamental DOM approach problem, not a concern-mixing problem. Splitting the file into smaller pieces would not improve architecture — it would just scatter imperative DOM code across more files. The only meaningful refactoring would be rewriting all innerHTML sheets as Vue components, which is a large UI rewrite with zero architectural payoff.
+- **CRUD logic** mixed in (`createMemoryFromSelection`, `removeMemoryFromSelection`, save logic in `openMemoryEntryEditor`) is tightly coupled to the imperative DOM event handlers — extracting it separately would require passing the same DOM-read values through an extra layer.
+- **Revisit if:** A decision is made to rewrite the memory sheet UI as proper Vue template components.
+
 ---
 
 ## Testing Checklist

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -720,9 +720,11 @@ Done:
 - `_cleanupScroll` (let) passed via `getCleanupScroll()`/`setCleanupScroll()` callbacks
 - ChatView.vue reduced from 3767 → 2995 lines (-772 lines, -20.5%)
 
-Not done (deferred):
+Not done (deferred — see ARCHITECTURE.md "Deferred Refactoring Items" for details):
 - `openChat()` (~400 lines) extraction into composable — deferred due to ~30+ dependency injections required; marginal ROI given ChatView already meets the <2000 line target
 - Context/tokenizer sheet actions (~32 lines) — too small for a dedicated composable
+- `themeState.js` (639 lines) — violates State ≠ service guard rail; preset CRUD/init should move to `themePresetService.js`. Deferred to next refactor pass.
+- `useMemorySheetUI.js` (844 lines) — intentionally excluded. ~600 lines of imperative DOM; splitting would not improve architecture. Only meaningful fix is Vue-template rewrite, out of scope.
 
 Expected output:
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -293,9 +293,14 @@ Phase 8 ChatView decomposition:
 - [done] `activeChatChar` plain `let` passed via `getActiveChatChar()`/`setActiveChatChar()` callbacks instead of direct capture
 - [done] `chatGenerationServices` lazy `let` passed via `getChatGenerationServices()` factory
 - [done] `_cleanupScroll` let passed via `getCleanupScroll()`/`setCleanupScroll()` callbacks
-- [not done] Extract `openChat()` (~400 lines) into composable — deferred: ~30+ dependency injections, marginal ROI
+- [not done] Extract `openChat()` (~400 lines) into composable — deferred: ~30+ dependency injections, marginal ROI (see ARCHITECTURE.md "Deferred Refactoring Items")
 - [not done] Extract context/tokenizer sheet actions (~32 lines) — too small for dedicated composable
 - [done] ChatView.vue reduced from 3767 → 1611 lines (-57%, target <2000 met)
+
+### Deferred Refactoring (documented in ARCHITECTURE.md)
+
+- `themeState.js` (639 lines) — violates State ≠ service. Extract preset CRUD/init into `themePresetService.js` (~340 lines). Deferred to next refactor pass.
+- `useMemorySheetUI.js` (844 lines) — do not refactor. ~600 lines of imperative DOM (innerHTML + querySelector); splitting would scatter without improving architecture. Only meaningful fix is full Vue-template rewrite, which is out of scope.
 
 This roadmap intentionally assumes the tokenizer and current context UI are already in place and are not being redesigned again unless a new decision is made explicitly.
 

--- a/src/components/ui/DesktopDropdown.vue
+++ b/src/components/ui/DesktopDropdown.vue
@@ -38,6 +38,12 @@ function recalcPosition() {
     };
 }
 
+function handleItemClick(item) {
+    if (item.disabled) return;
+    closeDesktopDropdown();
+    item.onClick?.();
+}
+
 watch(
     () => desktopDropdownState.value.visible,
     (val) => {
@@ -90,7 +96,7 @@ watch(
                             'dd-item--has-bg': item.image
                         }"
                         :style="item.image ? { backgroundImage: `url(${item.image})` } : {}"
-                        @click="!item.disabled && (item.onClick?.(), closeDesktopDropdown())"
+                        @click="handleItemClick(item)"
                     >
                         <div v-if="item.image" class="dd-card-overlay"></div>
                         <div v-if="item.isFeatured" class="dd-featured-badge">

--- a/src/composables/app/usePresetSelectors.js
+++ b/src/composables/app/usePresetSelectors.js
@@ -155,7 +155,7 @@ export function usePresetSelectors({ currentPreset, currentPresetId, editingPres
                 label: t('btn_delete') || 'Delete Preset',
                 icon: '<svg viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>',
                 iconColor: '#ff4444', isDestructive: true,
-                onClick: () => confirmDeletePreset(currentPreset.value.id)
+                onClick: () => { closeBottomSheet(); confirmDeletePreset(currentPreset.value.id); }
             });
         }
 

--- a/src/core/llm/usecases/vectorLoreInjection.js
+++ b/src/core/llm/usecases/vectorLoreInjection.js
@@ -170,11 +170,17 @@ export function injectLateVectorLoreMessages({ messages, newVectorEntries, safeC
         }
     }
 
+    const keptHistoryMessages = historyMessages.slice(historyMessages.length - includedHistoryCount);
+    const finalMessages = [];
+
+    for (const message of injectedMessages) {
+        if (!message.isHistory || keptHistoryMessages.includes(message)) {
+            finalMessages.push(message);
+        }
+    }
+
     return {
-        messages: [
-            ...staticMessages,
-            ...historyMessages.slice(historyMessages.length - includedHistoryCount)
-        ],
+        messages: finalMessages,
         vectorLoreTokens
     };
 }

--- a/src/core/services/presetImportService.js
+++ b/src/core/services/presetImportService.js
@@ -82,10 +82,14 @@ export function convertSTPreset(data, fileName) {
 
     let orderList = [];
     if (data.prompt_order && Array.isArray(data.prompt_order) && data.prompt_order.length > 0) {
-        // Some presets have multiple orders, we take the one with most items or just the first one
-        const bestOrder = data.prompt_order.reduce((prev, current) =>
-            (current.order.length > prev.order.length) ? current : prev
-            , data.prompt_order[0]);
+        // ST commonly stores the user-editable prompt layout under character_id 100001.
+        // Fall back to the densest order when that layout is not present.
+        const preferredOrder = data.prompt_order.find(order => order?.character_id === 100001 && Array.isArray(order.order) && order.order.length > 0);
+        const bestOrder = preferredOrder || data.prompt_order.reduce((prev, current) => {
+            const prevLen = Array.isArray(prev?.order) ? prev.order.length : 0;
+            const currentLen = Array.isArray(current?.order) ? current.order.length : 0;
+            return currentLen > prevLen ? current : prev;
+        }, data.prompt_order[0]);
         orderList = bestOrder.order;
     } else if (data.prompts) {
         orderList = data.prompts.map(p => ({ identifier: p.identifier, enabled: p.enabled !== false }));
@@ -142,7 +146,8 @@ export function convertSTPreset(data, fileName) {
     if (data.prompts) {
         data.prompts.forEach((p) => {
             if (!usedIdentifiers.has(p.identifier)) {
-                processBlock({ identifier: p.identifier, enabled: false }, true); // Pass true for isStashed
+                const promptEnabled = p.enabled !== false;
+                processBlock({ identifier: p.identifier, enabled: promptEnabled }, !promptEnabled);
             }
         });
     }

--- a/src/core/services/presetImportService.js
+++ b/src/core/services/presetImportService.js
@@ -147,7 +147,7 @@ export function convertSTPreset(data, fileName) {
         data.prompts.forEach((p) => {
             if (!usedIdentifiers.has(p.identifier)) {
                 const promptEnabled = p.enabled !== false;
-                processBlock({ identifier: p.identifier, enabled: promptEnabled }, !promptEnabled);
+                processBlock({ identifier: p.identifier, enabled: promptEnabled }, false);
             }
         });
     }


### PR DESCRIPTION
## Summary
- prefer the user ST prompt order layout during preset import and keep prompts that are missing from prompt_order active instead of stashing them
- preserve original message ordering after late vector lore injection so the chat_history anchor stays where the preset placed it
- keep imported custom ST blocks visible in the active preset flow instead of pushing chat history to the end of the final request

## Verification
- npm run build