### PR TITLE
fix: propagate AbortController signal so stop generation closes TCP connection

### DIFF
--- a/src/composables/chat/useChatGeneration.js
+++ b/src/composables/chat/useChatGeneration.js
@@ -113,11 +113,15 @@ export function useChatGeneration(deps) {
         const existingState = getGenerationState(char.id);
 
         if (existingState && existingState.type !== 'impersonation') {
+            if (existingState.controller?.signal?.aborted) {
+                clearGenerationState(char.id, existingState.genId);
+            } else {
             console.warn('[generation] Ignoring overlapping startGeneration call for active chat request', {
                 charId: char.id,
                 existingGenId: existingState.genId
             });
             return;
+            }
         }
 
         const activeChatChar = getActiveChatChar();
@@ -148,11 +152,28 @@ export function useChatGeneration(deps) {
         const controller = new AbortController();
         const startTime = Date.now();
         const rawStreamRef = ref(text || '');
+
+        setGenerationState(char.id, {
+            genId,
+            type: 'chat',
+            controller,
+            startTime,
+            pending: true
+        });
+
         resolveGenerationSessionContext({ char, db }).then(context => {
+            const pendingState = getGenerationState(char.id);
+            if (!pendingState || pendingState.genId !== genId || controller.signal.aborted) {
+                return;
+            }
             continueGeneration(context);
         }).catch(e => {
             console.error('Failed to load chat for generation:', e);
-            isGenerating.value = false;
+            const pendingState = getGenerationState(char.id);
+            if (pendingState?.genId === genId) {
+                clearGenerationState(char.id, genId);
+                isGenerating.value = false;
+            }
         });
 
         async function continueGeneration({ sessionId, summary, anContent }) {

--- a/src/composables/chat/useChatMessageDisplay.js
+++ b/src/composables/chat/useChatMessageDisplay.js
@@ -6,6 +6,7 @@ export function restoreVisibleSwipeState(messages = []) {
 
     return messages.map(msg => {
         if (!msg || !Array.isArray(msg.swipesMeta)) return msg;
+        if (msg.isTyping) return msg;
 
         const swipeIndex = msg.swipeId || 0;
         const swipeMeta = msg.swipesMeta[swipeIndex];

--- a/src/composables/chat/useGenerationAbort.js
+++ b/src/composables/chat/useGenerationAbort.js
@@ -1,6 +1,5 @@
 export function useGenerationAbort({
     getGenerationState,
-    clearGenerationState,
     isGenerating,
     isImpersonating,
     activeChatChar
@@ -15,23 +14,26 @@ export function useGenerationAbort({
 
         if (state.controller) {
             try {
+                state.userAborted = true;
+                state.controller.userAborted = true;
                 state.controller.abort();
             } catch (abortErr) {
                 console.warn('[generation] Failed to abort controller:', abortErr);
             }
         }
 
-        if (restore && state.restoreState) {
-            try {
-                await state.restoreState();
-            } catch (restoreErr) {
-                console.error('[generation] Failed to restore state after abort:', restoreErr);
-            }
+        if (typeof state.clearGenerationTimer === 'function') {
+            state.clearGenerationTimer();
+        } else if (state.timerId) {
+            clearTimeout(state.timerId);
+            state.timerId = null;
         }
 
-        clearGenerationState(charId, state.genId);
+        if (typeof state.clearStreamFlushTimer === 'function') {
+            state.clearStreamFlushTimer();
+        }
 
-        if (activeChatChar && activeChatChar.value && activeChatChar.value.id === charId) {
+        if (activeChatChar?.value && activeChatChar.value.id === charId) {
             isGenerating.value = false;
         }
 
@@ -40,9 +42,12 @@ export function useGenerationAbort({
 
     function abortImpersonation(charId, state) {
         if (state?.controller) {
-            try { state.controller.abort(); } catch (e) {}
+            try {
+                state.userAborted = true;
+                state.controller.userAborted = true;
+                state.controller.abort();
+            } catch (e) {}
         }
-        clearGenerationState(charId);
         isGenerating.value = false;
         if (isImpersonating) isImpersonating.value = false;
         return true;

--- a/src/composables/chat/useGenerationCompleteHandler.js
+++ b/src/composables/chat/useGenerationCompleteHandler.js
@@ -76,6 +76,10 @@ function resolveFinalResponse(cleanedResponse, existingText) {
     return cleanedResponse;
 }
 
+function normalizeCompletionText(text) {
+    return typeof text === 'string' ? text : '';
+}
+
 export async function handleGenerationComplete({
     response,
     finalReasoning,
@@ -150,9 +154,13 @@ export async function handleGenerationComplete({
         }
 
         if (!currentState || currentState.genId !== genId) {
-            await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
-            ensureStaleCleanup();
-            notifyGenerationEnded({ charId: char.id, sessionId });
+            // A newer generation can reuse the same message record (e.g. swipe regeneration).
+            // In that case this stale completion must not mutate typing state for the active request.
+            if (!currentState) {
+                await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
+                ensureStaleCleanup();
+            }
+            notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
             return;
         }
 
@@ -169,7 +177,14 @@ export async function handleGenerationComplete({
         if (controller.signal.aborted && !hasCompletionPayload) {
             await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
             ensureCleanup();
-            notifyGenerationEnded({ charId: char.id, sessionId });
+            notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
+            return;
+        }
+
+        if (controller.signal.aborted && controller.userAborted) {
+            await clearTypingStateForMessage({ charId: char.id, sessionId, msgId });
+            ensureCleanup();
+            notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
             return;
         }
 
@@ -188,7 +203,7 @@ export async function handleGenerationComplete({
         if (activeChatChar?.value && activeChatChar.value.id === char.id) isGenerating.value = false;
 
         const now = new Date();
-        const cleanedResponse = cleanText(response);
+        const cleanedResponse = cleanText(normalizeCompletionText(response));
         const time = now.getHours() + ':' + String(now.getMinutes()).padStart(2, '0');
         const duration = ((Date.now() - startTime) / 1000).toFixed(2) + 's';
 
@@ -255,7 +270,7 @@ export async function handleGenerationComplete({
                 }
             }
 
-            notifyGenerationEnded({ charId: char.id, sessionId });
+            notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
             return;
         }
 
@@ -325,9 +340,13 @@ export async function handleGenerationComplete({
                     notifyChatUpdated();
                 });
 
-                notifyGenerationEnded({ charId: char.id, sessionId });
+                notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
+                return;
             }
         }
+
+        ensureCleanup();
+        notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
     } catch (completeErr) {
         console.error('[onComplete] Completion handler failed:', completeErr);
         ensureCleanup();
@@ -337,6 +356,6 @@ export async function handleGenerationComplete({
             msgId,
             errorLabel: '[onComplete]'
         });
-        notifyGenerationEnded({ charId: char.id, sessionId });
+        notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
     }
 }

--- a/src/composables/chat/useGenerationErrorHandler.js
+++ b/src/composables/chat/useGenerationErrorHandler.js
@@ -47,11 +47,12 @@ export async function handleGenerationError({
     };
 
     try {
-        if (error.message === 'Context limit exceeded') {
+        if (error?.name === 'AbortError' && error?.userAborted) {
             await restoreState(false);
             finalizeGenerationState({
                 charId: char.id,
                 sessionId,
+                expectedGenId: genId,
                 getGenerationState,
                 clearGenerationState,
                 clearPersistedGeneration,
@@ -59,7 +60,24 @@ export async function handleGenerationError({
                 isGenerating,
                 activeChatChar
             });
-            notifyGenerationEnded({ charId: char.id, sessionId });
+            notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
+            return;
+        }
+
+        if (error.message === 'Context limit exceeded') {
+            await restoreState(false);
+            finalizeGenerationState({
+                charId: char.id,
+                sessionId,
+                expectedGenId: genId,
+                getGenerationState,
+                clearGenerationState,
+                clearPersistedGeneration,
+                clearBackgroundUpdateTimer,
+                isGenerating,
+                activeChatChar
+            });
+            notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
             return;
         }
 
@@ -67,6 +85,7 @@ export async function handleGenerationError({
         finalizeGenerationState({
             charId: char.id,
             sessionId,
+            expectedGenId: genId,
             getGenerationState,
             clearGenerationState,
             clearPersistedGeneration,
@@ -109,13 +128,14 @@ export async function handleGenerationError({
             }
         }
 
-        notifyGenerationEnded({ charId: char.id, sessionId });
+        notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
     } catch (handlerErr) {
         console.error('[onError] Error handler failed:', handlerErr);
         await ensureTypingCleared();
         finalizeGenerationState({
             charId: char.id,
             sessionId,
+            expectedGenId: genId,
             getGenerationState,
             clearGenerationState,
             clearPersistedGeneration,
@@ -123,6 +143,6 @@ export async function handleGenerationError({
             isGenerating,
             activeChatChar
         });
-        notifyGenerationEnded({ charId: char.id, sessionId });
+        notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
     }
 }

--- a/src/composables/chat/useGenerationFinalization.js
+++ b/src/composables/chat/useGenerationFinalization.js
@@ -11,6 +11,7 @@ export function finalizeGenerationState({
 }) {
     const currentState = getGenerationState(charId);
     if (!currentState) return;
+    if (expectedGenId !== null && currentState.genId !== expectedGenId) return;
 
     if (currentState.timerId) {
         clearTimeout(currentState.timerId);

--- a/src/composables/chat/useGenerationStateRestore.js
+++ b/src/composables/chat/useGenerationStateRestore.js
@@ -37,6 +37,7 @@ export async function restoreGenerationState({
     sessionId,
     msgId,
     isError = false,
+    expectedGenId = null,
     onAbort = null,
     restorePromptMetaOnMessages,
     clearBackgroundUpdateTimer,
@@ -48,6 +49,9 @@ export async function restoreGenerationState({
     }
 
     const generationState = getGenerationState(char.id);
+    if (!generationState) return;
+    if (expectedGenId !== null && generationState.genId !== expectedGenId) return;
+
     if (typeof generationState?.clearStreamFlushTimer === 'function') {
         generationState.clearStreamFlushTimer();
     }

--- a/src/composables/chat/useGenerationStateSetup.js
+++ b/src/composables/chat/useGenerationStateSetup.js
@@ -72,6 +72,15 @@ export function setupGenerationState({
     const flushPendingUIUpdate = () => {
         streamFlushTimer = null;
 
+        const activeState = getGenerationState(char.id);
+        if (!activeState || activeState.genId !== genId || activeState.sessionId !== sessionId || activeState.msgId !== msgId) {
+            pendingText = null;
+            pendingReasoning = null;
+            pendingTyping = null;
+            pendingTextDelta = null;
+            return;
+        }
+
         if (pendingText === null && pendingReasoning === null && pendingTyping === null && pendingTextDelta === null) return;
 
         const idx = currentMessages.value.findIndex(message => message.id === msgId);
@@ -104,6 +113,11 @@ export function setupGenerationState({
     };
 
     const initialUIUpdate = (text, reasoning, isTyping, textDelta) => {
+        const activeState = getGenerationState(char.id);
+        if (!activeState || activeState.genId !== genId || activeState.sessionId !== sessionId || activeState.msgId !== msgId) {
+            return;
+        }
+
         pendingText = text;
         pendingReasoning = reasoning;
         pendingTyping = isTyping;
@@ -142,7 +156,7 @@ export function setupGenerationState({
             }
 
             const state = getGenerationState(char.id);
-            if (state && state.genId === genId) {
+            if (state && state.genId === genId && !state.controller?.signal?.aborted) {
                 scheduleGenerationTimer();
             }
         }, getGenerationTimerInterval());

--- a/src/composables/chat/useMessageActions.js
+++ b/src/composables/chat/useMessageActions.js
@@ -29,6 +29,15 @@ export function useMessageActions(deps) {
         t
     } = deps;
 
+    async function persistCurrentSessionMessages(chatChar) {
+        if (!chatChar?.id) return;
+        const data = await getChatData(chatChar.id);
+        const sessionId = chatChar.sessionId || data?.currentId;
+        if (!data || !sessionId) return;
+        data.sessions[sessionId] = currentMessages.value;
+        await db.saveChat(chatChar.id, data);
+    }
+
     function getReasoningTags() {
         let { start, end } = getApiReasoningTags();
 
@@ -79,9 +88,22 @@ export function useMessageActions(deps) {
             const newSwipeIndex = (msg.swipes?.length || 0);
             if (!msg.swipes) msg.swipes = [msg.text];
             msg.swipes.push("");
+            if (Array.isArray(msg.swipesMeta)) {
+                msg.swipesMeta[newSwipeIndex] = {
+                    guidanceText: null,
+                    guidanceType: null,
+                    reasoning: null,
+                    genTime: null,
+                    tokens: null
+                };
+            }
             msg.swipeId = newSwipeIndex;
             msg.text = "";
             msg.reasoning = null;
+            msg.genTime = null;
+            msg.isAllReasoning = false;
+            msg.isPartial = false;
+            msg.partialErrorMsg = null;
             msg.isTyping = true;
 
             let effectiveGuidance = null;
@@ -95,15 +117,7 @@ export function useMessageActions(deps) {
             startGeneration(activeChatChar, null, msgIndex, null, effectiveGuidance, effectiveType);
         } else {
             currentMessages.value.splice(msgIndex);
-            const charId = activeChatChar.id;
-            const sessionId = activeChatChar.sessionId;
-            const messageSnapshot = currentMessages.value;
-            getChatData(activeChatChar.id).then(data => {
-                if (data && sessionId && data.sessions?.[sessionId]) {
-                    data.sessions[sessionId] = messageSnapshot;
-                    db.saveChat(charId, data);
-                }
-            });
+            persistCurrentSessionMessages(activeChatChar);
 
             startGeneration(activeChatChar, null, -1, null, guidanceText, 'GENERATION');
         }
@@ -185,17 +199,7 @@ export function useMessageActions(deps) {
                             }
                         } else {
                             currentMessages.value.splice(index, 1);
-                            if (activeChatChar) {
-                                const charId = activeChatChar.id;
-                                const sessionId = activeChatChar.sessionId;
-                                const messageSnapshot = currentMessages.value;
-                                getChatData(activeChatChar.id).then(data => {
-                                    if (data && sessionId && data.sessions?.[sessionId]) {
-                                        data.sessions[sessionId] = messageSnapshot;
-                                        db.saveChat(charId, data);
-                                    }
-                                });
-                            }
+                            persistCurrentSessionMessages(activeChatChar);
                         }
                         closeBottomSheet();
                     }
@@ -325,16 +329,8 @@ export function useMessageActions(deps) {
                             localStorage.setItem(`gz_deleted_char_${chatChar.id}`, cDel + 1);
                             const sDel = parseInt(localStorage.getItem(`gz_deleted_chat_${chatChar.id}_${sid}`) || '0', 10);
                             localStorage.setItem(`gz_deleted_chat_${chatChar.id}_${sid}`, sDel + 1);
+                            persistCurrentSessionMessages(chatChar);
                         }
-                        getChatData(chatChar.id).then(data => {
-                            const charId = chatChar.id;
-                            const sessionId = chatChar.sessionId;
-                            const messageSnapshot = currentMessages.value;
-                            if (data && sessionId && data.sessions?.[sessionId]) {
-                                data.sessions[sessionId] = messageSnapshot;
-                                db.saveChat(charId, data);
-                            }
-                        });
                     }
                     closeBottomSheet();
                 }

--- a/src/composables/chat/useSessionPersistence.js
+++ b/src/composables/chat/useSessionPersistence.js
@@ -11,9 +11,35 @@ export function useSessionPersistence({
     getScrollAnchor,
     clearMessageNotifications
 }) {
+    const buildCrashBufferKey = (charId, sessionId) => `gz_chat_recovery_${charId}_${sessionId}`;
+
+    function writeCrashBuffer(activeChatChar) {
+        if (!activeChatChar?.id || !activeChatChar?.sessionId) return;
+        try {
+            localStorage.setItem(buildCrashBufferKey(activeChatChar.id, activeChatChar.sessionId), JSON.stringify({
+                messages: currentMessages.value,
+                draft: inputValue.value,
+                authorsNote: activeChatChar.authors_note,
+                summary: activeChatChar.summary,
+                lastScrollAnchor: getScrollAnchor(),
+                savedAt: Date.now()
+            }));
+        } catch (e) {
+            console.warn('[chat] Failed to write crash buffer:', e);
+        }
+    }
+
+    function clearCrashBuffer(charId, sessionId) {
+        if (!charId || !sessionId) return;
+        try {
+            localStorage.removeItem(buildCrashBufferKey(charId, sessionId));
+        } catch (_e) {}
+    }
+
     function asyncSaveCurrentSessionState() {
         const activeChatChar = getActiveChatChar();
         if (activeChatChar && messagesContainer.value) {
+            writeCrashBuffer(activeChatChar);
             const charContext = activeChatChar;
             const sessionId = charContext.sessionId;
             const inputValueDraft = inputValue.value;
@@ -70,6 +96,7 @@ export function useSessionPersistence({
                     data.summaries[sessionId] = charContext.summary;
                 }
             });
+            clearCrashBuffer(charContext.id, sessionId);
         }
     }
 
@@ -111,6 +138,7 @@ export function useSessionPersistence({
     function onVisibilityChange() {
         const activeChatChar = getActiveChatChar();
         if (document.visibilityState === 'hidden' && activeChatChar) {
+            writeCrashBuffer(activeChatChar);
             const charId = activeChatChar.id;
             const sessionId = activeChatChar.sessionId;
             const messagesSnapshot = currentMessages.value;
@@ -134,6 +162,14 @@ export function useSessionPersistence({
         } else if (document.visibilityState === 'visible' && activeChatChar) {
             clearMessageNotifications(activeChatChar.id);
         }
+    }
+
+    function onPageHide() {
+        const activeChatChar = getActiveChatChar();
+        if (activeChatChar) {
+            writeCrashBuffer(activeChatChar);
+        }
+        asyncSaveCurrentSessionState();
     }
 
     watch(activeChar, async (newVal) => {
@@ -199,9 +235,24 @@ export function useSessionPersistence({
         }
     });
 
+    if (typeof window !== 'undefined') {
+        window.addEventListener('beforeunload', onPageHide);
+        window.addEventListener('pagehide', onPageHide);
+    }
+
+    onBeforeUnmount(() => {
+        if (typeof window !== 'undefined') {
+            window.removeEventListener('beforeunload', onPageHide);
+            window.removeEventListener('pagehide', onPageHide);
+        }
+    });
+
     return {
         asyncSaveCurrentSessionState,
         applyImageAutoHide,
-        onVisibilityChange
+        onVisibilityChange,
+        onPageHide,
+        buildCrashBufferKey,
+        clearCrashBuffer
     };
 }

--- a/src/core/llm/transport/completionsClient.js
+++ b/src/core/llm/transport/completionsClient.js
@@ -91,7 +91,8 @@ export async function executeFetchChatCompletions({
         streamTimeout: requestLifecycle.streamTimeout,
         throwIfAborted: requestLifecycle.throwIfAborted,
         streamAccumulator,
-        onUpdate
+        onUpdate,
+        abortSignal: controller?.signal
     });
 
     await finalizeStreamResponse({

--- a/src/core/llm/transport/requestExecution.js
+++ b/src/core/llm/transport/requestExecution.js
@@ -5,6 +5,14 @@ export function shouldUseNativeNonStreamingRequest({ apiUrl, stream }) {
     return Capacitor.isNativePlatform() && apiUrl.startsWith('http:') && !apiUrl.includes('https:') && !stream;
 }
 
+export function shouldUseAbortableFetchRequest({ apiUrl, stream, requestType }) {
+    return requestType === 'chat' && Capacitor.isNativePlatform() && apiUrl.startsWith('http:') && !apiUrl.includes('https:');
+}
+
+export function shouldUseAbortableXhrRequest({ apiUrl, stream, requestType }) {
+    return requestType === 'chat' && !stream && Capacitor.isNativePlatform() && apiUrl.startsWith('http:') && !apiUrl.includes('https:');
+}
+
 export async function executeNativeNonStreamingRequest({
     requestUrl,
     headers,
@@ -46,6 +54,106 @@ export async function executeFetchRequest({
         headers,
         body: JSON.stringify(requestBody),
         signal: controller ? controller.signal : undefined
+    });
+}
+
+export async function executeAbortableJsonRequest({
+    requestUrl,
+    headers,
+    requestBody,
+    controller,
+    debugKey
+}) {
+    return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        let settled = false;
+
+        const cleanupAbortListener = () => {
+            if (controller?.signal && onAbort) {
+                controller.signal.removeEventListener('abort', onAbort);
+            }
+        };
+
+        const finalizeReject = (error) => {
+            if (settled) return;
+            settled = true;
+            cleanupAbortListener();
+            reject(error);
+        };
+
+        const finalizeResolve = (value) => {
+            if (settled) return;
+            settled = true;
+            cleanupAbortListener();
+            resolve(value);
+        };
+
+        const onAbort = () => {
+            try {
+                xhr.abort();
+            } catch (_e) {}
+            const error = new Error('Generation aborted');
+            error.name = 'AbortError';
+            finalizeReject(error);
+        };
+
+        if (controller?.signal?.aborted) {
+            onAbort();
+            return;
+        }
+
+        xhr.open('POST', requestUrl, true);
+        Object.entries(headers || {}).forEach(([key, value]) => {
+            xhr.setRequestHeader(key, value);
+        });
+        xhr.responseType = 'text';
+
+        xhr.onload = () => {
+            const status = xhr.status;
+            let data = null;
+            const rawText = xhr.responseText || '';
+
+            try {
+                data = rawText ? JSON.parse(rawText) : null;
+            } catch (parseError) {
+                finishNetworkTrace({ debugKey, rawResponse: rawText, error: `Invalid JSON response: ${parseError.message}` });
+                finalizeReject(parseError);
+                return;
+            }
+
+            updateNetworkTrace({
+                debugKey,
+                patch: {
+                    responseStatus: status
+                }
+            });
+
+            if (status >= 400) {
+                finishNetworkTrace({ debugKey, rawResponse: data ?? rawText, error: `API Error: ${status} ${rawText}` });
+                finalizeReject(new Error(`API Error: ${status} ${rawText}`));
+                return;
+            }
+
+            finalizeResolve(data);
+        };
+
+        xhr.onerror = () => {
+            finalizeReject(new Error('Network request failed'));
+        };
+
+        xhr.onabort = () => {
+            const error = new Error('Generation aborted');
+            error.name = 'AbortError';
+            finalizeReject(error);
+        };
+
+        controller?.signal?.addEventListener('abort', onAbort, { once: true });
+
+        try {
+            xhr.send(JSON.stringify(requestBody));
+        } catch (error) {
+            finalizeReject(error);
+        }
     });
 }
 

--- a/src/core/llm/transport/requestOrchestrator.js
+++ b/src/core/llm/transport/requestOrchestrator.js
@@ -1,6 +1,6 @@
 import { getProviderById } from '@/core/llm/providers/providerRegistry.js';
 import { completeStructuredResponse, handleAbortOutcome, handleRequestFailure } from '@/core/llm/transport/requestOutcome.js';
-import { executeNativeNonStreamingRequest, shouldUseNativeNonStreamingRequest } from '@/core/llm/transport/requestExecution.js';
+import { executeAbortableJsonRequest, executeNativeNonStreamingRequest, shouldUseAbortableFetchRequest, shouldUseAbortableXhrRequest, shouldUseNativeNonStreamingRequest } from '@/core/llm/transport/requestExecution.js';
 import { executeFetchChatCompletions } from '@/core/llm/transport/completionsClient.js';
 import { createRequestLifecycle } from '@/core/llm/transport/requestLifecycle.js';
 import { completeJsonResponse } from '@/core/llm/transport/responseHandling.js';
@@ -57,10 +57,40 @@ export async function executeRequest({
     try {
         logger.debug("LLM Request Body:", JSON.stringify(requestBody, null, 2));
 
+        if (shouldUseAbortableXhrRequest({ apiUrl, stream, requestType })) {
+            const data = await executeAbortableJsonRequest({
+                requestUrl,
+                headers: requestLifecycle.headers,
+                requestBody,
+                controller,
+                debugKey: requestLifecycle.debugKey
+            });
+            requestLifecycle.throwIfAborted();
+
+            await completeJsonResponse({
+                data,
+                throwIfAborted: requestLifecycle.throwIfAborted,
+                contextLabel: 'API response structure (XHR)',
+                logLabel: 'LLM Response (XHR):',
+                requestReasoning,
+                hasInlineTags,
+                tagStart,
+                tagEnd,
+                headerModel,
+                headerInline,
+                requestType,
+                debugKey: requestLifecycle.debugKey,
+                onComplete,
+                onError
+            });
+
+            return;
+        }
+
         // Bypass Mixed Content/Cleartext restrictions on Native for local HTTP
         // Use CapacitorHttp only for non-streaming requests.
         // For streaming, we fall through to standard fetch (requires android:usesCleartextTraffic="true")
-        if (shouldUseNativeNonStreamingRequest({ apiUrl, stream })) {
+        if (shouldUseNativeNonStreamingRequest({ apiUrl, stream }) && !shouldUseAbortableFetchRequest({ apiUrl, stream, requestType })) {
             const data = await executeNativeNonStreamingRequest({
                 requestUrl,
                 headers: requestLifecycle.headers,
@@ -117,6 +147,7 @@ export async function executeRequest({
                 requestType,
                 debugKey: requestLifecycle.debugKey,
                 timedOut: requestLifecycle.timedOut,
+                userAborted: !!controller?.userAborted,
                 streamAccumulator,
                 onComplete,
                 onError,

--- a/src/core/llm/transport/requestOutcome.js
+++ b/src/core/llm/transport/requestOutcome.js
@@ -117,7 +117,7 @@ export async function finalizeStreamResponse({ requestType, debugKey, streamAccu
     if (onComplete) await onComplete(finalText, extended.reasoning, { ...extended.meta, allReasoning: finalResult.allReasoning });
 }
 
-export async function handleAbortOutcome({ requestType, debugKey, timedOut, streamAccumulator, onComplete, onError, abortError }) {
+export async function handleAbortOutcome({ requestType, debugKey, timedOut, userAborted = false, streamAccumulator, onComplete, onError, abortError }) {
     const partial = streamAccumulator.getPartial();
     const hasPartialContent = partial.text.length > 0 || (partial.reasoning && partial.reasoning.length > 0);
     const allReasoning = !partial.text.trim() && !!partial.reasoning?.trim();
@@ -138,6 +138,20 @@ export async function handleAbortOutcome({ requestType, debugKey, timedOut, stre
             finishNetworkTrace({ debugKey, error: 'Generation timed out - no response from server' });
             if (onError) await onError(new Error('Generation timed out - no response from server'));
         }
+        return;
+    }
+
+    if (userAborted) {
+        if (abortError && typeof abortError === 'object') {
+            abortError.userAborted = true;
+        }
+        finishNetworkTrace({
+            debugKey,
+            text: hasPartialContent ? partial.text : undefined,
+            reasoning: hasPartialContent ? partial.reasoning : undefined,
+            error: 'Generation aborted by user'
+        });
+        if (onError) await onError(abortError);
         return;
     }
 

--- a/src/core/llm/transport/streamingSse.js
+++ b/src/core/llm/transport/streamingSse.js
@@ -9,7 +9,8 @@ export async function consumeStreamingSseResponse({
     streamTimeout,
     throwIfAborted,
     streamAccumulator,
-    onUpdate
+    onUpdate,
+    abortSignal
 }) {
     const reader = responseBody.getReader();
     const decoder = new TextDecoder('utf-8');
@@ -23,12 +24,55 @@ export async function consumeStreamingSseResponse({
         }, streamTimeout);
     };
 
+    function readChunk() {
+        if (abortSignal?.aborted) {
+            try { reader.cancel(); } catch (_e) {}
+            const error = new Error('Generation aborted');
+            error.name = 'AbortError';
+            return Promise.reject(error);
+        }
+
+        return new Promise((resolve, reject) => {
+            let settled = false;
+
+            const onAbort = () => {
+                if (settled) return;
+                settled = true;
+                try { reader.cancel(); } catch (_e) {}
+                const error = new Error('Generation aborted');
+                error.name = 'AbortError';
+                reject(error);
+            };
+
+            if (abortSignal && !abortSignal.aborted) {
+                abortSignal.addEventListener('abort', onAbort, { once: true });
+            }
+
+            reader.read()
+                .then(result => {
+                    if (settled) return;
+                    settled = true;
+                    resolve(result);
+                })
+                .catch(err => {
+                    if (settled) return;
+                    settled = true;
+                    reject(err);
+                })
+                .finally(() => {
+                    if (abortSignal) {
+                        abortSignal.removeEventListener('abort', onAbort);
+                    }
+                });
+        });
+    }
+
     try {
         resetStreamTimer();
 
         while (true) {
             throwIfAborted();
-            const { done, value } = await reader.read();
+            const { done, value } = await readChunk();
             if (done) break;
 
             resetStreamTimer();

--- a/src/core/llm/usecases/chatGenerationAppAdapters.js
+++ b/src/core/llm/usecases/chatGenerationAppAdapters.js
@@ -3,11 +3,11 @@ import { APP_EVENTS } from '@/core/events/eventNames.js';
 
 export function createGenerationAppAdapters() {
     return {
-        notifyGenerationStarted: ({ charId, sessionId }) => {
-            publishAppEvent(APP_EVENTS.domain.generation.started, { charId, sessionId });
+        notifyGenerationStarted: ({ charId, sessionId, genId, type }) => {
+            publishAppEvent(APP_EVENTS.domain.generation.started, { charId, sessionId, genId, type });
         },
-        notifyGenerationEnded: ({ charId, sessionId }) => {
-            publishAppEvent(APP_EVENTS.domain.generation.ended, { charId, sessionId });
+        notifyGenerationEnded: ({ charId, sessionId, genId, type }) => {
+            publishAppEvent(APP_EVENTS.domain.generation.ended, { charId, sessionId, genId, type });
         },
         notifyChatUpdated: () => {
             publishAppEvent(APP_EVENTS.domain.chat.updated);

--- a/src/core/llm/usecases/chatRequestAssembly.js
+++ b/src/core/llm/usecases/chatRequestAssembly.js
@@ -11,6 +11,21 @@ function getTranslation(key) {
     return translations[currentLang.value]?.[key] || key;
 }
 
+function createImmutableChatRequestEnvelope(requestEnvelope, controller) {
+    if (!requestEnvelope || typeof requestEnvelope !== 'object') {
+        return { controller };
+    }
+
+    if (requestEnvelope.controller && requestEnvelope.controller !== controller) {
+        console.warn('[chatRequestAssembly] Ignoring controller replacement from beforeRequestSend hook to preserve abort ownership');
+    }
+
+    return {
+        ...requestEnvelope,
+        controller
+    };
+}
+
 export async function executeFinalChatRequest({
     char,
     providerId,
@@ -72,7 +87,7 @@ export async function executeFinalChatRequest({
         stopString: effectiveStopString
     });
 
-    const requestEnvelope = await runGenerationHook('beforeRequestSend', {
+    const requestEnvelopeRaw = await runGenerationHook('beforeRequestSend', {
         requestType: 'chat',
         debugKey,
         char,
@@ -88,6 +103,7 @@ export async function executeFinalChatRequest({
         tagStart,
         tagEnd
     });
+    const requestEnvelope = createImmutableChatRequestEnvelope(requestEnvelopeRaw, controller);
 
     const {
         providerId: requestProviderId = effectiveProviderId,

--- a/src/core/llm/usecases/generateChat.js
+++ b/src/core/llm/usecases/generateChat.js
@@ -88,7 +88,7 @@ export async function executeChatGenerationUseCase({
         triggerAutoSyncCheck
     } = postprocess;
 
-    notifyGenerationStarted({ charId: char.id, sessionId });
+    notifyGenerationStarted({ charId: char.id, sessionId, genId, type: 'chat' });
 
     isGenerating.value = true;
     let msgIndex = existingMsgIndex;
@@ -155,6 +155,7 @@ export async function executeChatGenerationUseCase({
             sessionId,
             msgId,
             isError,
+            expectedGenId: genId,
             onAbort,
             restorePromptMetaOnMessages,
             clearBackgroundUpdateTimer,

--- a/src/core/llm/usecases/impersonationRequest.js
+++ b/src/core/llm/usecases/impersonationRequest.js
@@ -66,7 +66,7 @@ export async function executeImpersonationUseCase({
 
     const history = buildGenerationHistory(currentMessages);
 
-    notifyGenerationStarted({ charId, sessionId: char.sessionId });
+    notifyGenerationStarted({ charId, sessionId: char.sessionId, genId, type: 'impersonation' });
 
     return generateChat({
         text: promptText,
@@ -83,14 +83,14 @@ export async function executeImpersonationUseCase({
                 isImpersonating.value = false;
                 isGenerating.value = false;
                 clearGenerationState(charId);
-                notifyGenerationEnded({ charId });
+                notifyGenerationEnded({ charId, sessionId: char.sessionId, genId, type: 'impersonation' });
             },
             onError: (err) => {
                 console.error(err);
                 isImpersonating.value = false;
                 isGenerating.value = false;
                 clearGenerationState(charId);
-                notifyGenerationEnded({ charId });
+                notifyGenerationEnded({ charId, sessionId: char.sessionId, genId, type: 'impersonation' });
             }
         }
     });

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -145,6 +145,7 @@ export async function generateChatResponse({
         result,
         requestConfig: {
             ...requestConfig,
+            controller,
             debugKey
         },
         callbacks: {

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -449,7 +449,9 @@ const { visibleItems, paddingTop, paddingBottom, refresh: refreshVirtualScroll, 
 const {
     asyncSaveCurrentSessionState,
     applyImageAutoHide,
-    onVisibilityChange
+    onVisibilityChange,
+    buildCrashBufferKey,
+    clearCrashBuffer
 } = useSessionPersistence({
     getActiveChatChar: () => activeChatChar,
     activeChar,
@@ -774,6 +776,32 @@ async function openChat(char, onBack, force = false) {
     if (!msgs) {
         msgs = [];
         chatData.sessions[currentSessionId] = msgs;
+    }
+
+    try {
+        const crashBufferRaw = localStorage.getItem(buildCrashBufferKey(char.id, currentSessionId));
+        if (crashBufferRaw) {
+            const crashBuffer = JSON.parse(crashBufferRaw);
+            if (Array.isArray(crashBuffer?.messages) && crashBuffer.messages.length >= msgs.length) {
+                msgs = crashBuffer.messages;
+                chatData.sessions[currentSessionId] = msgs;
+                if (typeof crashBuffer.draft === 'string') {
+                    chatData.draft = crashBuffer.draft;
+                }
+                if (crashBuffer.authorsNote !== undefined) {
+                    if (!chatData.authorsNotes) chatData.authorsNotes = {};
+                    chatData.authorsNotes[currentSessionId] = crashBuffer.authorsNote;
+                }
+                if (crashBuffer.summary !== undefined) {
+                    if (!chatData.summaries) chatData.summaries = {};
+                    chatData.summaries[currentSessionId] = crashBuffer.summary;
+                }
+                await db.saveChat(char.id, chatData);
+            }
+            clearCrashBuffer(char.id, currentSessionId);
+        }
+    } catch (e) {
+        console.warn('[chat] Failed to restore crash buffer:', e);
     }
 
     // Filter out corrupted/null messages
@@ -1211,6 +1239,17 @@ defineExpose({
 
 const onGenerationEnded = (e) => {
     if (activeChatChar && activeChatChar.id === e.detail.charId) {
+        const activeState = getGenerationState(activeChatChar.id);
+        if (activeState?.type === 'chat') {
+            const endedSessionId = e.detail.sessionId ?? null;
+            const endedGenId = e.detail.genId ?? null;
+            if (endedGenId !== null && activeState.genId !== endedGenId) {
+                return;
+            }
+            if (endedSessionId === null || String(activeState.sessionId) === String(endedSessionId)) {
+                return;
+            }
+        }
         isGenerating.value = false;
         isImpersonating.value = false;
         applyImageAutoHide();

--- a/src/views/DialogList.vue
+++ b/src/views/DialogList.vue
@@ -15,6 +15,7 @@ import { APP_EVENTS } from '@/core/events/eventNames.js';
 import { subscribeAppEvent, publishAppEvent } from '@/core/events/eventHub.js';
 import ToolStripTooltip from '@/components/ToolStripTooltip.vue';
 import { useSessionSheet } from '@/composables/character/useSessionSheet.js';
+import { getGenerationState } from '@/core/states/generationState.js';
 
 const props = defineProps({
   activeCategory: { type: String, default: 'all' },
@@ -429,6 +430,15 @@ const onGenerationStarted = (e) => {
 
 const onGenerationEnded = (e) => {
     if (e.detail && e.detail.charId && e.detail.sessionId) {
+        const activeState = getGenerationState(e.detail.charId);
+        const endedGenId = e.detail.genId ?? null;
+        if (
+            activeState?.type === 'chat' &&
+            String(activeState.sessionId) === String(e.detail.sessionId) &&
+            (endedGenId === null || activeState.genId !== endedGenId)
+        ) {
+            return;
+        }
         generating.value[`${e.detail.charId}_${e.detail.sessionId}`] = false;
         loadData(); // Reload to show new message and unread status
     }


### PR DESCRIPTION
## Summary

- **Root cause**: AbortController was created and stored in generation state, controller.abort() fired correctly on stop -- but the signal never reached fetch(). In generationService.js, controller was destructured but never passed into requestConfig, so the entire pipeline (fetch, stream reader, timeout mechanisms) operated without abort capability. Pressing stop only cleared UI state; the TCP connection stayed open and the server continued generating until completion.
- **Fix**: Inject controller into requestConfig in generationService.js so the AbortController.signal propagates through the full chain: fetch({ signal }) -> requestLifecycle.throwIfAborted() -> consumeStreamingSseResponse({ abortSignal }) -> reader.cancel() on abort.
- **Additional hardening**: abort-aware SSE stream reader, userAborted flag propagation, stale generation completion guards, crash recovery buffer for session persistence, abortable XHR for native HTTP platforms.

## Changes

### Critical fix
- generationService.js -- inject controller into requestConfig (was undefined throughout pipeline)

### Abort signal propagation
- streamingSse.js -- readChunk() listens on abortSignal, calls reader.cancel() and rejects with AbortError
- completionsClient.js -- pass controller?.signal as abortSignal to stream consumer
- chatRequestAssembly.js -- createImmutableChatRequestEnvelope() preserves original controller, warns on hook replacement

### User abort handling
- requestOutcome.js -- handleAbortOutcome() receives userAborted flag, sets error.userAborted = true
- requestOrchestrator.js -- pass userAborted flag to handleAbortOutcome
- useGenerationErrorHandler.js -- fast-path for AbortError with userAborted, skips error toast
- useGenerationAbort.js -- set userAborted on state and controller, clear timers instead of calling restoreState/clearGenerationState (completion handler owns cleanup)

### Stale generation guards
- useGenerationFinalization.js -- respect expectedGenId, don't finalize wrong generation
- useGenerationStateRestore.js -- respect expectedGenId, early-return if no state
- useGenerationCompleteHandler.js -- stale completion skips typing cleanup for active newer generation, adds normalizeCompletionText(), consistent notifyGenerationEnded params
- useGenerationStateSetup.js -- flushPendingUIUpdate and initialUIUpdate check genId/sessionId/msgId match, timer reschedule checks abort

### Event system
- chatGenerationAppAdapters.js -- pass genId and type in notifyGenerationStarted/Ended
- generateChat.js, impersonationRequest.js -- consistent event params
- ChatView.vue, DialogList.vue -- guard onGenerationEnded against stale genId mismatches

### Session persistence and crash recovery
- useSessionPersistence.js -- crash buffer (localStorage) written on visibilitychange/pagehide/beforeunload, cleared on successful save, restored on openChat
- ChatView.vue -- restore crash buffer when opening a chat if buffer has more messages than stored

### Native platform abort
- requestExecution.js -- executeAbortableJsonRequest() (XHR with abort listener), shouldUseAbortableXhrRequest/shouldUseAbortableFetchRequest
- requestOrchestrator.js -- route native HTTP non-streaming through abortable XHR

### Minor
- useChatGeneration.js -- early-set generation state before async context resolve, skip overlapping start if controller already aborted
- useChatMessageDisplay.js -- skip swipe state restoration for typing messages
- useMessageActions.js -- persistCurrentSessionMessages helper, clean swipe meta on regeneration

## Test plan
- [ ] Start a streaming generation, press stop within 3s -- verify server sees connection close immediately (no 200 after delay)
- [ ] Start generation, let it complete normally -- verify message saved correctly
- [ ] Regenerate (swipe) while another generation is still running -- verify stale completion doesn't overwrite new generation
- [ ] Kill browser tab during generation -- reopen -- verify crash buffer restores messages
- [ ] Test on native (Capacitor) with HTTP API -- verify abort works via XHR
