### PR TITLE
fix: import reliability and preset tap-through on Android

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,8 @@ git checkout -b feat/memorybook-ui feat/multi-vector
 | Branch | Purpose | PR |
 |--------|---------|----|
 | `origin/dev` | Local mirror of upstream integration branch | No PR |
-| `feat/refactor-phase1-event-hub` | Phase 1–13l structural refactor (event hub, request ownership, composable extraction, transport split, use-case re-architecture, App.vue/PresetView/lorebookState/ChatMessage/ChatInput/LorebookSheet/ApiView/CharacterList/ThemeSettingsView decomposition) | Not yet |
+| `feat/refactor-phase1-event-hub` | Phase 1–13l structural refactor (event hub, request ownership, composable extraction, transport split, use-case re-architecture, App.vue/PresetView/lorebookState/ChatMessage/ChatInput/LorebookSheet/ApiView/CharacterList/ThemeSettingsView decomposition) | Merged into `feat/chat-persistence-and-reasoning-fixes` |
+| `feat/chat-persistence-and-reasoning-fixes` | Abort signal propagation, stale generation guards, crash recovery buffer, abortable XHR, swipe metadata cleanup | Not yet |
 
 ### Historical (merged & deleted)
 - `feat/cloud-sync` → merged via PR #20

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,8 +55,9 @@ Current behavior:
 `nav.*` (19 events):
 - `openApiSheet`, `navigateTo`, `openCharacterEditor`, `openChat`, `openOnboarding`, `openBackupSheet`, `openSyncSheet`, `openConflictSheet`, `openConnections`, `openFsRequest`, `openGlossary`, `openHolocards`, `openImageViewer`, `openItemEditor`, `openLorebookEntry`, `openNotificationsSheet`, `openPersonaEditor`, `openPresetSheet`, `triggerOpenImage`
 
-`domain.*` (11 events):
+- `domain.*` (11 events):
 - `chat.updated`, `character.updated`, `generation.{started,ended,promptReady,requestDispatched}`, `lorebook.regexScriptsChanged`, `sync.dataRefreshed`, `settings.{apiContextChanged,changed,languageChanged}`
+- Generation started/ended events carry `{ charId, sessionId, genId, type }` — `genId` for stale-generation filtering, `type` for `chat`/`impersonation` disambiguation
 
 `debug.*` (6 events):
 - `promptPreviewUpdated`, `requestTrace{Started,Updated,LineAppended,Finished}`, `vueError`
