### PR TITLE
fix: gdrive multi-folder resolution + stale cache invalidation

### DIFF
--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -422,21 +422,58 @@ async function folderHasContent(folderId) {
     return (data.files?.length || 0) > 0;
 }
 
-async function getGlazeFolderId() {
-    if (folderIdCache) return folderIdCache;
+export function invalidateGlazeFolderCache() {
+    folderIdCache = null;
+    _folderIdCache.clear();
+}
+
+async function getGlazeFolderId(invalidate = false) {
+    if (invalidate) {
+        folderIdCache = null;
+        _folderIdCache.clear();
+    }
+    if (folderIdCache) {
+        const check = await apiRequest(`${API_BASE}/files/${folderIdCache}?fields=id&supportsAllDrives=false`);
+        if (check.ok) return folderIdCache;
+        folderIdCache = null;
+        _folderIdCache.clear();
+    }
     const folders = await findFoldersByName(FOLDER_NAME, null);
     if (folders.length === 0) return null;
     if (folders.length === 1) {
         folderIdCache = folders[0].id;
         return folderIdCache;
     }
+    let bestFolder = null;
     for (const folder of folders) {
-        if (await folderHasContent(folder.id)) {
-            folderIdCache = folder.id;
-            return folderIdCache;
+        const manifestFile = await findFileByName('manifest.json', folder.id);
+        if (manifestFile) {
+            bestFolder = folder;
+            break;
         }
     }
-    folderIdCache = folders[0].id;
+    if (!bestFolder) {
+        for (const folder of folders) {
+            if (await folderHasContent(folder.id)) {
+                bestFolder = folder;
+                break;
+            }
+        }
+    }
+    if (!bestFolder) {
+        bestFolder = folders[0];
+    }
+    folderIdCache = bestFolder.id;
+    for (const folder of folders) {
+        if (folder.id !== bestFolder.id) {
+            const hasContent = await folderHasContent(folder.id);
+            if (!hasContent) {
+                try {
+                    await apiRequest(`${API_BASE}/files/${folder.id}`, { method: 'DELETE' });
+                } catch {}
+            }
+        }
+    }
     return folderIdCache;
 }
 
@@ -470,6 +507,8 @@ async function getOrCreateFolder(name, parentId) {
     return createFolder(name, parentId);
 }
 
+const _folderIdCache = new Map();
+
 export async function ensureFolder(path) {
     const parts = path.split('/').filter(Boolean);
     let parentId = null;
@@ -479,6 +518,7 @@ export async function ensureFolder(path) {
         if (!parentId) {
             parentId = await createFolder(FOLDER_NAME, null);
             folderIdCache = parentId;
+            _folderIdCache.clear();
         }
         for (let i = 1; i < parts.length; i++) {
             parentId = await getOrCreateFolder(parts[i], parentId);
@@ -495,8 +535,6 @@ export async function ensureFolder(path) {
 
     return parentId;
 }
-
-const _folderIdCache = new Map();
 
 async function resolvePathToParent(path) {
     const parts = path.replace(/^\//, '').split('/');
@@ -644,11 +682,17 @@ export async function upload(path, data) {
     }
 }
 
-export async function download(path) {
+export async function download(path, _retry = false) {
     const { parentId, fileName } = await resolvePathToParent(path);
     const file = await findFileByName(fileName, parentId);
 
-    if (!file) return null;
+    if (!file) {
+        if (!_retry && parentId === folderIdCache) {
+            invalidateGlazeFolderCache();
+            return download(path, true);
+        }
+        return null;
+    }
 
     const response = await apiRequest(
         `${API_BASE}/files/${file.id}?alt=media`
@@ -715,6 +759,7 @@ export async function deleteFolder(path) {
             throw new Error(`Delete folder failed ${response.status}`);
         }
         folderIdCache = null;
+        _folderIdCache.clear();
         return true;
     }
     const parts = path.replace(/^\//, '').split('/').filter(Boolean);

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -624,6 +624,9 @@ export async function pullEntities(adapter, key, onProgress, onConflict) {
 
 async function readManifest(adapter) {
     try {
+        if (adapter.ensureFolder) {
+            await adapter.ensureFolder(CLOUD_BASE);
+        }
         const result = await adapter.download(cloudPath(ENTITY_TYPES.MANIFEST));
         if (result) {
             return JSON.parse(result.data);


### PR DESCRIPTION
## Summary

- **getGlazeFolderId** now validates the cached folder ID with an API call before returning it — if the folder was deleted externally, the cache is invalidated and a fresh lookup runs
- **Multi-folder resolution** prioritizes the folder with manifest.json, then any folder with content, then the first folder — empty duplicate folders are auto-deleted
- **download()** retries with cache invalidation when a file isn't found and the parentId matches a stale cache entry
- **Cache cleanup** — _folderIdCache (subfolder cache) is cleared whenever folderIdCache is reset, and in ensureFolder when creating a new root Glaze folder
- **Defensive ensureFolder** call in readManifest() before downloading the manifest

Fixes the bug where GDrive had two Glaze folders and the wrong one was cached, making sync "not see" the manifest after the user moved files and deleted the old folder.

## Test plan
- Connect GDrive account that has two Glaze folders — verify the one with manifest.json is selected
- Delete the active Glaze folder externally, then sync — verify cache invalidation kicks in
- Sync should work normally after folder deletion without app restart