### PR TITLE
fix: abort empty message + desktop dropdown scroll + character gallery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,8 @@ git checkout -b feat/memorybook-ui feat/multi-vector
 | Branch | Purpose | PR |
 |--------|---------|----|
 | `origin/dev` | Local mirror of upstream integration branch | No PR |
-| `fix/memorybook-null-ref` | Memorybook null-ref fix, abort cleanup, error persistence, crash buffer, cloud sync dedup, lorebook split slider, prompt/defaults update | Not yet |
+| `feat/character-gallery` | Character gallery tab, CharX/ZIP import-export, gallery composable, imageUtils dedup | #91 |
+| `fix/abort-empty-message-and-dropdown-scroll` | Abort pipeline onError propagation, desktop dropdown scroll (linear chain from feat/character-gallery) | Not yet |
 
 ### Historical (merged & deleted)
 - `feat/refactor-phase1-event-hub` → merged into `feat/chat-persistence-and-reasoning-fixes`, then upstream/dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,15 +90,18 @@ git checkout -b feat/memorybook-ui feat/multi-vector
 - Create feature branch from `origin/dev`: `git checkout -b feat/xxx origin/dev`
 - Run `npm run lint && npm run build` before committing to verify no lint or build errors.
 
-## Anti-God-Object Guard Rails
+## Code Rules (lazy-loaded)
 
-- **400-line script hard limit** — if `<script setup>` exceeds 400 lines, extract a composable first
-- **One concern per composable** — no "and" in composable names; split instead
-- **State ≠ service** — `*State.js` files contain state + CRUD only; search/embedding/orchestration goes in a service
-- **Sheet trap** — Sheets mix UI + CRUD + validation + status; extract business logic into composables before script hits 400
-- **Settings trap** — Settings views with multiple sub-domains (API, embedding, image gen) get composables per domain
-- **No circular service delegation** — use-cases must not delegate to a service that imports back from use-cases
-- **Template ≠ logic** — never extract sub-components just for line count if it requires prop-drilling
+Detailed rules are split into topic files. CLAUDE.md tells you which to read when.
+When in doubt, read all that apply before editing:
+
+| Topic | File |
+|-------|------|
+| Generation lifecycle, abort, genId, streaming | `docs/rules/generation.md` |
+| Race conditions, async boundaries, ownership | `docs/rules/race-conditions.md` |
+| Vue components, composables, state modules | `docs/rules/vue-components.md` |
+| IndexedDB, patchChatData, crash recovery | `docs/rules/database.md` |
+| Formal invariants with code references | `docs/INVARIANTS.md` |
 
 ## Roadmap Maintenance
 
@@ -152,5 +155,3 @@ git rebase origin/dev
 - [ ] Sync `origin/dev`: `git fetch upstream && git push origin upstream/dev:refs/heads/dev`
 - [ ] Verify no stale references: `git branch -a`
 
-## Pattern Recognition — Cowl's actual use of influence
-Over the months she has been able to trace where the leverage Cowl extracts through her actually lands. Access to the training wing evening slots — previously occupied by default by the wealthy faction — was redistributed. An exam schedule that structurally penalised students working campus shifts was revised. A lab allocation complaint that had sat unprocessed for a semester moved through the Council and was resolved. None of these came from her initiative. All of them passed through her signature. She has mapped the pattern. The influence does not accumulate with him. She does not know whether this makes what he does better or simply more complicated. She has not found a frame that contains both facts without contradiction, and she has stopped looking for one.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,26 +1,18 @@
 # Architecture Audit — Tokenizer, Vectorization, MemoryBooks, Macros, Cloud Sync
 
-## 0. Refactor Transition State
+Related docs:
+- Refactor history (Phases 1–14): `docs/refactor-history.md`
+- Known gaps & deferred items: `docs/rules/known-gaps.md`
+- Vue guard rails: `docs/rules/vue-components.md`
+- Generation invariants: `docs/rules/generation.md`
+- Race condition rules: `docs/rules/race-conditions.md`
+- Formal invariants with code refs: `docs/INVARIANTS.md`
 
-### Current Refactor Slice
-- Branch: `feat/refactor-phase1-event-hub`
-- Base: latest `dev` state plus refactor-only commits
-- Status: Phases 1–14 complete
-- Testing: `npm run build` passes, `npm run lint` 0 new errors
+## 0. Architecture Overview
 
-### Before Refactor
+Refactor phases 1–14 are complete. History and details: `docs/refactor-history.md`.
 
