### PR TITLE
fix: memorybook defaults, message schema slimming, OOM sync guard, abort cleanup

### DIFF
--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -63,6 +63,17 @@ The current roadmap is:
 
 ### Bugs on fix/memorybook-null-ref
 
+26. **Fix: chat payload OOM crash on sync + message data bloat**
+    - Status: `done`
+    - Files: `src/core/services/syncEngine.js`, `src/core/services/adapters/nativeFetch.js`, `src/core/services/adapters/dropboxAdapter.js`, `src/core/services/adapters/gdriveAdapter.js`, `src/utils/db.js`, `src/composables/chat/useChatGeneration.js`, `src/composables/chat/useGenerationPromptReady.js`, `src/core/services/chatImporter.js`
+    - Issue: Chat data could reach 30+ MB per chat due to redundant heavy fields duplicated across messages: `persona.avatar` (base64 image, ~50KB each) stored on every user message; `triggeredLorebooks[].content` (full entry text) stored on every generated message; `triggeredMemories[].content` and `.messageIds` stored on every generated message. On native platforms, sync uploads/downloads through the Capacitor bridge serialize the entire payload as a JSON string in one chunk, causing OOM crashes for large chats.
+    - Fix:
+      1. **Message schema slimmed down**: `persona` on messages now stores only `{id, name}` instead of the full persona object with avatar. `triggeredLorebooks` now stores `{id, name, lorebookId, lorebookName, _source}` without `content`. `triggeredMemories` now stores `{id, name}` without `content` or `messageIds`. U resolves by `persona.id` lookup at render time.
+      2. **Migration on load**: `stripHeavyFields()` in `normalizeChatData` strips legacy heavy fields from existing messages when chat data is loaded.
+      3. **Import-time stripping**: `normalizeImportedMessage()` also strips persona avatar and triggered content from imported chats.
+      4. **Native fetch bypass**: `safeUploadFetch` in `nativeFetch.js` uses `CapacitorWebFetch` (bypasses native bridge serialization) for upload/download operations in both Dropbox and Google Drive adapters.
+      5. **Sync size guard**: `MAX_SYNC_PAYLOAD_BYTES` (30MB) check in syncEngine skips entities that exceed the limit with a console warning, preventing OOM crashes.
+
 11. **Fix: abort not cleaning generationState or persistedGeneration flags**
     - Status: `done`
     - Files: `src/composables/chat/useGenerationAbort.js`, `src/views/DialogList.vue`

--- a/src/components/sheets/MemoryBooksSheet.vue
+++ b/src/components/sheets/MemoryBooksSheet.vue
@@ -51,7 +51,8 @@ const emit = defineEmits([
   'delete-draft',
   'delete-entry',
   'cancel-draft',
-  'change-model'
+  'change-model',
+  'flush-save'
 ]);
 
 const sheet = ref(null);
