### PR TITLE
fix: switch to drive scope + harden gdrive adapter safety

### DIFF
--- a/src/composables/app/useGdriveFolderPicker.js
+++ b/src/composables/app/useGdriveFolderPicker.js
@@ -62,18 +62,14 @@ export function useGdriveFolderPicker() {
         isCreatingFolder.value = true;
         pickerError.value = '';
         try {
-            const verified = await gdriveAdapter.verifyFolderId(folderId);
-            if (!verified) {
-                pickerError.value = 'Folder not found or not accessible. Make sure the folder is shared with your Google account.';
-                return;
-            }
+            await gdriveAdapter.verifyFolderId(folderId);
             await gdriveAdapter.setGlazeFolderId(folderId);
             gdriveFolderId.value = folderId;
             gdriveFolderStatus.value = 'found';
             folderIdInput.value = '';
         } catch (e) {
             console.error('[useGdriveFolderPicker] link failed:', e);
-            pickerError.value = e.message;
+            pickerError.value = e.message || 'Could not access folder. Make sure it exists and is shared with your Google account.';
         } finally {
             isCreatingFolder.value = false;
         }

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -20,7 +20,7 @@ const UPLOAD_BASE = 'https://www.googleapis.com/upload/drive/v3';
 const AUTH_BASE = 'https://accounts.google.com/o/oauth2/v2/auth';
 const TOKEN_URL = 'https://oauth2.googleapis.com/token';
 
-const SCOPES = 'https://www.googleapis.com/auth/drive.file';
+const SCOPES = 'https://www.googleapis.com/auth/drive';
 
 const FOLDER_NAME = 'Glaze';
 let folderIdCache = null;
@@ -515,13 +515,20 @@ export async function verifyFolderId(folderId) {
         const response = await apiRequest(
             `${API_BASE}/files/${encodeURIComponent(folderId)}?fields=id,name,mimeType,trashed&supportsAllDrives=true`
         );
-        if (!response.ok) return null;
+        if (!response.ok) {
+            const err = await response.json().catch(() => ({}));
+            throw new Error(err.error?.message || `Failed to access folder (${response.status})`);
+        }
         const data = await response.json();
-        if (data.trashed) return null;
-        if (data.mimeType !== 'application/vnd.google-apps.folder') return null;
+        if (data.trashed) throw new Error('Folder is in trash');
+        if (data.mimeType !== 'application/vnd.google-apps.folder') throw new Error('Not a folder');
+        folderIdCache = folderId;
+        _folderIdCache.clear();
         return data;
-    } catch {
-        return null;
+    } catch (e) {
+        folderIdCache = null;
+        _folderIdCache.clear();
+        throw e;
     }
 }
 

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -420,14 +420,30 @@ async function findFolderByName(name, parentId) {
     return data.files?.[0]?.id || null;
 }
 
