### PR TITLE
fix: fallback to default reasoning tags in edit mode

### DIFF
--- a/src/composables/chat/useMessageActions.js
+++ b/src/composables/chat/useMessageActions.js
@@ -344,6 +344,12 @@ export function useMessageActions(deps) {
         showBottomSheet({ title: t('sheet_title_msg_actions'), items });
     }
 
+    function getReasoningTagsForEdit() {
+        const tags = getReasoningTags();
+        if (tags.start && tags.end) return tags;
+        return getApiReasoningTags();
+    }
+
     function enterEditMode(msg) {
         msg._iigMap = msg._iigMap || {};
         const { text, map } = prepareEditText(msg?.text || '', msg._iigMap);
@@ -351,7 +357,7 @@ export function useMessageActions(deps) {
 
         let editBody = text;
         if (msg.reasoning) {
-            const { start: tagStart, end: tagEnd } = getReasoningTags();
+            const { start: tagStart, end: tagEnd } = getReasoningTagsForEdit();
             editBody = tagStart + msg.reasoning + tagEnd + '\n' + text;
         }
 
@@ -383,7 +389,7 @@ export function useMessageActions(deps) {
 
         let newReasoning = null;
 
-        const { start: tagStart, end: tagEnd } = getReasoningTags();
+        const { start: tagStart, end: tagEnd } = getReasoningTagsForEdit();
 
         if (tagStart && tagEnd) {
             const startIndex = newText.indexOf(tagStart);


### PR DESCRIPTION
## Summary
- Fix reasoning block edit mode losing reasoning when custom tags are empty (common for native reasoning models like DeepSeek/o3)
- When `getReasoningTags()` returns empty start/end, `enterEditMode` now falls back to `getApiReasoningTags()` defaults so reasoning is properly wrapped in tags and `saveEdit` can parse them back out
- Fix Rule 3 violation: `saveCurrentMessages` in `useContextCutoff.js` used read-mutate-write (`getChatData` → mutate → `saveChat`) which races on concurrent writes. Now uses `patchChatData` which serializes via `queueDbWrite`

## Test plan
- [ ] Edit a message that has a reasoning block (native reasoning model) — verify reasoning appears in the edit textarea wrapped in tags
- [ ] Save the edit without changes — verify reasoning is preserved
- [ ] Edit reasoning text and save — verify updated reasoning is stored
- [ ] Test with custom reasoning tags configured in preset — verify custom tags are used
- [ ] Test with empty reasoning tags in preset — verify fallback to default tags
- [ ] Hide/unhide messages in tokenizer — verify changes persist without data loss