@@ -89,8 +90,8 @@ const generationSettingsSummary = computed(() => {
   const autoGenerate = props.memoryBook.settings?.autoGenerateEnabled === true ? 'auto text' : 'manual text';
   const delayed = props.memoryBook.settings?.useDelayedAutomation !== false ? 'delayed' : 'immediate';
   const target = props.memoryBook.settings?.injectionTarget === 'summary_macro' ? '{{summary}}' : 'summary block';
-  const maxEntries = Math.max(1, Math.min(20, Number(props.memoryBook.settings?.maxInjectedEntries || 3)));
-  const batchSize = Math.max(1, Math.min(50, Number(props.memoryBook.settings?.batchSize || 1)));
+  const maxEntries = Math.max(1, Math.min(20, Number(props.memoryBook.settings?.maxInjectedEntries || 7)));
+  const batchSize = Math.max(1, Math.min(50, Number(props.memoryBook.settings?.batchSize || 3)));
   const outputTokens = Number.isFinite(Number(props.memoryBook.settings?.generationMaxTokens)) && Number(props.memoryBook.settings?.generationMaxTokens) > 0
     ? `${Math.round(Number(props.memoryBook.settings.generationMaxTokens))} out`
     : 'auto out';
@@ -228,7 +229,7 @@ async function openQuickModelSelector() {
 
 // Helper functions
 function normalizeAutoCreateInterval(memoryBook) {
-  return Math.max(1, Math.min(100, Number(memoryBook?.settings?.autoCreateInterval || 12)));
+  return Math.max(1, Math.min(200, Number(memoryBook?.settings?.autoCreateInterval || 15)));
 }
 
 function formatElapsedSeconds(ms) {
@@ -271,11 +272,13 @@ function open() {
 
 // Called by SheetView @close event (user swiped down or tapped overlay)
 function onSheetClose() {
+  emit('flush-save');
   emit('close');
 }
 
 // Called programmatically from parent via ref (memoryBooksSheet.value.close())
 function close() {
+  emit('flush-save');
   sheet.value?.close();
 }
 

--- a/src/composables/chat/useChatGeneration.js
+++ b/src/composables/chat/useChatGeneration.js
@@ -77,7 +77,7 @@ export function useChatGeneration(deps) {
                 timestamp: now.getTime(),
                 image: attachedImage,
                 tokens: estimateTokens(processedText),
-                persona: { ...activePersona.value },
+                persona: { id: activePersona.value?.id, name: activePersona.value?.name },
                 guidanceText: effectiveGuidance,
                 guidanceType: effectiveGuidanceType,
                 ...createBaseMessageMeta()

--- a/src/composables/chat/useGenerationAbort.js
+++ b/src/composables/chat/useGenerationAbort.js
@@ -1,4 +1,6 @@
 import { clearPersistedGeneration } from '@/core/states/generationState.js';
+import { publishAppEvent } from '@/core/events/eventHub.js';
+import { APP_EVENTS } from '@/core/events/eventNames.js';
 
 export function useGenerationAbort({
     getGenerationState,
@@ -14,6 +16,8 @@ export function useGenerationAbort({
         if (state.type === 'impersonation') {
             return abortImpersonation(charId, state);
         }
+
+        const { sessionId, genId, type } = state;
 
         if (state.controller) {
             try {
@@ -36,19 +40,25 @@ export function useGenerationAbort({
             state.clearStreamFlushTimer();
         }
 
-        if (activeChatChar?.value && activeChatChar.value.id === charId) {
-            isGenerating.value = false;
-        }
+        isGenerating.value = false;
 
-        if (state.sessionId) {
-            clearPersistedGeneration(charId, state.sessionId);
+        if (sessionId) {
+            clearPersistedGeneration(charId, sessionId);
         }
         clearGenerationState(charId);
+
+        publishAppEvent(APP_EVENTS.domain.generation.ended, {
+            charId,
+            sessionId: sessionId ?? null,
+            genId: genId ?? null,
+            type: type || 'chat'
+        });
 
         return true;
     }
 
     function abortImpersonation(charId, state) {
+        const { sessionId, genId } = state || {};
         if (state?.controller) {
             try {
                 state.userAborted = true;
@@ -58,10 +68,18 @@ export function useGenerationAbort({
         }
         isGenerating.value = false;
         if (isImpersonating) isImpersonating.value = false;
-        if (state?.sessionId) {
-            clearPersistedGeneration(charId, state.sessionId);
+        if (sessionId) {
+            clearPersistedGeneration(charId, sessionId);
         }
         clearGenerationState(charId);
+
+        publishAppEvent(APP_EVENTS.domain.generation.ended, {
+            charId,
+            sessionId: sessionId ?? null,
+            genId: genId ?? null,
+            type: 'impersonation'
+        });
+
         return true;
     }
 

--- a/src/composables/chat/useGenerationErrorHandler.js
+++ b/src/composables/chat/useGenerationErrorHandler.js
@@ -24,7 +24,16 @@ export async function handleGenerationError({
     const { getChatData, db } = persistence;
     const { notifyGenerationEnded } = app;
     const state = getGenerationState(char.id);
-    if (!state || state.genId !== genId) return;
+    if (!state || state.genId !== genId) {
+        await clearTypingStateForMessage({
+            charId: char.id,
+            sessionId,
+            msgId,
+            errorLabel: '[onError-stale]'
+        });
+        notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
+        return;
+    }
 
     if (typeof state.clearStreamFlushTimer === 'function') {
         state.clearStreamFlushTimer();

--- a/src/composables/chat/useGenerationFinalization.js
+++ b/src/composables/chat/useGenerationFinalization.js
@@ -28,7 +28,5 @@ export function finalizeGenerationState({
     }
     clearPersistedGeneration(charId, sessionId);
     clearGenerationState(charId, expectedGenId);
-    if (activeChatChar?.value && activeChatChar.value.id === charId) {
-        isGenerating.value = false;
-    }
+    isGenerating.value = false;
 }

--- a/src/composables/chat/useGenerationPromptReady.js
+++ b/src/composables/chat/useGenerationPromptReady.js
@@ -2,7 +2,6 @@ function mapTriggeredLorebooks(loreEntries) {
     return loreEntries.map(entry => ({
         id: entry.id,
         name: entry.comment || entry.name || entry.keys?.[0] || 'Entry',
-        content: entry.content,
         lorebookName: entry.lorebookName,
         lorebookId: entry.lorebookId,
         _source: entry._source || 'keyword'
@@ -12,9 +11,7 @@ function mapTriggeredLorebooks(loreEntries) {
 function mapTriggeredMemories(memoryEntries) {
     return (memoryEntries || []).map(entry => ({
         id: entry.id,
-        name: entry.title || 'Memory',
-        content: entry.content || '',
-        messageIds: Array.isArray(entry.messageIds) ? entry.messageIds : []
+        name: entry.title || 'Memory'
     }));
 }
 

--- a/src/composables/chat/useMemoryAutomation.js
+++ b/src/composables/chat/useMemoryAutomation.js
@@ -618,7 +618,7 @@ export function useMemoryAutomation({
 
         const draftsNeedingGeneration = (Array.isArray(memoryBook.pendingDrafts) ? memoryBook.pendingDrafts : [])
             .filter(d => !d.content && d.status === 'pending_generation' && !memoryDraftState.value?.activeDrafts?.[d.id]);
-        const maxBatchSize = Math.max(1, Math.min(50, Number(memoryBook.settings?.batchSize) || 1));
+        const maxBatchSize = Math.max(1, Math.min(50, Number(memoryBook.settings?.batchSize) || 3));
 
         if (!draftsNeedingGeneration.length) {
             showToast(memoryDraftState.value?.activeCount ? 'All remaining drafts are already generating' : 'No drafts need generation');

--- a/src/composables/chat/useMemorySheetUI.js
+++ b/src/composables/chat/useMemorySheetUI.js
@@ -463,12 +463,12 @@ export function useMemorySheetUI({
                 </div>
                 <div class="settings-item">
                     <label>Create Memory Every N Messages</label>
-                    <input id="memory-auto-interval-input" type="number" min="1" max="200" step="1" value="${state.autoCreateInterval}" placeholder="12">
+                    <input id="memory-auto-interval-input" type="number" min="1" max="200" step="1" value="${state.autoCreateInterval}" placeholder="15">
                     <div class="context-sheet-note">User-facing interval for future automatic memory creation and import bootstrap segmentation.</div>
                 </div>
                 <div class="settings-item">
                     <label>Max Generate Batch</label>
-                    <input id="memory-batch-size-input" type="number" min="1" max="50" step="1" value="${state.batchSize}" placeholder="1">
+                    <input id="memory-batch-size-input" type="number" min="1" max="50" step="1" value="${state.batchSize}" placeholder="3">
                     <div class="context-sheet-note">Limits how many pending drafts the batch generate button starts at once.</div>
                 </div>
                 <div class="settings-item-checkbox">
@@ -480,7 +480,7 @@ export function useMemorySheetUI({
                 </div>
                 <div class="settings-item">
                     <label>Memory Entries In Prompt</label>
-                    <input id="memory-max-injected-input" type="number" min="1" max="20" step="1" value="${state.maxInjectedEntries}" placeholder="3">
+                    <input id="memory-max-injected-input" type="number" min="1" max="20" step="1" value="${state.maxInjectedEntries}" placeholder="7">
                     <div class="context-sheet-note">How many retrieved memory entries can be injected into the prompt at once.</div>
                 </div>
                 <div class="settings-item">
@@ -583,13 +583,16 @@ export function useMemorySheetUI({
                     : Math.max(200, Math.min(32000, Number.isFinite(Number(maxTokensValue)) ? Math.round(Number(maxTokensValue)) : 2000));
                 settings.autoCreateEnabled = !!content.querySelector('#memory-auto-create-toggle')?.checked;
                 settings.autoGenerateEnabled = !!content.querySelector('#memory-auto-generate-toggle')?.checked;
-                const autoIntervalValue = Number(content.querySelector('#memory-auto-interval-input')?.value || state.autoCreateInterval || 12);
-                settings.autoCreateInterval = Math.max(1, Math.min(200, Number.isFinite(autoIntervalValue) ? Math.round(autoIntervalValue) : 12));
-                const batchSizeValue = Number(content.querySelector('#memory-batch-size-input')?.value || state.batchSize || 1);
-                settings.batchSize = Math.max(1, Math.min(50, Number.isFinite(batchSizeValue) ? Math.round(batchSizeValue) : 1));
+                const autoIntervalRaw = content.querySelector('#memory-auto-interval-input')?.value?.trim();
+                const autoIntervalValue = autoIntervalRaw !== '' ? Number(autoIntervalRaw) : 15;
+                settings.autoCreateInterval = Number.isFinite(autoIntervalValue) && autoIntervalValue > 0 ? Math.max(1, Math.min(200, Math.round(autoIntervalValue))) : 15;
+                const batchSizeRaw = content.querySelector('#memory-batch-size-input')?.value?.trim();
+                const batchSizeValue = batchSizeRaw !== '' ? Number(batchSizeRaw) : 3;
+                settings.batchSize = Number.isFinite(batchSizeValue) && batchSizeValue > 0 ? Math.max(1, Math.min(50, Math.round(batchSizeValue))) : 3;
                 settings.useDelayedAutomation = !!content.querySelector('#memory-delayed-automation-toggle')?.checked;
-                const maxInjectedValue = Number(content.querySelector('#memory-max-injected-input')?.value || state.maxInjectedEntries || 3);
-                settings.maxInjectedEntries = Math.max(1, Math.min(20, Number.isFinite(maxInjectedValue) ? Math.round(maxInjectedValue) : 3));
+                const maxInjectedRaw = content.querySelector('#memory-max-injected-input')?.value?.trim();
+                const maxInjectedValue = maxInjectedRaw !== '' ? Number(maxInjectedRaw) : 7;
+                settings.maxInjectedEntries = Number.isFinite(maxInjectedValue) && maxInjectedValue > 0 ? Math.max(1, Math.min(20, Math.round(maxInjectedValue))) : 7;
                 settings.injectionTarget = state.injectionTarget === 'summary_macro' ? 'summary_macro' : 'summary_block';
                 settings.promptPreset = state.promptPreset || 'detailed_beats';
                 memoryBook.updatedAt = Date.now();

--- a/src/core/llm/usecases/memoryContextInjection.js
+++ b/src/core/llm/usecases/memoryContextInjection.js
@@ -135,7 +135,7 @@ export async function buildMemoryInjection({ char, history, summary, safeContext
     const topEntries = scoredEntries
         .filter(item => item.score > 0)
         .sort((a, b) => b.score - a.score)
-        .slice(0, Math.max(1, settings.maxInjectedEntries || 3))
+        .slice(0, Math.max(1, settings.maxInjectedEntries || 7))
         .map(item => item.entry);
 
     if (!topEntries.length) {

--- a/src/core/llm/usecases/promptPayloadBuilder.js
+++ b/src/core/llm/usecases/promptPayloadBuilder.js
@@ -65,7 +65,7 @@ export async function getMemoryReserveEstimate(char, safeContext) {
         const activeEntries = (Array.isArray(memoryBook?.entries) ? memoryBook.entries : [])
             .filter(e => e && (e.status || 'active') === 'active' && (e.content || '').trim());
         if (!settings.enabled || !activeEntries.length) return 0;
-        const maxInjected = Math.max(1, Math.min(20, settings.maxInjectedEntries || 3));
+        const maxInjected = Math.max(1, Math.min(20, settings.maxInjectedEntries || 7));
         let totalContentLen = 0;
         for (const entry of activeEntries.slice(0, maxInjected)) {
             totalContentLen += (entry.content || '').trim().length;

--- a/src/core/llm/usecases/vectorLoreInjection.js
+++ b/src/core/llm/usecases/vectorLoreInjection.js
@@ -51,7 +51,6 @@ function resolveLateVectorLorePosition(entry) {
 
 export function mergeLateVectorLoreEntries(result, vectorResults = []) {
     const keywordEntries = normalizeKeywordLoreEntries(result?.loreEntries || []);
-    const keywordIds = new Set(keywordEntries.map(entry => entry.id));
 
     const maxInjectedEntries = Math.max(1, Math.min(100, Number(lorebookState.globalSettings?.maxInjectedEntries || 5)));
     const split = Math.max(0, Math.min(100, Number(lorebookState.globalSettings?.keywordVectorSplit ?? 50)));
@@ -59,11 +58,13 @@ export function mergeLateVectorLoreEntries(result, vectorResults = []) {
     const vectorSlots = maxInjectedEntries - keywordSlots;
 
     const limitedKeywords = keywordEntries.slice(0, keywordSlots);
-    const limitedKeywordIds = new Set(limitedKeywords.map(entry => entry.id));
+    const allKeywordIds = new Set(keywordEntries.map(entry => entry.id));
+    const unusedKeywordSlots = keywordSlots - limitedKeywords.length;
+    const adjustedVectorSlots = vectorSlots + unusedKeywordSlots;
 
     const vectorEntries = limitVectorLoreEntries(
-        vectorResults.filter(entry => !limitedKeywordIds.has(entry.id)),
-        vectorSlots
+        vectorResults.filter(entry => !allKeywordIds.has(entry.id)),
+        adjustedVectorSlots
     );
 
     vectorEntries.forEach(entry => { entry._source = 'vector'; });

--- a/src/core/services/adapters/dropboxAdapter.js
+++ b/src/core/services/adapters/dropboxAdapter.js
@@ -4,6 +4,7 @@ import { App } from '@capacitor/app';
 import { db } from '@/utils/db.js';
 import { DROPBOX_APP_KEY } from '@/core/config/syncConfig.js';
 import { SYNC_TOKENS_KEY } from '@/core/states/syncState.js';
+import { safeUploadFetch } from './nativeFetch.js';
 
 const REDIRECT_URI_NATIVE = import.meta.env.VITE_DROPBOX_REDIRECT_NATIVE || 'com.hydall.glaze://oauth/dropbox';
 const REDIRECT_URI_WEB = import.meta.env.VITE_DROPBOX_REDIRECT_WEB || `${window.location.origin}/oauth/dropbox/redirect.html`;
@@ -369,7 +370,7 @@ async function contentUpload(path, data, accessToken) {
 
     const body = typeof data === 'string' ? data : JSON.stringify(data);
 
-    const response = await fetch(`${CONTENT_BASE}/files/upload`, {
+    const response = await safeUploadFetch(`${CONTENT_BASE}/files/upload`, {
         method: 'POST',
         headers: {
             'Authorization': `Bearer ${accessToken}`,
@@ -408,7 +409,7 @@ async function contentDownload(path, accessToken) {
         accessToken = tokens.access_token;
     }
 
-    const response = await fetch(`${CONTENT_BASE}/files/download`, {
+    const response = await safeUploadFetch(`${CONTENT_BASE}/files/download`, {
         method: 'POST',
         headers: {
             'Authorization': `Bearer ${accessToken}`,

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -4,6 +4,7 @@ import { App } from '@capacitor/app';
 import { db } from '@/utils/db.js';
 import { GDRIVE_CLIENT_ID, GDRIVE_CLIENT_SECRET } from '@/core/config/syncConfig.js';
 import { SYNC_TOKENS_KEY } from '@/core/states/syncState.js';
+import { safeUploadFetch } from './nativeFetch.js';
 
 const getNativeRedirectUri = () => {
     if (import.meta.env.VITE_GDRIVE_REDIRECT_NATIVE) return import.meta.env.VITE_GDRIVE_REDIRECT_NATIVE;
@@ -544,14 +545,41 @@ export async function upload(path, data) {
     const body = typeof data === 'string' ? data : JSON.stringify(data);
 
     if (existingFile) {
-        const response = await apiRequest(
+        const accessToken = await getValidAccessToken();
+        if (!accessToken) throw new Error('Not connected to Google Drive');
+
+        const response = await safeUploadFetch(
             `${UPLOAD_BASE}/files/${existingFile.id}?uploadType=media`,
             {
                 method: 'PATCH',
-                headers: { 'Content-Type': 'application/octet-stream' },
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`,
+                    'Content-Type': 'application/octet-stream'
+                },
                 body
             }
         );
+
+        if (response.status === 401) {
+            const tokens = await getTokens();
+            if (tokens?.refresh_token) {
+                const refreshed = await refreshAccessToken(tokens.refresh_token);
+                const retry = await safeUploadFetch(
+                    `${UPLOAD_BASE}/files/${existingFile.id}?uploadType=media`,
+                    {
+                        method: 'PATCH',
+                        headers: {
+                            'Authorization': `Bearer ${refreshed.access_token}`,
+                            'Content-Type': 'application/octet-stream'
+                        },
+                        body
+                    }
+                );
+                if (!retry.ok) throw new Error(`Upload failed ${retry.status}`);
+                return retry.json();
+            }
+            throw Object.assign(new Error('Session expired'), { status: 401 });
+        }
 
         if (!response.ok) {
             const err = await response.json().catch(() => ({}));
@@ -560,6 +588,9 @@ export async function upload(path, data) {
 
         return response.json();
     } else {
+        const accessToken = await getValidAccessToken();
+        if (!accessToken) throw new Error('Not connected to Google Drive');
+
         const metadata = {
             name: fileName,
             parents: [parentId]
@@ -571,14 +602,38 @@ export async function upload(path, data) {
             `--${boundary}\r\nContent-Type: application/octet-stream\r\n\r\n${body}\r\n` +
             `--${boundary}--`;
 
-        const response = await apiRequest(
+        const response = await safeUploadFetch(
             `${UPLOAD_BASE}/files?uploadType=multipart&fields=id`,
             {
                 method: 'POST',
-                headers: { 'Content-Type': `multipart/related; boundary=${boundary}` },
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`,
+                    'Content-Type': `multipart/related; boundary=${boundary}`
+                },
                 body: multipartBody
             }
         );
+
+        if (response.status === 401) {
+            const tokens = await getTokens();
+            if (tokens?.refresh_token) {
+                const refreshed = await refreshAccessToken(tokens.refresh_token);
+                const retry = await safeUploadFetch(
+                    `${UPLOAD_BASE}/files?uploadType=multipart&fields=id`,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': `Bearer ${refreshed.access_token}`,
+                            'Content-Type': `multipart/related; boundary=${boundary}`
+                        },
+                        body: multipartBody
+                    }
+                );
+                if (!retry.ok) throw new Error(`Upload failed ${retry.status}`);
+                return retry.json();
+            }
+            throw Object.assign(new Error('Session expired'), { status: 401 });
+        }
 
         if (!response.ok) {
             const err = await response.json().catch(() => ({}));

--- a/src/core/services/adapters/nativeFetch.js
+++ b/src/core/services/adapters/nativeFetch.js
@@ -1,0 +1,11 @@
+export function getNativeSafeFetch() {
+    if (typeof window !== 'undefined' && window.CapacitorWebFetch) {
+        return window.CapacitorWebFetch;
+    }
+    return fetch;
+}
+
+export async function safeUploadFetch(url, options) {
+    const fetchFn = getNativeSafeFetch();
+    return fetchFn(url, options);
+}

--- a/src/core/services/chatImporter.js
+++ b/src/core/services/chatImporter.js
@@ -16,6 +16,16 @@ function normalizeImportedMessage(msg) {
     if (typeof msg.memoryCoverage.stale !== 'boolean') msg.memoryCoverage.stale = false;
     if (!Array.isArray(msg.triggeredLorebooks)) msg.triggeredLorebooks = msg.triggeredLorebooks ? msg.triggeredLorebooks : [];
     if (!Array.isArray(msg.triggeredMemories)) msg.triggeredMemories = msg.triggeredMemories ? msg.triggeredMemories : [];
+    if (msg.persona && typeof msg.persona === 'object') {
+        const { id, name } = msg.persona;
+        msg.persona = { id: id || null, name: name || null };
+    }
+    if (Array.isArray(msg.triggeredLorebooks)) {
+        msg.triggeredLorebooks = msg.triggeredLorebooks.map(({ content: _content, ...rest }) => rest);
+    }
+    if (Array.isArray(msg.triggeredMemories)) {
+        msg.triggeredMemories = msg.triggeredMemories.map(({ content: _content, messageIds: _messageIds, ...rest }) => rest);
+    }
     return msg;
 }
 
@@ -549,8 +559,8 @@ function convertMessage(stMsg, userPersona) {
     // User specific
     if (role === 'user') {
         scMsg.persona = {
-            name: userPersona?.name || stMsg.name || "User",
-            avatar: userPersona?.avatar || null
+            id: userPersona?.id || null,
+            name: userPersona?.name || stMsg.name || "User"
         };
     }
 

--- a/src/core/services/memoryBooksService.js
+++ b/src/core/services/memoryBooksService.js
@@ -68,8 +68,8 @@ export function countCompletedExchangesSince(startCount, currentCount) {
 }
 
 export function normalizeAutoCreateInterval(memoryBook) {
-    const raw = Number(memoryBook?.settings?.autoCreateInterval || 12);
-    return Math.max(1, Math.min(200, Number.isFinite(raw) ? Math.round(raw) : 12));
+    const raw = Number(memoryBook?.settings?.autoCreateInterval || 15);
+    return Math.max(1, Math.min(200, Number.isFinite(raw) ? Math.round(raw) : 15));
 }
 
 // ============================================================================

--- a/src/core/services/memoryPromptPresets.js
+++ b/src/core/services/memoryPromptPresets.js
@@ -7,7 +7,7 @@ export const builtInMemoryPrompts = [
             'Preserve the original language. Exclude casual [OOC] conversation, BUT if OOC messages contain story rules, formatting instructions, backstory clarifications, or scene-setting directives, reflect those instructions in the memory entry under the relevant sections.',
             '',
             'Use this markdown structure (skip sections if not applicable):',
-            'Timeline: Always label as "Day N" (Day 1, Day 2, Day 3, etc.) — increment the day counter each time a new in-story day begins. Write clock times HH:MM; If the scene spans multiple days, write "Day N–M HH:MM-HH:MM".',
+            'Timeline: Always label as "Day N" (Day 1, Day 2, Day 3, etc.) — increment the day counter each time a new in-story day begins. Write clock times HH:MM;  If the scene spans multiple days, write "Day N–M HH:MM-HH:MM".',
             'Story Beats: Important plot events and developments',
             'Key Interactions: Significant character exchanges and relationship shifts',
             'Notable Details: Important objects, settings, revelations, quotes',

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -1,8 +1,11 @@
 import { db, getSyncDeletedEntries, clearSyncDeletedEntry } from '@/utils/db.js';
 import { encryptForSync, decryptFromSync, hasSyncKey, getSyncKey } from '@/core/services/crypto/keyManager.js';
 import { isSyncIncludingApiKeys } from '@/core/config/ProviderProfiles.js';
+import { showToast } from '@/core/states/toastState.js';
 
 const CLOUD_BASE = '/Glaze';
+
+const MAX_SYNC_PAYLOAD_BYTES = 30 * 1024 * 1024;
 
 const ENTITY_TYPES = {
     CHARACTER: 'character',
@@ -349,6 +352,11 @@ async function readCloudEntityByEntry(adapter, entry, key) {
         result = await adapter.download(altPath);
     }
     if (!result) return null;
+    if (result.data.length > MAX_SYNC_PAYLOAD_BYTES) {
+        console.warn(`[sync] Skipping download ${entry.type} ${entry.id}: payload ${Math.round(result.data.length / 1024 / 1024)}MB exceeds limit`);
+        showToast(`Sync: ${entry.type} too large (${Math.round(result.data.length / 1024 / 1024)}MB), skipped`, 5000);
+        return null;
+    }
     const parsed = JSON.parse(result.data);
     return decryptEntity(parsed, key);
 }
@@ -491,7 +499,15 @@ async function pushManifestV2(adapter, key, onProgress) {
 
                 if (payload !== null && payload !== undefined) {
                     const encrypted = await encryptEntity(payload, key);
-                    await adapter.upload(localEntry.path, JSON.stringify(encrypted));
+                    const serialized = JSON.stringify(encrypted);
+                    if (serialized.length > MAX_SYNC_PAYLOAD_BYTES) {
+                        console.warn(`[sync] Skipping ${localEntry.type} ${localEntry.id}: payload ${Math.round(serialized.length / 1024 / 1024)}MB exceeds ${Math.round(MAX_SYNC_PAYLOAD_BYTES / 1024 / 1024)}MB limit`);
+                        showToast(`${localEntry.type} too large to sync (${Math.round(serialized.length / 1024 / 1024)}MB), skipped`, 5000);
+                        skipped++;
+                        if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                        return;
+                    }
+                    await adapter.upload(localEntry.path, serialized);
                 }
             }
 

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -13,6 +13,30 @@ function toPlain(data) {
     return JSON.parse(JSON.stringify(data));
 }
 
+function stripHeavyFields(message) {
+    if (!message || typeof message !== 'object') return message;
+    if (message.persona && typeof message.persona === 'object') {
+        const { id, name } = message.persona;
+        message.persona = { id: id || null, name: name || null };
+    }
+    if (Array.isArray(message.triggeredLorebooks)) {
+        message.triggeredLorebooks = message.triggeredLorebooks.map(lb => ({
+            id: lb.id,
+            name: lb.name || lb.comment,
+            lorebookName: lb.lorebookName,
+            lorebookId: lb.lorebookId,
+            _source: lb._source
+        }));
+    }
+    if (Array.isArray(message.triggeredMemories)) {
+        message.triggeredMemories = message.triggeredMemories.map(mem => ({
+            id: mem.id,
+            name: mem.name || mem.title
+        }));
+    }
+    return message;
+}
+
 function ensureMessageMetadata(message) {
     if (!message || typeof message !== 'object') return message;
     if (!message.id) {
@@ -52,7 +76,10 @@ function normalizeChatData(chatData) {
 
     for (const [sessionId, messages] of Object.entries(chatData.sessions)) {
         const safeMessages = Array.isArray(messages) ? messages.filter(Boolean) : [];
-        safeMessages.forEach(ensureMessageMetadata);
+        safeMessages.forEach(msg => {
+            ensureMessageMetadata(msg);
+            stripHeavyFields(msg);
+        });
         chatData.sessions[sessionId] = safeMessages;
     }
 

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -79,6 +79,7 @@ import GlossarySheet from '@/components/sheets/GlossarySheet.vue';
 import MemoryBooksSheet from '@/components/sheets/MemoryBooksSheet.vue';
 import { addDeletedStats, migrateStatsIfNeeded } from '@/core/services/statsService.js';
 import { showToast } from '@/core/states/toastState.js';
+import { ensureSessionMemoryBook } from '@/core/services/memorySchema.js';
 import { triggerAutoSyncCheck } from '@/composables/chat/useAutoSync.js';
 import { useMemoryBooks } from '@/composables/chat/useMemoryBooks.js';
 import { useMemoryAutomation } from '@/composables/chat/useMemoryAutomation.js';
@@ -1043,8 +1044,24 @@ async function openChat(char, onBack, force = false) {
         if (consumePendingCutoffRecalc()) {
             updateContextCutoff();
         }
-        // Update pending memory indicators
         updatePendingMemoryMessageIds(activeChatChar);
+    }
+}
+
+async function handleMemoryFlushSave() {
+    if (!activeChatChar || !currentMemoryBookData.value) return;
+    try {
+        const chatData = await getChatData(activeChatChar.id);
+        if (chatData) {
+            const sessionId = activeChatChar.sessionId || chatData.currentId;
+            const memoryBook = ensureSessionMemoryBook(chatData, sessionId);
+            memoryBook.updatedAt = Date.now();
+            await db.saveChat(activeChatChar.id, chatData);
+            await loadCurrentMemoryBook(activeChatChar);
+            await updatePendingMemoryMessageIds(activeChatChar);
+        }
+    } catch (e) {
+        console.error('[MemoryBooks] flush-save error:', e);
     }
 }
 
@@ -1611,6 +1628,7 @@ onUnmounted(() => {
             :memory-draft-state="memoryDraftState"
             :pending-memory-message-ids="pendingMemoryMessageIds"
             @close="() => {}"
+            @flush-save="handleMemoryFlushSave"
             @open-settings="handleMemoryOpenSettings"
             @open-maintenance="handleMemoryOpenMaintenance"
             @open-preview="handleMemoryPreview"


### PR DESCRIPTION
## Summary

- **Slim message schema** - strip persona.avatar/prompt and triggeredLorebooks[].content/triggeredMemories[].content from chat messages. Store only {id, name} references; avatar resolved at render, lore/memory content not used by UI or automation. Migration on load (stripHeavyFields in normalizeChatData) + import-time stripping. Cuts ~10MB+ per large chat.

- **OOM sync guard** - use native CapacitorWebFetch for upload/download (bypasses bridge serialization). 30MB MAX_SYNC_PAYLOAD_BYTES guard with user-visible toast on skip.

- **Generation abort cleanup** - abortActiveChatGeneration and abortImpersonation now call clearGenerationState + clearPersistedGeneration, fixing stuck isGenerating/gz_generating_ flags after Stop.

- **Memorybook defaults unified** - autoCreateInterval 15 (was 12 in some places), batchSize 3 (was 1), maxInjectedEntries 7 (was 3). Empty number inputs in settings form now reset to schema defaults instead of retaining old values.

- **MemoryBooksSheet close handler** - emit flush-save on sheet close, ChatView persists and reloads memory book state on dismiss.

- **keywordVectorSplit** - redistributed unused keyword slots to vector quota instead of leaving them wasted.

## Test plan
- [ ] Open a large chat, verify messages render correctly (avatars, lorebook/memory badges still show names)
- [ ] Clear a memory settings number field and hit Save - should reset to default (15 for interval, 3 for batch, 7 for max entries)
- [ ] Click Stop during generation - verify isGenerating flag clears and gz_generating_ localStorage key is removed
- [ ] Sync a chat over 30MB - should see a toast warning, no crash
- [ ] Open MemoryBooksSheet, make changes, swipe down to close - changes should persist