### PR TITLE
fix: chat message self-restore after deletion, sidebar refresh, cloud sync wipe

### DIFF
--- a/src/composables/chat/useMessageActions.js
+++ b/src/composables/chat/useMessageActions.js
@@ -9,6 +9,8 @@ import { showToast } from '@/core/states/toastState.js';
 import { getApiReasoningTags } from '@/core/config/APISettings.js';
 import { getEffectivePreset } from '@/core/states/presetState.js';
 import { reconcileSessionMemoryState } from '@/core/services/memoryBooksService.js';
+import { publishAppEvent } from '@/core/events/eventHub.js';
+import { APP_EVENTS } from '@/core/events/eventNames.js';
 
 export function useMessageActions(deps) {
     const {
@@ -36,6 +38,8 @@ export function useMessageActions(deps) {
         if (!data || !sessionId) return;
         data.sessions[sessionId] = currentMessages.value;
         await db.saveChat(chatChar.id, data);
+        try { localStorage.removeItem(`gz_chat_recovery_${chatChar.id}_${sessionId}`); } catch (_e) {}
+        publishAppEvent(APP_EVENTS.domain.chat.updated);
     }
 
     function getReasoningTags() {
@@ -197,10 +201,10 @@ export function useMessageActions(deps) {
                             } else {
                                 abortActiveChatGeneration(activeChatChar.id);
                             }
-                        } else {
-                            currentMessages.value.splice(index, 1);
-                            persistCurrentSessionMessages(activeChatChar);
-                        }
+} else {
+                             currentMessages.value.splice(index, 1);
+                             persistCurrentSessionMessages(activeChatChar);
+                         }
                         closeBottomSheet();
                     }
                 }]