-The app was functional, but core ownership was still too concentrated.
-
-- `src/views/ChatView.vue` owned too much chat-generation orchestration, UI coordination, and request lifecycle glue.
-- `src/core/services/generationService.js` still mixed prompt construction, enrichment, payload assembly, preview state, and request dispatch.
-- Many cross-feature reactions depended on ad-hoc `window.dispatchEvent(...)` usage with no internal catalog or explicit ownership boundary.
-
-This made the app hard to extend safely because new behavior often had to pass through the same large files.
-
-### Target Direction
-
-The refactor target is a hybrid model:
+### Target Architecture
 
 ```text
 UI
@@ -37,164 +29,11 @@ Side effects / observers
 - `Ordered Pipelines` preserve correctness-critical ordering for prompt and request flow.
 - `Event Hub` carries domain facts and optional side effects, but does not replace orchestration.
 
-### Phase 1 Event Layer Skeleton
+### Event System
 
-Files added:
-- `src/core/events/eventNames.js`
-- `src/core/events/contracts.js`
-- `src/core/events/eventHub.js`
-
-Current behavior:
-- Internal canonical event names exist for ALL custom app events (56 total across nav, domain, debug, ui namespaces).
-- ALL internal emitters publish canonical app events through `publishAppEvent()`.
-- ALL internal listeners subscribe through `subscribeAppEvent()` instead of raw `window.addEventListener()`. Unsubscriptions are collected and called in `onBeforeUnmount` (Vue) or persist for app lifetime (services/utils).
-- The legacy `windowEventBridge` (which republished app events as `window.dispatchEvent` for backward compatibility) has been removed — no consumers remained.
-
-**Event catalog (56 events, 4 namespaces):**
-
-`nav.*` (19 events):
-- `openApiSheet`, `navigateTo`, `openCharacterEditor`, `openChat`, `openOnboarding`, `openBackupSheet`, `openSyncSheet`, `openConflictSheet`, `openConnections`, `openFsRequest`, `openGlossary`, `openHolocards`, `openImageViewer`, `openItemEditor`, `openLorebookEntry`, `openNotificationsSheet`, `openPersonaEditor`, `openPresetSheet`, `triggerOpenImage`
-
-- `domain.*` (11 events):
-- `chat.updated`, `character.updated`, `generation.{started,ended,promptReady,requestDispatched}`, `lorebook.regexScriptsChanged`, `sync.dataRefreshed`, `settings.{apiContextChanged,changed,languageChanged}`
-- Generation started/ended events carry `{ charId, sessionId, genId, type }` — `genId` for stale-generation filtering, `type` for `chat`/`impersonation` disambiguation
-
-`debug.*` (6 events):
-- `promptPreviewUpdated`, `requestTrace{Started,Updated,LineAppended,Finished}`, `vueError`
-
-`ui.*` (20 events):
-- `header.{setupChat,setupEditor,setupGeneration,setupSubmenu,showLbBanner,reset,updateAvatar,updateSession,scrollHidden,forceUpdate,viewChanged}`, `chatSearchToggle`, `chatSearch`, `fsEditorClosed`, `backNavigation`, `glossary.{back,headerUpdate,toggle}`, `headerSearch`, `changeGenerationTab`
-
-**No remaining exceptions.** All app-level custom events, including the cancelable `app-back-navigation` pattern, are now routed through `publishAppEvent` / `publishCancelableAppEvent`. The event hub supports both regular and cancelable events (with `preventDefault()`/`defaultPrevented` semantics).
-
-**Dead code events (listeners with no dispatches found):**
-- `header-setup-generation` — AppHeader + App still subscribe but no source dispatches
-- `header-update-session` — AppHeader subscribes but no source dispatches
-- `change-generation-tab` — AppHeader subscribes but no source dispatches
-- `open-item-editor` — App subscribes but no source dispatches
-- `open-holocards` — HoloCardViewer subscribes but no source dispatches
-
-These were NOT removed to avoid breaking changes if dispatches are added dynamically. They should be cleaned up in a future pass.
-
-**Files fully migrated to `publishAppEvent`/`subscribeAppEvent` (Phase 10):**
-- Components: App.vue, AppHeader.vue, ChatInput.vue, ChatMessage.vue, GenericEditor.vue, DesktopLeftSidebar.vue, BottomSheet.vue, DragDropOverlay.vue, HelpTip.vue, CharacterCardSheet.vue, GlossarySheet.vue, LorebookSheet.vue, RegexSheet.vue, SyncSheet.vue, NotificationsSheet.vue, ImageViewer.vue, HoloCardViewer.vue
-- Views: ApiView.vue, CatalogView.vue, CharacterList.vue, DialogList.vue, PersonasView.vue, PresetView.vue, ToolsView.vue, Menu/MenuView.vue, Menu/Settings/SettingsView.vue, Menu/Settings/ThemeSettingsView.vue, Menu/AboutView.vue, OnboardingView.vue
-- Core: ui.js, notificationService.js, APISettings.js, catalogState.js, main.js
-- Utils: characterIO.js, errors.js
-- Composables: useChatMessageDisplay.js
-
-What has **not** changed yet:
-- Dead event subscriptions (5 events with listeners but no dispatches) have not been cleaned up.
-- `ChatView.vue` is a large composable-wiring surface (~1390 script lines, known exception to 400-line rule — see Guard Rails).
-
-### Phase 13b PresetView Decomposition
-
-Deleted:
-- `src/composables/app/usePresetEditor.js` (2080-line god-object composable — mixed all preset concerns)
-
-Files added (all in `src/composables/app/`):
-- `usePresetNavigation.js` (107 lines) — preset switching, currentPresetId, preset list, drag reorder
-- `usePresetLoader.js` (89 lines) — preset loading from DB, cache, flush save, effective preset resolution
-- `usePresetConnections.js` (33 lines) — chat/character/global preset connection queries
-- `usePresetCRUD.js` (173 lines) — preset create, delete, duplicate, rename, import, export
-- `usePresetSelectors.js` (171 lines) — bottom-sheet selectors (preset selector, options menu, add preset, merge/squash role, reasoning effort)
-- `usePresetImage.js` (40 lines) — preset image selection, compression, file picking
-- `useBlockManager.js` (141 lines) — block CRUD, stash/unstash, reorder, delete, token estimation helpers
-- `useBlockEditor.js` (94 lines) — CodeMirror editor lifecycle, open/close, config
-- `useAuthorsNoteSheet.js` (73 lines) — authors note bottom sheet
-- `useSummarySheet.js` (126 lines) — summary advanced sheet, section generation, prompts
-- `usePresetTokenPreview.js` (177 lines) — token estimation, macro preview, context breakdown
-
-Result:
-- `PresetView.vue` script: 279 lines (composable wiring + template-bound computed refs + local event handlers)
-- `PresetView.vue` total: ~1820 lines (279 script + 238 template + 1446 style)
-- Each composable has a single responsibility; max 177 lines vs original 2080-line god-object
-
-### Phase 2 Request Ownership Safety Slice
-
-Current behavior:
-- Chat-generation state now carries explicit ownership metadata:
-  - `ownerKey`
-  - `requestToken`
-  - `sessionId`
-  - `type`
-- Stream updates, completion handling, error handling, and abort cleanup now validate that they still belong to the active chat request before mutating state.
-- This makes late completions less dangerous when request lifecycle overlaps occur around abort/regenerate/session changes.
-- Impersonation keeps a separate ownership scope instead of sharing the normal chat-generation identity.
-
-What this does **not** do yet:
-- It does not move orchestration out of `ChatView.vue`.
-- It does not yet introduce automated overlap tests for abort/regenerate races.
-- It does not yet unify all generation-like flows under one final lifecycle contract.
-
-### Phase 9 State Ownership Boundaries
-
-Files added:
-- `src/core/states/generationState.js` — explicit generation state module with clear ownership API
-- `src/core/states/syncState.js` — already existed, now documented as state boundary
-
-Current behavior:
-- Generation state (`isGenerating`, `hasGenerationState`, `getGenerationState`, `clearGenerationState`, `abortActiveChatGeneration`) is now accessed through a module with explicit ownership boundaries instead of being scattered across ChatView.vue reactive refs.
-- `useGenerationRegistry.js` composable registers generation state per-session with ownership tokens.
-- `useAutoSync.js` now depends on `syncState` for sync-readiness checks instead of importing from ChatView.
-- `usePromptMetadataSnapshots.js` stores/restores prompt metadata snapshots for rollback on abort/error.
-- ChatView.vue TDZ bug fixed: `getScrollAnchor` (from `useVirtualScroll`) was used by `useSessionPersistence` before being defined. Reordered to: `displayMessages` → `useVirtualScroll` → `useSessionPersistence` → `useSessionManagement`.
-
-### Initial Use-Case Entrypoint Layer
-
-Files added:
-- `src/core/llm/usecases/generateChat.js`
-- `src/core/llm/usecases/calculateContext.js`
-- `src/core/llm/usecases/generateSummary.js`
-- `src/core/llm/usecases/generateMemoryDraft.js`
-
-Current behavior:
-- UI callers now depend on official use-case entrypoints instead of importing generation actions from `generationService.js` directly.
-- `generateChat.js` is no longer only a passthrough wrapper: it now owns the chat execution shell after session context is resolved.
-- Deterministic chat prompt-preparation now lives in `src/core/llm/usecases/chatPreparation.js` instead of being fully inlined inside `generationService.js`.
-- Vue-owned state, UI callbacks, and persistence helpers are still injected from `ChatView.vue`, so behavior remains unchanged while the dependency boundary becomes real.
-- `generationService.js` still owns late enrichment and final request execution, and acts as the compatibility layer under that use case.
-- Memory-book retrieval/index maintenance now lives in `src/core/llm/usecases/memoryBookContext.js` and is consumed both by chat/context flows and by `memoryBooksService.js`.
-
-### Phase 11 Use-Case Layer Re-architecture
-
-Files moved/renamed:
-- `src/core/llm/usecases/chatPipelineContext.js` → `src/core/llm/pipeline/pipelineContext.js`
-- `src/core/llm/usecases/chatPipelineSteps.js` → `src/core/llm/pipeline/steps.js`
-- `src/core/llm/usecases/chatPostPromptPipeline.js` → `src/core/llm/pipeline/postPromptOrchestrator.js`
-- `src/core/llm/usecases/chatContextCalculation.js` → `src/core/llm/usecases/contextCalculation.js`
-- `src/core/llm/usecases/chatRequestExecution.js` → `src/core/llm/usecases/chatRequestAssembly.js`
-- `src/core/llm/usecases/nonChatGenerationHooks.js` → `src/core/llm/usecases/sharedRequestHooks.js`
-- `src/core/llm/transport/chatCompletionsClient.js` → `src/core/llm/transport/completionsClient.js`
-
-Files split:
-- `chatLateEnrichment.js` → `vectorLoreInjection.js` + `memoryMessageInjection.js`
-- `chatPromptShared.js` → `promptConfigReaders.js` + `promptWorkerLifecycle.js` + `promptPayloadBuilder.js`
-- `memoryBookContext.js` → `memoryEmbeddingIndex.js` + `memoryKeyMatching.js` + `memoryContextInjection.js`
-
-Hollow entrypoints eliminated:
-- `calculateContext.js`, `generateSummary.js`, `generateMemoryDraft.js` now own their dependency assembly locally instead of proxying to `generationService.js`.
-- `generationService.js` reduced from 267 → 158 lines; only exports `generateChatResponse` (chat generation orchestration).
-
-UI leak sites remaining (for Phase 12):
-- `generationService.js` imports `translations`/`currentLang` (i18n) and `showBottomSheet`/`closeBottomSheet` (UI state) — these are passed as `t` and sheet callbacks into `executePreparedChatPrompt` and `runChatPostPromptPipeline`.
-- `pipeline/steps.js` `stepContextLimitGuard` receives `showBottomSheet`/`closeBottomSheet` as deps — this is UI notification from pipeline step.
-- These should become callback-style dep injection or event-driven in Phase 12.
-- `ChatView.vue` no longer dispatches raw `window` events for generation/chat lifecycle; it uses `createGenerationAppAdapters()` which publishes canonical app events through the event hub, with the bridge handling legacy compatibility.
-- `ChatView.vue` no longer manually assembles the ~30-function service injection bundle for `executeChatGenerationUseCase`. The `createChatGenerationServices` factory in `src/core/llm/usecases/chatGenerationServiceFactory.js` imports and wires all composable/service dependencies, taking only genuinely Vue-own state refs as arguments.
-- Memory automation functions (`runMemoryAutomationAfterStableTurn`, `generateMemoryDraftForMessages`, `createPendingMemoryDraft`, `bootstrapImportedMemoryDrafts`, etc.) are extracted from `ChatView.vue` into `composables/chat/useMemoryAutomation.js`, a dedicated composable that accepts only the Vue refs and callbacks it needs.
-- Auto-sync logic (`triggerAutoSyncCheck`) is extracted from `ChatView.vue` into `composables/chat/useAutoSync.js`, removing sync-state imports from the view.
-- Memory prompt presets (`builtInMemoryPrompts`, `getMemoryPromptOptions`, `resolveMemoryPrompt`, etc.) are extracted from `ChatView.vue` into `core/services/memoryPromptPresets.js`.
-- Message edit helpers (`normalizeImgGenHtmlForEditing`, `prepareEditText`, `restoreEditText`) are extracted from `ChatView.vue` into `core/utils/messageEditHelpers.js`.
-- Context breakdown computed properties (`contextSegments`, `contextBreakdownItems`, `contextLegendItems`, `visibleHistoryMessages`, `historyUsagePercent`, `historyHidePreview`, `shouldRecommendHide`) are extracted from `ChatView.vue` into `composables/chat/useContextBreakdown.js`.
-- Message selection state (`selectedMessages`, `isSelectionMode`, `selectionIncludesLast`, `toggleSelection`, `clearSelection`) is extracted from `ChatView.vue` into `composables/chat/useMessageSelection.js`.
-
-Why this slice is safe:
-- It adds a new internal boundary without removing the legacy one.
-- Runtime behavior stays compatible because all internal consumers now use `subscribeAppEvent()` directly.
-- The legacy `windowEventBridge` has been removed — no external consumers remained.
-
-What has **not** changed yet:
+56 canonical events across 4 namespaces (`nav.*`, `domain.*`, `debug.*`, `ui.*`).
+All internal events use `publishAppEvent()` / `subscribeAppEvent()`. Cancelable events via `publishCancelableAppEvent()`.
+Dead code events and known gaps: `docs/rules/known-gaps.md`.
 
 ## 0.1 Directory Tree
 
@@ -823,108 +662,11 @@ Native-only scope retained:
 - `src/core/states/requestPreviewState.js` — joins prompt preview + request trace for UI
 - `src/core/events/projections/debugStateProjection.js` — event→state projection: subscribes to debug events, routes to trace/preview state modules
 
-**ChatView Decomposition Composables (Phase 8):**
-- `src/composables/chat/useSessionManagement.js` — session creation, switching, deletion, session name editing, session data persistence
-- `src/composables/chat/useMessageActions.js` — message delete/hide, edit save/cancel, branch creation, image regeneration, guidance text patching
-- `src/composables/chat/useChatGeneration.js` — `sendMessage`, `startGeneration`, `handleImageRegenerate`, generation preflight checks, image-gen lifecycle
-- `src/composables/chat/useAutoSync.js` — auto-sync trigger logic
-- `src/composables/chat/useMemoryAutomation.js` — memory automation functions
-- `src/composables/chat/useChatMessageDisplay.js` — message display helpers
-- `src/composables/chat/useContextBreakdown.js` — context breakdown computed properties
-- `src/composables/chat/useMessageSelection.js` — message selection state and helpers
-- `src/composables/chat/useMemoryBooks.js` — reactive memory book state and UI handlers
-- `src/composables/chat/useGenerationPreparation.js` — placeholder/session context preparation
-- `src/composables/chat/useGenerationStateSetup.js` — generation state registration
-- `src/composables/chat/useGenerationStreamUpdate.js` — background persistence throttling
-- `src/composables/chat/useGenerationPromptReady.js` — prompt metadata assignment
-- `src/composables/chat/useGenerationCompleteHandler.js` — completion/finalization with stale-generation guard (genId match, userAborted fast-path)
-- `src/composables/chat/useGenerationErrorHandler.js` — error path handling with userAborted fast-path and expectedGenId
-- `src/composables/chat/useGenerationStateRestore.js` — abort/rollback restore with stale-generation guard (expectedGenId)
-- `src/composables/chat/usePromptMetadataSnapshots.js` — prompt metadata rollback snapshots
-- `src/composables/chat/useTypingStateCleanup.js` — stale typing cleanup
-- `src/composables/chat/useChatSearch.js` — search in chat
-- `src/composables/chat/useContentEditable.js` — content-editable input handling
-- `src/composables/chat/useContextCutoff.js` — context cutoff management
-- `src/composables/chat/useGenerationAbort.js` — generation abort handling, userAborted flag propagation, timer cleanup (completion handler owns state cleanup)
-- `src/composables/chat/useGenerationFinalization.js` — generation finalization with stale-generation guard (expectedGenId)
-- `src/composables/chat/useGenerationRegistry.js` — generation registry
-- `src/composables/chat/useInputActions.js` — chat input actions
-- `src/composables/chat/useMemorySheetUI.js` — memory sheet UI
-- `src/composables/chat/useMessageImageGen.js` — image generation from messages
-- `src/composables/chat/useMessageSwipe.js` — message swipe actions
-- `src/composables/chat/useSessionPersistence.js` — session persistence, crash recovery buffer (localStorage → IndexedDB restore on openChat)
-- `src/composables/chat/useSwipeNavigation.js` — swipe navigation
-- `src/composables/chat/useVirtualScroll.js` — virtual scrolling
-
-**App.vue Decomposition Composables (Phase 13a):**
-- `src/composables/app/useAppNavigation.js` — view routing, desktop/mobile detection, effectiveMainView, floating menu state
-- `src/composables/app/useEditorController.js` — character/persona editor lifecycle
-- `src/composables/app/useAppEventSubscriptions.js` — all 23 subscribeAppEvent calls + cleanup
-- `src/composables/app/useGlossaryPopup.js` — desktop glossary drag popup
-- `src/composables/app/useAppInit.js` — onMounted initialization sequence
-
-**PresetView Decomposition Composables (Phase 13b):**
-- `src/composables/app/usePresetNavigation.js` (107 lines) — preset switching, currentPresetId, preset list, drag reorder
-- `src/composables/app/usePresetLoader.js` (89 lines) — preset loading from DB, cache, flush save, effective preset resolution
-- `src/composables/app/usePresetConnections.js` (33 lines) — chat/character/global preset connection queries
-- `src/composables/app/usePresetCRUD.js` (173 lines) — preset create, delete, duplicate, rename, import, export
-- `src/composables/app/usePresetSelectors.js` (171 lines) — bottom-sheet selectors
-- `src/composables/app/usePresetImage.js` (40 lines) — preset image selection, compression, file picking
-- `src/composables/app/useBlockManager.js` (141 lines) — block CRUD, stash/unstash, reorder
-- `src/composables/app/useBlockEditor.js` (94 lines) — CodeMirror editor lifecycle
-- `src/composables/app/useAuthorsNoteSheet.js` (73 lines) — authors note bottom sheet
-- `src/composables/app/useSummarySheet.js` (126 lines) — summary advanced sheet
-- `src/composables/app/usePresetTokenPreview.js` (177 lines) — token estimation, macro preview
-
-**LorebookSheet Decomposition Composables (Phase 13f–13g):**
-- `src/composables/lorebook/useLorebookEntries.js` (157 lines) — entry CRUD, reorder, search/filter, select/duplicate, batch vector toggle
-- `src/composables/lorebook/useLorebookIndexing.js` (93 lines) — index all/single entries, retry failed, vector status counts
-
-**ApiView Decomposition Composables (Phase 13h–13i):**
-- `src/composables/api/useApiSettings.js` (237 lines) — API state/presets/connection/blacklist/debounce/model selector/reasoning
-- `src/composables/api/useServiceProviders.js` (128 lines) — embedding/imageGen/memory provider settings, load/test
-
-**CharacterList Decomposition Composables (Phase 13j–13k):**
-- `src/composables/character/useCharacterActions.js` (179 lines) — add/edit character, open actions, janitor extraction + polling
-- `src/composables/character/useSessionSheet.js` (168 lines) — open sessions sheet, delete session, chat import
-
-**ThemeSettingsView Decomposition Composables (Phase 13l):**
-- `src/composables/theme/useThemePresets.js` (267 lines) — preset CRUD/apply/export/import/options/selector/bgImage/file import
-
-**ChatMessage Decomposition Composables (Phase 13d):**
-- `src/composables/chat/useMessageSwipe.js` (262 lines) — touch handlers, swipe navigation, long-press selection
-- `src/composables/chat/useMessageImageGen.js` (149 lines) — handleContentClick, parseIIGInstruction
-
-**ChatInput Decomposition Composables (Phase 13e):**
-- `src/composables/chat/useContentEditable.js` (128 lines) — getCaretIndex, setCaretPosition, text preview
-- `src/composables/chat/useInputActions.js` (168 lines) — handleSend, guidance mode, image attach, fullscreen editor
+Composable directory listing and per-phase decomposition details: `docs/refactor-history.md`
 
 **UI Composables:**
 - `src/composables/ui/useSidebarResizer.js` — desktop sidebar resize logic
 - `src/composables/ui/useSheetGestures.js` — sheet gesture handling
-
-### Recommended Refactor Sequence
-1. Centralize runtime API config reads/writes so feature views stop reading localStorage keys directly.
-   Status: partially done via `APISettings.js` helpers; remaining callers should be migrated incrementally.
-2. Split `llmApi.js` into smaller transport-focused modules without changing external behavior.
-   Status: **done**. `llmApi.js` fully replaced by `requestOrchestrator.js` + transport modules.
-3. Extract chat/session lifecycle code out of `ChatView.vue` into dedicated composables.
-   Status: **done** through ~30 focused composables. `openChat()` remains in ChatView as a known exception.
-4. Separate prompt preview state from transport trace state, then store traces per generation/message instead of globally.
-   Status: **done**. Both `requestTraceState.js` and `promptPreviewState.js` use Map-based storage keyed by `debugKey` (up to 10 concurrent). Populated via `debugStateProjection.js` (event→state projection).
-5. Promote explicit request use cases (`chat`, `summary`, `memory_draft`) with a shared normalized transport result shape.
-   Status: **done**. Each use case owns its dependency assembly. `impersonationRequest.js` added as fourth type. `model_discovery` uses provider directly.
-6. Document the worker/service split so future prompt and retrieval changes have a stable boundary.
-   Status: partially done in this document; should be kept current as retrieval/prompt work continues.
-
-### Migration Guardrails
-- Keep streaming and non-streaming behavior functionally identical while splitting modules.
-- Preserve the native/mobile fallback where stream bodies are unavailable.
-- Preserve partial-response recovery on abort/timeout until a new event contract fully replaces callbacks.
-- Keep network trace capture optional and removable.
-- Avoid changing prompt semantics during the initial transport/config refactor.
-- Keep the embedding/vectorization stack out of this refactor until the chat/provider architecture stabilizes.
-- Keep `MemoryBooks -> generateMemoryDraft(apiConfigOverride)` behavior compatible until a later step adds explicit provider selection for custom memory generation.
 
 ---
 
@@ -1089,48 +831,7 @@ Native-only scope retained:
 
 ---
 
-## Anti-God-Object Guard Rails
-
-These rules prevent the gradual re-accumulation of responsibilities that motivated Phases 8–13.
-
-1. **Hard limit 400 lines script** — if `<script setup>` exceeds 400 lines, extract a composable before adding more logic. Template lines do not count toward this limit.
-   - **Known exception:** `ChatView.vue` (~1390 script lines) is a composable-wiring surface that coordinates ~30 composables. Further extraction would cause prop-drilling and violate Guard Rail #7. This is accepted as a permanent exception.
-
-2. **One concern per composable** — if a composable name contains "and" (e.g., `useFooAndBar`), split it. A composable should be namable by a single noun phrase.
-
-3. **State separate from services** — a reactive state module (`*State.js`) should contain state + simple CRUD. Search, embedding, and orchestration logic belongs in a dedicated service or composable, not in the state module itself.
-
-4. **Sheet pattern** — Sheet components are the most common god-object trap. A Sheet typically mixes UI rendering + CRUD actions + validation + status tracking. Extract business logic into a composable before the sheet script exceeds 400 lines.
-
-5. **Settings view pattern** — Settings views tend to accumulate sub-settings tabs (API, embedding, image gen, memory). Each sub-settings domain should be its own composable if the total script exceeds 400 lines.
-
-6. **No circular imports via services** — Use-case files must not delegate to a service that imports back from use-cases. If a service is a middleman between a use-case and lower layers, inline the service or invert the dependency.
-
-7. **Template is not logic** — 1000+ lines of template is acceptable for complex UI. The decomposition target is script logic, not HTML structure. Never extract a sub-component solely to reduce line count if it requires excessive prop-drilling.
-
-## Deferred Refactoring Items
-
-These files exceed the 400-line guard rail but are intentionally left as-is. Each entry explains why refactoring is deferred.
-
-### `ChatView.vue` — `openChat()` extraction (~400 lines inline)
-
-- **Status:** Deferred
-- **Reason:** `openChat()` has ~30+ dependency injections. Extracting it into a composable would create a massive parameter list and prop-drilling surface with no architectural gain — ChatView is already a composable-wiring shell. Accepted as permanent exception (see Guard Rail #1).
-- **Revisit if:** A new feature requires testing `openChat()` in isolation, or the function grows significantly beyond its current scope.
-
-### `themeState.js` (639 lines) — State ≠ service violation
-
-- **Status:** Deferred (next refactor pass)
-- **Problem:** Violates Guard Rail #3. File mixes reactive state + simple setters (~300 lines, correct) with preset CRUD orchestration (`initTheme`, `applyPreset`, `createPreset/switchPreset/deletePreset/updatePresetMeta/exportThemePreset/importThemePreset`, ~340 lines, should be a service).
-- **Proposed fix:** Extract preset orchestration into `themePresetService.js`. `themeState.js` would retain only `themeState` reactive + setter functions (~300 lines).
-- **Risk:** Low — preset functions already delegate to `themePersistence.js`, `themeMigration.js`, `themeRenderer.js`. The extraction boundary is clear.
-
-### `useMemorySheetUI.js` (844 lines) — imperative DOM anti-pattern
-
-- **Status:** Do not refactor
-- **Reason:** ~600 of 844 lines are `document.createElement('div')` + `innerHTML` + `querySelector` + `addEventListener`. This is a fundamental DOM approach problem, not a concern-mixing problem. Splitting the file into smaller pieces would not improve architecture — it would just scatter imperative DOM code across more files. The only meaningful refactoring would be rewriting all innerHTML sheets as Vue components, which is a large UI rewrite with zero architectural payoff.
-- **CRUD logic** mixed in (`createMemoryFromSelection`, `removeMemoryFromSelection`, save logic in `openMemoryEntryEditor`) is tightly coupled to the imperative DOM event handlers — extracting it separately would require passing the same DOM-read values through an extra layer.
-- **Revisit if:** A decision is made to rewrite the memory sheet UI as proper Vue template components.
+Guard rails and deferred items have been moved to `docs/rules/vue-components.md` and `docs/rules/known-gaps.md`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,19 @@ npm run build && npx cap sync ios && npx cap open ios
 | App settings | localStorage | `gz_*` |
 | Session vars | localStorage | `gz_vars_{charId}_{sessionId}` |
 
+## Context-Sensitive Rules
+
+When editing files matching a pattern below, READ the corresponding rule file FIRST and apply those rules:
+
+| When editing... | Read this |
+|----------------|-----------|
+| Generation, transport, streaming, abort, use-cases | `docs/rules/generation.md` |
+| Any async boundary, callbacks from transport, DB writes | `docs/rules/race-conditions.md` |
+| Vue components, composables, state modules | `docs/rules/vue-components.md` |
+| IndexedDB reads/writes, `db.js`, `patchChatData` | `docs/rules/database.md` |
+| Architecture details, directory structure, full flow | `ARCHITECTURE.md` |
+| Formal invariants with code references | `docs/INVARIANTS.md` |
+
 ## Do NOT
 
 - Add TypeScript

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -18,6 +18,10 @@ state exists, the call is silently rejected (`ChatView.vue:2221-2227`).
 For every `setGenerationState(charId, ...)`, there must be a matching
 `clearGenerationState(charId, ...)` on every exit path: completion, error, abort, or unmount.
 
+**Abort path:** `useGenerationAbort` delegates cleanup to `handleGenerationError → finalizeGenerationState`
+instead of calling `clearGenerationState` directly, to avoid double-cleanup and stale guard conflicts.
+This satisfies the invariant — `clearGenerationState` is still called, just from the error handler.
+
 **Previously violated (fixed in Phase 2):**
 - ~~Stale completion path (`useGenerationCompleteHandler.js:136-141`) calls `ensureStaleCleanup` but does NOT call `clearGenerationState`.~~ **Fixed:** `ensureStaleCleanup` now uses `finalizeGenerationState` which always calls `clearGenerationState`.
 - ~~`onUnmounted` (`ChatView.vue:3428-3455`) aborts controllers and clears timers but does NOT call `clearGenerationState`.~~ **Fixed:** `onUnmounted` now calls `clearGenerationState(charId)` after cleanup.

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -254,6 +254,8 @@ When `controller.abort()` is called:
 - The streaming SSE loop checks `throwIfAborted()` every iteration (`streamingSse.js:30`)
 - `chatPreparedPromptExecution.js:63-65` checks before running the worker
 - `chatRequestExecution.js:47-49` checks before dispatching the request
+- Pipeline loop breaks and calls `onError(AbortError)` with `userAborted` from controller (`postPromptOrchestrator.js:80-90`)
+- All early abort checks propagate `userAborted` from controller (`steps.js:128-132`, `chatRequestAssembly.js:124-128`, `chatPreparedPromptExecution.js:63-67`)
 
 ### INV-A2: Regenerate during active generation is silently rejected
 
@@ -271,6 +273,10 @@ generation is active. This is intentional — impersonation overwrites the exist
 `restoreState()` rolls back: pending swipe, placeholder message, isTyping flag,
 and prompt metadata snapshots. The chat must return to the state it was in before
 the generation started.
+
+`handleGenerationError` treats ALL `AbortError` (regardless of `userAborted` flag)
+as silent cleanup — no error toast, no error message in chat. Empty placeholder
+messages are removed; partial text is preserved via `rollbackPendingSwipe`.
 
 ---
 

--- a/docs/refactor-history.md
+++ b/docs/refactor-history.md
@@ -1,0 +1,176 @@
+# Refactor History
+
+Completed phases of the architecture refactor. This file is for reference only — it records what was done and why, not what to do next.
+
+For current gaps and deferred items, see `docs/rules/known-gaps.md`.
+
+## Target Architecture
+
+The refactor target is a hybrid model:
+
+```text
+UI
+  -> Use Cases
+    -> Ordered Pipelines
+      -> Transport
+
+Side effects / observers
+  <- Event Hub <- Use Cases / Pipelines
+```
+
+- `UI` gathers user intent and renders state.
+- `Use Cases` own actions like chat generation, summary generation, and memory-draft generation.
+- `Ordered Pipelines` preserve correctness-critical ordering for prompt and request flow.
+- `Event Hub` carries domain facts and optional side effects, but does not replace orchestration.
+
+## Before Refactor
+
+The app was functional, but core ownership was too concentrated:
+
+- `ChatView.vue` owned too much chat-generation orchestration, UI coordination, and request lifecycle glue.
+- `generationService.js` mixed prompt construction, enrichment, payload assembly, preview state, and request dispatch.
+- Many cross-feature reactions depended on ad-hoc `window.dispatchEvent(...)` with no catalog or ownership boundary.
+
+## Phase 1 — Event Layer Skeleton
+
+Files added: `eventNames.js`, `contracts.js`, `eventHub.js`
+
+- 56 canonical events across 4 namespaces (`nav.*`, `domain.*`, `debug.*`, `ui.*`)
+- All internal emitters use `publishAppEvent()`, all listeners use `subscribeAppEvent()`
+- Legacy `windowEventBridge` removed
+- Cancelable events via `publishCancelableAppEvent()` with `preventDefault()` semantics
+- Dead code events (5): listeners with no dispatches — not removed, future cleanup
+
+Files migrated: App.vue, AppHeader.vue, ChatInput.vue, ChatMessage.vue, GenericEditor.vue, DesktopLeftSidebar.vue, BottomSheet.vue, DragDropOverlay.vue, HelpTip.vue, CharacterCardSheet.vue, GlossarySheet.vue, LorebookSheet.vue, RegexSheet.vue, SyncSheet.vue, NotificationsSheet.vue, ImageViewer.vue, HoloCardViewer.vue, ApiView.vue, CatalogView.vue, CharacterList.vue, DialogList.vue, PersonasView.vue, PresetView.vue, ToolsView.vue, MenuView.vue, SettingsView.vue, ThemeSettingsView.vue, AboutView.vue, OnboardingView.vue, ui.js, notificationService.js, APISettings.js, catalogState.js, main.js, characterIO.js, errors.js, useChatMessageDisplay.js
+
+## Phase 2 — Request Ownership Safety Slice
+
+- Generation state carries `ownerKey`, `requestToken`, `sessionId`, `type`
+- Stream/completion/error/abort validate ownership before mutating state
+- Impersonation keeps separate ownership scope
+- Fixed: `onUnmounted` now calls `clearGenerationState`
+- Fixed: stale completion path uses `finalizeGenerationState`
+
+## Phase 9 — State Ownership Boundaries
+
+- `generationState.js` — explicit generation state module with ownership API
+- `useGenerationRegistry.js` — registers generation state per-session with ownership tokens
+- `useAutoSync.js` — depends on `syncState` instead of importing from ChatView
+- `usePromptMetadataSnapshots.js` — stores/restores snapshots for rollback
+- Fixed TDZ bug: `getScrollAnchor` reorder in ChatView.vue
+
+## Phase 11 — Use-Case Layer Re-architecture
+
+File renames/moves:
+- `chatPipelineContext.js` → `pipeline/pipelineContext.js`
+- `chatPipelineSteps.js` → `pipeline/steps.js`
+- `chatPostPromptPipeline.js` → `pipeline/postPromptOrchestrator.js`
+- `chatContextCalculation.js` → `usecases/contextCalculation.js`
+- `chatRequestExecution.js` → `usecases/chatRequestAssembly.js`
+- `nonChatGenerationHooks.js` → `usecases/sharedRequestHooks.js`
+- `chatCompletionsClient.js` → `transport/completionsClient.js`
+
+File splits:
+- `chatLateEnrichment.js` → `vectorLoreInjection.js` + `memoryMessageInjection.js`
+- `chatPromptShared.js` → `promptConfigReaders.js` + `promptWorkerLifecycle.js` + `promptPayloadBuilder.js`
+- `memoryBookContext.js` → `memoryEmbeddingIndex.js` + `memoryKeyMatching.js` + `memoryContextInjection.js`
+
+Hollow entrypoints eliminated: `calculateContext.js`, `generateSummary.js`, `generateMemoryDraft.js` now own their dependency assembly locally.
+
+`generationService.js` reduced from 267 → 158 lines.
+
+## Phase 12 — Transport Split & Legacy Cleanup
+
+- Transport fully split: `requestOrchestrator.js` → `completionsClient.js`, `requestLifecycle.js`, `requestExecution.js`, `streamingSse.js`, `responseHandling.js`, `requestOutcome.js`, `requestRuntimePolicy.js`, `streamAccumulator.js`, `responseNormalizer.js`, `sseParser.js`
+- Dead params removed from use-case signatures
+- `createChatGenerationServices` factory wires all deps, ChatView no longer assembles ~30-function injection bundle
+
+## Phase 13a — App.vue Decomposition
+
+App.vue: 1229 → 622 lines script. Extracted:
+- `useAppNavigation.js` — view routing, desktop/mobile detection
+- `useEditorController.js` — character/persona editor lifecycle
+- `useAppEventSubscriptions.js` — 23 subscribeAppEvent calls + cleanup
+- `useGlossaryPopup.js` — desktop glossary drag popup
+- `useAppInit.js` — onMounted initialization sequence
+
+## Phase 13b — PresetView Decomposition
+
+Deleted: `usePresetEditor.js` (2080-line god-object)
+
+Extracted (all `src/composables/app/`):
+- `usePresetNavigation.js` (107) — switching, list, drag reorder
+- `usePresetLoader.js` (89) — loading, cache, flush save
+- `usePresetConnections.js` (33) — connection queries
+- `usePresetCRUD.js` (173) — create, delete, duplicate, rename, import, export
+- `usePresetSelectors.js` (171) — bottom-sheet selectors
+- `usePresetImage.js` (40) — image selection, compression
+- `useBlockManager.js` (141) — block CRUD, stash/unstash
+- `useBlockEditor.js` (94) — CodeMirror lifecycle
+- `useAuthorsNoteSheet.js` (73) — authors note sheet
+- `useSummarySheet.js` (126) — summary sheet
+- `usePresetTokenPreview.js` (177) — token estimation, macro preview
+
+PresetView.vue: 279 lines script (from 2080).
+
+## Phase 13c — lorebookState.js Decomposition
+
+lorebookState.js: 1319 → 326 lines (state + CRUD). Extracted:
+- `lorebookSearchService.js` (182) — keyword scan logic
+- `lorebookVectorSearch.js` (431) — vector search, hybrid/descriptor scoring
+- `lorebookEmbeddingService.js` (352) — embedding orchestration, hash, status
+- Re-exports from lorebookState.js for backward compatibility
+
+## Phase 13d — ChatMessage.vue Decomposition
+
+ChatMessage.vue: 1985 → 1621 lines. Extracted:
+- `useMessageSwipe.js` (262) — touch/swipe/long-press
+- `useMessageImageGen.js` (149) — image gen handler
+
+Script: 624 → 334 lines.
+
+## Phase 13e — ChatInput.vue Decomposition
+
+ChatInput.vue: 1155 → 905 lines. Extracted:
+- `useContentEditable.js` (128) — caret, text, preview
+- `useInputActions.js` (168) — send, guidance, image, fullscreen
+
+Script: 420 → 170 lines.
+
+## Phase 13f–13g — LorebookSheet.vue Decomposition
+
+Extracted:
+- `useLorebookEntries.js` (157) — entry CRUD, reorder, search/filter
+- `useLorebookIndexing.js` (93) — index, retry, status counts
+
+Script: 572 → 290 lines.
+
+## Phase 13h–13i — ApiView.vue Decomposition
+
+Extracted:
+- `useApiSettings.js` (237) — API state, presets, connection, model selector
+- `useServiceProviders.js` (128) — embedding, imageGen, memory provider settings
+
+Script: ~645 → 140 lines.
+
+## Phase 13j–13k — CharacterList.vue Decomposition
+
+Extracted:
+- `useCharacterActions.js` (179) — add/import, edit, export, favorite, delete
+- `useSessionSheet.js` (168) — session list, CRUD, import chat
+
+Script: 585 → 175 lines.
+
+## Phase 13l — ThemeSettingsView.vue Decomposition
+
+Extracted:
+- `useThemePresets.js` (267) — preset CRUD, apply, export, import
+
+Script: 495 → 236 lines.
+
+## Phase 14 — Final Legacy Cleanup
+
+- Deleted 7 dead re-export shims + dead `useViewer` composable
+- Removed `getLegacyApiConfig`/`getLegacyEmbeddingConfig` + `emitLegacyCompatibleEvent`
+- Migrated `app-back-navigation` from `window.dispatchEvent` to `publishCancelableAppEvent`
+- Removed `windowEventBridge` entirely

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -1,0 +1,46 @@
+# Database Rules
+
+Rules for all code that reads from or writes to IndexedDB.
+
+## patchChatData for read-mutate-write
+
+NEVER:
+```javascript
+const data = await db.getChat(charId);
+data.messages.push(newMsg);
+await db.saveChat(charId, data);
+```
+
+ALWAYS:
+```javascript
+await patchChatData(charId, draft => {
+  draft.messages.push(newMsg);
+});
+```
+
+`patchChatData` serializes read-mutate-write via `queueDbWrite`. Two concurrent saves WILL corrupt data without it.
+
+## Save before state cleanup
+
+When finalizing a generation, persist data to DB BEFORE clearing reactive state. If you clear state first and the save fails, data is lost.
+
+## Crash recovery buffer
+
+`useSessionPersistence.js` writes a crash buffer to `localStorage` on `visibilitychange`, `pagehide`, and `beforeunload`. On `openChat()`, if crash buffer has more messages than stored session, buffer is restored to IndexedDB.
+
+Key format: `gz_chat_recovery_{charId}_{sessionId}`
+
+## Background persistence throttling
+
+During active generation, stream text is persisted to DB at reduced frequency:
+- Web: moderate throttle
+- Native / battery-saver: aggressive throttle
+
+This reduces IndexedDB churn while ensuring no data loss on crash.
+
+## Embedding storage
+
+Store: `embeddings`
+Schema v8: `{ id, sourceType, sourceId, vectors[], textHash, retrievalHints, updatedAt }`
+
+Legacy support: single `vector` field for pre-v8 entries.

--- a/docs/rules/generation.md
+++ b/docs/rules/generation.md
@@ -38,6 +38,15 @@ controller.abort()
 
 **Never break this chain.** If `controller` doesn't reach `fetch()`, stop button only clears UI while TCP stays open.
 
+### Pipeline abort propagation
+
+When `controller.signal.aborted` is true before the HTTP request starts (e.g. during
+vector search, memory injection, or context limit guard), the pipeline loop breaks
+and calls `onError(AbortError)` with `userAborted` propagated from `ctx.controller`.
+This ensures the abort chain reaches `handleGenerationError` regardless of when the
+abort fires. All early abort checks (`stepRequestExecution`, `chatRequestAssembly`,
+`chatPreparedPromptExecution`) also set `userAborted` from the controller.
+
 ## State cleanup on every exit path
 
 For every `setGenerationState(charId, ...)` there MUST be a `clearGenerationState(charId, ...)` on:

--- a/docs/rules/generation.md
+++ b/docs/rules/generation.md
@@ -1,0 +1,82 @@
+# Generation Lifecycle Rules
+
+Mandatory rules for any code that participates in chat generation, summary, memory draft, or transport.
+
+Full formal invariants with code references: `docs/INVARIANTS.md`
+
+## Generation types and their scopes
+
+| Type | Registry | Streaming | Abort | State isolation |
+|------|----------|-----------|-------|-----------------|
+| Chat | `generationStates` (genId) | Yes | Shared `AbortController` | Per charId |
+| Summary | None | No | Caller-owned | No chat state mutation |
+| Memory draft | Own `memoryDraftAbortControllers` | No | Per-draft controller | Per charId, separate from chat |
+
+## Mutual exclusion
+
+- Chat generation and memory draft CANNOT run simultaneously for the same charId (guards in BOTH directions)
+- Summary is stateless and can run alongside anything
+- Background operations (auto-sync, embedding indexing) must check `isGenerating` before starting
+
+## genId ownership
+
+Every chat generation gets a unique `genId`. All callbacks (`onUpdate`, `onComplete`, `onError`) MUST verify `genId` matches `generationStates[charId]` before mutating state. If mismatch — discard or route to stale cleanup.
+
+`requestToken = "${scope}:${charId}:${sessionId}:${genId}"` — fully qualified ownership identifier.
+
+## Abort signal chain
+
+```
+controller.abort()
+  → AbortController.signal.aborted = true
+  → completionsClient passes signal to fetch()
+  → streamingSse checks throwIfAborted() per chunk
+  → reader.cancel() closes TCP connection
+  → handleAbortOutcome() routes with userAborted flag
+  → onError(AbortError) fast-paths without error toast
+```
+
+**Never break this chain.** If `controller` doesn't reach `fetch()`, stop button only clears UI while TCP stays open.
+
+## State cleanup on every exit path
+
+For every `setGenerationState(charId, ...)` there MUST be a `clearGenerationState(charId, ...)` on:
+- Completion
+- Error
+- Abort
+- Component unmount
+
+`clearGenerationState(charId, expectedGenId)` prevents double-cleanup from abort clearing a newer generation's state.
+
+## Partial text on abort
+
+- Streaming: preserve partial text as completed message
+- Non-streaming: no partial text available (by design)
+- This asymmetry is intentional
+
+## Prompt ordering (do not reorder)
+
+1. Keyword lorebook scan (in Worker)
+2. Vector lorebook scan (after Worker, deduplicated against keyword results)
+3. Memory injection (guarded by 35% token budget)
+4. Context cutoff trims oldest first
+
+## Stream vs non-stream parity
+
+Both paths must produce identical `onComplete(text, reasoning)` for the same API response. Native HTTP (`CapacitorHttp`) and `fetch()` must normalize to the same output structure.
+
+## PR verification checklist
+
+Before merging any structural PR:
+- [ ] Chat generation produces correct responses
+- [ ] Stop preserves partial text when available
+- [ ] Regenerate while generating is safely rejected
+- [ ] Character switch during generation continues background generation
+- [ ] Prompt block order matches preset definition
+- [ ] Lorebook keyword + vector results correctly merged
+- [ ] Memory injection respects token budget guard
+- [ ] History cutoff trims oldest first
+- [ ] Summary returns string without affecting chat state
+- [ ] Memory draft doesn't affect generation registry
+- [ ] Context limit exceeded caught and shown
+- [ ] API not configured caught and shown

--- a/docs/rules/generation.md
+++ b/docs/rules/generation.md
@@ -48,6 +48,11 @@ For every `setGenerationState(charId, ...)` there MUST be a `clearGenerationStat
 
 `clearGenerationState(charId, expectedGenId)` prevents double-cleanup from abort clearing a newer generation's state.
 
