### PR TITLE
docs: add race condition prevention checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,5 +152,55 @@ git rebase origin/dev
 - [ ] Sync `origin/dev`: `git fetch upstream && git push origin upstream/dev:refs/heads/dev`
 - [ ] Verify no stale references: `git branch -a`
 
+## Race Condition Prevention Checklist
+
+Every new feature or fix that touches async boundaries, generation state, or IndexedDB must satisfy these rules before commit.
+
+### Rule 1: Every `await` is a checkpoint
+
+After any `await`, always verify you still own the state:
+
+- **Not aborted?** `controller.signal.aborted`
+- **Same generation?** `isGenerationStateCurrent(charId, genId)`
+- **Same session?** `sessionId === expected`
+
+Pattern:
+```javascript
+const result = await someAsyncWork();
+if (controller?.signal?.aborted) return;
+if (!isGenerationStateCurrent(charId, genId)) return;
+```
+
+### Rule 2: No state mutation without ownership
+
+- `onComplete` / `onError` / `onUpdate` callbacks MUST check `genId` before mutating any reactive state
+- New composables that participate in generation lifecycle MUST use `useGenerationRegistry` for ownership tokens
+- Transient state (isGenerating, typing placeholder, pending swipe) is owned by a single generation token and auto-cleaned on finalization
+
+### Rule 3: `patchChatData` for all read-mutate-write
+
+- NEVER do `const data = await db.getChat(charId); /* mutate */; await db.saveChat(charId, data)` — this is a race
+- ALWAYS use `patchChatData(charId, draft => { /* mutate draft */ })` — serializes read-mutate-write via `queueDbWrite`
+- New composables that persist chat state must import `patchChatData` from `db.js`
+
+### Rule 4: New async boundaries need stale guards
+
+When adding a new composable or service function that:
+- receives callbacks from transport/pipeline/use-case layer
+- mutates Vue reactive state
+- persists data to IndexedDB
+
+...it MUST include a staleness/ownership check before the mutation. Without it, a late completion from an aborted generation WILL corrupt state.
+
+### Rule 5: Mutual exclusion for concurrent operations
+
+- Chat generation and memory draft generation are mutually exclusive (checked in both directions)
+- If adding a new request type that runs alongside chat generation, add mutual exclusion guards in BOTH directions
+- Background operations (auto-sync, embedding indexing) must check `isGenerating` before starting
+
+### Why this matters
+
+The hybrid architecture has more boundaries than the old flat structure. Each boundary is a potential race surface. The old code had the same races — they were just invisible because everything mutated shared state in one call stack. The new architecture makes races visible, and these rules make them preventable.
+
 ## Pattern Recognition — Cowl's actual use of influence
 Over the months she has been able to trace where the leverage Cowl extracts through her actually lands. Access to the training wing evening slots — previously occupied by default by the wealthy faction — was redistributed. An exam schedule that structurally penalised students working campus shifts was revised. A lab allocation complaint that had sat unprocessed for a semester moved through the Council and was resolved. None of these came from her initiative. All of them passed through her signature. She has mapped the pattern. The influence does not accumulate with him. She does not know whether this makes what he does better or simply more complicated. She has not found a frame that contains both facts without contradiction, and she has stopped looking for one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,13 @@ npm run build && npx cap sync ios && npx cap open ios
 - Break SillyTavern V2 format compatibility for character cards
 - Use `window.dispatchEvent` / `window.addEventListener` for app events — use `publishAppEvent` / `subscribeAppEvent` instead
 - **Read, display, or output contents of `.env` file** — it contains secrets
+
+## Race Condition Prevention
+
+Every new feature or fix that touches async boundaries, generation state, or IndexedDB must satisfy these rules before commit.
+
+1. **Every `await` is a checkpoint** — after any `await`, verify: not aborted (`controller.signal.aborted`), same generation (`isGenerationStateCurrent(charId, genId)`), same session (`sessionId === expected`)
+2. **No state mutation without ownership** — `onComplete`/`onError`/`onUpdate` callbacks MUST check `genId` before mutating reactive state. New composables in generation lifecycle MUST use `useGenerationRegistry` for ownership tokens
+3. **`patchChatData` for all read-mutate-write** — NEVER `getChat → mutate → saveChat` (race). ALWAYS `patchChatData(charId, draft => { /* mutate draft */ })` (serialized via `queueDbWrite`)
+4. **New async boundaries need stale guards** — any composable/service that receives transport callbacks, mutates Vue reactive state, or persists to IndexedDB MUST check staleness/ownership before the mutation
+5. **Mutual exclusion for concurrent operations** — chat generation and memory draft are mutually exclusive (guards in both directions). If adding a new concurrent request type, add exclusion guards in BOTH directions. Background operations must check `isGenerating` before starting


### PR DESCRIPTION
## Summary

- Add race condition prevention checklist to AGENTS.md (full version with code examples and rationale)
- Add condensed 5-rule version to CLAUDE.md for quick reference during commits

The hybrid architecture has more async boundaries than the old flat structure, making races visible rather than hidden. These rules codify the patterns already established across PRs 72-86 so that future features and fixes don't reintroduce the same classes of race conditions.

### Rules added

1. Every await is a checkpoint - verify abort/genId/session after any async boundary
2. No state mutation without ownership - callbacks must check genId, new composables use useGenerationRegistry
3. patchChatData for all read-mutate-write - never getChat then mutate then saveChat; always patchChatData with queueDbWrite
4. New async boundaries need stale guards - any composable receiving transport callbacks must check staleness before mutation
5. Mutual exclusion for concurrent operations - chat vs memory draft guards in both directions; background ops check isGenerating