### PR TITLE
fix: serialize read-mutate-write in patchChatData, await saves before clearing state

### DIFF
--- a/src/composables/chat/useSessionManagement.js
+++ b/src/composables/chat/useSessionManagement.js
@@ -129,7 +129,7 @@ export function useSessionManagement(deps) {
                 isActive: isCurrent,
                 onClick: async () => {
                     if (sid !== currentSessionId) {
-                        asyncSaveCurrentSessionState();
+                        await asyncSaveCurrentSessionState();
                         await dbSwitchSession(char.id, sid);
                         await loadChats();
                         openChat({ ...char, sessionId: sid }, null, true);
@@ -236,7 +236,7 @@ export function useSessionManagement(deps) {
     }
 
     async function createNewSession(char) {
-        asyncSaveCurrentSessionState();
+        await asyncSaveCurrentSessionState();
         await dbCreateSession(char.id);
         await loadChats();
 

--- a/src/composables/chat/useSessionPersistence.js
+++ b/src/composables/chat/useSessionPersistence.js
@@ -46,7 +46,7 @@ export function useSessionPersistence({
             const currentAnchor = getScrollAnchor();
             const messagesSnapshot = currentMessages.value;
 
-            db.patchChatData(charContext.id, (data) => {
+            const savePromise = db.patchChatData(charContext.id, (data) => {
                 data.lastScrollAnchor = currentAnchor;
                 data.draft = inputValueDraft;
 
@@ -95,7 +95,8 @@ export function useSessionPersistence({
                     data.summaries[sessionId] = charContext.summary;
                 }
             });
-            clearCrashBuffer(charContext.id, sessionId);
+            savePromise.then(() => clearCrashBuffer(charContext.id, sessionId)).catch(() => {});
+            return savePromise;
         }
     }
 
@@ -125,10 +126,9 @@ export function useSessionPersistence({
             const charId = activeChatChar.id;
             const sessionId = activeChatChar.sessionId;
             const messageSnapshot = currentMessages.value;
-            getChatData(activeChatChar.id).then(data => {
-                if (data && sessionId && data.sessions?.[sessionId]) {
+            db.patchChatData(charId, (data) => {
+                if (sessionId && data.sessions?.[sessionId]) {
                     data.sessions[sessionId] = messageSnapshot;
-                    db.saveChat(charId, data);
                 }
             });
         }
@@ -144,7 +144,7 @@ export function useSessionPersistence({
             const draft = inputValue.value;
             const authorsNote = activeChatChar.authors_note;
             const summary = activeChatChar.summary;
-            db.patchChatData(charId, (data) => {
+            const savePromise = db.patchChatData(charId, (data) => {
                 if (sessionId) {
                     data.sessions[sessionId] = JSON.parse(JSON.stringify(messagesSnapshot));
                 }
@@ -158,6 +158,7 @@ export function useSessionPersistence({
                     data.summaries[sessionId] = summary;
                 }
             });
+            savePromise.then(() => clearCrashBuffer(charId, sessionId)).catch(() => {});
         } else if (document.visibilityState === 'visible' && activeChatChar) {
             clearMessageNotifications(activeChatChar.id);
         }
@@ -168,69 +169,54 @@ export function useSessionPersistence({
         if (activeChatChar) {
             writeCrashBuffer(activeChatChar);
         }
-        asyncSaveCurrentSessionState();
     }
 
     watch(activeChar, async (newVal) => {
         if (!newVal) return;
 
-        const chatData = await getChatData(newVal.id);
-        if (!chatData) return;
-        const sessionId = chatData.currentId;
         let changed = false;
 
         if (newVal.summary !== undefined) {
-            if (!chatData.summaries) chatData.summaries = {};
-            let currentSum = chatData.summaries[sessionId];
-            if (typeof currentSum === 'string') {
-                currentSum = { content: currentSum, depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
-            } else if (!currentSum) {
-                currentSum = { content: '', depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
-            }
-            if (currentSum.content !== newVal.summary) {
-                chatData.summaries[sessionId] = { ...currentSum, content: newVal.summary };
-                changed = true;
-            }
+            changed = true;
         }
 
         if (newVal.authors_note !== undefined) {
-            if (!chatData.authorsNotes) chatData.authorsNotes = {};
-            const storedAn = chatData.authorsNotes[sessionId];
-            const currentAN = typeof storedAn === 'string' ? storedAn : storedAn?.content || '';
-            if (currentAN !== newVal.authors_note) {
-                chatData.authorsNotes[sessionId] = newVal.authors_note;
-                changed = true;
-            }
+            changed = true;
         }
 
-        if (changed) await db.saveChat(newVal.id, chatData);
+        if (changed) {
+            const summary = newVal.summary;
+            const authorsNote = newVal.authors_note;
+            await db.patchChatData(newVal.id, (data) => {
+                const sessionId = data.currentId;
+                if (summary !== undefined) {
+                    if (!data.summaries) data.summaries = {};
+                    let currentSum = data.summaries[sessionId];
+                    if (typeof currentSum === 'string') {
+                        currentSum = { content: currentSum, depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    } else if (!currentSum) {
+                        currentSum = { content: '', depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    }
+                    if (currentSum.content !== summary) {
+                        data.summaries[sessionId] = { ...currentSum, content: summary };
+                    }
+                }
+                if (authorsNote !== undefined) {
+                    if (!data.authorsNotes) data.authorsNotes = {};
+                    const storedAn = data.authorsNotes[sessionId];
+                    const currentAN = typeof storedAn === 'string' ? storedAn : storedAn?.content || '';
+                    if (currentAN !== authorsNote) {
+                        data.authorsNotes[sessionId] = authorsNote;
+                    }
+                }
+            });
+        }
     }, { deep: true });
 
     onBeforeUnmount(() => {
         const activeChatChar = getActiveChatChar();
         if (activeChatChar && messagesContainer.value) {
-            const charId = activeChatChar.id;
-            const sessionId = activeChatChar.sessionId;
-            const currentAnchor = getScrollAnchor();
-            const draft = inputValue.value;
-            const messagesSnapshot = currentMessages.value;
-            const authorsNote = activeChatChar.authors_note;
-            const summary = activeChatChar.summary;
-            db.patchChatData(charId, (data) => {
-                data.lastScrollAnchor = currentAnchor;
-                data.draft = draft;
-                if (sessionId) {
-                    data.sessions[sessionId] = JSON.parse(JSON.stringify(messagesSnapshot));
-                }
-                if (authorsNote !== undefined) {
-                    if (!data.authorsNotes) data.authorsNotes = {};
-                    data.authorsNotes[sessionId] = authorsNote;
-                }
-                if (summary !== undefined) {
-                    if (!data.summaries) data.summaries = {};
-                    data.summaries[sessionId] = summary;
-                }
-            });
+            writeCrashBuffer(activeChatChar);
         }
     });
 

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -532,27 +532,29 @@ export const db = {
         }
     },
     patchChatData: async (charId, patchFn) => {
-        const data = await db.getChat(charId);
-        if (!data) return;
-        patchFn(data);
-        const normalized = normalizeChatData(data);
-        const snapshot = toPlain(normalized);
-        try {
-            await queueDbWrite(() => db.set(`gz_chat_${charId}`, snapshot));
-            try { localStorage.removeItem(`gz_fb_chat_${charId}`); } catch (_e) {}
-        } catch (err) {
-            console.error('[DB] Chat patch failed, saving to localStorage fallback:', err);
-            showToast('Chat write failed, backup saved locally', 3000);
+        return queueDbWrite(async () => {
+            const data = await db.getChat(charId);
+            if (!data) return;
+            patchFn(data);
+            const normalized = normalizeChatData(data);
+            const snapshot = toPlain(normalized);
             try {
-                localStorage.setItem(`gz_fb_chat_${charId}`, JSON.stringify({
-                    ...snapshot,
-                    _fb: Date.now()
-                }));
-            } catch (fbErr) {
-                console.error('[DB] Fallback save also failed:', fbErr);
+                await db.set(`gz_chat_${charId}`, snapshot);
+                try { localStorage.removeItem(`gz_fb_chat_${charId}`); } catch (_e) {}
+            } catch (err) {
+                console.error('[DB] Chat patch failed, saving to localStorage fallback:', err);
+                showToast('Chat write failed, backup saved locally', 3000);
+                try {
+                    localStorage.setItem(`gz_fb_chat_${charId}`, JSON.stringify({
+                        ...snapshot,
+                        _fb: Date.now()
+                    }));
+                } catch (fbErr) {
+                    console.error('[DB] Fallback save also failed:', fbErr);
+                }
+                throw err;
             }
-            throw err;
-        }
+        });
     },
     createSession: async (charId) => {
         let data = await db.get(`gz_chat_${charId}`);

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -1066,10 +1066,11 @@ async function handleMemoryFlushSave() {
     }
 }
 
-function closeChat() {
-    updateAppColors(true); // Revert colors
+async function closeChat() {
+    updateAppColors(true);
+    let savePromise = null;
     if (activeChatChar && messagesContainer.value) {
-        asyncSaveCurrentSessionState();
+        savePromise = asyncSaveCurrentSessionState();
         messagesContainer.value.removeEventListener('scroll', onScroll);
     }
     
@@ -1079,6 +1080,11 @@ function closeChat() {
     }
 
     publishAppEvent(APP_EVENTS.ui.header.reset);
+
+    if (savePromise) {
+        try { await savePromise; } catch (_e) {}
+    }
+
     activeChatChar = null;
     activeChar.value = null;
     setTrackedContext(null, null);


### PR DESCRIPTION
Root cause of lost chat messages and disappearing memorybooks: patchChatData read outside queueDbWrite, so concurrent saves read stale data and overwrote each other.

Changes:
- db.patchChatData: full read-mutate-write cycle now inside queueDbWrite
- closeChat(): async, awaits save before clearing in-memory state
- Crash buffer: clearCrashBuffer only after confirmed DB write
- beforeunload/pagehide: removed async save; crash buffer is safety net
- onBeforeUnmount: crash buffer only, no async patchChatData
- activeChar watcher and applyImageAutoHide: converted to patchChatData
- useSessionManagement: await asyncSaveCurrentSessionState on session switch

Test plan:
- npm run lint passes, npm run build succeeds
- Manual: switch chats rapidly, verify no message/memorybook loss
- Manual: background/foreground on mobile, verify crash buffer recovery