--- a/src/composables/chat/useSessionPersistence.js
+++ b/src/composables/chat/useSessionPersistence.js
@@ -44,13 +44,14 @@ export function useSessionPersistence({
             const sessionId = charContext.sessionId;
             const inputValueDraft = inputValue.value;
             const currentAnchor = getScrollAnchor();
+            const messagesSnapshot = currentMessages.value;
 
             db.patchChatData(charContext.id, (data) => {
                 data.lastScrollAnchor = currentAnchor;
                 data.draft = inputValueDraft;
 
-                if (sessionId && data.sessions && data.sessions[sessionId]) {
-                    const msgs = data.sessions[sessionId];
+                if (sessionId) {
+                    const msgs = JSON.parse(JSON.stringify(messagesSnapshot));
                     for (let i = msgs.length - 1; i >= 0; i--) {
                         const msg = msgs[i];
                         if (msg.isEditing) {
@@ -144,8 +145,8 @@ export function useSessionPersistence({
             const authorsNote = activeChatChar.authors_note;
             const summary = activeChatChar.summary;
             db.patchChatData(charId, (data) => {
-                if (sessionId && messagesSnapshot.length > 0) {
-                    data.sessions[sessionId] = messagesSnapshot;
+                if (sessionId) {
+                    data.sessions[sessionId] = JSON.parse(JSON.stringify(messagesSnapshot));
                 }
                 data.draft = draft;
                 if (authorsNote !== undefined) {
@@ -218,8 +219,8 @@ export function useSessionPersistence({
             db.patchChatData(charId, (data) => {
                 data.lastScrollAnchor = currentAnchor;
                 data.draft = draft;
-                if (sessionId && messagesSnapshot.length > 0) {
-                    data.sessions[sessionId] = messagesSnapshot;
+                if (sessionId) {
+                    data.sessions[sessionId] = JSON.parse(JSON.stringify(messagesSnapshot));
                 }
                 if (authorsNote !== undefined) {
                     if (!data.authorsNotes) data.authorsNotes = {};

--- a/src/core/services/adapters/dropboxAdapter.js
+++ b/src/core/services/adapters/dropboxAdapter.js
@@ -482,7 +482,28 @@ export async function download(path) {
 }
 
 export async function deleteFolder(path) {
-    return apiCall('/files/delete_v2', { path: stripAppFolderPrefix(path) || '' });
+    const strippedPath = stripAppFolderPrefix(path);
+    if (!strippedPath) {
+        let cursor = null;
+        let entries = [];
+        try {
+            const result = await apiCall('/files/list_folder', { path: '', recursive: true, include_deleted: false });
+            entries = result?.entries || [];
+            cursor = result?.cursor || null;
+            while (result?.has_more && cursor) {
+                const more = await apiCall('/files/list_folder/continue', { cursor });
+                entries.push(...(more?.entries || []));
+                cursor = more?.cursor || null;
+            }
+        } catch {}
+        for (const entry of entries) {
+            try {
+                await apiCall('/files/delete_v2', { path: entry.path_lower || entry.path_display });
+            } catch {}
+        }
+        return true;
+    }
+    return apiCall('/files/delete_v2', { path: strippedPath });
 }
 
 export async function deleteFile(fileOrPath) {

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -433,8 +433,11 @@ async function getGlazeFolderId(invalidate = false) {
         _folderIdCache.clear();
     }
     if (folderIdCache) {
-        const check = await apiRequest(`${API_BASE}/files/${folderIdCache}?fields=id&supportsAllDrives=false`);
-        if (check.ok) return folderIdCache;
+        const check = await apiRequest(`${API_BASE}/files/${folderIdCache}?fields=id,trashed&supportsAllDrives=false`);
+        if (check.ok) {
+            const data = await check.json();
+            if (!data.trashed) return folderIdCache;
+        }
         folderIdCache = null;
         _folderIdCache.clear();
     }

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -381,9 +381,9 @@ async function applyCloudEntry(adapter, entry, key) {
     } else if (entry.type === ENTITY_TYPES.PERSONA) {
         await db.put('personas', entity);
         await clearSyncDeletedEntry(entry.type, entry.id);
-    } else if (entry.type === ENTITY_TYPES.CHAT) {
-        await db.set(`gz_chat_${entry.id}`, entity);
-        await clearSyncDeletedEntry(entry.type, entry.id);
+} else if (entry.type === ENTITY_TYPES.CHAT) {
+            await db.saveChat(entry.id, entity);
+            await clearSyncDeletedEntry(entry.type, entry.id);
     } else if (entry.type === ENTITY_TYPES.LOREBOOKS) {
         await db.set('gz_lorebooks', entity);
     } else if (entry.type === ENTITY_TYPES.API_PRESETS) {
@@ -453,6 +453,9 @@ async function runParallel(tasks, concurrency = 5) {
 }
 
 async function pushManifestV2(adapter, key, onProgress) {
+    if (adapter.ensureFolder) {
+        await adapter.ensureFolder(CLOUD_BASE);
+    }
     const cloudManifest = await readCloudManifestV2(adapter);
     const localManifest = await buildLocalManifestV2();
     const cloudEntries = cloudManifest?.entries || {};
@@ -624,9 +627,6 @@ export async function pullEntities(adapter, key, onProgress, onConflict) {
 
 async function readManifest(adapter) {
     try {
-        if (adapter.ensureFolder) {
-            await adapter.ensureFolder(CLOUD_BASE);
-        }
         const result = await adapter.download(cloudPath(ENTITY_TYPES.MANIFEST));
         if (result) {
             return JSON.parse(result.data);
@@ -702,6 +702,9 @@ const WIPE_POLL_INTERVAL = 2000;
 const WIPE_MAX_POLLS = 10;
 
 export async function wipeCloudData(adapter, onProgress) {
+    if (adapter.invalidateGlazeFolderCache) {
+        adapter.invalidateGlazeFolderCache();
+    }
     if (onProgress) onProgress({ phase: 'deleting', message: 'Deleting cloud data...' });
     try {
         const result = await adapter.deleteFolder(CLOUD_BASE);

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -11,6 +11,7 @@ let unsubRegexChanged = null;
 let unsubChatSearch = null;
 let unsubApiContextChanged = null;
 let unsubSettingsChanged = null;
+let unsubSyncDataRefreshed = null;
 let _appStateListener = null;
 
 import * as memoryBooksService from '@/core/services/memoryBooksService.js';
@@ -1393,8 +1394,8 @@ onMounted(() => {
                 const messagesSnapshot = currentMessages.value;
                 const draft = inputValue.value;
                 db.patchChatData(charId, (data) => {
-                    if (sessionId && messagesSnapshot.length > 0) {
-                        data.sessions[sessionId] = messagesSnapshot;
+                    if (sessionId) {
+                        data.sessions[sessionId] = JSON.parse(JSON.stringify(messagesSnapshot));
                     }
                     data.draft = draft;
                 });
@@ -1414,6 +1415,7 @@ onMounted(() => {
     unsubChatSearch = subscribeAppEvent(APP_EVENTS.ui.chatSearch, ({ detail }) => onChatSearch({ detail }));
     unsubApiContextChanged = subscribeAppEvent(APP_EVENTS.domain.settings.apiContextChanged, updateContextCutoff);
     unsubSettingsChanged = subscribeAppEvent(APP_EVENTS.domain.settings.changed, restartVisibleGenerationTimers);
+    unsubSyncDataRefreshed = subscribeAppEvent(APP_EVENTS.domain.sync.dataRefreshed, () => loadChats());
 });
 
 watch(() => currentMessages.value.length, () => {
@@ -1495,6 +1497,7 @@ onUnmounted(() => {
     if (unsubChatSearch) { unsubChatSearch(); unsubChatSearch = null; }
     if (unsubApiContextChanged) { unsubApiContextChanged(); unsubApiContextChanged = null; }
     if (unsubSettingsChanged) { unsubSettingsChanged(); unsubSettingsChanged = null; }
+    if (unsubSyncDataRefreshed) { unsubSyncDataRefreshed(); unsubSyncDataRefreshed = null; }
     clearCutoffTimers();
 
     // Reset chatViewRoot height to prevent stale inline style leaking to next mount


### PR DESCRIPTION
- Fix deleted messages self-restoring on re-entering chat: asyncSaveCurrentSessionState used stale IDB data, now uses currentMessages.value with deep clone
- Fix crash buffer restoring deleted messages: clear crash buffer in persistCurrentSessionMessages
- Fix empty session not saved: changed length>0 check to just sessionId check
- Fix sidebar not refreshing after deletion: publishAppEvent after await db.saveChat
- Fix GDrive sync after wipe: ensureFolder moved to push, cache checks trashed status
- Fix Dropbox wipe: delete contents individually
- Fix cloud chat apply: db.saveChat instead of raw db.set
- Reload chats on sync data refresh event