### PR TITLE
fix: remove ensureFolder from OAuth connect, throw on failed folder search

### DIFF
--- a/src/core/services/adapters/dropboxAdapter.js
+++ b/src/core/services/adapters/dropboxAdapter.js
@@ -303,8 +303,6 @@ async function exchangeCodeForToken(code, verifier, redirectUri) {
 
     localStorage.removeItem('gz_dropbox_pkce_verifier');
     localStorage.removeItem('gz_dropbox_pkce_state');
-
-    await ensureFolder('/Glaze');
 }
 
 export async function disconnect() {

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -357,7 +357,6 @@ async function exchangeCodeForToken(code, verifier, redirectUri) {
     localStorage.removeItem('gz_gdrive_pkce_state');
 
     folderIdCache = null;
-    await ensureFolder('/Glaze');
 }
 
 export async function disconnect() {
@@ -390,7 +389,10 @@ async function findFoldersByName(name, parentId) {
         `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name)`
     );
 
-    if (!response.ok) return [];
+    if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.error?.message || `Failed to search for folder '${name}' (${response.status})`);
+    }
     const data = await response.json();
     return data.files || [];
 }
@@ -407,7 +409,10 @@ async function findFolderByName(name, parentId) {
         `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name)`
     );
 
-    if (!response.ok) return null;
+    if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.error?.message || `Failed to search for folder '${name}' (${response.status})`);
+    }
     const data = await response.json();
     return data.files?.[0]?.id || null;
 }


### PR DESCRIPTION
## Summary
- Remove ensureFolder('/Glaze') from exchangeCodeForToken in both GDrive and Dropbox adapters — connecting should not create folders
- Make indFoldersByName and indFolderByName throw on non-OK API responses instead of silently returning []/
ull — prevents creating duplicate empty folders on transient errors

## Why

Connecting to GDrive called ensureFolder('/Glaze') immediately after OAuth. If indFoldersByName failed silently (transient network error), it returned [], so getGlazeFolderId returned 
ull, and a new empty Glaze folder was created. The cache was then set to this empty folder, so sync would never find the manifest in the real folder.

Folders are now created lazily on first push (syncService.fullPush calls ensureFolder). For first-time users with no cloud data, cloudHasData() returns alse cleanly instead of creating an empty folder.