-async function folderHasContent(folderId) {
-    const query = `'${folderId}' in parents and trashed=false`;
+async function folderHasRealContent(folderId) {
+    const query = `'${folderId}' in parents and trashed=false and name!='manifest.json'`;
     const response = await apiRequest(
         `${API_BASE}/files?q=${encodeURIComponent(query)}&spaces=drive&fields=files(id)&pageSize=1&includeItemsFromAllDrives=true&supportsAllDrives=true`
     );
-    if (!response.ok) return false;
+    if (!response.ok) return true;
     const data = await response.json();
     return (data.files?.length || 0) > 0;
+}
+
+async function folderHasManifest(folderId) {
+    const file = await findFileByName('manifest.json', folderId);
+    return !!file;
+}
+
+async function isOurGlazeFolder(folderId) {
+    return await folderHasManifest(folderId);
+}
+
+async function isSafeToDeleteGlazeFolder(folderId) {
+    const hasManifest = await folderHasManifest(folderId);
+    if (hasManifest) return true;
+    const hasContent = await folderHasRealContent(folderId);
+    return !hasContent;
 }
 
 export function invalidateGlazeFolderCache() {
@@ -560,21 +576,16 @@ async function getGlazeFolderId(invalidate = false) {
     }
     const folders = await findFoldersByName(FOLDER_NAME, null);
     if (folders.length === 0) return null;
-    if (folders.length === 1) {
-        folderIdCache = folders[0].id;
-        return folderIdCache;
-    }
     let bestFolder = null;
     for (const folder of folders) {
-        const manifestFile = await findFileByName('manifest.json', folder.id);
-        if (manifestFile) {
+        if (await isOurGlazeFolder(folder.id)) {
             bestFolder = folder;
             break;
         }
     }
     if (!bestFolder) {
         for (const folder of folders) {
-            if (await folderHasContent(folder.id)) {
+            if (await folderHasRealContent(folder.id)) {
                 bestFolder = folder;
                 break;
             }
@@ -585,13 +596,10 @@ async function getGlazeFolderId(invalidate = false) {
     }
     folderIdCache = bestFolder.id;
     for (const folder of folders) {
-        if (folder.id !== bestFolder.id) {
-            const hasContent = await folderHasContent(folder.id);
-            if (!hasContent) {
-                try {
-                    await apiRequest(`${API_BASE}/files/${folder.id}`, { method: 'DELETE' });
-                } catch {}
-            }
+        if (folder.id !== bestFolder.id && await isSafeToDeleteGlazeFolder(folder.id)) {
+            try {
+                await apiRequest(`${API_BASE}/files/${folder.id}?supportsAllDrives=true`, { method: 'DELETE' });
+            } catch {}
         }
     }
     return folderIdCache;
@@ -701,6 +709,7 @@ async function findFileByName(name, parentId) {
 }
 
 export async function upload(path, data) {
+    assertGlazePath(path);
     const { parentId, fileName } = await resolvePathToParent(path);
     const existingFile = await findFileByName(fileName, parentId);
 
@@ -807,6 +816,7 @@ export async function upload(path, data) {
 }
 
 export async function download(path, _retry = false) {
+    assertGlazePath(path);
     const { parentId, fileName } = await resolvePathToParent(path);
     const file = await findFileByName(fileName, parentId);
 
@@ -835,6 +845,7 @@ export async function download(path, _retry = false) {
 }
 
 export async function listFolder(path) {
+    assertGlazePath(path);
     const parts = path.replace(/^\//, '').split('/').filter(Boolean);
     let parentId = null;
 
@@ -920,8 +931,19 @@ export async function deleteFile(fileOrPath) {
     let resolvedPath = '';
 
     if (typeof fileOrPath === 'object' && fileOrPath?.id) {
-        fileId = fileOrPath.id;
         resolvedPath = fileOrPath?.path_display || fileOrPath?.path || '';
+        assertGlazePath(resolvedPath);
+        if (!resolvedPath) {
+            const glazeId = await getGlazeFolderId();
+            if (!glazeId || !fileOrPath.id) throw new Error('Refusing to delete file without path verification');
+            const meta = await apiRequest(`${API_BASE}/files/${fileOrPath.id}?fields=parents&supportsAllDrives=true`);
+            if (!meta.ok) throw new Error('Refusing to delete file: cannot verify parent');
+            const metaData = await meta.json();
+            if (!metaData.parents?.includes(glazeId)) {
+                throw new Error(`Refusing to delete file outside Glaze folder`);
+            }
+        }
+        fileId = fileOrPath.id;
     } else {
         resolvedPath = typeof fileOrPath === 'string'
             ? fileOrPath


### PR DESCRIPTION
## Summary

Switches Google Drive OAuth scope from `drive.file` to `drive` and adds safety guards to prevent accidental data loss.

### Why `drive.file` doesn't work
`drive.file` only grants access to files created by the app **with that specific token**. A folder created on device A is invisible to device B, making cross-device sync impossible.

### Changes
- **Scope**: `drive.file` → `drive` — required for cross-device sync
- **Path guards**: `assertGlazePath()` added to `upload`, `download`, `listFolder`, `deleteFile` — all operations restricted to `/Glaze/` prefix
- **deleteFile by ID**: when called with a file object (no path string), verifies the file's parent is the Glaze folder before deleting
- **getGlazeFolderId**: duplicate Glaze folders are only deleted if they contain our `manifest.json` or are empty. Folders with user data and no manifest are never touched
- **verifyFolderId**: restored (works with full `drive` scope) — throws descriptive errors instead of silently returning null
- **Composable**: updated to catch thrown errors from `verifyFolderId`

### Important
Users will need to reconnect Google Drive — the old `drive.file` token is incompatible with the new scope. The OAuth consent screen will now show "See, edit, create, and delete all of your Google Drive files".