### PR TITLE
fix: use patchChatData in saveCurrentMessages

### DIFF
--- a/src/composables/chat/useContextCutoff.js
+++ b/src/composables/chat/useContextCutoff.js
@@ -49,11 +49,11 @@ export function useContextCutoff({
     async function saveCurrentMessages() {
         const activeChatChar = getActiveChatChar();
         if (!activeChatChar) return;
-        const data = await getChatData(activeChatChar.id);
-        if (!data) return;
-        const sessionId = activeChatChar.sessionId || data.currentId;
-        data.sessions[sessionId] = currentMessages.value;
-        await db.saveChat(activeChatChar.id, data);
+        await db.patchChatData(activeChatChar.id, (data) => {
+            if (!data) return;
+            const sessionId = activeChatChar.sessionId || data.currentId;
+            data.sessions[sessionId] = currentMessages.value;
+        });
     }
 
     async function updateContextCutoff() {


### PR DESCRIPTION
## Summary
Rule 3 violation: \saveCurrentMessages\ in \useContextCutoff.js\ used read-mutate-write (\getChatData\ → mutate → \saveChat\) which races on concurrent writes. Now uses \patchChatData\ which serializes via \queueDbWrite\.

## Test plan
- [ ] Hide/unhide messages in tokenizer — verify changes persist without data loss
- [ ] Switch chats rapidly while hiding/unhiding — verify no data corruption