+**Abort path delegation:** `useGenerationAbort` does NOT call `clearGenerationState` directly.
+It delegates cleanup to `handleGenerationError → restoreState → finalizeGenerationState`,
+which calls `clearGenerationState` with the correct `expectedGenId`. Calling `clearGenerationState`
+in both abort and error handler would cause double-cleanup and race conditions with stale guards.
+
 ## Partial text on abort
 
 - Streaming: preserve partial text as completed message

--- a/docs/rules/known-gaps.md
+++ b/docs/rules/known-gaps.md
@@ -1,0 +1,59 @@
+# Known Gaps & Deferred Items
+
+Current architectural problems and intentionally deferred refactoring items.
+
+## Current Design Problems
+
+### ChatView.vue is a large composable-wiring surface
+
+~1390 script lines. Known exception to the 400-line guard rail. Further extraction would cause prop-drilling (30+ shared dependencies). `openChat()` (~400 lines) remains due to high dependency count. This is accepted as permanent tech debt.
+
+### Runtime config has multiple owners
+
+`localStorage`, IndexedDB API presets, reactive `ApiView.vue` state, onboarding writes, and direct reads in feature views all mutate API config. No single boundary controls reads/writes.
+
+### Worker/service boundary not clearly documented
+
+Keyword lore lives in the worker, vector retrieval and memory injection happen later in the service layer. The boundary is functional but not documented as a contract.
+
+### Callback signatures flexible but brittle
+
+Chat, summary, and memory-draft flows share callback shapes (`onUpdate`, `onComplete`, `onError`) but each flow adds subtle differences. This makes adding new request types error-prone.
+
+## Deferred Refactoring Items
+
+### `ChatView.vue` — `openChat()` extraction (~400 lines inline)
+
+- **Status:** Deferred
+- **Reason:** ~30+ dependency injections. Extracting would create massive parameter list with no architectural gain. ChatView is already a composable-wiring shell.
+- **Revisit if:** A new feature requires testing `openChat()` in isolation, or the function grows significantly.
+
+### `themeState.js` (639 lines) — State ≠ service violation
+
+- **Status:** Deferred (next refactor pass)
+- **Problem:** Violates Guard Rail #3. Mixes reactive state + setters (~300 lines, correct) with preset CRUD orchestration (~340 lines, should be a service).
+- **Proposed fix:** Extract preset orchestration into `themePresetService.js`. `themeState.js` retains only reactive + setter functions (~300 lines).
+- **Risk:** Low — preset functions already delegate to `themePersistence.js`, `themeMigration.js`, `themeRenderer.js`.
+
+### `useMemorySheetUI.js` (844 lines) — imperative DOM anti-pattern
+
+- **Status:** Do not refactor
+- **Reason:** ~600 of 844 lines are `document.createElement` + `innerHTML` + `querySelector` + `addEventListener`. This is a fundamental DOM approach problem, not a concern-mixing problem. Splitting would scatter imperative DOM code across more files. The only meaningful refactoring would be rewriting innerHTML sheets as Vue components — large UI rewrite with zero architectural payoff.
+- **Revisit if:** A decision is made to rewrite the memory sheet UI as proper Vue template components.
+
+## Dead Code
+
+### Dead event subscriptions (5 events with listeners but no dispatches)
+
+- `header-setup-generation` — AppHeader + App subscribe, no source dispatches
+- `header-update-session` — AppHeader subscribes, no source dispatches
+- `change-generation-tab` — AppHeader subscribes, no source dispatches
+- `open-item-editor` — App subscribes, no source dispatches
+- `open-holocards` — HoloCardViewer subscribes, no source dispatches
+
+Not removed to avoid breaking changes if dispatches are added dynamically. Should be cleaned up in a future pass.
+
+## UI Leak Sites Remaining (from Phase 11)
+
+- `generationService.js` imports `translations`/`currentLang` (i18n) and `showBottomSheet`/`closeBottomSheet` (UI state) — these should become callback-style dep injection or event-driven.
+- `pipeline/steps.js` `stepContextLimitGuard` receives `showBottomSheet`/`closeBottomSheet` as deps — UI notification from pipeline step.

