### PR TITLE
feat: mobile Picker via redirect + drive.file scope + folder ID fallback

### DIFF
--- a/public/oauth/gdrive/picker.html
+++ b/public/oauth/gdrive/picker.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Glaze — Select Folder</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body { font-family: sans-serif; text-align: center; padding-top: 40%; }
+        .error { color: #d32f2f; }
+    </style>
+</head>
+<body>
+    <p id="status">Loading Google Picker...</p>
+    <script src="https://apis.google.com/js/api.js"></script>
+    <script>
+        const params = new URLSearchParams(window.location.hash.substring(1) || window.location.search);
+        const accessToken = params.get('token');
+        const appId = params.get('appId');
+        const nativeScheme = params.get('nativeScheme') || 'com.hydall.glaze';
+
+        if (!accessToken) {
+            document.getElementById('status').textContent = 'Error: No access token provided.';
+            document.getElementById('status').className = 'error';
+        }
+
+        function onPickerLoaded() {
+            const view = new google.picker.DocsView(google.picker.ViewId.DOCS)
+                .setSelectFolderEnabled(true)
+                .setMimeTypes('application/vnd.google-apps.folder')
+                .setMode(google.picker.DocsViewMode.LIST);
+
+            const picker = new google.picker.PickerBuilder()
+                .setAppId(appId || '')
+                .setOAuthToken(accessToken)
+                .addView(view)
+                .setTitle('Select Glaze folder')
+                .setCallback(onPickerAction)
+                .build();
+            picker.setVisible(true);
+            document.getElementById('status').textContent = '';
+        }
+
+        function onPickerAction(data) {
+            if (data.action === google.picker.Action.PICKED) {
+                const folder = data.docs[0];
+                const result = JSON.stringify({ id: folder.id, name: folder.name });
+                const redirectUrl = nativeScheme + '://picker/gdrive?folderId=' + encodeURIComponent(folder.id) + '&folderName=' + encodeURIComponent(folder.name);
+                window.location.href = redirectUrl;
+            } else if (data.action === google.picker.Action.CANCEL) {
+                const redirectUrl = nativeScheme + '://picker/gdrive?cancelled=1';
+                window.location.href = redirectUrl;
+            }
+        }
+
+        if (accessToken) {
+            gapi.load('picker', { callback: onPickerLoaded });
+        }
+    </script>
+</body>
+</html>

--- a/src/components/sheets/SyncSheet.vue
+++ b/src/components/sheets/SyncSheet.vue
@@ -536,13 +536,11 @@ onMounted(async () => {
                         <span v-if="isCreatingFolder">{{ t('sync_creating') || 'Creating...' }}</span>
                         <span v-else>{{ t('sync_gdrive_create_folder') || 'Create New Folder' }}</span>
                     </button>
-                    <template v-if="!isNativePlatform">
-                        <button class="bs-btn bs-secondary-btn" @click="selectExistingFolder" :disabled="isCreatingFolder || isPickingFolder">
+                    <button class="bs-btn bs-secondary-btn" @click="selectExistingFolder" :disabled="isCreatingFolder || isPickingFolder">
                             <svg viewBox="0 0 24 24"><path d="M10 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/></svg>
                             <span v-if="isPickingFolder">{{ t('sync_selecting') || 'Selecting...' }}</span>
                             <span v-else>{{ t('sync_gdrive_select_folder') || 'Select Existing Folder' }}</span>
                         </button>
-                    </template>
                     <div class="bs-section" style="margin-top: 8px;">
                         <div class="bs-section-title" style="font-size: 0.85em;">
                             {{ t('sync_gdrive_link_by_id') || 'Or link by folder ID' }}

--- a/src/composables/app/useGdriveFolderPicker.js
+++ b/src/composables/app/useGdriveFolderPicker.js
@@ -26,9 +26,6 @@ export function useGdriveFolderPicker() {
     }
 
     async function selectExistingFolder() {
-        if (isNativePlatform) {
-            return await linkFolderById();
-        }
         isPickingFolder.value = true;
         pickerError.value = '';
         try {

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -464,6 +464,10 @@ export async function pickFolder() {
     const accessToken = await getValidAccessToken();
     if (!accessToken) throw new Error('Not connected to Google Drive');
 
+    if (Capacitor.isNativePlatform()) {
+        return await pickFolderNative(accessToken);
+    }
+
     await loadPickerApi();
 
     return new Promise((resolve, reject) => {
@@ -497,6 +501,75 @@ export async function pickFolder() {
     });
 }
 
+async function pickFolderNative(accessToken) {
+    const appId = GDRIVE_CLIENT_ID?.split('-')[0] || '';
+    const pickerUrl = `${window.location.origin}/oauth/gdrive/picker.html` +
+        `#token=${encodeURIComponent(accessToken)}` +
+        `&appId=${encodeURIComponent(appId)}` +
+        `&nativeScheme=com.hydall.glaze`;
+
+    return new Promise((resolve, reject) => {
+        let resolved = false;
+        let listener;
+
+        const cleanup = () => {
+            if (listener) {
+                listener.then(handle => handle.remove()).catch(() => {});
+                listener = null;
+            }
+        };
+
+        const onAppUrlOpen = async (data) => {
+            try {
+                const url = new URL(data.url);
+                if (url.host !== 'picker' || url.pathname !== '/gdrive') return;
+
+                if (resolved) return;
+                resolved = true;
+                cleanup();
+
+                if (url.searchParams.get('cancelled') === '1') {
+                    resolve(null);
+                    return;
+                }
+
+                const folderId = url.searchParams.get('folderId');
+                const folderName = url.searchParams.get('folderName');
+                if (folderId) {
+                    resolve({ id: folderId, name: folderName || '' });
+                } else {
+                    resolve(null);
+                }
+            } catch (e) {
+                if (!resolved) {
+                    resolved = true;
+                    cleanup();
+                    reject(e);
+                }
+            } finally {
+                try { await Browser.close(); } catch {}
+            }
+        };
+
+        listener = App.addListener('appUrlOpen', onAppUrlOpen);
+        Browser.open({ url: pickerUrl }).catch(e => {
+            if (!resolved) {
+                resolved = true;
+                cleanup();
+                reject(e);
+            }
+        });
+
+        setTimeout(() => {
+            if (!resolved) {
+                resolved = true;
+                cleanup();
+                resolve(null);
+            }
+        }, 120000);
+    });
+}
+
 export { getGlazeFolderId };
 
 export function extractFolderId(input) {
@@ -511,18 +584,9 @@ export function extractFolderId(input) {
 }
 
 export async function verifyFolderId(folderId) {
-    try {
-        const response = await apiRequest(
-            `${API_BASE}/files/${encodeURIComponent(folderId)}?fields=id,name,mimeType,trashed&supportsAllDrives=true`
-        );
-        if (!response.ok) return null;
-        const data = await response.json();
-        if (data.trashed) return null;
-        if (data.mimeType !== 'application/vnd.google-apps.folder') return null;
-        return data;
-    } catch {
-        return null;
-    }
+    folderIdCache = folderId;
+    _folderIdCache.clear();
+    return { id: folderId };
 }
 
 async function getGlazeFolderId(invalidate = false) {


### PR DESCRIPTION
## Summary

Adds Google Picker support for mobile (Capacitor) and keeps `drive.file` scope.

### What changed
- **Mobile Picker**: `pickFolderNative()` opens `picker.html` in system browser with access token. Picker redirects folder selection back to app via `com.hydall.glaze://picker/gdrive?folderId=...` custom URL scheme
- **picker.html**: Standalone page that loads Google Picker API with access token from URL hash, sends selected folder ID back through native redirect
- **Picker on all platforms**: Removed `isNativePlatform` gate — "Select Existing Folder" button now shown everywhere (web = popup Picker, mobile = redirect Picker)
- **`drive.file` scope**: Sufficient when Picker grants access to the selected folder
- **`verifyFolderId` simplified**: No `files.get` API call (unreliable with `drive.file` on folders not created by app). Just saves the folder ID — sync operations will fail with clear error if folder is inaccessible
- **Folder ID fallback retained**: Manual input for copying folder ID between devices

### How it works
1. **Web/Electron**: Standard Google Picker popup → returns folder ID
2. **Mobile**: System browser opens `picker.html` → Picker renders inside → user picks folder → redirects back via custom URL scheme → `App.addListener('appUrlOpen')` captures result
3. **Fallback**: User can paste folder ID or URL manually