### PR TITLE
fix: Google Drive sync reliability + folder picker

### DIFF
--- a/src/components/sheets/SyncSheet.vue
+++ b/src/components/sheets/SyncSheet.vue
@@ -22,6 +22,7 @@ import { isSyncIncludingApiKeys, setSyncIncludeApiKeys } from '@/core/config/Pro
 import { db } from '@/utils/db.js';
 import { APP_EVENTS } from '@/core/events/eventNames.js';
 import { publishAppEvent } from '@/core/events/eventHub.js';
+import { useGdriveFolderPicker } from '@/composables/app/useGdriveFolderPicker.js';
 
 const sheet = ref(null);
 defineProps({ zIndex: { type: Number, default: 1005 } });
@@ -41,6 +42,16 @@ const restoreSuccess = ref(false);
 const localSyncStatus = ref('');
 const syncResult = ref(null);
 const syncIncludeApiKeys = ref(isSyncIncludingApiKeys());
+const {
+    gdriveFolderStatus,
+    isPickingFolder,
+    isCreatingFolder,
+    pickerError,
+    checkGdriveFolder,
+    selectExistingFolder,
+    createNewFolder,
+    resetFolderStatus
+} = useGdriveFolderPicker();
 
 watch(syncIncludeApiKeys, (val) => {
     setSyncIncludeApiKeys(val);
@@ -168,6 +179,7 @@ const connectGdrive = async () => {
         const info = await gdriveAdapter.getAccountInfo();
         accountInfo.value = info;
         await afterConnect();
+        await checkGdriveFolder();
     } catch (e) {
         console.error('[SyncSheet] Google Drive connect failed:', e);
         setSyncError(e.message);
@@ -190,6 +202,7 @@ const disconnectProvider = async () => {
         accountInfo.value = null;
         localSyncStatus.value = '';
         syncResult.value = null;
+        resetFolderStatus();
     } catch (e) {
         console.error('[SyncSheet] Disconnect failed:', e);
     } finally {
@@ -487,6 +500,34 @@ onMounted(async () => {
 </div>
                     <div class="sync-progress-bar-container">
                         <div class="sync-progress-bar" :style="{ width: syncProgress.total > 0 ? (syncProgress.current / syncProgress.total * 100) + '%' : '0%' }"></div>
+                    </div>
+                </div>
+
+                <!-- GDrive folder picker -->
+                <div v-if="syncProvider === 'gdrive' && gdriveFolderStatus === 'not_found'" class="bs-section">
+                    <div class="bs-section-title">
+                        {{ t('sync_gdrive_folder') || 'Glaze Folder' }}
+                    </div>
+                    <div class="bs-hint">
+                        {{ t('sync_gdrive_folder_not_found') || 'No Glaze folder found in your Google Drive. Create a new one or select an existing folder.' }}
+                    </div>
+                    <div v-if="pickerError" class="bs-hint" style="color: var(--text-secondary, #ff9500);">
+                        {{ pickerError }}
+                    </div>
+                    <button class="bs-btn bs-primary-btn" @click="createNewFolder" :disabled="isCreatingFolder || isPickingFolder">
+                        <svg viewBox="0 0 24 24"><path d="M20 6h-8l-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-1 8h-3v3h-2v-3h-3v-2h3V9h2v3h3v2z"/></svg>
+                        <span v-if="isCreatingFolder">{{ t('sync_creating') || 'Creating...' }}</span>
+                        <span v-else>{{ t('sync_gdrive_create_folder') || 'Create New Folder' }}</span>
+                    </button>
+                    <button class="bs-btn bs-secondary-btn" @click="selectExistingFolder" :disabled="isCreatingFolder || isPickingFolder">
+                        <svg viewBox="0 0 24 24"><path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/></svg>
+                        <span v-if="isPickingFolder">{{ t('sync_selecting') || 'Selecting...' }}</span>
+                        <span v-else>{{ t('sync_gdrive_select_folder') || 'Select Existing Folder' }}</span>
+                    </button>
+                </div>
+                <div v-else-if="syncProvider === 'gdrive' && gdriveFolderStatus === 'checking'" class="bs-section">
+                    <div class="bs-hint">
+                        {{ t('sync_gdrive_checking') || 'Checking Google Drive for Glaze folder...' }}
                     </div>
                 </div>
 

--- a/src/composables/app/useGdriveFolderPicker.js
+++ b/src/composables/app/useGdriveFolderPicker.js
@@ -1,0 +1,73 @@
+import { ref } from 'vue';
+import * as gdriveAdapter from '@/core/services/adapters/gdriveAdapter.js';
+
+export function useGdriveFolderPicker() {
+    const gdriveFolderStatus = ref('unchecked');
+    const isPickingFolder = ref(false);
+    const isCreatingFolder = ref(false);
+    const pickerError = ref('');
+
+    async function checkGdriveFolder() {
+        gdriveFolderStatus.value = 'checking';
+        pickerError.value = '';
+        try {
+            const folderId = await gdriveAdapter.getGlazeFolderId();
+            gdriveFolderStatus.value = folderId ? 'found' : 'not_found';
+        } catch (e) {
+            console.error('[useGdriveFolderPicker] check failed:', e);
+            gdriveFolderStatus.value = 'not_found';
+            pickerError.value = e.message;
+        }
+    }
+
+    async function selectExistingFolder() {
+        isPickingFolder.value = true;
+        pickerError.value = '';
+        try {
+            const result = await gdriveAdapter.pickFolder();
+            if (result) {
+                await gdriveAdapter.setGlazeFolderId(result.id);
+                gdriveFolderStatus.value = 'found';
+            }
+        } catch (e) {
+            console.error('[useGdriveFolderPicker] pick failed:', e);
+            pickerError.value = e.message;
+        } finally {
+            isPickingFolder.value = false;
+        }
+    }
+
+    async function createNewFolder() {
+        isCreatingFolder.value = true;
+        pickerError.value = '';
+        try {
+            await gdriveAdapter.ensureFolder('/Glaze');
+            const folderId = await gdriveAdapter.getGlazeFolderId(true);
+            if (folderId) {
+                await gdriveAdapter.setGlazeFolderId(folderId);
+            }
+            gdriveFolderStatus.value = 'found';
+        } catch (e) {
+            console.error('[useGdriveFolderPicker] create failed:', e);
+            pickerError.value = e.message;
+        } finally {
+            isCreatingFolder.value = false;
+        }
+    }
+
+    function resetFolderStatus() {
+        gdriveFolderStatus.value = 'unchecked';
+        pickerError.value = '';
+    }
+
+    return {
+        gdriveFolderStatus,
+        isPickingFolder,
+        isCreatingFolder,
+        pickerError,
+        checkGdriveFolder,
+        selectExistingFolder,
+        createNewFolder,
+        resetFolderStatus
+    };
+}

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -24,6 +24,7 @@ const SCOPES = 'https://www.googleapis.com/auth/drive.file';
 
 const FOLDER_NAME = 'Glaze';
 let folderIdCache = null;
+let pickerApiLoaded = false;
 
 function getRedirectUri() {
     if (Capacitor.isNativePlatform()) return REDIRECT_URI_NATIVE;
@@ -85,11 +86,13 @@ async function refreshAccessToken(refreshToken) {
         throw Object.assign(new Error(err.error_description || 'Token refresh failed'), { status: response.status });
     }
 
+    const existing = await getTokens();
     const data = await response.json();
     const newTokens = {
         access_token: data.access_token,
         refresh_token: refreshToken,
-        expires_at: Date.now() + (data.expires_in || 3600) * 1000
+        expires_at: Date.now() + (data.expires_in || 3600) * 1000,
+        ...(existing?.folderId ? { folderId: existing.folderId } : {})
     };
     await saveTokens(newTokens);
     return newTokens;
@@ -397,20 +400,6 @@ async function findFoldersByName(name, parentId) {
     return data.files || [];
 }
 
-async function findFoldersByNameBroad(name) {
-    const query = `name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
-    const response = await apiRequest(
-        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name)&includeItemsFromAllDrives=true&supportsAllDrives=true`
-    );
-
-    if (!response.ok) {
-        const err = await response.json().catch(() => ({}));
-        throw new Error(err.error?.message || `Failed to search for folder '${name}' (${response.status})`);
-    }
-    const data = await response.json();
-    return data.files || [];
-}
-
 async function findFolderByName(name, parentId) {
     let query = `name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
     if (parentId) {
@@ -446,19 +435,95 @@ export function invalidateGlazeFolderCache() {
     _folderIdCache.clear();
 }
 
+export async function setGlazeFolderId(folderId) {
+    folderIdCache = folderId;
+    const tokens = await getTokens();
+    if (tokens) {
+        tokens.folderId = folderId;
+        await saveTokens(tokens);
+    }
+}
+
+async function loadPickerApi() {
+    if (pickerApiLoaded && window.google?.picker) return;
+    return new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = 'https://apis.google.com/js/api.js';
+        script.onload = () => {
+            window.gapi.load('picker', {
+                callback: () => { pickerApiLoaded = true; resolve(); },
+                onerror: () => reject(new Error('Failed to load Google Picker API'))
+            });
+        };
+        script.onerror = () => reject(new Error('Failed to load Google API script'));
+        document.head.appendChild(script);
+    });
+}
+
+export async function pickFolder() {
+    const accessToken = await getValidAccessToken();
+    if (!accessToken) throw new Error('Not connected to Google Drive');
+
+    await loadPickerApi();
+
+    return new Promise((resolve, reject) => {
+        try {
+            const appId = GDRIVE_CLIENT_ID?.split('-')[0] || '';
+            const view = new window.google.picker.DocsView(
+                window.google.picker.ViewId.DOCS
+            )
+                .setSelectFolderEnabled(true)
+                .setMimeTypes('application/vnd.google-apps.folder')
+                .setMode(window.google.picker.DocsViewMode.LIST);
+
+            const picker = new window.google.picker.PickerBuilder()
+                .setAppId(appId)
+                .setOAuthToken(accessToken)
+                .addView(view)
+                .setTitle('Select Glaze folder')
+                .setCallback((data) => {
+                    if (data.action === window.google.picker.Action.PICKED) {
+                        const folder = data.docs[0];
+                        resolve({ id: folder.id, name: folder.name });
+                    } else if (data.action === window.google.picker.Action.CANCEL) {
+                        resolve(null);
+                    }
+                })
+                .build();
+            picker.setVisible(true);
+        } catch (e) {
+            reject(e);
+        }
+    });
+}
+
+export { getGlazeFolderId };
+
 async function getGlazeFolderId(invalidate = false) {
     if (invalidate) {
         folderIdCache = null;
         _folderIdCache.clear();
     }
     if (folderIdCache) {
-        const check = await apiRequest(`${API_BASE}/files/${folderIdCache}?fields=id,trashed&supportsAllDrives=true`);
+        const check = await apiRequest(`${API_BASE}/files/${folderIdCache}?fields=id,trashed,name&supportsAllDrives=true`);
         if (check.ok) {
             const data = await check.json();
-            if (!data.trashed) return folderIdCache;
+            if (!data.trashed && data.name === FOLDER_NAME) return folderIdCache;
         }
         folderIdCache = null;
         _folderIdCache.clear();
+    }
+    const persistedTokens = await getTokens();
+    if (persistedTokens?.folderId && persistedTokens.folderId !== folderIdCache) {
+        const check = await apiRequest(`${API_BASE}/files/${persistedTokens.folderId}?fields=id,trashed,name&supportsAllDrives=true`);
+        if (check.ok) {
+            const data = await check.json();
+            if (!data.trashed && data.name === FOLDER_NAME) {
+                folderIdCache = persistedTokens.folderId;
+                _folderIdCache.clear();
+                return folderIdCache;
+            }
+        }
     }
     const folders = await findFoldersByName(FOLDER_NAME, null);
     if (folders.length === 0) return null;

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -386,7 +386,21 @@ async function findFoldersByName(name, parentId) {
     }
 
     const response = await apiRequest(
-        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name)`
+        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name)&includeItemsFromAllDrives=true&supportsAllDrives=true`
+    );
+
+    if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.error?.message || `Failed to search for folder '${name}' (${response.status})`);
+    }
+    const data = await response.json();
+    return data.files || [];
+}
+
+async function findFoldersByNameBroad(name) {
+    const query = `name='${name}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
+    const response = await apiRequest(
+        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name)&includeItemsFromAllDrives=true&supportsAllDrives=true`
     );
 
     if (!response.ok) {
@@ -406,7 +420,7 @@ async function findFolderByName(name, parentId) {
     }
 
     const response = await apiRequest(
-        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name)`
+        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name)&includeItemsFromAllDrives=true&supportsAllDrives=true`
     );
 
     if (!response.ok) {
@@ -420,7 +434,7 @@ async function findFolderByName(name, parentId) {
 async function folderHasContent(folderId) {
     const query = `'${folderId}' in parents and trashed=false`;
     const response = await apiRequest(
-        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id)&pageSize=1`
+        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id)&pageSize=1&includeItemsFromAllDrives=true&supportsAllDrives=true`
     );
     if (!response.ok) return false;
     const data = await response.json();
@@ -438,7 +452,7 @@ async function getGlazeFolderId(invalidate = false) {
         _folderIdCache.clear();
     }
     if (folderIdCache) {
-        const check = await apiRequest(`${API_BASE}/files/${folderIdCache}?fields=id,trashed&supportsAllDrives=false`);
+        const check = await apiRequest(`${API_BASE}/files/${folderIdCache}?fields=id,trashed&supportsAllDrives=true`);
         if (check.ok) {
             const data = await check.json();
             if (!data.trashed) return folderIdCache;
@@ -494,7 +508,7 @@ async function createFolder(name, parentId) {
         body.parents = [parentId];
     }
 
-    const response = await apiRequest(`${API_BASE}/files?fields=id`, {
+    const response = await apiRequest(`${API_BASE}/files?fields=id&supportsAllDrives=true`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
@@ -576,10 +590,14 @@ async function findFileByName(name, parentId) {
     if (!parentId) return null;
     const query = `name='${name}' and '${parentId}' in parents and trashed=false`;
     const response = await apiRequest(
-        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name,modifiedTime)`
+        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name,modifiedTime)&includeItemsFromAllDrives=true&supportsAllDrives=true`
     );
 
-    if (!response.ok) return null;
+    if (!response.ok) {
+        if (response.status === 404) return null;
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.error?.message || `Failed to search for file '${name}' (${response.status})`);
+    }
     const data = await response.json();
     return data.files?.[0] || null;
 }
@@ -595,7 +613,7 @@ export async function upload(path, data) {
         if (!accessToken) throw new Error('Not connected to Google Drive');
 
         const response = await safeUploadFetch(
-            `${UPLOAD_BASE}/files/${existingFile.id}?uploadType=media`,
+            `${UPLOAD_BASE}/files/${existingFile.id}?uploadType=media&supportsAllDrives=true`,
             {
                 method: 'PATCH',
                 headers: {
@@ -611,7 +629,7 @@ export async function upload(path, data) {
             if (tokens?.refresh_token) {
                 const refreshed = await refreshAccessToken(tokens.refresh_token);
                 const retry = await safeUploadFetch(
-                    `${UPLOAD_BASE}/files/${existingFile.id}?uploadType=media`,
+                    `${UPLOAD_BASE}/files/${existingFile.id}?uploadType=media&supportsAllDrives=true`,
                     {
                         method: 'PATCH',
                         headers: {
@@ -665,7 +683,7 @@ export async function upload(path, data) {
             if (tokens?.refresh_token) {
                 const refreshed = await refreshAccessToken(tokens.refresh_token);
                 const retry = await safeUploadFetch(
-                    `${UPLOAD_BASE}/files?uploadType=multipart&fields=id`,
+`${UPLOAD_BASE}/files?uploadType=multipart&fields=id&supportsAllDrives=true`,
                     {
                         method: 'POST',
                         headers: {
@@ -703,7 +721,7 @@ export async function download(path, _retry = false) {
     }
 
     const response = await apiRequest(
-        `${API_BASE}/files/${file.id}?alt=media`
+        `${API_BASE}/files/${file.id}?alt=media&supportsAllDrives=true`
     );
 
     if (!response.ok) {
@@ -736,7 +754,7 @@ export async function listFolder(path) {
 
     const query = `'${parentId}' in parents and trashed=false`;
     const response = await apiRequest(
-        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name,mimeType,modifiedTime)&pageSize=1000`
+        `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id,name,mimeType,modifiedTime)&pageSize=1000&includeItemsFromAllDrives=true&supportsAllDrives=true`
     );
 
     if (!response.ok) return { entries: [] };
@@ -758,11 +776,27 @@ export async function listFolderContinue() {
     return { entries: [], has_more: false };
 }
 
+const GLAZE_PATH_PREFIX = '/Glaze';
+
+function assertGlazePath(path) {
+    if (!path || !path.startsWith(GLAZE_PATH_PREFIX)) {
+        throw new Error(`Refusing to delete outside Glaze folder: ${path}`);
+    }
+}
+
 export async function deleteFolder(path) {
+    assertGlazePath(path);
     if (path === '/Glaze' || path === `/${FOLDER_NAME}`) {
         const folderId = await getGlazeFolderId();
         if (!folderId) return false;
-        const response = await apiRequest(`${API_BASE}/files/${folderId}`, { method: 'DELETE' });
+        const verifyResponse = await apiRequest(`${API_BASE}/files/${folderId}?fields=name&supportsAllDrives=true`);
+        if (verifyResponse.ok) {
+            const verifyData = await verifyResponse.json();
+            if (verifyData.name !== FOLDER_NAME) {
+                throw new Error(`Safety check failed: folder ID ${folderId} is named "${verifyData.name}", expected "${FOLDER_NAME}". Aborting delete.`);
+            }
+        }
+        const response = await apiRequest(`${API_BASE}/files/${folderId}?supportsAllDrives=true`, { method: 'DELETE' });
         if (!response.ok && response.status !== 204) {
             throw new Error(`Delete folder failed ${response.status}`);
         }
@@ -776,7 +810,7 @@ export async function deleteFolder(path) {
     const { parentId } = await resolvePathToParent(parentPath);
     const folderId = await findFolderByName(folderName, parentId);
     if (!folderId) return false;
-    const response = await apiRequest(`${API_BASE}/files/${folderId}`, { method: 'DELETE' });
+    const response = await apiRequest(`${API_BASE}/files/${folderId}?supportsAllDrives=true`, { method: 'DELETE' });
     if (!response.ok && response.status !== 204) {
         throw new Error(`Delete folder failed ${response.status}`);
     }
@@ -785,21 +819,24 @@ export async function deleteFolder(path) {
 
 export async function deleteFile(fileOrPath) {
     let fileId = null;
+    let resolvedPath = '';
 
     if (typeof fileOrPath === 'object' && fileOrPath?.id) {
         fileId = fileOrPath.id;
+        resolvedPath = fileOrPath?.path_display || fileOrPath?.path || '';
     } else {
-        const path = typeof fileOrPath === 'string'
+        resolvedPath = typeof fileOrPath === 'string'
             ? fileOrPath
             : (fileOrPath?.path_display || fileOrPath?.path || '');
-        const { parentId, fileName } = await resolvePathToParent(path);
+        assertGlazePath(resolvedPath);
+        const { parentId, fileName } = await resolvePathToParent(resolvedPath);
         const file = await findFileByName(fileName, parentId);
         if (!file) return null;
         fileId = file.id;
     }
 
     const response = await apiRequest(
-        `${API_BASE}/files/${fileId}`,
+        `${API_BASE}/files/${fileId}?supportsAllDrives=true`,
         { method: 'DELETE' }
     );
 

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -531,9 +531,14 @@ async function pushManifestV2(adapter, key, onProgress) {
 }
 
 async function pullManifestV2(adapter, key, onProgress, onConflict) {
-    const cloudManifest = await readCloudManifestV2(adapter);
+    let cloudManifest;
+    try {
+        cloudManifest = await readCloudManifestV2(adapter);
+    } catch (e) {
+        throw new Error(`Cannot access cloud data: ${e.message}`);
+    }
     if (!cloudManifest) {
-        throw new Error('Cloud manifest v2 not found');
+        throw new Error(`Cloud manifest not found. No sync data was found in the cloud folder. If this is a new device, try pushing your local data first.`);
     }
 
     const localManifest = await buildLocalManifestV2();
@@ -631,8 +636,11 @@ async function readManifest(adapter) {
         if (result) {
             return JSON.parse(result.data);
         }
-    } catch {}
-    return null;
+        return null;
+    } catch (e) {
+        console.error('[syncEngine] readManifest failed:', e);
+        throw new Error(`Failed to read cloud manifest: ${e.message}`);
+    }
 }
 
 async function listAllFiles(adapter) {


### PR DESCRIPTION
## Summary

- **gdriveAdapter**: Fix `findFileByName` silently swallowing API errors (403/500) as "not found", which caused `manifest not found` masking real permission issues. Now throws on non-404 errors.
- **gdriveAdapter**: Add `assertGlazePath()` guard on all delete operations — refuses any path outside `/Glaze/`, preventing accidental data loss. `deleteFolder('/Glaze')` additionally verifies folder name via API before deleting.
- **gdriveAdapter**: Add `supportsAllDrives=true` to all Drive API calls for shared drive compatibility. `includeItemsFromAllDrives=true` on all search queries.
- **gdriveAdapter**: Persist `folderId` in sync tokens — survives page reloads and token refreshes. `getGlazeFolderId` checks persisted ID (with API verification) before searching.
- **gdriveAdapter**: Add `pickFolder()` — opens Google Picker dialog using OAuth token + appId from clientId, no separate developerKey needed. Lets user manually select an existing Glaze folder when auto-search fails (e.g. on a new device, or folder in a shared drive / subdirectory).
- **gdriveAdapter**: Add `setGlazeFolderId()` to save selected folder ID.
- **syncEngine**: `readManifest` now propagates errors instead of `catch {}` returning null. `pullManifestV2` gives actionable error messages when manifest is missing vs inaccessible.
- **SyncSheet**: Show folder picker section when GDrive is connected but no Glaze folder is found — "Create New Folder" and "Select Existing Folder" buttons with loading/error states.
- **useGdriveFolderPicker composable**: Reactive folder status tracking, `checkGdriveFolder()`, `selectExistingFolder()`, `createNewFolder()`, `resetFolderStatus()`.

## Scope concern

The `drive.file` OAuth scope shows **"View and manage files created by this app"** — not "entire Drive". The `supportsAllDrives` and `includeItemsFromAllDrives` parameters do **not** change the OAuth prompt. Google Picker is the standard mechanism for `drive.file` to access folders that the app didn't create itself — the user explicitly grants access by selecting the folder.