### PR TITLE
fix: character card updates not propagating to active chat & sidebar

### DIFF
--- a/src/components/sheets/CharacterCardEditorSheet.vue
+++ b/src/components/sheets/CharacterCardEditorSheet.vue
@@ -6,6 +6,8 @@ import Editor from '@/components/editors/GenericEditor.vue';
 import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import { db } from '@/utils/db.js';
+import { publishAppEvent } from '@/core/events/eventHub.js';
+import { APP_EVENTS } from '@/core/events/eventNames.js';
 import HelpTip from '@/components/ui/HelpTip.vue';
 
 const sheet = ref(null);
@@ -58,7 +60,7 @@ async function onSave(newVal) {
         delete charToSave.summary;
 
         await db.saveCharacter(charToSave);
-        window.dispatchEvent(new CustomEvent('character-updated', { detail: { character: charToSave } }));
+        publishAppEvent(APP_EVENTS.domain.character.updated, { character: charToSave });
     }
 }
 

--- a/src/components/sheets/CharacterCardSheet.vue
+++ b/src/components/sheets/CharacterCardSheet.vue
@@ -171,7 +171,7 @@ async function openCharacterEditor() {
     if (index !== -1) {
         closeBottomSheet();
         close();
-        window.dispatchEvent(new CustomEvent('open-character-editor', { detail: { index } }));
+        publishAppEvent(APP_EVENTS.nav.openCharacterEditor, { index });
     }
 }
 
@@ -204,6 +204,7 @@ async function toggleFavorite() {
     if (!char?.id) return;
     const updated = { ...char, fav: !char.fav };
     await db.saveCharacter(updated, -1);
+    publishAppEvent(APP_EVENTS.domain.character.updated, { character: updated });
     if (isControlled.value) {
         emit('update:visible', true);
     } else {

--- a/src/composables/app/useAppEventSubscriptions.js
+++ b/src/composables/app/useAppEventSubscriptions.js
@@ -179,6 +179,23 @@ export function useAppEventSubscriptions({
         appEventUnsubs.push(subscribeAppEvent(APP_EVENTS.ui.header.reset, onHeaderReset));
         appEventUnsubs.push(subscribeAppEvent(APP_EVENTS.domain.sync.dataRefreshed, onSyncDataRefreshed));
 
+        appEventUnsubs.push(subscribeAppEvent(APP_EVENTS.domain.character.updated, (e) => {
+            const char = e?.detail?.character;
+            if (char && activeChatCharObj.value && String(char.id) === String(activeChatCharObj.value.id)) {
+                const sessionId = activeChatCharObj.value.sessionId;
+                activeChatCharObj.value = { ...char, sessionId };
+            } else if (!char && activeChatCharObj.value) {
+                const charId = activeChatCharObj.value.id;
+                db.getAll('characters').then(chars => {
+                    const fresh = chars.find(c => String(c.id) === String(charId));
+                    if (fresh) {
+                        const sessionId = activeChatCharObj.value.sessionId;
+                        activeChatCharObj.value = { ...fresh, sessionId };
+                    }
+                });
+            }
+        }));
+
         appEventUnsubs.push(subscribeAppEvent(APP_EVENTS.nav.openGlossary, handleGlossaryOpen));
         appEventUnsubs.push(subscribeAppEvent(APP_EVENTS.ui.glossary.toggle, handleGlossaryToggle));
         appEventUnsubs.push(subscribeAppEvent(APP_EVENTS.ui.glossary.headerUpdate, ({ detail }) => onGlossaryHeaderUpdate(detail)));

--- a/src/composables/app/useEditorController.js
+++ b/src/composables/app/useEditorController.js
@@ -3,6 +3,8 @@ import { db, markSyncDeletedEntry } from '@/utils/db.js';
 import { addPersona, updatePersona, deletePersona, allPersonas } from '@/core/states/personaState.js';
 import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetState.js';
 import { translations } from '@/utils/i18n.js';
+import { publishAppEvent } from '@/core/events/eventHub.js';
+import { APP_EVENTS } from '@/core/events/eventNames.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 
 const t = (key) => translations[currentLang.value]?.[key] || key;
@@ -90,6 +92,7 @@ export function useEditorController({ currentView, currentChatSessionId, waitFor
         if (currentView.value === 'view-character-edit') {
             if (editingCharacter.value && editingCharacter.value.name && editingCharacter.value.name.trim() !== '') {
                 await db.saveCharacter(editingCharacter.value, editingCharacterIndex.value);
+                publishAppEvent(APP_EVENTS.domain.character.updated, { character: editingCharacter.value });
                 closeEditor();
             } else {
                 showBottomSheet({
@@ -134,8 +137,10 @@ export function useEditorController({ currentView, currentChatSessionId, waitFor
                 await db.saveCharacter(val, -1);
                 const chars = (await db.getAll('characters')) || [];
                 editingCharacterIndex.value = chars.length - 1;
+                publishAppEvent(APP_EVENTS.domain.character.updated, { character: val });
             } else {
                 await db.saveCharacter(val, editingCharacterIndex.value);
+                publishAppEvent(APP_EVENTS.domain.character.updated, { character: val });
             }
         } else if (currentView.value === 'view-persona-edit') {
             if (!val.name) return;
@@ -229,7 +234,7 @@ export function useEditorController({ currentView, currentChatSessionId, waitFor
 
                     comp.openChat(activeChatCharObj.value, () => {
                         currentView.value = chatPreviousView.value || 'view-dialogs';
-                    });
+                    }, isEditingChar);
 
                     if (shouldOpenPersonasOnReturn.value) {
                         shouldOpenPersonasOnReturn.value = false;

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -1275,11 +1275,23 @@ const onGenerationEnded = (e) => {
     }
 };
 
-const onCharacterUpdated = (e) => {
-    if (activeChatChar && activeChatChar.id === e.detail.character.id) {
-        activeChatChar = e.detail.character;
-        activeChar.value = e.detail.character;
+const onCharacterUpdated = async (e) => {
+    if (!activeChatChar) return;
+    const updatedChar = e?.detail?.character;
+    if (updatedChar && updatedChar.id === activeChatChar.id) {
+        activeChatChar = updatedChar;
+        activeChar.value = updatedChar;
         publishAppEvent(APP_EVENTS.ui.header.updateAvatar, activeChatChar);
+    } else {
+        const charId = activeChatChar.id;
+        const allChars = await db.getAll('characters');
+        const freshChar = allChars.find(c => String(c.id) === String(charId));
+        if (freshChar) {
+            freshChar.sessionId = activeChatChar.sessionId;
+            activeChatChar = freshChar;
+            activeChar.value = freshChar;
+            publishAppEvent(APP_EVENTS.ui.header.updateAvatar, activeChatChar);
+        }
     }
 };
 


### PR DESCRIPTION
Fix character card changes not propagating to active chat view and desktop sidebar.

- CharacterCardEditorSheet: replaced dead window CustomEvent with publishAppEvent
- CharacterCardSheet: fixed broken Edit button (dead native CustomEvent)
- CharacterCardSheet: publish character.updated on toggleFavorite
- useEditorController: publish character.updated on save/autosave
- useAppEventSubscriptions: sync nav.activeChatCharObj on character.updated
- ChatView: onCharacterUpdated re-reads from DB when no payload
- ChatView: closeEditor passes force=isEditingChar to bypass cache skip