### PR TITLE
fix: folder ID input instead of Google Picker for mobile

### DIFF
--- a/src/components/sheets/SyncSheet.vue
+++ b/src/components/sheets/SyncSheet.vue
@@ -509,7 +509,7 @@ onMounted(async () => {
                         {{ t('sync_gdrive_folder') || 'Glaze Folder' }}
                     </div>
                     <div class="bs-hint">
-                        {{ t('sync_gdrive_folder_not_found') || 'No Glaze folder found in your Google Drive. Create a new one or select an existing folder.' }}
+                        {{ t('sync_gdrive_folder_not_found') || 'No Glaze folder found in your Google Drive. Create a new one or link an existing folder.' }}
                     </div>
                     <div v-if="pickerError" class="bs-hint" style="color: var(--text-secondary, #ff9500);">
                         {{ pickerError }}
@@ -519,11 +519,34 @@ onMounted(async () => {
                         <span v-if="isCreatingFolder">{{ t('sync_creating') || 'Creating...' }}</span>
                         <span v-else>{{ t('sync_gdrive_create_folder') || 'Create New Folder' }}</span>
                     </button>
-                    <button class="bs-btn bs-secondary-btn" @click="selectExistingFolder" :disabled="isCreatingFolder || isPickingFolder">
-                        <svg viewBox="0 0 24 24"><path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/></svg>
-                        <span v-if="isPickingFolder">{{ t('sync_selecting') || 'Selecting...' }}</span>
-                        <span v-else>{{ t('sync_gdrive_select_folder') || 'Select Existing Folder' }}</span>
-                    </button>
+                    <template v-if="!isNativePlatform">
+                        <button class="bs-btn bs-secondary-btn" @click="selectExistingFolder" :disabled="isCreatingFolder || isPickingFolder">
+                            <svg viewBox="0 0 24 24"><path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/></svg>
+                            <span v-if="isPickingFolder">{{ t('sync_selecting') || 'Selecting...' }}</span>
+                            <span v-else>{{ t('sync_gdrive_select_folder') || 'Select Existing Folder' }}</span>
+                        </button>
+                    </template>
+                    <div class="bs-section" style="margin-top: 8px;">
+                        <div class="bs-section-title" style="font-size: 0.85em;">
+                            {{ t('sync_gdrive_link_by_id') || 'Or link by folder ID' }}
+                        </div>
+                        <div class="bs-hint" style="font-size: 0.8em;">
+                            {{ t('sync_gdrive_link_hint') || 'Open the folder in Google Drive, copy the URL or ID from the address bar, and paste it here.' }}
+                        </div>
+                        <div style="display: flex; gap: 8px; align-items: center;">
+                            <input
+                                v-model="folderIdInput"
+                                type="text"
+                                class="bs-input"
+                                :placeholder="t('sync_gdrive_folder_id_placeholder') || 'Folder ID or URL'"
+                                style="flex: 1; min-width: 0; padding: 6px 10px; border-radius: 8px; border: 1px solid var(--border-color, #444); background: var(--bg-tertiary, #222); color: var(--text-primary, #eee);"
+                                @keydown.enter="linkFolderById"
+                            />
+                            <button class="bs-btn bs-secondary-btn" @click="linkFolderById" :disabled="isCreatingFolder || !folderIdInput.trim()" style="padding: 6px 14px;">
+                                {{ t('sync_gdrive_link') || 'Link' }}
+                            </button>
+                        </div>
+                    </div>
                 </div>
                 <div v-else-if="syncProvider === 'gdrive' && gdriveFolderStatus === 'checking'" class="bs-section">
                     <div class="bs-hint">

--- a/src/components/sheets/SyncSheet.vue
+++ b/src/components/sheets/SyncSheet.vue
@@ -43,12 +43,16 @@ const localSyncStatus = ref('');
 const syncResult = ref(null);
 const syncIncludeApiKeys = ref(isSyncIncludingApiKeys());
 const {
+    gdriveFolderId,
     gdriveFolderStatus,
     isPickingFolder,
     isCreatingFolder,
     pickerError,
+    folderIdInput,
+    isNativePlatform,
     checkGdriveFolder,
     selectExistingFolder,
+    linkFolderById,
     createNewFolder,
     resetFolderStatus
 } = useGdriveFolderPicker();
@@ -378,6 +382,11 @@ const open = async () => {
 };
 const close = () => sheet.value?.close();
 
+const copyFolderId = () => {
+    if (!gdriveFolderId.value) return;
+    navigator.clipboard.writeText(gdriveFolderId.value).catch(() => {});
+};
+
 defineExpose({ open, close });
 
 onMounted(async () => {
@@ -458,6 +467,14 @@ onMounted(async () => {
                         <div class="sync-status-text">
 {{ statusLabel }}
 </div>
+                    </div>
+
+                    <div v-if="syncProvider === 'gdrive' && gdriveFolderId" class="sync-folder-id-row">
+                        <span class="sync-folder-id-label">{{ t('sync_gdrive_folder_id') || 'Folder ID' }}</span>
+                        <code class="sync-folder-id-value">{{ gdriveFolderId }}</code>
+                        <button class="sync-copy-btn" @click="copyFolderId" :title="t('sync_copy') || 'Copy'">
+                            <svg viewBox="0 0 24 24" style="width:16px;height:16px;fill:currentColor"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
+                        </button>
                     </div>
 
                     <button v-if="syncConflicts.length > 0" class="sync-resolve-btn" @click="openConflictSheet">
@@ -878,6 +895,45 @@ onMounted(async () => {
 .sync-status-text {
     font-size: 13px;
     color: var(--text-gray, #8e8e93);
+}
+
+.sync-folder-id-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 6px;
+    padding: 6px 10px;
+    background: var(--bg-tertiary, #222);
+    border-radius: 8px;
+    font-size: 12px;
+}
+.sync-folder-id-label {
+    color: var(--text-gray, #8e8e93);
+    white-space: nowrap;
+}
+.sync-folder-id-value {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: monospace;
+    font-size: 11px;
+    color: var(--text-primary, #eee);
+}
+.sync-copy-btn {
+    background: none;
+    border: none;
+    color: var(--text-gray, #8e8e93);
+    cursor: pointer;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+    transition: color 0.2s;
+}
+.sync-copy-btn:hover {
+    color: var(--text-primary, #eee);
 }
 
 .sync-resolve-btn {

--- a/src/composables/app/useGdriveFolderPicker.js
+++ b/src/composables/app/useGdriveFolderPicker.js
@@ -1,4 +1,5 @@
 import { ref } from 'vue';
+import { Capacitor } from '@capacitor/core';
 import * as gdriveAdapter from '@/core/services/adapters/gdriveAdapter.js';
 
 export function useGdriveFolderPicker() {
@@ -6,6 +7,8 @@ export function useGdriveFolderPicker() {
     const isPickingFolder = ref(false);
     const isCreatingFolder = ref(false);
     const pickerError = ref('');
+    const folderIdInput = ref('');
+    const isNativePlatform = Capacitor.isNativePlatform();
 
     async function checkGdriveFolder() {
         gdriveFolderStatus.value = 'checking';
@@ -21,6 +24,9 @@ export function useGdriveFolderPicker() {
     }
 
     async function selectExistingFolder() {
+        if (isNativePlatform) {
+            return await linkFolderById();
+        }
         isPickingFolder.value = true;
         pickerError.value = '';
         try {
@@ -34,6 +40,38 @@ export function useGdriveFolderPicker() {
             pickerError.value = e.message;
         } finally {
             isPickingFolder.value = false;
+        }
+    }
+
+    async function linkFolderById() {
+        const input = folderIdInput.value.trim();
+        if (!input) {
+            pickerError.value = 'Please enter a folder ID or Google Drive URL';
+            return;
+        }
+
+        const folderId = gdriveAdapter.extractFolderId(input);
+        if (!folderId) {
+            pickerError.value = 'Could not parse folder ID from input';
+            return;
+        }
+
+        isCreatingFolder.value = true;
+        pickerError.value = '';
+        try {
+            const verified = await gdriveAdapter.verifyFolderId(folderId);
+            if (!verified) {
+                pickerError.value = 'Folder not found or not accessible. Make sure the folder is shared with your Google account.';
+                return;
+            }
+            await gdriveAdapter.setGlazeFolderId(folderId);
+            gdriveFolderStatus.value = 'found';
+            folderIdInput.value = '';
+        } catch (e) {
+            console.error('[useGdriveFolderPicker] link failed:', e);
+            pickerError.value = e.message;
+        } finally {
+            isCreatingFolder.value = false;
         }
     }
 
@@ -58,6 +96,7 @@ export function useGdriveFolderPicker() {
     function resetFolderStatus() {
         gdriveFolderStatus.value = 'unchecked';
         pickerError.value = '';
+        folderIdInput.value = '';
     }
 
     return {
@@ -65,8 +104,11 @@ export function useGdriveFolderPicker() {
         isPickingFolder,
         isCreatingFolder,
         pickerError,
+        folderIdInput,
+        isNativePlatform,
         checkGdriveFolder,
         selectExistingFolder,
+        linkFolderById,
         createNewFolder,
         resetFolderStatus
     };

--- a/src/composables/app/useGdriveFolderPicker.js
+++ b/src/composables/app/useGdriveFolderPicker.js
@@ -3,6 +3,7 @@ import { Capacitor } from '@capacitor/core';
 import * as gdriveAdapter from '@/core/services/adapters/gdriveAdapter.js';
 
 export function useGdriveFolderPicker() {
+    const gdriveFolderId = ref('');
     const gdriveFolderStatus = ref('unchecked');
     const isPickingFolder = ref(false);
     const isCreatingFolder = ref(false);
@@ -15,6 +16,7 @@ export function useGdriveFolderPicker() {
         pickerError.value = '';
         try {
             const folderId = await gdriveAdapter.getGlazeFolderId();
+            gdriveFolderId.value = folderId || '';
             gdriveFolderStatus.value = folderId ? 'found' : 'not_found';
         } catch (e) {
             console.error('[useGdriveFolderPicker] check failed:', e);
@@ -33,6 +35,7 @@ export function useGdriveFolderPicker() {
             const result = await gdriveAdapter.pickFolder();
             if (result) {
                 await gdriveAdapter.setGlazeFolderId(result.id);
+                gdriveFolderId.value = result.id;
                 gdriveFolderStatus.value = 'found';
             }
         } catch (e) {
@@ -65,6 +68,7 @@ export function useGdriveFolderPicker() {
                 return;
             }
             await gdriveAdapter.setGlazeFolderId(folderId);
+            gdriveFolderId.value = folderId;
             gdriveFolderStatus.value = 'found';
             folderIdInput.value = '';
         } catch (e) {
@@ -83,6 +87,7 @@ export function useGdriveFolderPicker() {
             const folderId = await gdriveAdapter.getGlazeFolderId(true);
             if (folderId) {
                 await gdriveAdapter.setGlazeFolderId(folderId);
+                gdriveFolderId.value = folderId;
             }
             gdriveFolderStatus.value = 'found';
         } catch (e) {
@@ -95,11 +100,13 @@ export function useGdriveFolderPicker() {
 
     function resetFolderStatus() {
         gdriveFolderStatus.value = 'unchecked';
+        gdriveFolderId.value = '';
         pickerError.value = '';
         folderIdInput.value = '';
     }
 
     return {
+        gdriveFolderId,
         gdriveFolderStatus,
         isPickingFolder,
         isCreatingFolder,

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -499,6 +499,32 @@ export async function pickFolder() {
 
 export { getGlazeFolderId };
 
+export function extractFolderId(input) {
+    if (!input) return null;
+    input = input.trim();
+    const driveUrlMatch = input.match(/\/folders\/([a-zA-Z0-9_-]+)/);
+    if (driveUrlMatch) return driveUrlMatch[1];
+    const openUrlMatch = input.match(/[?&]id=([a-zA-Z0-9_-]+)/);
+    if (openUrlMatch) return openUrlMatch[1];
+    if (/^[a-zA-Z0-9_-]{10,}$/.test(input)) return input;
+    return null;
+}
+
+export async function verifyFolderId(folderId) {
+    try {
+        const response = await apiRequest(
+            `${API_BASE}/files/${encodeURIComponent(folderId)}?fields=id,name,mimeType,trashed&supportsAllDrives=true`
+        );
+        if (!response.ok) return null;
+        const data = await response.json();
+        if (data.trashed) return null;
+        if (data.mimeType !== 'application/vnd.google-apps.folder') return null;
+        return data;
+    } catch {
+        return null;
+    }
+}
+
 async function getGlazeFolderId(invalidate = false) {
     if (invalidate) {
         folderIdCache = null;


### PR DESCRIPTION
## Summary

Google Picker doesn't work in Capacitor WebView (mobile) — opens browser but button clicks do nothing. This PR replaces it with a folder ID/URL input field as the primary method, keeping Picker as a web-only convenience.

- Add `extractFolderId()` — parses folder ID from 3 formats: `/folders/ID`, `?id=ID`, bare ID string
- Add `verifyFolderId()` — validates folder exists and is accessible via Drive API before persisting
- On native (Capacitor): skip Picker entirely, show input field + "Link" button
- On web/Electron: keep "Select Existing Folder" Picker button + folder ID input as fallback
- Clear error messages when folder not found or not accessible