--- a/docs/rules/race-conditions.md
+++ b/docs/rules/race-conditions.md
@@ -1,0 +1,59 @@
+# Race Condition Prevention Rules
+
+Every new feature or fix that touches async boundaries, generation state, or IndexedDB must satisfy these rules before commit.
+
+## Rule 1: Every `await` is a checkpoint
+
+After any `await`, always verify you still own the state:
+
+- Not aborted? `controller.signal.aborted`
+- Same generation? `isGenerationStateCurrent(charId, genId)`
+- Same session? `sessionId === expected`
+
+Pattern:
+```javascript
+const result = await someAsyncWork();
+if (controller?.signal?.aborted) return;
+if (!isGenerationStateCurrent(charId, genId)) return;
+```
+
+## Rule 2: No state mutation without ownership
+
+- `onComplete` / `onError` / `onUpdate` callbacks MUST check `genId` before mutating any reactive state
+- New composables that participate in generation lifecycle MUST use `useGenerationRegistry` for ownership tokens
+- Transient state (isGenerating, typing placeholder, pending swipe) is owned by a single generation token and auto-cleaned on finalization
+
+## Rule 3: `patchChatData` for all read-mutate-write
+
+- NEVER do `const data = await db.getChat(charId); /* mutate */; await db.saveChat(charId, data)` — this is a race
+- ALWAYS use `patchChatData(charId, draft => { /* mutate draft */ })` — serializes read-mutate-write via `queueDbWrite`
+- New composables that persist chat state must import `patchChatData` from `db.js`
+
+## Rule 4: New async boundaries need stale guards
+
+When adding a new composable or service function that:
+- receives callbacks from transport/pipeline/use-case layer
+- mutates Vue reactive state
+- persists data to IndexedDB
+
+...it MUST include a staleness/ownership check before the mutation. Without it, a late completion from an aborted generation WILL corrupt state.
+
+## Rule 5: Mutual exclusion for concurrent operations
+
+- Chat generation and memory draft generation are mutually exclusive (checked in both directions)
+- If adding a new request type that runs alongside chat generation, add mutual exclusion guards in BOTH directions
+- Background operations (auto-sync, embedding indexing) must check `isGenerating` before starting
+
+## Why this matters
+
+The hybrid architecture has more boundaries than the old flat structure. Each boundary is a potential race surface. The old code had the same races — they were just invisible because everything mutated shared state in one call stack. The new architecture makes races visible, and these rules make them preventable.
+
+## Known race classes and their fixes
+
+| Race | Cause | Fix |
+|------|-------|-----|
+| Stale completion mutates new typing state | Callback didn't check genId | `expectedGenId` in finalize/restore/complete |
+| Abort didn't reach fetch() | controller not in requestConfig | Signal chain through `createImmutableChatRequestEnvelope` |
+| Read-mutate-write in IndexedDB | `saveChat` without serialization | `patchChatData` with `queueDbWrite` |
+| Registry leak after unmount | `clearGenerationState` not called | Fix in `onUnmounted` |
+| Memory draft + chat generation simultaneously | No mutual exclusion | Block in both directions |