@@ -535,7 +536,7 @@ MemorySettings: {
 - `src/core/llm/transport/requestOrchestrator.js` — Transport entrypoint that resolves provider, wires runtime policy, and dispatches to execution path
 - `src/core/llm/transport/completionsClient.js` — Fetch-based `/chat/completions` execution
 - `src/core/llm/transport/requestLifecycle.js` — Timeouts, abort guards, request headers, trace start
-- `src/core/llm/transport/requestExecution.js` — Native non-stream vs fetch execution split
+- `src/core/llm/transport/requestExecution.js` — Native non-stream vs fetch execution split, abortable XHR for native HTTP
 - `src/core/llm/transport/streamingSse.js` — SSE stream consumption and delta dispatch
 - `src/core/llm/transport/responseHandling.js` — One-shot/native response shaping
 - `src/core/llm/transport/requestOutcome.js` — Abort/timeout/failure completion policy
@@ -582,9 +583,10 @@ MemorySettings: {
    - context breakdown assembly
    - request-body creation and sanitization
    - `lastPrompt` snapshot for request preview UI
-  5. `generationService.js` calls `chatRequestAssembly.js:executeFinalChatRequest()` which calls `requestOrchestrator.js:executeRequest()` with transport config, reasoning config, request type, abort controller, and callbacks.
-  6. `requestOrchestrator.js` resolves the provider from `providerRegistry.js`, sets up `requestRuntimePolicy`, `streamAccumulator`, and `requestLifecycle`, then dispatches through either `completionsClient.js` (fetch streaming) or `requestExecution.js` (native non-stream).
-7. The transport executes `/chat/completions` using either:
+5. `generationService.js` calls `chatRequestAssembly.js:executeFinalChatRequest()` which calls `requestOrchestrator.js:executeRequest()` with transport config, reasoning config, request type, abort controller, and callbacks.
+   `chatRequestAssembly.js` injects `controller` into `requestConfig` via `createImmutableChatRequestEnvelope()` — preserving abort ownership even through extension hooks.
+   6. `requestOrchestrator.js` resolves the provider from `providerRegistry.js`, sets up `requestRuntimePolicy`, `streamAccumulator`, and `requestLifecycle`, then dispatches through `completionsClient.js` (fetch streaming), `executeAbortableJsonRequest` (XHR for native non-stream), or `requestExecution.js` (native non-stream fallback).
+   7. The transport executes `/chat/completions` using either:
    - `CapacitorHttp.post()` for native non-stream local HTTP requests
    - `fetch()` for web and streaming requests
 8. The transport parses either:
@@ -636,11 +638,48 @@ MemorySettings: {
 - `ApiView.vue` writes many of those values directly back to `localStorage`, and also mutates the active API preset record.
 - `ChatView.vue` still performs some direct localStorage reads for preflight config checks.
 
+### Abort Signal Propagation (PR #72)
+
+Before PR #72, `AbortController` was created and stored in generation state, but the signal never reached `fetch()`. Pressing stop only cleared UI state; the TCP connection stayed open until the server finished.
+
+**Current signal chain:**
+1. `ChatView.vue` creates `AbortController` and passes `controller` into `useChatGeneration.startGeneration()`
+2. `generationService.js:generateChatResponse()` injects `controller` into `requestConfig` (the critical fix — was `undefined` before)
+3. `chatRequestAssembly.js:createImmutableChatRequestEnvelope()` preserves the original controller, warns if extension hooks try to replace it
+4. `requestOrchestrator.js:executeRequest()` passes `controller?.signal` as `abortSignal` to `completionsClient.js`
+5. `completionsClient.js` passes `abortSignal` to `streamingSse.js:consumeStreamingSseResponse()`
+6. `streamingSse.js:readChunk()` listens on `abortSignal`, calls `reader.cancel()` and rejects with `AbortError`
+7. `requestOutcome.js:handleAbortOutcome()` receives `userAborted` flag and routes accordingly
+
+**User abort flow:**
+1. User presses stop → `useGenerationAbort.js` sets `state.userAborted = true`, `state.controller.userAborted = true`, calls `controller.abort()`
+2. Abort signal propagates through the chain above → `reader.cancel()` closes the TCP connection immediately
+3. `handleAbortOutcome()` sees `userAborted = true` → tags `abortError.userAborted = true` → calls `onError(abortError)`
+4. `useGenerationErrorHandler.js` fast-paths `AbortError` with `userAborted` → skips error toast, restores state, finalizes generation
+
+**Stale generation guards:**
+- `useGenerationFinalization.js` — `expectedGenId` check prevents finalizing a wrong generation
+- `useGenerationStateRestore.js` — `expectedGenId` check, early-return if no state
+- `useGenerationCompleteHandler.js` — stale completion skips typing cleanup for active newer generation
+- `useGenerationStateSetup.js` — `flushPendingUIUpdate` and `initialUIUpdate` check `genId`/`sessionId`/`msgId` match; timer reschedule checks abort
+
+### Crash Recovery Buffer (PR #72)
+
+`useSessionPersistence.js` now maintains a crash recovery buffer in `localStorage`:
+- `writeCrashBuffer()` writes on `visibilitychange` (hidden), `pagehide`, and `beforeunload`
+- Buffer contains: `messages`, `draft`, `authorsNote`, `summary`, `lastScrollAnchor`, `savedAt`
+- `clearCrashBuffer()` called after successful `asyncSaveCurrentSessionState()`
+- On `openChat()`, if crash buffer has more messages than stored session, buffer is restored and persisted to IndexedDB
+- Key format: `gz_chat_recovery_{charId}_{sessionId}`
+
 ### Transport Behavior Today
 - Request endpoint is always `${apiUrl}/chat/completions` for generation and `${apiUrl}/models` for model discovery.
 - `CONNECT_TIMEOUT` and `STREAM_TIMEOUT` are read from `localStorage` through `requestLifecycle.js`.
 - Streaming requests use SSE parsing with `data: ...` lines and `[DONE]` termination.
 - If a streaming response body is unavailable on the current runtime, the transport falls back to one-shot JSON parsing instead of hard-failing.
+- **Abort signal propagation**: `AbortController.signal` now reaches `fetch()` through the full chain. Stream reader listens on signal and cancels immediately on abort.
+- **Native non-streaming abort**: XHR-based `executeAbortableJsonRequest()` used for native HTTP non-streaming chat requests, allowing abort to close the TCP connection (CapacitorHttp does not support abort).
+- **User abort vs timeout**: `userAborted` flag distinguishes intentional stop from timeout/failure. User abort skips error toast and partial-content recovery.
 - Abort handling is dual-purpose:
   - user abort may still preserve partial text
   - timeout-triggered abort is treated as an error and may preserve partial text with `partialError`
@@ -709,6 +748,9 @@ Native-only scope retained:
 - Runtime config has multiple owners: `localStorage`, IndexedDB API presets, reactive `ApiView.vue` state, onboarding writes, and direct reads in feature views.
 - Worker/service boundaries are not documented clearly: keyword lore lives in the worker, vector retrieval and memory injection happen later in the service layer.
 - Callback signatures are flexible but brittle across chat, summary, and memory-draft flows.
+- **Resolved (PR #72):** AbortController signal previously did not reach `fetch()`, so stop button only cleared UI state while TCP connection stayed open. Now signal propagates end-to-end through `requestConfig` → `completionsClient` → `streamingSse:readChunk()`.
+- **Resolved (PR #72):** Stale completions from aborted generations could mutate typing state for newer active generations. Now guarded by `expectedGenId` checks in finalize/restore/complete/setup paths.
+- **Resolved (PR #72):** No crash recovery — closing the browser tab during generation or auto-save race conditions could lose messages. Now `useSessionPersistence` writes crash buffer on `pagehide`/`beforeunload`/`visibilitychange`.
 
 ### Actual Architecture (Landed)
 
@@ -728,8 +770,8 @@ Native-only scope retained:
 - `requestOrchestrator.js` — Transport entrypoint: resolves provider, wires runtime policy, dispatches
 - `completionsClient.js` — Fetch-based `/chat/completions` execution
 - `requestLifecycle.js` — Timeout setup, abort guards, request headers
-- `requestExecution.js` — Native non-stream vs fetch execution branching
-- `streamingSse.js` — SSE stream consumption and delta dispatch
+- `requestExecution.js` — Native non-stream vs fetch execution branching, abortable XHR for native HTTP (`executeAbortableJsonRequest`)
+- `streamingSse.js` — SSE stream consumption and delta dispatch, abort-signal–aware chunk reader
 - `sseParser.js` — SSE line parsing
 - `responseHandling.js` — One-shot/native completion shaping
 - `requestOutcome.js` — Abort/timeout/failure completion policy
@@ -795,22 +837,22 @@ Native-only scope retained:
 - `src/composables/chat/useGenerationStateSetup.js` — generation state registration
 - `src/composables/chat/useGenerationStreamUpdate.js` — background persistence throttling
 - `src/composables/chat/useGenerationPromptReady.js` — prompt metadata assignment
-- `src/composables/chat/useGenerationCompleteHandler.js` — completion/finalization
-- `src/composables/chat/useGenerationErrorHandler.js` — error path handling
-- `src/composables/chat/useGenerationStateRestore.js` — abort/rollback restore
+- `src/composables/chat/useGenerationCompleteHandler.js` — completion/finalization with stale-generation guard (genId match, userAborted fast-path)
+- `src/composables/chat/useGenerationErrorHandler.js` — error path handling with userAborted fast-path and expectedGenId
+- `src/composables/chat/useGenerationStateRestore.js` — abort/rollback restore with stale-generation guard (expectedGenId)
 - `src/composables/chat/usePromptMetadataSnapshots.js` — prompt metadata rollback snapshots
 - `src/composables/chat/useTypingStateCleanup.js` — stale typing cleanup
 - `src/composables/chat/useChatSearch.js` — search in chat
 - `src/composables/chat/useContentEditable.js` — content-editable input handling
 - `src/composables/chat/useContextCutoff.js` — context cutoff management
-- `src/composables/chat/useGenerationAbort.js` — generation abort handling
-- `src/composables/chat/useGenerationFinalization.js` — generation finalization
+- `src/composables/chat/useGenerationAbort.js` — generation abort handling, userAborted flag propagation, timer cleanup (completion handler owns state cleanup)
+- `src/composables/chat/useGenerationFinalization.js` — generation finalization with stale-generation guard (expectedGenId)
 - `src/composables/chat/useGenerationRegistry.js` — generation registry
 - `src/composables/chat/useInputActions.js` — chat input actions
 - `src/composables/chat/useMemorySheetUI.js` — memory sheet UI
 - `src/composables/chat/useMessageImageGen.js` — image generation from messages
 - `src/composables/chat/useMessageSwipe.js` — message swipe actions
-- `src/composables/chat/useSessionPersistence.js` — session persistence
+- `src/composables/chat/useSessionPersistence.js` — session persistence, crash recovery buffer (localStorage → IndexedDB restore on openChat)
 - `src/composables/chat/useSwipeNavigation.js` — swipe navigation
 - `src/composables/chat/useVirtualScroll.js` — virtual scrolling
 
@@ -1134,8 +1176,12 @@ These files exceed the 400-line guard rail but are intentionally left as-is. Eac
 - [ ] Chat requests succeed in both streaming and non-streaming modes
 - [ ] Native non-stream requests still work through `CapacitorHttp`
 - [ ] Missing stream reader fallback still produces a complete response
-- [ ] User abort preserves partial text when expected
-- [ ] Timeout abort reports an error and does not leave phantom typing state
+- [ ] User abort closes the TCP connection immediately (signal reaches `fetch()`)
+- [ ] Abort during streaming stops chunk reading immediately (readChunk abort listener)
+- [ ] Native HTTP non-stream abort works through XHR (`executeAbortableJsonRequest`)
+- [ ] User abort skips error toast and partial-content recovery
+- [ ] Timeout abort still shows error toast
+- [ ] Stale completions from previous generations do not mutate newer generation's typing state
 - [ ] Summary and memory-draft requests do not regress while chat transport is refactored
 - [ ] Request preview still shows the final built payload after prompt assembly
 - [ ] Network trace capture remains optional and does not affect generation success
@@ -1143,6 +1189,7 @@ These files exceed the 400-line guard rail but are intentionally left as-is. Eac
 - [ ] Native auto-sync does not start while active generation is still running
 - [ ] Prompt metadata rollback still works after abort/error paths
 - [ ] Late vector lore still respects `maxInjectedEntries` after transport/refactor changes
+- [ ] Crash buffer recovery: messages survive browser crash/force-close during generation
 
 ### Cloud Sync
 - [ ] Provider buttons only appear when their env keys are configured

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1161,6 +1161,59 @@ Active branch: `fast-fixes`
     - Commits: `f33a9d3`, `915dbf3`
     - PR: pending
 
+16. **Fix: Abort signal propagation, stale generation guards, and crash recovery**
+    - Status: `done`
+    - Complexity: hard
+    - Branch: `feat/chat-persistence-and-reasoning-fixes`
+    - Issue: Three interrelated bugs causing stuck generations, lost messages, and non-functional stop button
+    - Root causes:
+      - `AbortController.signal` never reached `fetch()` — stop button only cleared UI state, TCP connection stayed open
+      - Stale completions from aborted generations could mutate typing state for newer active generations
+      - No crash recovery — closing the browser tab during generation or auto-save race conditions could lose messages
+      - Swipe regeneration left stale `isAllReasoning`, `isPartial`, `partialErrorMsg`, `genTime` on the new swipe
+      - `useChatMessageDisplay.js` tried to restore swipe state on typing messages
+    - Fixes applied:
+      - **Abort signal propagation**: `generationService.js` injects `controller` into `requestConfig`; `chatRequestAssembly.js` preserves controller through `createImmutableChatRequestEnvelope()`; `completionsClient.js` passes `abortSignal` to `streamingSse.js`; `readChunk()` listens on signal, calls `reader.cancel()` immediately
+      - **userAborted flag**: `useGenerationAbort.js` sets `state.userAborted = true` + `state.controller.userAborted = true` before abort; propagated through `requestOutcome.js:handleAbortOutcome()` → `useGenerationErrorHandler.js` fast-path
+      - **Abortable XHR for native HTTP**: `requestExecution.js:executeAbortableJsonRequest()` — XHR-based request for native non-streaming chat, since `CapacitorHttp` does not support abort
+      - **Stale generation guards**: `expectedGenId` check added to `useGenerationFinalization.js`, `useGenerationStateRestore.js`, `useGenerationCompleteHandler.js`; `useGenerationStateSetup.js` checks `genId`/`sessionId`/`msgId` match before UI updates and timer reschedule
+      - **Event payload enrichment**: `notifyGenerationStarted`/`Ended` now carry `genId` + `type`; `ChatView.vue:onGenerationEnded` and `DialogList.vue` filter stale events by `genId`
+      - **Crash recovery buffer**: `useSessionPersistence.js` writes `localStorage` buffer on `pagehide`/`beforeunload`/`visibilitychange:hidden`; `openChat()` restores buffer if it has more messages than stored session
+      - **Swipe metadata reset**: New swipe gets clean `swipesMeta`, `genTime`, `isAllReasoning`, `isPartial`, `partialErrorMsg` defaults
+      - **Typing message guard**: `useChatMessageDisplay.js:restoreVisibleSwipeState` skips typing messages
+      - **Timer cleanup**: `useGenerationAbort.js` clears generation timer and stream flush timer instead of running full restore+clear sequence; completion handler owns final state cleanup
+    - Files modified:
+      - `src/core/services/generationService.js` — inject controller into requestConfig
+      - `src/core/llm/usecases/chatRequestAssembly.js` — immutable controller envelope
+      - `src/core/llm/usecases/generateChat.js` — genId/type in events, expectedGenId in restore
+      - `src/core/llm/usecases/impersonationRequest.js` — genId/type in events
+      - `src/core/llm/usecases/chatGenerationAppAdapters.js` — genId/type in started/ended events
+      - `src/core/llm/transport/requestOrchestrator.js` — abortable XHR dispatch, userAborted flag
+      - `src/core/llm/transport/requestExecution.js` — abortable XHR, shouldUseAbortableFetchRequest/XhrRequest
+      - `src/core/llm/transport/completionsClient.js` — pass abortSignal to streamingSse
+      - `src/core/llm/transport/streamingSse.js` — abort-signal-aware readChunk()
+      - `src/core/llm/transport/requestOutcome.js` — userAborted handling in handleAbortOutcome
+      - `src/composables/chat/useGenerationAbort.js` — userAborted flag, timer cleanup
+      - `src/composables/chat/useGenerationCompleteHandler.js` — stale guard, userAborted fast-path, normalizeCompletionText
+      - `src/composables/chat/useGenerationErrorHandler.js` — userAborted fast-path, expectedGenId
+      - `src/composables/chat/useGenerationFinalization.js` — expectedGenId guard
+      - `src/composables/chat/useGenerationStateRestore.js` — expectedGenId guard, null-check
+      - `src/composables/chat/useGenerationStateSetup.js` — genId/sessionId/msgId guard on UI updates
+      - `src/composables/chat/useChatGeneration.js` — abort-clear on overlapping start, genId guard on pending state
+      - `src/composables/chat/useSessionPersistence.js` — crash buffer write/restore/clear, pagehide/beforeunload
+      - `src/composables/chat/useMessageActions.js` — persistCurrentSessionMessages helper, swipe metadata reset
+      - `src/composables/chat/useChatMessageDisplay.js` — skip typing messages in restoreVisibleSwipeState
+      - `src/views/ChatView.vue` — crash buffer recovery in openChat, stale event filter in onGenerationEnded
+      - `src/views/DialogList.vue` — stale generation event filter by genId
+    - Testing:
+      - [not tested] Verify stop generation immediately closes the connection (no lingering TCP traffic)
+      - [not tested] Verify abort during streaming stops chunk reading immediately
+      - [not tested] Verify native HTTP non-stream abort works through XHR
+      - [not tested] Verify user abort does not show error toast
+      - [not tested] Verify stale completions from previous generations do not affect newer generation
+      - [not tested] Verify crash buffer recovery restores messages after force-close
+      - [not tested] Verify swipe regeneration has clean metadata (no stale genTime/isPartial)
+
 15. **Image Generation Improvements — Info Blocks & Dynamic Character State**
     - Status: `not started`
     - Complexity: hard
@@ -1248,8 +1301,9 @@ Active branch: `fast-fixes`
     - Background/location detail enrichment from lorebooks
 
 ### Branch Strategy (updated)
-- Current bugfix chain: merged and closed (`fixes/mobile-network-memorybooks-batch1` -> PR #46, `fixes/regressions-post-merge` -> PR #47)
-- Current refactor branch: `feat/network-architecture-refactor`
+- Current bugfix branch: `feat/chat-persistence-and-reasoning-fixes`
+- Previous bugfix chain: merged and closed (`fixes/mobile-network-memorybooks-batch1` -> PR #46, `fixes/regressions-post-merge` -> PR #47)
+- Previous refactor branch: `feat/network-architecture-refactor` (merged into current)
 - Previous: Merged branches deleted (bug-fixes, feat/dual-lorebook-debug)
 - Policy: **Linear chain workflow** — each feature branches from previous feature OR origin/dev for new chains
 - Never create branches from dev that contain multiple unmerged features
@@ -1263,10 +1317,10 @@ Manual Verification:
 - [not done] Verify on a narrow mobile viewport that long chat character names, session names, and lorebook/preset/persona banner text do not overlap the back button or right-side action button.
 - [not done] Verify non-chat views with long localized titles still truncate cleanly after the new safe-area padding.
 
-## Provider / Network Refactor (Active)
+## Provider / Network Refactor (Complete — merged into `feat/chat-persistence-and-reasoning-fixes`)
 
-Branch: `feat/network-architecture-refactor`
-Status: In progress
+Branch: `feat/network-architecture-refactor` → merged into `feat/chat-persistence-and-reasoning-fixes`
+Status: Done
 Goal: finish moving chat/provider request architecture toward explicit provider, assembler, and transport boundaries without changing prompt semantics or regressing mobile/network behavior.
 
 ### Current State
@@ -1316,7 +1370,8 @@ Tested status:
 
 Still not done:
 - [not done] Move more remaining direct runtime API config access behind `APISettings.js` helpers, especially lower-priority UI code and legacy toggles.
-- [not done] Extract generation session lifecycle out of `ChatView.vue` into a dedicated composable/service.
+- [done] Extract generation session lifecycle out of `ChatView.vue` into a dedicated composable/service. — Done through ~30 focused composables.
+- [done] Split `llmApi.js` into transport modules — Done in Phase 12a.
 - [done] Separate prompt preview storage from network trace storage and stop relying on singleton global last-trace state. — **Done as Candidate 4.** Prompt preview keyed by generation/session, trace history keyed by request.
 - [done] Promote explicit request use cases (`generateChat`, `generateSummary`, `generateMemoryDraft`, `calculateContext`) instead of keeping orchestration concentrated in `generationService.js`. — **Done in Phase 11.** `calculateContext.js`, `generateSummary.js`, `generateMemoryDraft.js` now own their dependency assembly locally. `generationService.js` reduced from 267 → 172 lines, only exports `generateChatResponse`.
 - [done] Split `llmApi.js` into transport modules — **Done in Phase 12a.** `llmApi.js` moved to `transport/requestOrchestrator.js`, i18n coupling extracted to `reasoningHeaders.js`, dead `requestReasoning` param removed from `streamAccumulator` and `streamingSse`.

--- a/src/components/sheets/LorebookSheet.vue
+++ b/src/components/sheets/LorebookSheet.vue
@@ -294,18 +294,29 @@ function handleCreateLorebook() {
 function handleImportLorebook() {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = '.json';
     input.onchange = async (e) => {
         const file = e.target.files[0];
         if (!file) return;
         const reader = new FileReader();
+        reader.onerror = () => {
+            alert('Failed to read file. Please try again.');
+        };
         reader.onload = async (ev) => {
             try {
-                const json = JSON.parse(ev.target.result);
-                await importSTLorebook(json, file.name);
+                const text = ev.target.result;
+                if (typeof text !== 'string' || !text.trim()) {
+                    alert('File is empty or could not be read.');
+                    return;
+                }
+                const json = JSON.parse(text);
+                const result = await importSTLorebook(json, file.name);
+                if (result) {
+                    const { saveLorebooks } = await import('@/core/states/lorebookState.js');
+                    await saveLorebooks();
+                }
             } catch (err) {
-                console.error(err);
-                alert('Error importing lorebook: ' + err.message);
+                console.error('[lorebook] Import failed:', err);
+                alert('Error importing lorebook: ' + (err.message || 'Unknown error'));
             }
         };
         reader.readAsText(file);

--- a/src/components/ui/DragDropOverlay.vue
+++ b/src/components/ui/DragDropOverlay.vue
@@ -87,8 +87,9 @@ const onDrop = async (e) => {
                 const json = JSON.parse(text);
 
                 if (json.entries) {
-                    const { importSTLorebook } = await import('@/core/states/lorebookState.js');
+                    const { importSTLorebook, saveLorebooks } = await import('@/core/states/lorebookState.js');
                     await importSTLorebook(json, file.name);
+                    await saveLorebooks();
                     showSuccess('Import Successful', 'Successfully imported lorebook: ' + (json.name || file.name.replace('.json', '')));
                     isProcessing.value = false;
                     return;
@@ -119,14 +120,42 @@ const onDrop = async (e) => {
                     return;
                 } else if (json.blocks && Array.isArray(json.blocks)) {
                     const { presetState, savePresets, initPresetState } = await import('@/core/states/presetState.js');
+                    const { finalizeImportedPreset } = await import('@/core/services/presetImportService.js');
                     if (!presetState.initialized) {
                         await initPresetState();
                     }
-                    const newPreset = { ...json };
-                    if (!newPreset.id) newPreset.id = Date.now().toString();
-                    presetState.presets[newPreset.id] = newPreset;
+                    let preset = { ...json };
+                    if (!preset.id) preset.id = Date.now().toString();
+                    preset = finalizeImportedPreset(preset);
+                    presetState.presets[preset.id] = preset;
                     savePresets();
-                    showSuccess('Import Successful', 'Successfully imported preset: ' + (newPreset.name || 'Unnamed'));
+                    showSuccess('Import Successful', 'Successfully imported preset: ' + (preset.name || 'Unnamed'));
+                    isProcessing.value = false;
+                    return;
+                } else if (json.prompts && Array.isArray(json.prompts)) {
+                    const { presetState, savePresets, initPresetState } = await import('@/core/states/presetState.js');
+                    const { convertSTPreset, finalizeImportedPreset } = await import('@/core/services/presetImportService.js');
+                    if (!presetState.initialized) {
+                        await initPresetState();
+                    }
+                    let preset = convertSTPreset(json, file.name.replace('.json', ''));
+                    preset = finalizeImportedPreset(preset);
+                    presetState.presets[preset.id] = preset;
+                    savePresets();
+                    showSuccess('Import Successful', 'Successfully imported SillyTavern preset: ' + (preset.name || 'Unnamed'));
+                    isProcessing.value = false;
+                    return;
+                } else if (json.tabs && Array.isArray(json.tabs)) {
+                    const { presetState, savePresets, initPresetState } = await import('@/core/states/presetState.js');
+                    const { convertLatexPreset, finalizeImportedPreset } = await import('@/core/services/presetImportService.js');
+                    if (!presetState.initialized) {
+                        await initPresetState();
+                    }
+                    let preset = convertLatexPreset(json, file.name.replace('.json', ''));
+                    preset = finalizeImportedPreset(preset);
+                    presetState.presets[preset.id] = preset;
+                    savePresets();
+                    showSuccess('Import Successful', 'Successfully imported LaTeX preset: ' + (preset.name || 'Unnamed'));
                     isProcessing.value = false;
                     return;
                 } else if (json.themeMode || json.accentColor || json.bgOpacity !== undefined) {
@@ -160,6 +189,11 @@ const onDrop = async (e) => {
                 showSuccess(
                     translations[lang]?.sheet_title_char_options || 'Import Successful',
                     (translations[lang]?.msg_import_char_success || 'Successfully imported character:') + ' ' + charData.name
+                );
+            } else if (file.name.toLowerCase().endsWith('.json')) {
+                const lang = currentLang.value;
+                showError(
+                    (translations[lang]?.msg_import_char_failed || 'Failed to import file') + ': Unrecognized JSON format. Expected a character card, lorebook, preset, regex script, or theme file.'
                 );
             }
         } catch (error) {

--- a/src/composables/app/usePresetCRUD.js
+++ b/src/composables/app/usePresetCRUD.js
@@ -135,9 +135,19 @@ export function usePresetCRUD({ currentPreset, currentPresetId, editingPresetId,
         const file = event.target.files[0];
         if (!file) return;
         const reader = new FileReader();
+        reader.onerror = () => {
+            alert('Failed to read file. Please try again.');
+            event.target.value = '';
+        };
         reader.onload = (e) => {
             try {
-                const json = JSON.parse(e.target.result);
+                const text = e.target.result;
+                if (typeof text !== 'string' || !text.trim()) {
+                    alert('File is empty or could not be read.');
+                    event.target.value = '';
+                    return;
+                }
+                const json = JSON.parse(text);
                 const format = detectPresetFormat(json);
                 let preset;
                 if (format === 'latex') preset = convertLatexPreset(json, file.name.replace(/\.json$/i, ''));
@@ -149,8 +159,11 @@ export function usePresetCRUD({ currentPreset, currentPresetId, editingPresetId,
                 editingPresetId.value = preset.id;
                 updateHeaderState();
             } catch (err) {
-                console.error("Error parsing JSON:", err);
-                alert("Invalid JSON file");
+                if (err instanceof SyntaxError) {
+                    alert('Invalid JSON file: the file is not valid JSON.');
+                } else {
+                    alert('Failed to import preset: ' + (err.message || 'Unknown error'));
+                }
             }
             event.target.value = '';
         };

--- a/src/views/OnboardingView.vue
+++ b/src/views/OnboardingView.vue
@@ -297,13 +297,16 @@ async function savePreset() {
 function triggerPresetImport() {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = '.json';
     input.onchange = async (e) => {
         const file = e.target.files[0];
         if (!file) return;
         
         try {
             const text = await file.text();
+            if (!text || !text.trim()) {
+                alert(translations[currentLang.value]?.onboarding_import_error || 'File is empty or could not be read.');
+                return;
+            }
             const data = JSON.parse(text);
             
             initPresetState();
@@ -325,7 +328,7 @@ function triggerPresetImport() {
                     return;
                 }
             } else {
-                alert(translations[currentLang.value]?.onboarding_import_error || 'Unknown preset format');
+                alert(translations[currentLang.value]?.onboarding_import_error || 'Unknown preset format. Expected SillyTavern, LaTeX, or Glaze JSON.');
                 return;
             }
 
@@ -335,7 +338,10 @@ function triggerPresetImport() {
             savePresets();
             next();
         } catch (err) {
-            alert(translations[currentLang.value]?.onboarding_import_error + err.message);
+            const errorMsg = err instanceof SyntaxError
+                ? 'Invalid JSON file: the file is not valid JSON.'
+                : (err.message || 'Unknown error');
+            alert((translations[currentLang.value]?.onboarding_import_error || 'Import error: ') + errorMsg);
         }
     };
     input.click();

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -1725,6 +1725,7 @@ Add Block
     top: 0; left: 0; width: 100%; height: 100%;
     background: linear-gradient(to top, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0.3) 100%);
     z-index: 1;
+    pointer-events: none;
 }
 
 .ps-card > *:not(.ps-card-overlay):not(.ps-featured-badge):not(.ps-card-actions) {

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -595,7 +595,6 @@ Add Block
         type="file"
         id="preset-file-input"
         style="display: none" 
-        accept=".json" 
         @change="onFileSelected"
     >
     <input 


### PR DESCRIPTION
## Summary

- **Lorebook import**: Remove `.json` accept filter from file picker (was causing Android file selector to grey out JSON files and silently reject them), add `FileReader.onerror` handler, add empty-file check, add explicit `saveLorebooks()` after drag-drop import
- **Preset import**: Remove `.json` accept filter from all file pickers (PresetView, OnboardingView), improve error messages for invalid/unrecognized files (distinguish SyntaxError from other errors)
- **DragDropOverlay**: Add SillyTavern/LaTeX preset format detection with proper conversion (`convertSTPreset`/`convertLatexPreset` + `finalizeImportedPreset`), add explicit `saveLorebooks()` after lorebook import, show error for unrecognized JSON files instead of silent fallback
- **OnboardingView**: Fix `undefined + err.message` concatenation bug when translation key is missing
- **PresetView**: Add `pointer-events: none` to `.ps-card-overlay` so taps pass through the overlay on Android WebView

## Test plan

- [ ] Import a lorebook JSON with object-keyed entries (SillyTavern format) via LorebookSheet import button
- [ ] Import a lorebook via drag-and-drop
- [ ] Import a SillyTavern preset via PresetView "Import" button
- [ ] Import a LaTeX preset via PresetView "Import" button
- [ ] Try importing a non-JSON file — should show a clear error, not silently fail
- [ ] On Android: open preset list, tap a preset with an image — should activate, not be blocked by overlay
- [ ] On Android: file picker should show all files, not grey out non-.json files