--- a/docs/rules/vue-components.md
+++ b/docs/rules/vue-components.md
@@ -1,0 +1,55 @@
+# Vue Component Rules
+
+Rules for writing and refactoring Vue components and composables.
+
+## Size limits
+
+- **400-line hard limit** on `<script setup>` — if exceeded, extract a composable first
+- No exceptions without documented justification in AGENTS.md
+
+## Composable extraction
+
+- **One concern per composable** — no "and" in composable names; split instead
+  - `usePresetEditor.js` (2080 lines, god-object) → 11 composables with max 177 lines each
+  - `useAppNavigation.js`, `useEditorController.js`, etc.
+- **State ≠ service** — `*State.js` files contain state + CRUD only; search/embedding/orchestration goes in a service
+- **No circular service delegation** — use-cases must not delegate to a service that imports back from use-cases
+
+## Known traps
+
+### Sheet trap
+Sheets mix UI + CRUD + validation + status. Extract business logic into composables before script hits 400 lines.
+
+### Settings trap
+Settings views with multiple sub-domains (API, embedding, image gen) get composables per domain.
+
+### Template ≠ logic
+Never extract sub-components just for line count if it requires prop-drilling. Prop-drilling is worse than a long script.
+
+## Directory conventions
+
+```
+src/composables/
+  api/         — API/runtime config composables
+  app/         — App-level init, event subscriptions, onboarding
+  character/   — Character editor, thumbnails, import/export
+  chat/        — Chat generation, context, memory, message selection, auto-sync
+  lorebook/    — Lorebook vector status, embedding logic
+  theme/       — Theme presets, settings, renderer
+  ui/          — Header, glossary, viewer composables
+
+src/core/states/   — Reactive state modules (state + CRUD only)
+src/core/services/  — Business logic services
+src/views/          — Page-level components (composable wiring)
+```
+
+## Event system
+
+- ALL internal events use `publishAppEvent()` / `subscribeAppEvent()` — never `window.dispatchEvent`
+- Cancelable events use `publishCancelableAppEvent()` with `preventDefault()` semantics
+- Unsubscriptions in `onBeforeUnmount` (Vue) or app lifetime (services/utils)
+- Event catalog: 56 events across 4 namespaces (`nav.*`, `domain.*`, `debug.*`, `ui.*`)
+
+## ChatView.vue exception
+
+ChatView.vue (~1390 script lines) is a known exception to the 400-line rule. Further extraction would cause prop-drilling due to 30+ shared dependencies. `openChat()` (~400 lines) remains due to high dependency count. This is acknowledged tech debt.

--- a/src/components/sheets/CharacterCardSheet.vue
+++ b/src/components/sheets/CharacterCardSheet.vue
@@ -106,21 +106,118 @@ const allFirstMessages = computed(() => {
 });
 
 const activeTab = ref('info');
-const sheetTabs = computed(() => [
-    { id: 'info', label: getTranslated('tab_info', 'Information') || 'Information' },
-    { id: 'prompts', label: getTranslated('tab_prompts', 'Prompts') || 'Prompts' }
-]);
+const galleryImages = computed(() => {
+    const imgs = currentCharData.value?.images;
+    return Array.isArray(imgs) ? imgs : [];
+});
+const isLocalCharacter = computed(() => !!currentCharData.value?.id);
+const sheetTabs = computed(() => {
+    const tabs = [
+        { id: 'info', label: getTranslated('tab_info', 'Information') || 'Information' },
+        { id: 'prompts', label: getTranslated('tab_prompts', 'Prompts') || 'Prompts' }
+    ];
+    if (galleryImages.value.length > 0 || isLocalCharacter.value) {
+        tabs.push({ id: 'gallery', label: getTranslated('tab_gallery', 'Gallery') || 'Gallery' });
+    }
+    return tabs;
+});
+
+const tabSliderOffset = computed(() => {
+    const idx = sheetTabs.value.findIndex(t => t.id === activeTab.value);
+    return idx >= 0 ? idx * 100 : 0;
+});
 
 const allTags = computed(() => {
     const tags = currentCharData.value?.tags;
     return Array.isArray(tags) ? tags.filter(Boolean) : [];
 });
 
+function openGalleryImage(img) {
+    publishAppEvent(APP_EVENTS.nav.openImageViewer, { src: img.src });
+}
+
+function triggerGalleryImageUpload() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.multiple = true;
+    input.onchange = async (e) => {
+        const files = Array.from(e.target.files);
+        if (!files.length) return;
+        const char = currentCharData.value;
+        if (!char) return;
+        if (!Array.isArray(char.images)) char.images = [];
+        for (const file of files) {
+            const src = await fileToDataUrl(file);
+            let thumbnail = null;
+            try {
+                const { generateThumbnail } = await import('@/utils/thumbnailUtils.js');
+                thumbnail = await generateThumbnail(src, 300);
+            } catch (_e) { /* skip thumbnail */ }
+            char.images.push({
+                id: 'img_' + Math.random().toString(36).slice(2, 10),
+                src,
+                name: file.name || '',
+                thumbnail
+            });
+        }
+        if (char.id) {
+            await db.saveCharacter(char, -1);
+            publishAppEvent(APP_EVENTS.domain.character.updated, { character: char });
+        }
+        if (!isControlled.value) {
+            localCharData.value = { ...char };
+        }
+    };
+    input.click();
+}
+
+async function deleteGalleryImage(imgId) {
+    const char = currentCharData.value;
+    if (!char?.images) return;
+    char.images = char.images.filter(img => img.id !== imgId);
+    if (char.id) {
+        await db.saveCharacter(char, -1);
+        publishAppEvent(APP_EVENTS.domain.character.updated, { character: char });
+    }
+    if (!isControlled.value) {
+        localCharData.value = { ...char };
+    }
+}
+
+function confirmDeleteGalleryImage(img) {
+    showBottomSheet({
+        title: getTranslated('confirm_delete_image', 'Delete image?'),
+        items: [
+            {
+                label: getTranslated('btn_yes', 'Yes'),
+                icon: '<svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>',
+                iconColor: '#ff4444',
+                isDestructive: true,
+                onClick: () => { closeBottomSheet(); deleteGalleryImage(img.id); }
+            },
+            {
+                label: getTranslated('btn_no', 'No'),
+                icon: '<svg viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>',
+                onClick: () => closeBottomSheet()
+            }
+        ]
+    });
+}
+
+function fileToDataUrl(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}
+
 const creatorProfileUrl = computed(() => {
     const char = currentCharData.value || {};
     return char.creator_id ? `https://janitorai.com/profiles/${char.creator_id}` : '';
 });
-const isLocalCharacter = computed(() => !!currentCharData.value?.id);
 const canOpenChat = computed(() => isLocalCharacter.value);
 
 const menuIcon = '<svg viewBox="0 0 24 24"><path d="M12 8a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm0 8a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm0 8a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"/></svg>';
@@ -361,15 +458,13 @@ function openHeroImage() {
                 </div>
 
                 <div class="tabs-row">
-                    <div class="top-tabs-container tabs-2">
-                        <div class="tab-slider" :style="{ transform: `translateX(${activeTab === 'prompts' ? '100%' : '0'})` }"></div>
-                        <div class="top-tab" :class="{ active: activeTab === 'info' }" @click="activeTab = 'info'">
-                            <svg class="tab-icon" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>
-                            <span>{{ getTranslated('tab_info', 'Information') || 'Information' }}</span>
-                        </div>
-                        <div class="top-tab" :class="{ active: activeTab === 'prompts' }" @click="activeTab = 'prompts'">
-                            <svg class="tab-icon" viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
-                            <span>{{ getTranslated('tab_prompts', 'Prompts') || 'Prompts' }}</span>
+                    <div class="top-tabs-container" :class="'tabs-' + sheetTabs.length">
+                        <div class="tab-slider" :style="{ transform: `translateX(${tabSliderOffset}%)` }"></div>
+                        <div v-for="tab in sheetTabs" :key="tab.id" class="top-tab" :class="{ active: activeTab === tab.id }" @click="activeTab = tab.id">
+                            <svg v-if="tab.id === 'info'" class="tab-icon" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>
+                            <svg v-else-if="tab.id === 'prompts'" class="tab-icon" viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
+                            <svg v-else-if="tab.id === 'gallery'" class="tab-icon" viewBox="0 0 24 24"><path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/></svg>
+                            <span>{{ tab.label }}</span>
                         </div>
                     </div>
                 </div>
@@ -393,9 +488,8 @@ function openHeroImage() {
                             <div class="section-label">Creator Notes</div>
                             <div class="char-desc" v-html="infoDescriptionHtml"></div>
                         </div>
-                    </div> <!-- /info tab -->
-                
-                <div v-else :key="'prompts-' + (currentCharData.id || currentCharData.name)" class="tab-content prompts-tab-content">
+                    </div><!-- /info tab -->
+                    <div v-else-if="activeTab === 'prompts'" :key="'prompts-' + (currentCharData.id || currentCharData.name)" class="tab-content prompts-tab-content">
                         <div class="menu-group char-desc-group" v-for="section in promptSections" :key="section.key">
                             <div class="settings-item">
                                 <div class="label-row desc-header" @click="toggleSection(section.key)">
@@ -432,7 +526,23 @@ function openHeroImage() {
                                 </div>
                             </div>
                         </div>
-                    </div> <!-- /prompts tab -->
+                    </div><!-- /prompts tab -->
+                    <div v-else-if="activeTab === 'gallery'" :key="'gallery-' + (currentCharData.id || currentCharData.name)" class="tab-content gallery-tab-content">
+                        <div class="gallery-grid" v-if="galleryImages.length > 0">
+                            <div v-for="img in galleryImages" :key="img.id" class="gallery-item" @click="openGalleryImage(img)">
+                                <img :src="img.thumbnail || img.src" class="gallery-thumb" loading="lazy" />
+                                <button v-if="isLocalCharacter" class="gallery-delete-btn" @click.stop="confirmDeleteGalleryImage(img)" v-html="deleteIcon"></button>
+                            </div>
+                        </div>
+                        <div v-if="galleryImages.length === 0" class="gallery-empty">
+                            <svg viewBox="0 0 24 24" class="gallery-empty-icon"><path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/></svg>
+                            <span>{{ getTranslated('gallery_empty', 'No images in gallery') || 'No images in gallery' }}</span>
+                        </div>
+                        <button v-if="isLocalCharacter" class="gallery-add-btn" @click="triggerGalleryImageUpload">
+                            <svg viewBox="0 0 24 24"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
+                            <span>{{ getTranslated('gallery_add', 'Add Images') || 'Add Images' }}</span>
+                        </button>
+                    </div><!-- /gallery tab -->
                 </Transition>
             </div>
         </div> <!-- /char-sheet -->
@@ -894,5 +1004,121 @@ function openHeroImage() {
     position: static;
     right: auto;
     bottom: auto;
+}
+
+.gallery-tab-content {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+}
+
+.gallery-item {
+    position: relative;
+    aspect-ratio: 1;
+    border-radius: 12px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.gallery-item:active {
+    transform: scale(0.95);
+}
+
+.gallery-thumb {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.gallery-delete-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    border: none;
+    color: #ff4444;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    padding: 0;
+}
+
+.gallery-item:hover .gallery-delete-btn,
+.gallery-item:active .gallery-delete-btn {
+    opacity: 1;
+}
+
+.gallery-delete-btn :deep(svg) {
+    width: 14px !important;
+    height: 14px !important;
+    fill: currentColor !important;
+}
+
+.gallery-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 40px 16px;
+    color: rgba(255, 255, 255, 0.35);
+}
+
+.gallery-empty-icon {
+    width: 48px;
+    height: 48px;
+    fill: currentColor;
+    opacity: 0.4;
+}
+
+.gallery-empty span {
+    font-size: 14px;
+}
+
+.gallery-add-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 20px;
+    border-radius: 14px;
+    background: rgba(var(--vk-blue-rgb, 64, 128, 255), 0.12);
+    color: var(--vk-blue, #4080ff);
+    border: 1px solid rgba(var(--vk-blue-rgb, 64, 128, 255), 0.2);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    width: 100%;
+}
+
+.gallery-add-btn:active {
+    transform: scale(0.97);
+    opacity: 0.85;
+}
+
+.gallery-add-btn svg {
+    width: 20px;
+    height: 20px;
+    fill: currentColor;
 }
 </style>

--- a/src/components/sheets/CharacterCardSheet.vue
+++ b/src/components/sheets/CharacterCardSheet.vue
@@ -9,6 +9,7 @@ import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetStat
 import { db, markSyncDeletedEntry } from '@/utils/db.js';
 import { exportCharacterAsV2Json, exportCharacterAsV2Png } from '@/utils/characterIO.js';
 import { useSessionSheet } from '@/composables/character/useSessionSheet.js';
+import { useCharacterGallery } from '@/composables/character/useCharacterGallery.js';
 import { APP_EVENTS } from '@/core/events/eventNames.js';
 import { publishAppEvent } from '@/core/events/eventHub.js';
 
@@ -106,11 +107,15 @@ const allFirstMessages = computed(() => {
 });
 
 const activeTab = ref('info');
-const galleryImages = computed(() => {
-    const imgs = currentCharData.value?.images;
-    return Array.isArray(imgs) ? imgs : [];
-});
-const isLocalCharacter = computed(() => !!currentCharData.value?.id);
+
+const {
+    galleryImages,
+    isLocalCharacter,
+    openGalleryImage,
+    triggerGalleryImageUpload,
+    confirmDeleteGalleryImage
+} = useCharacterGallery({ currentCharData, isControlled, localCharData });
+
 const sheetTabs = computed(() => {
     const tabs = [
         { id: 'info', label: getTranslated('tab_info', 'Information') || 'Information' },
@@ -131,88 +136,6 @@ const allTags = computed(() => {
     const tags = currentCharData.value?.tags;
     return Array.isArray(tags) ? tags.filter(Boolean) : [];
 });
-
-function openGalleryImage(img) {
-    publishAppEvent(APP_EVENTS.nav.openImageViewer, { src: img.src });
-}
-
-function triggerGalleryImageUpload() {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = 'image/*';
-    input.multiple = true;
-    input.onchange = async (e) => {
-        const files = Array.from(e.target.files);
-        if (!files.length) return;
-        const char = currentCharData.value;
-        if (!char) return;
-        if (!Array.isArray(char.images)) char.images = [];
-        for (const file of files) {
-            const src = await fileToDataUrl(file);
-            let thumbnail = null;
-            try {
-                const { generateThumbnail } = await import('@/utils/thumbnailUtils.js');
-                thumbnail = await generateThumbnail(src, 300);
-            } catch (_e) { /* skip thumbnail */ }
-            char.images.push({
-                id: 'img_' + Math.random().toString(36).slice(2, 10),
-                src,
-                name: file.name || '',
-                thumbnail
-            });
-        }
-        if (char.id) {
-            await db.saveCharacter(char, -1);
-            publishAppEvent(APP_EVENTS.domain.character.updated, { character: char });
-        }
-        if (!isControlled.value) {
-            localCharData.value = { ...char };
-        }
-    };
-    input.click();
-}
-
-async function deleteGalleryImage(imgId) {
-    const char = currentCharData.value;
-    if (!char?.images) return;
-    char.images = char.images.filter(img => img.id !== imgId);
-    if (char.id) {
-        await db.saveCharacter(char, -1);
-        publishAppEvent(APP_EVENTS.domain.character.updated, { character: char });
-    }
-    if (!isControlled.value) {
-        localCharData.value = { ...char };
-    }
-}
-
-function confirmDeleteGalleryImage(img) {
-    showBottomSheet({
-        title: getTranslated('confirm_delete_image', 'Delete image?'),
-        items: [
-            {
-                label: getTranslated('btn_yes', 'Yes'),
-                icon: '<svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>',
-                iconColor: '#ff4444',
-                isDestructive: true,
-                onClick: () => { closeBottomSheet(); deleteGalleryImage(img.id); }
-            },
-            {
-                label: getTranslated('btn_no', 'No'),
-                icon: '<svg viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>',
-                onClick: () => closeBottomSheet()
-            }
-        ]
-    });
-}
-
-function fileToDataUrl(file) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result);
-        reader.onerror = reject;
-        reader.readAsDataURL(file);
-    });
-}
 
 const creatorProfileUrl = computed(() => {
     const char = currentCharData.value || {};

--- a/src/components/ui/BottomSheet.vue
+++ b/src/components/ui/BottomSheet.vue
@@ -590,7 +590,7 @@ onBeforeUnmount(() => {
     border: 1px solid rgba(128, 128, 128, 0.2);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
     border-radius: 16px;
-    overflow: hidden;
+    overflow: clip;
 }
 
 .sheet-item {

--- a/src/components/ui/DesktopDropdown.vue
+++ b/src/components/ui/DesktopDropdown.vue
@@ -4,9 +4,8 @@ import { desktopDropdownState, closeDesktopDropdown } from '@/core/states/deskto
 
 // Реактивный стиль позиционирования — пересчитывается при открытии
 const dropdownStyle = ref({});
-const DROPDOWN_WIDTH = 220;
-const ITEM_HEIGHT = 42; // approx px per item
-const PADDING = 12; // px from viewport edges
+const PADDING = 12;
+const MAX_VISIBLE_ITEMS = 12;
 
 function recalcPosition() {
     const { x, y, items, isTriggered, bigInfo } = desktopDropdownState.value;
@@ -14,8 +13,12 @@ function recalcPosition() {
     
     const width = isTriggered ? 280 : 220;
     const itemHeight = isTriggered ? 56 : 42;
-    let estimatedHeight = itemCount * itemHeight + 16;
-    if (bigInfo) estimatedHeight += 120; // Approx height for bigInfo block
+    const visibleItems = Math.min(itemCount, MAX_VISIBLE_ITEMS);
+    let estimatedHeight = visibleItems * itemHeight + 16;
+    if (bigInfo) estimatedHeight += 120;
+    if (desktopDropdownState.value.title || desktopDropdownState.value.headerAction) {
+        estimatedHeight += 32;
+    }
 
     let left = x;
     let top = y;
@@ -84,7 +87,8 @@ watch(
                     </div>
 
                     <!-- Items -->
-                    <div
+                    <div class="dd-items-scroll">
+                        <div
                         v-for="(item, idx) in desktopDropdownState.items"
                         :key="idx"
                         class="dd-item"
@@ -133,6 +137,7 @@ FEATURED
                             <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/>
                         </svg>
                     </div>
+                    </div>
                 </div>
             </div>
         </Transition>
@@ -160,7 +165,25 @@ FEATURED
     padding: 8px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
     transition: background-color 0.3s ease, border-color 0.3s ease, width 0.3s ease;
-    overflow: hidden;
+    overflow: clip;
+    max-height: calc(100vh - 24px);
+    display: flex;
+    flex-direction: column;
+}
+
+.dd-items-scroll {
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    flex: 1;
+    min-height: 0;
+}
+
+.dd-items-scroll::-webkit-scrollbar {
+    width: 4px;
+}
+.dd-items-scroll::-webkit-scrollbar-thumb {
+    background: rgba(128, 128, 128, 0.3);
+    border-radius: 2px;
 }
 
 .dd-panel--triggered {

--- a/src/composables/character/useCharacterActions.js
+++ b/src/composables/character/useCharacterActions.js
@@ -211,6 +211,14 @@ export function useCharacterActions({ characters, loadCharacters }) {
                                             exportCharacterAsCharX(char);
                                             closeBottomSheet();
                                         }
+                                    },
+                                    {
+                                        label: t('label_export_zip', 'ZIP (with gallery)'),
+                                        icon: '<svg viewBox="0 0 24 24"><path d="M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6 10H6v-2h8v2zm4-4H6v-2h12v2z"/></svg>',
+                                        onClick: () => {
+                                            exportCharacterAsCharX(char, true);
+                                            closeBottomSheet();
+                                        }
                                     }
                                 ]
                             });

--- a/src/composables/character/useCharacterActions.js
+++ b/src/composables/character/useCharacterActions.js
@@ -1,4 +1,4 @@
-import { triggerCharacterImport, extractCharacterBook, exportCharacterAsV2Json, exportCharacterAsV2Png } from '@/utils/characterIO.js';
+import { triggerCharacterImport, extractCharacterBook, exportCharacterAsV2Json, exportCharacterAsV2Png, exportCharacterAsCharX } from '@/utils/characterIO.js';
 import { importCharacter } from '@/core/states/catalogState.js';
 import { datacatExtract, datacatExtractionStatus, datacatGetCharacter } from '@/core/services/catalog/datacatProvider.js';
 import { db, markSyncDeletedEntry } from '@/utils/db.js';
@@ -201,6 +201,14 @@ export function useCharacterActions({ characters, loadCharacters }) {
                                         icon: '<svg viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>',
                                         onClick: () => {
                                             exportCharacterAsV2Json(char);
+                                            closeBottomSheet();
+                                        }
+                                    },
+                                    {
+                                        label: t('label_export_charx', 'CharX (with gallery)'),
+                                        icon: '<svg viewBox="0 0 24 24"><path d="M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6 10H6v-2h8v2zm4-4H6v-2h12v2z"/></svg>',
+                                        onClick: () => {
+                                            exportCharacterAsCharX(char);
                                             closeBottomSheet();
                                         }
                                     }

--- a/src/composables/character/useCharacterGallery.js
+++ b/src/composables/character/useCharacterGallery.js
@@ -1,0 +1,107 @@
+import { computed } from 'vue';
+import { db } from '@/utils/db.js';
+import { fileToDataUrl } from '@/utils/imageUtils.js';
+import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetState.js';
+import { publishAppEvent } from '@/core/events/eventHub.js';
+import { APP_EVENTS } from '@/core/events/eventNames.js';
+import { translations } from '@/utils/i18n.js';
+import { currentLang } from '@/core/config/APPSettings.js';
+
+function getTranslated(key, fallback) {
+    return translations[currentLang.value]?.[key] || fallback;
+}
+
+export function useCharacterGallery({ currentCharData, isControlled, localCharData }) {
+    const galleryImages = computed(() => {
+        const imgs = currentCharData.value?.images;
+        return Array.isArray(imgs) ? imgs : [];
+    });
+
+    const isLocalCharacter = computed(() => !!currentCharData.value?.id);
+
+    function openGalleryImage(img) {
+        publishAppEvent(APP_EVENTS.nav.openImageViewer, { src: img.src });
+    }
+
+    async function addGalleryImages(files) {
+        const char = currentCharData.value;
+        if (!char) return;
+        if (!Array.isArray(char.images)) char.images = [];
+        for (const file of files) {
+            const src = await fileToDataUrl(file);
+            let thumbnail = null;
+            try {
+                const { generateThumbnail } = await import('@/utils/thumbnailUtils.js');
+                thumbnail = await generateThumbnail(src, 300);
+            } catch (_e) { /* skip thumbnail */ }
+            char.images.push({
+                id: 'img_' + Math.random().toString(36).slice(2, 10),
+                src,
+                name: file.name || '',
+                thumbnail
+            });
+        }
+        if (char.id) {
+            await db.saveCharacter(char, -1);
+            publishAppEvent(APP_EVENTS.domain.character.updated, { character: char });
+        }
+        if (!isControlled.value) {
+            localCharData.value = { ...char };
+        }
+    }
+
+    function triggerGalleryImageUpload() {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'image/*';
+        input.multiple = true;
+        input.onchange = async (e) => {
+            const files = Array.from(e.target.files);
+            if (!files.length) return;
+            await addGalleryImages(files);
+        };
+        input.click();
+    }
+
+    async function deleteGalleryImage(imgId) {
+        const char = currentCharData.value;
+        if (!char?.images) return;
+        char.images = char.images.filter(img => img.id !== imgId);
+        if (char.id) {
+            await db.saveCharacter(char, -1);
+            publishAppEvent(APP_EVENTS.domain.character.updated, { character: char });
+        }
+        if (!isControlled.value) {
+            localCharData.value = { ...char };
+        }
+    }
+
+    function confirmDeleteGalleryImage(img) {
+        showBottomSheet({
+            title: getTranslated('confirm_delete_image', 'Delete image?'),
+            items: [
+                {
+                    label: getTranslated('btn_yes', 'Yes'),
+                    icon: '<svg viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>',
+                    iconColor: '#ff4444',
+                    isDestructive: true,
+                    onClick: () => { closeBottomSheet(); deleteGalleryImage(img.id); }
+                },
+                {
+                    label: getTranslated('btn_no', 'No'),
+                    icon: '<svg viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>',
+                    onClick: () => closeBottomSheet()
+                }
+            ]
+        });
+    }
+
+    return {
+        galleryImages,
+        isLocalCharacter,
+        openGalleryImage,
+        triggerGalleryImageUpload,
+        deleteGalleryImage,
+        confirmDeleteGalleryImage
+    };
+}

--- a/src/composables/chat/useGenerationAbort.js
+++ b/src/composables/chat/useGenerationAbort.js
@@ -17,7 +17,7 @@ export function useGenerationAbort({
             return abortImpersonation(charId, state);
         }
 
-        const { sessionId, genId, type } = state;
+        const { sessionId, type } = state;
 
         if (state.controller) {
             try {
@@ -45,14 +45,6 @@ export function useGenerationAbort({
         if (sessionId) {
             clearPersistedGeneration(charId, sessionId);
         }
-        clearGenerationState(charId);
-
-        publishAppEvent(APP_EVENTS.domain.generation.ended, {
-            charId,
-            sessionId: sessionId ?? null,
-            genId: genId ?? null,
-            type: type || 'chat'
-        });
 
         return true;
     }

--- a/src/composables/chat/useGenerationErrorHandler.js
+++ b/src/composables/chat/useGenerationErrorHandler.js
@@ -25,12 +25,34 @@ export async function handleGenerationError({
     const { notifyGenerationEnded } = app;
     const state = getGenerationState(char.id);
     if (!state || state.genId !== genId) {
-        await clearTypingStateForMessage({
-            charId: char.id,
-            sessionId,
-            msgId,
-            errorLabel: '[onError-stale]'
-        });
+        if (error?.name === 'AbortError' && error?.userAborted) {
+            const idx = currentMessages.value.findIndex(m => m.id === msgId);
+            if (idx !== -1) {
+                const msg = currentMessages.value[idx];
+                const isEmptyPlaceholder = !msg.text?.trim() && msg.swipes?.length === 1 && !msg.swipes[0]?.trim();
+                if (isEmptyPlaceholder) {
+                    currentMessages.value.splice(idx, 1);
+                    try {
+                        const data = await getChatData(char.id);
+                        if (data && sessionId && data.sessions[sessionId]) {
+                            data.sessions[sessionId] = currentMessages.value;
+                            await db.saveChat(char.id, data);
+                        }
+                    } catch (dbErr) {
+                        console.error('[onError-stale] Failed to remove empty placeholder from DB:', dbErr);
+                    }
+                } else {
+                    msg.isTyping = false;
+                }
+            }
+        } else {
+            await clearTypingStateForMessage({
+                charId: char.id,
+                sessionId,
+                msgId,
+                errorLabel: '[onError-stale]'
+            });
+        }
         notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });
         return;
     }

--- a/src/composables/chat/useGenerationErrorHandler.js
+++ b/src/composables/chat/useGenerationErrorHandler.js
@@ -25,7 +25,7 @@ export async function handleGenerationError({
     const { notifyGenerationEnded } = app;
     const state = getGenerationState(char.id);
     if (!state || state.genId !== genId) {
-        if (error?.name === 'AbortError' && error?.userAborted) {
+        if (error?.name === 'AbortError') {
             const idx = currentMessages.value.findIndex(m => m.id === msgId);
             if (idx !== -1) {
                 const msg = currentMessages.value[idx];
@@ -78,7 +78,7 @@ export async function handleGenerationError({
     };
 
     try {
-        if (error?.name === 'AbortError' && error?.userAborted) {
+        if (error?.name === 'AbortError') {
             await restoreState(false);
             finalizeGenerationState({
                 charId: char.id,

--- a/src/composables/chat/useGenerationErrorHandler.js
+++ b/src/composables/chat/useGenerationErrorHandler.js
@@ -21,7 +21,7 @@ export async function handleGenerationError({
     formatError,
     sendMessageNotification
 }) {
-    const { getChatData, db } = persistence;
+    const { patchChatData } = persistence;
     const { notifyGenerationEnded } = app;
     const state = getGenerationState(char.id);
     if (!state || state.genId !== genId) {
@@ -33,11 +33,11 @@ export async function handleGenerationError({
                 if (isEmptyPlaceholder) {
                     currentMessages.value.splice(idx, 1);
                     try {
-                        const data = await getChatData(char.id);
-                        if (data && sessionId && data.sessions[sessionId]) {
-                            data.sessions[sessionId] = currentMessages.value;
-                            await db.saveChat(char.id, data);
-                        }
+                        await patchChatData(char.id, draft => {
+                            if (sessionId && draft.sessions[sessionId]) {
+                                draft.sessions[sessionId] = currentMessages.value;
+                            }
+                        });
                     } catch (dbErr) {
                         console.error('[onError-stale] Failed to remove empty placeholder from DB:', dbErr);
                     }
@@ -143,20 +143,20 @@ export async function handleGenerationError({
                 msg.swipes[msg.swipeId || 0] = msg.text;
             }
         } else {
-            const data = await getChatData(char.id);
-            if (data && data.sessions[sessionId]) {
-                const dbIdx = data.sessions[sessionId].findIndex(m => m.id === msgId);
-                if (dbIdx !== -1) {
-                    const msg = data.sessions[sessionId][dbIdx];
-                    msg.text = formatError(error, rawStreamText);
-                    msg.isError = true;
-                    msg.isTyping = false;
-                    if (msg.swipes && msg.swipes.length > 0) {
-                        msg.swipes[msg.swipeId || 0] = msg.text;
+            await patchChatData(char.id, draft => {
+                if (sessionId && draft.sessions[sessionId]) {
+                    const dbIdx = draft.sessions[sessionId].findIndex(m => m.id === msgId);
+                    if (dbIdx !== -1) {
+                        const msg = draft.sessions[sessionId][dbIdx];
+                        msg.text = formatError(error, rawStreamText);
+                        msg.isError = true;
+                        msg.isTyping = false;
+                        if (msg.swipes && msg.swipes.length > 0) {
+                            msg.swipes[msg.swipeId || 0] = msg.text;
+                        }
                     }
-                    await db.saveChat(char.id, data);
                 }
-            }
+            });
         }
 
         notifyGenerationEnded({ charId: char.id, sessionId, genId, type: 'chat' });

--- a/src/core/llm/pipeline/postPromptOrchestrator.js
+++ b/src/core/llm/pipeline/postPromptOrchestrator.js
@@ -77,5 +77,17 @@ export async function runChatPostPromptPipeline({
         return;
     }
 
+    if (ctx.isAborted) {
+        const { onError } = callbacks;
+        if (onError) {
+            const abortErr = new DOMException('Aborted', 'AbortError');
+            if (ctx.controller?.userAborted) {
+                abortErr.userAborted = true;
+            }
+            onError(abortErr);
+        }
+        return;
+    }
+
     return ctx;
 }

--- a/src/core/llm/pipeline/steps.js
+++ b/src/core/llm/pipeline/steps.js
@@ -127,7 +127,13 @@ export async function stepRequestExecution(ctx, deps) {
 
     if (ctx.isAborted) {
         const { onError } = ctx.callbacks;
-        if (onError) onError(new DOMException('Aborted', 'AbortError'));
+        if (onError) {
+            const abortErr = new DOMException('Aborted', 'AbortError');
+            if (ctx.controller?.userAborted) {
+                abortErr.userAborted = true;
+            }
+            onError(abortErr);
+        }
         return;
     }
 

--- a/src/core/llm/usecases/chatGenerationServiceFactory.js
+++ b/src/core/llm/usecases/chatGenerationServiceFactory.js
@@ -41,7 +41,7 @@ export function createChatGenerationServices({
     const registry = useGenerationRegistry();
     const { clearTypingStateForMessage } = useTypingStateCleanup({ currentMessages, getChatData, db });
     const app = createGenerationAppAdapters();
-    const persistence = { getChatData, db };
+    const persistence = { getChatData, db, patchChatData: db.patchChatData.bind(db) };
 
     return {
         state: {

--- a/src/core/llm/usecases/chatPreparedPromptExecution.js
+++ b/src/core/llm/usecases/chatPreparedPromptExecution.js
@@ -61,7 +61,13 @@ export async function executePreparedChatPrompt({
     }
 
     if (controller?.signal?.aborted) {
-        if (onError) onError(new DOMException('Aborted', 'AbortError'));
+        if (onError) {
+            const abortErr = new DOMException('Aborted', 'AbortError');
+            if (controller?.userAborted) {
+                abortErr.userAborted = true;
+            }
+            onError(abortErr);
+        }
         return null;
     }
 

--- a/src/core/llm/usecases/chatRequestAssembly.js
+++ b/src/core/llm/usecases/chatRequestAssembly.js
@@ -122,7 +122,13 @@ export async function executeFinalChatRequest({
     onPreviewReady?.(finalPreviewBody);
 
     if (requestController?.signal?.aborted) {
-        if (onError) onError(new DOMException('Aborted', 'AbortError'));
+        if (onError) {
+            const abortErr = new DOMException('Aborted', 'AbortError');
+            if (requestController?.userAborted) {
+                abortErr.userAborted = true;
+            }
+            onError(abortErr);
+        }
         return;
     }
 

--- a/src/utils/characterIO.js
+++ b/src/utils/characterIO.js
@@ -11,6 +11,7 @@ import { saveFile } from '../core/services/fileSaver.js';
 import { importSTLorebook } from '@/core/states/lorebookState.js';
 import { publishAppEvent } from '@/core/events/eventHub.js';
 import { APP_EVENTS } from '@/core/events/eventNames.js';
+import JSZip from 'jszip';
 
 // ─── Import ──────────────────────────────────────────────────────────────────
 
@@ -20,11 +21,14 @@ import { APP_EVENTS } from '@/core/events/eventNames.js';
  * @returns {Promise<Object>} - Character data object
  */
 export async function parseCharacterCard(file) {
-    if (file.type === 'image/png' || file.name.toLowerCase().endsWith('.png')) {
-        return await parsePng(file);
-    } else {
-        return await parseJson(file);
+    const name = file.name.toLowerCase();
+    if (name.endsWith('.charx') || name.endsWith('.zip')) {
+        return await parseCharX(file);
     }
+    if (file.type === 'image/png' || name.endsWith('.png')) {
+        return await parsePng(file);
+    }
+    return await parseJson(file);
 }
 
 function parseJson(file) {
@@ -154,6 +158,110 @@ async function parsePng(file) {
     return normalized;
 }
 
+async function parseCharX(file) {
+    const zip = await JSZip.loadAsync(file);
+
+    const cardFile = zip.file('card.json');
+    if (!cardFile) throw new Error("No card.json found in CharX archive");
+
+    const cardText = await cardFile.async('string');
+    const cardJson = JSON.parse(cardText);
+
+    const normalized = normalizeCharacterData(cardJson);
+
+    const embeddedAssets = Array.isArray(cardJson.data?.assets) ? cardJson.data.assets : [];
+
+    const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'webp', 'gif', 'apng', 'avif', 'bmp', 'jfif']);
+    const galleryItems = [];
+
+    for (const asset of embeddedAssets) {
+        if (!asset || asset.type === 'icon' || asset.type === 'user_icon') continue;
+
+        const ext = (asset.ext || '').toLowerCase();
+        if (!IMAGE_EXTS.has(ext)) continue;
+
+        const zipPath = getEmbeddedZipPath(asset.uri);
+        if (!zipPath) {
+            if (asset.uri && asset.uri.startsWith('data:image')) {
+                galleryItems.push({
+                    id: 'img_' + Math.random().toString(36).slice(2, 10),
+                    src: asset.uri,
+                    name: asset.name || '',
+                    thumbnail: null
+                });
+            }
+            continue;
+        }
+
+        const zippedFile = zip.file(zipPath);
+        if (!zippedFile) continue;
+
+        const blob = await zippedFile.async('blob');
+        const dataUrl = await blobToDataUrl(blob, ext);
+
+        galleryItems.push({
+            id: 'img_' + Math.random().toString(36).slice(2, 10),
+            src: dataUrl,
+            name: asset.name || '',
+            thumbnail: null
+        });
+    }
+
+    const iconAsset = embeddedAssets.find(a => a && (a.type === 'icon') && a.uri);
+    if (iconAsset) {
+        const iconPath = getEmbeddedZipPath(iconAsset.uri);
+        if (iconPath) {
+            const iconFile = zip.file(iconPath);
+            if (iconFile) {
+                const iconExt = (iconAsset.ext || 'png').toLowerCase();
+                const iconBlob = await iconFile.async('blob');
+                normalized.avatar = await blobToDataUrl(iconBlob, iconExt);
+            }
+        }
+    }
+
+    for (const img of galleryItems) {
+        try {
+            img.thumbnail = await generateThumbnail(img.src, 300);
+        } catch (_e) { /* skip */ }
+    }
+    normalized.images = galleryItems;
+
+    if (normalized.avatar) {
+        try {
+            const thumbs = await generateAllThumbnails(normalized.avatar);
+            normalized.thumbnail = thumbs.thumbnail;
+            normalized.mini_thumbnail = thumbs.mini_thumbnail;
+        } catch (e) {
+            console.error("Failed to generate thumbnails for CharX avatar:", e);
+        }
+    }
+
+    return normalized;
+}
+
+function getEmbeddedZipPath(uri) {
+    if (typeof uri !== 'string') return null;
+    const prefixes = ['embeded://', 'embedded://', '__asset:'];
+    for (const prefix of prefixes) {
+        if (uri.startsWith(prefix)) {
+            return uri.slice(prefix.length);
+        }
+    }
+    return null;
+}
+
+function blobToDataUrl(blob, ext) {
+    const mimeMap = { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', webp: 'image/webp', gif: 'image/gif', avif: 'image/avif', apng: 'image/apng', bmp: 'image/bmp', jfif: 'image/jpeg' };
+    const mime = mimeMap[ext] || 'image/png';
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(new File([blob], 'asset', { type: mime }));
+    });
+}
+
 function normalizeCharacterData(json) {
     let data;
     if ((json.spec === 'chara_card_v2' || json.spec === 'chara_card_v3') && json.data) {
@@ -225,7 +333,7 @@ function fileToBase64(file) {
 export function triggerCharacterImport(onImport) {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = '.json,application/json,.png,image/png'; // JSON and PNG
+    input.accept = '.json,application/json,.png,image/png,.charx,.zip';
 
     input.onchange = async (e) => {
         const file = e.target.files[0];

--- a/src/utils/characterIO.js
+++ b/src/utils/characterIO.js
@@ -7,6 +7,7 @@ import { currentLang } from '@/core/config/APPSettings.js';
 import { db } from '@/utils/db.js';
 import { logger } from './logger.js';
 import { generateThumbnail, generateAllThumbnails } from './thumbnailUtils.js';
+import { fileToDataUrl, blobToDataUrl } from './imageUtils.js';
 import { saveFile } from '../core/services/fileSaver.js';
 import { importSTLorebook } from '@/core/states/lorebookState.js';
 import { publishAppEvent } from '@/core/events/eventHub.js';
@@ -142,7 +143,7 @@ async function parsePng(file) {
     if (!charaData) throw new Error("No character data found in PNG (tEXt chunk 'chara' or 'ccv3')");
 
     // Convert the image to base64 for use as the avatar
-    const avatarBase64 = await fileToBase64(file);
+    const avatarBase64 = await fileToDataUrl(file);
     const normalized = normalizeCharacterData(charaData);
     normalized.avatar = avatarBase64; // Avatar from the file takes priority
 
@@ -292,17 +293,6 @@ function getEmbeddedZipPath(uri) {
     return null;
 }
 
-function blobToDataUrl(blob, ext) {
-    const mimeMap = { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', webp: 'image/webp', gif: 'image/gif', avif: 'image/avif', apng: 'image/apng', bmp: 'image/bmp', jfif: 'image/jpeg' };
-    const mime = mimeMap[ext] || 'image/png';
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result);
-        reader.onerror = reject;
-        reader.readAsDataURL(new File([blob], 'asset', { type: mime }));
-    });
-}
-
 function normalizeCharacterData(json) {
     let data;
     if ((json.spec === 'chara_card_v2' || json.spec === 'chara_card_v3') && json.data) {
@@ -356,15 +346,6 @@ export async function extractCharacterBook(charData) {
     delete charData.character_book;
 
     return lorebook;
-}
-
-function fileToBase64(file) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = () => resolve(reader.result);
-        reader.onerror = reject;
-        reader.readAsDataURL(file);
-    });
 }
 
 /**

--- a/src/utils/characterIO.js
+++ b/src/utils/characterIO.js
@@ -161,62 +161,93 @@ async function parsePng(file) {
 async function parseCharX(file) {
     const zip = await JSZip.loadAsync(file);
 
-    const cardFile = zip.file('card.json');
-    if (!cardFile) throw new Error("No card.json found in CharX archive");
-
-    const cardText = await cardFile.async('string');
-    const cardJson = JSON.parse(cardText);
-
-    const normalized = normalizeCharacterData(cardJson);
-
-    const embeddedAssets = Array.isArray(cardJson.data?.assets) ? cardJson.data.assets : [];
-
+    let normalized;
+    let cardJson;
     const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'webp', 'gif', 'apng', 'avif', 'bmp', 'jfif']);
-    const galleryItems = [];
 
-    for (const asset of embeddedAssets) {
-        if (!asset || asset.type === 'icon' || asset.type === 'user_icon') continue;
+    const cardFile = zip.file('card.json');
+    if (cardFile) {
+        const cardText = await cardFile.async('string');
+        cardJson = JSON.parse(cardText);
+        normalized = normalizeCharacterData(cardJson);
 
-        const ext = (asset.ext || '').toLowerCase();
-        if (!IMAGE_EXTS.has(ext)) continue;
-
-        const zipPath = getEmbeddedZipPath(asset.uri);
-        if (!zipPath) {
-            if (asset.uri && asset.uri.startsWith('data:image')) {
-                galleryItems.push({
-                    id: 'img_' + Math.random().toString(36).slice(2, 10),
-                    src: asset.uri,
-                    name: asset.name || '',
-                    thumbnail: null
-                });
+        const iconAsset = (cardJson.data?.assets || []).find(a => a && (a.type === 'icon') && a.uri);
+        if (iconAsset) {
+            const iconPath = getEmbeddedZipPath(iconAsset.uri);
+            if (iconPath) {
+                const iconFile = zip.file(iconPath);
+                if (iconFile) {
+                    const iconExt = (iconAsset.ext || 'png').toLowerCase();
+                    const iconBlob = await iconFile.async('blob');
+                    normalized.avatar = await blobToDataUrl(iconBlob, iconExt);
+                }
             }
-            continue;
         }
+    } else {
+        const pngEntry = Object.keys(zip.files).find(
+            f => f.toLowerCase().endsWith('.png') && !zip.files[f].dir
+        );
+        if (!pngEntry) throw new Error("No card.json or PNG found in archive");
 
-        const zippedFile = zip.file(zipPath);
-        if (!zippedFile) continue;
-
-        const blob = await zippedFile.async('blob');
-        const dataUrl = await blobToDataUrl(blob, ext);
-
-        galleryItems.push({
-            id: 'img_' + Math.random().toString(36).slice(2, 10),
-            src: dataUrl,
-            name: asset.name || '',
-            thumbnail: null
-        });
+        const pngBlob = await zip.file(pngEntry).async('blob');
+        const pngFile = new File([pngBlob], pngEntry, { type: 'image/png' });
+        normalized = await parsePng(pngFile);
+        cardJson = null;
     }
 
-    const iconAsset = embeddedAssets.find(a => a && (a.type === 'icon') && a.uri);
-    if (iconAsset) {
-        const iconPath = getEmbeddedZipPath(iconAsset.uri);
-        if (iconPath) {
-            const iconFile = zip.file(iconPath);
-            if (iconFile) {
-                const iconExt = (iconAsset.ext || 'png').toLowerCase();
-                const iconBlob = await iconFile.async('blob');
-                normalized.avatar = await blobToDataUrl(iconBlob, iconExt);
+    const embeddedAssets = cardJson?.data?.assets || [];
+    const galleryItems = [];
+
+    if (embeddedAssets.length > 0) {
+        for (const asset of embeddedAssets) {
+            if (!asset || asset.type === 'icon' || asset.type === 'user_icon') continue;
+
+            const ext = (asset.ext || '').toLowerCase();
+            if (!IMAGE_EXTS.has(ext)) continue;
+
+            const zipPath = getEmbeddedZipPath(asset.uri);
+            if (!zipPath) {
+                if (asset.uri && asset.uri.startsWith('data:image')) {
+                    galleryItems.push({
+                        id: 'img_' + Math.random().toString(36).slice(2, 10),
+                        src: asset.uri,
+                        name: asset.name || '',
+                        thumbnail: null
+                    });
+                }
+                continue;
             }
+
+            const zippedFile = zip.file(zipPath);
+            if (!zippedFile) continue;
+
+            const blob = await zippedFile.async('blob');
+            const dataUrl = await blobToDataUrl(blob, ext);
+
+            galleryItems.push({
+                id: 'img_' + Math.random().toString(36).slice(2, 10),
+                src: dataUrl,
+                name: asset.name || '',
+                thumbnail: null
+            });
+        }
+    } else {
+        const imageFiles = Object.keys(zip.files).filter(f => {
+            if (zip.files[f].dir) return false;
+            const ext = f.split('.').pop().toLowerCase();
+            return IMAGE_EXTS.has(ext) && f !== Object.keys(zip.files).find(p => p.toLowerCase().endsWith('.png'));
+        });
+
+        for (const imgPath of imageFiles) {
+            const ext = imgPath.split('.').pop().toLowerCase();
+            const blob = await zip.file(imgPath).async('blob');
+            const dataUrl = await blobToDataUrl(blob, ext);
+            galleryItems.push({
+                id: 'img_' + Math.random().toString(36).slice(2, 10),
+                src: dataUrl,
+                name: imgPath.split('/').pop().replace(/\.[^.]+$/, ''),
+                thumbnail: null
+            });
         }
     }
 
@@ -608,4 +639,68 @@ export async function exportCharacterAsV2Png(character) {
 
     const blob = new Blob([resultPng], { type: 'image/png' });
     await saveFile(fileName, blob, 'image/png', 'characters');
+}
+
+export async function exportCharacterAsCharX(character) {
+    const zip = new JSZip();
+    const v3Data = prepareV3Data(character);
+    const finalAssets = [];
+
+    if (character.avatar) {
+        try {
+            const avatarData = await dataUrlToBinary(character.avatar);
+            const avatarExt = guessImageExt(character.avatar, 'png');
+            zip.file(`icon.${avatarExt}`, avatarData);
+            finalAssets.push({
+                type: 'icon',
+                name: 'main',
+                uri: `embedded://icon.${avatarExt}`,
+                ext: avatarExt
+            });
+        } catch (_e) { /* skip avatar in charx */ }
+    }
+
+    if (Array.isArray(character.images)) {
+        for (let i = 0; i < character.images.length; i++) {
+            const img = character.images[i];
+            if (!img.src) continue;
+            try {
+                const imgData = await dataUrlToBinary(img.src);
+                const imgExt = guessImageExt(img.src, 'png');
+                const imgName = sanitizeAssetName(img.name || `image_${i + 1}`);
+                const zipPath = `images/${imgName}.${imgExt}`;
+                zip.file(zipPath, imgData);
+                finalAssets.push({
+                    type: 'custom',
+                    name: imgName,
+                    uri: `embedded://${zipPath}`,
+                    ext: imgExt
+                });
+            } catch (_e) { /* skip broken image */ }
+        }
+    }
+
+    v3Data.assets = finalAssets;
+    zip.file('card.json', JSON.stringify(v3Data, null, 2));
+
+    const fileName = `${(character.name || 'character').replace(/[/\\?%*:|"<>]/g, '-')}.charx`;
+    const content = await zip.generateAsync({ type: 'blob', compression: 'DEFLATE' });
+    await saveFile(fileName, content, 'application/zip', 'characters');
+}
+
+async function dataUrlToBinary(dataUrl) {
+    const res = await fetch(dataUrl);
+    return await res.arrayBuffer();
+}
+
+function guessImageExt(dataUrl, fallback) {
+    const match = dataUrl.match(/^data:image\/(\w+)/);
+    if (!match) return fallback;
+    const raw = match[1].toLowerCase();
+    if (raw === 'jpeg') return 'jpg';
+    return raw;
+}
+
+function sanitizeAssetName(name) {
+    return name.replace(/[/\\?%*:|"<>]/g, '_').replace(/\s+/g, '_').substring(0, 64) || 'image';
 }

--- a/src/utils/characterIO.js
+++ b/src/utils/characterIO.js
@@ -324,7 +324,7 @@ function normalizeCharacterData(json) {
 
     if (Array.isArray(data.assets) && data.assets.length > 0) {
         data.images = data.assets
-            .filter(a => a.type === 'icon' || a.type === 'custom' || !a.type)
+            .filter(a => a.type !== 'icon' && a.type !== 'user_icon')
             .filter(a => a.uri && (a.uri.startsWith('data:image') || a.uri.startsWith('http')))
             .map(a => ({
                 id: 'img_' + Math.random().toString(36).slice(2, 10),

--- a/src/utils/characterIO.js
+++ b/src/utils/characterIO.js
@@ -651,7 +651,7 @@ export async function exportCharacterAsV2Png(character) {
     await saveFile(fileName, blob, 'image/png', 'characters');
 }
 
-export async function exportCharacterAsCharX(character) {
+export async function exportCharacterAsCharX(character, useZipExt = false) {
     const zip = new JSZip();
     const v3Data = prepareV3Data(character);
     const finalAssets = [];
@@ -693,7 +693,7 @@ export async function exportCharacterAsCharX(character) {
     v3Data.assets = finalAssets;
     zip.file('card.json', JSON.stringify(v3Data, null, 2));
 
-    const fileName = `${(character.name || 'character').replace(/[/\\?%*:|"<>]/g, '-')}.charx`;
+    const fileName = `${(character.name || 'character').replace(/[/\\?%*:|"<>]/g, '-')}.${useZipExt ? 'zip' : 'charx'}`;
     const content = await zip.generateAsync({ type: 'blob', compression: 'DEFLATE' });
     await saveFile(fileName, content, 'application/zip', 'characters');
 }

--- a/src/utils/characterIO.js
+++ b/src/utils/characterIO.js
@@ -51,6 +51,17 @@ function parseJson(file) {
                         console.error('Failed to generate thumbnail from JSON', e);
                     }
                 }
+                if (Array.isArray(normalized.images) && normalized.images.length > 0) {
+                    for (const img of normalized.images) {
+                        if (!img.thumbnail && img.src) {
+                            try {
+                                img.thumbnail = await generateThumbnail(img.src, 300);
+                            } catch (e) {
+                                console.warn('Failed to generate thumbnail for gallery image:', e);
+                            }
+                        }
+                    }
+                }
                 resolve(normalized);
             } catch (err) {
                 reject(new Error("JSON read error: " + err.message));
@@ -129,6 +140,17 @@ async function parsePng(file) {
         console.error("Failed to generate thumbnails for PNG:", e);
     }
 
+    if (Array.isArray(normalized.images) && normalized.images.length > 0) {
+        for (const img of normalized.images) {
+            try {
+                const thumb = await generateThumbnail(img.src, 300);
+                img.thumbnail = thumb;
+            } catch (e) {
+                console.warn('Failed to generate thumbnail for gallery image:', e);
+            }
+        }
+    }
+
     return normalized;
 }
 
@@ -147,10 +169,27 @@ function normalizeCharacterData(json) {
         data.name = "Unknown";
     }
 
-    // No avatar — set null so the placeholder is shown (see .avatar-placeholder in components.css)
     if (!data.avatar || data.avatar === 'none') {
         data.avatar = null;
     }
+
+    if (Array.isArray(data.assets) && data.assets.length > 0) {
+        data.images = data.assets
+            .filter(a => a.type === 'icon' || a.type === 'custom' || !a.type)
+            .filter(a => a.uri && (a.uri.startsWith('data:image') || a.uri.startsWith('http')))
+            .map(a => ({
+                id: 'img_' + Math.random().toString(36).slice(2, 10),
+                src: a.uri,
+                name: a.name || '',
+                thumbnail: null
+            }));
+    }
+    delete data.assets;
+
+    if (!Array.isArray(data.images)) {
+        data.images = [];
+    }
+
     return data;
 }
 
@@ -272,22 +311,19 @@ export async function generateMissingThumbnails() {
 function prepareV2Data(character, excludeAvatar = false) {
     const data = JSON.parse(JSON.stringify(character));
 
-    // Remove internal IDs and Glaze-specific fields if present
     delete data.id;
     delete data.sessionId;
     delete data.color;
     delete data.thumbnail;
+    delete data.mini_thumbnail;
+    delete data.images;
 
     if (excludeAvatar) {
         delete data.avatar;
     }
 
-    // character_book is excluded from export; extensions is kept as an empty object
-    // because SillyTavern may require it to be present
     delete data.character_book;
 
-    // Ensure all required V2 spec fields are present (SillyTavern)
-    // Field order follows Alice.json
     const exportData = {
         name: data.name || "",
         first_mes: data.first_mes || "",
@@ -305,21 +341,42 @@ function prepareV2Data(character, excludeAvatar = false) {
         extensions: {}
     };
 
-    // Include avatar only if not excluded
     if (!excludeAvatar && data.avatar) {
         exportData.avatar = data.avatar;
     }
 
-    // Remove undefined fields
     Object.keys(exportData).forEach(key => {
         if (exportData[key] === undefined) delete exportData[key];
     });
 
-    // Field order matters (Alice.json): data comes before spec
     return {
         data: exportData,
         spec: "chara_card_v2",
         spec_version: "2.0"
+    };
+}
+
+function prepareV3Data(character) {
+    const v2 = prepareV2Data(character, true);
+    const v3Data = { ...v2.data };
+
+    if (Array.isArray(character.images) && character.images.length > 0) {
+        v3Data.assets = character.images.map(img => ({
+            type: 'custom',
+            name: img.name || '',
+            uri: img.src,
+            ext: img.src.startsWith('data:image/png') ? 'png'
+                : img.src.startsWith('data:image/jpeg') || img.src.startsWith('data:image/jpg') ? 'jpg'
+                : img.src.startsWith('data:image/webp') ? 'webp' : 'png'
+        }));
+    } else {
+        v3Data.assets = [];
+    }
+
+    return {
+        data: v3Data,
+        spec: "chara_card_v3",
+        spec_version: "3.0"
     };
 }
 
@@ -360,7 +417,8 @@ function crc32(data) {
  * Export a character as a PNG with embedded character data.
  */
 export async function exportCharacterAsV2Png(character) {
-    const v2Data = prepareV2Data(character);
+    const hasGallery = Array.isArray(character.images) && character.images.length > 0;
+    const cardData = hasGallery ? prepareV3Data(character) : prepareV2Data(character);
     const fileName = `${(character.name || 'character').replace(/[/\\?%*:|"<>]/g, '-')}.png`;
 
     // 1. Get the base image
@@ -405,8 +463,8 @@ export async function exportCharacterAsV2Png(character) {
 
     // 2. Prepare the tEXt chunk data
     // tEXt format: Keyword + null byte + Text
-    const keyword = "chara";
-    const textData = btoa(unescape(encodeURIComponent(JSON.stringify(v2Data)))); // Base64-encoded UTF-8 string
+    const keyword = hasGallery ? "ccv3" : "chara";
+    const textData = btoa(unescape(encodeURIComponent(JSON.stringify(cardData)))); // Base64-encoded UTF-8 string
 
     const encoder = new TextEncoder();
     const keywordBytes = encoder.encode(keyword);

--- a/src/utils/characterIO.js
+++ b/src/utils/characterIO.js
@@ -23,12 +23,22 @@ import JSZip from 'jszip';
 export async function parseCharacterCard(file) {
     const name = file.name.toLowerCase();
     if (name.endsWith('.charx') || name.endsWith('.zip')) {
+        const isRar = await detectRar(file);
+        if (isRar) {
+            throw new Error("RAR archives are not supported. Please re-save the archive as ZIP (.charx) and try again.");
+        }
         return await parseCharX(file);
     }
     if (file.type === 'image/png' || name.endsWith('.png')) {
         return await parsePng(file);
     }
     return await parseJson(file);
+}
+
+async function detectRar(file) {
+    const header = await file.slice(0, 7).arrayBuffer();
+    const sig = new Uint8Array(header);
+    return sig[0] === 0x52 && sig[1] === 0x61 && sig[2] === 0x72 && sig[3] === 0x21;
 }
 
 function parseJson(file) {

--- a/src/utils/imageUtils.js
+++ b/src/utils/imageUtils.js
@@ -1,0 +1,24 @@
+export function fileToDataUrl(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}
+
+const MIME_MAP = {
+    png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
+    webp: 'image/webp', gif: 'image/gif', avif: 'image/avif',
+    apng: 'image/apng', bmp: 'image/bmp', jfif: 'image/jpeg'
+};
+
+export function blobToDataUrl(blob, ext) {
+    const mime = MIME_MAP[ext] || 'image/png';
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(new File([blob], 'asset', { type: mime }));
+    });
+}


### PR DESCRIPTION
## Summary

- **Fix empty message on immediate abort**: Pipeline loop broke silently without calling `onError` when `controller.signal.aborted` was true before HTTP request started. All early abort paths now call `onError(AbortError)` with `userAborted` propagated from controller. `handleGenerationError` now treats ALL `AbortError` as silent cleanup (no error toast), not just those with `userAborted` flag.
- **Fix desktop model dropdown not scrollable**: `DesktopDropdown.vue` `.dd-panel` had `overflow:hidden` with no max-height, clipping all items beyond viewport. Added scrollable `.dd-items-scroll` container with `MAX_VISIBLE_ITEMS` cap for position calculation.
- **Character gallery tab**: V3 assets support, CharX/ZIP import-export, gallery composable, imageUtils dedup (from linear chain branch `feat/character-gallery` #91)
- **Race conditions, sheet bloat, code duplication fixes** (from linear chain)

## Changed files

| File | Change |
|------|--------|
| `postPromptOrchestrator.js` | `onError(AbortError)` after pipeline break with `userAborted` propagation |
| `steps.js` | Early abort in `stepRequestExecution` propagates `userAborted` |
| `chatRequestAssembly.js` | Early abort propagates `userAborted` from controller |
| `chatPreparedPromptExecution.js` | Early abort propagates `userAborted` from controller |
| `useGenerationErrorHandler.js` | All `AbortError` - silent cleanup (not just `userAborted`) |
| `DesktopDropdown.vue` | Scrollable items container, `max-height`, position capping |
| `generation.md`, `INVARIANTS.md` | Documented abort pipeline propagation and silent cleanup |

## Invariant compliance

- **INV-C2**: `clearGenerationState` called on every exit path via `finalizeGenerationState`
- **INV-A1**: Abort propagates through all layers (pipeline loop + early checks)
- **INV-A4**: All `AbortError` - `restoreState(false)` (no error toast)
- **Abort delegation**: `useGenerationAbort` does not call `clearGenerationState` directly
