### PR TITLE
fix: token count prompt-only regex accuracy + mobile selection auto-scroll

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,6 +101,11 @@ src/
 - `estimateTokens(text)` — Uses GPTTokenizer with base64 media stripping
 - Stripping prevents embedded images from inflating token counts
 
+**Token Count in ChatMessage.vue:**
+- `tokenCount` computed always applies `applyRegexes(..., ephemerality=2)` (prompt-only) to the message text before estimating
+- This ensures the displayed per-message token count accounts for regex stripping that will happen during actual prompt building
+- Previously conditioned on `combinedMessageData.regexes` which only contained ephemerality=1 (both) regexes, missing prompt-only stripping
+
 **Context Calculation (`generationWorker.js`):**
 - `calculateContext()` — Computes token breakdown by source:
   - `character` — Character card content
@@ -667,6 +672,7 @@ Composable directory listing and per-phase decomposition details: `docs/refactor
 **UI Composables:**
 - `src/composables/ui/useSidebarResizer.js` — desktop sidebar resize logic
 - `src/composables/ui/useSheetGestures.js` — sheet gesture handling
+- `src/composables/chat/useSelectionAutoScroll.js` — mobile text selection auto-scroll near viewport edges, uses `isProgrammaticScrolling` guard to avoid `pointer-events: none` on messages during scroll
 
 ---
 

--- a/src/components/chat/ChatMessage.vue
+++ b/src/components/chat/ChatMessage.vue
@@ -220,12 +220,10 @@ const tokenCount = computed(() => {
     if (raw === 0) return 0;
     const text = props.message.text;
     if (!text) return raw;
-    const regexes = combinedMessageData.value.regexes;
-    const hasRegexStripped = regexes && regexes.length > 0;
-    if (!hasRegexStripped) return raw;
-    const macroed = replaceMacros(text, props.activeChatChar, getEffectivePersona(props.activeChatChar?.id, props.activeChatChar?.sessionId));
+    const effPersona = getEffectivePersona(props.activeChatChar?.id, props.activeChatChar?.sessionId);
+    const macroed = replaceMacros(text, props.activeChatChar, effPersona);
     const depth = props.totalMessages > 0 ? props.totalMessages - 1 - props.index : undefined;
-    const stripped = applyRegexes(macroed, props.message.role === 'user' ? 1 : 2, 2, { charId: props.activeChatChar?.id, sessionId: props.activeChatChar?.sessionId, char: props.activeChatChar, persona: getEffectivePersona(props.activeChatChar?.id, props.activeChatChar?.sessionId), depth });
+    const stripped = applyRegexes(macroed, props.message.role === 'user' ? 1 : 2, 2, { charId: props.activeChatChar?.id, sessionId: props.activeChatChar?.sessionId, char: props.activeChatChar, persona: effPersona, depth });
     if (stripped === macroed) return raw;
     return estimateTokens(stripped);
 });

--- a/src/composables/chat/useSelectionAutoScroll.js
+++ b/src/composables/chat/useSelectionAutoScroll.js
@@ -1,0 +1,92 @@
+import { onMounted, onBeforeUnmount } from 'vue';
+
+const EDGE_ZONE = 50;
+const SCROLL_SPEED = 8;
+const SCROLL_INTERVAL = 16;
+
+export function useSelectionAutoScroll(containerRef, isProgrammaticScrolling) {
+    let scrollTimer = null;
+    let isActive = false;
+
+    function startScroll(direction) {
+        stopScroll();
+        if (isProgrammaticScrolling?.value !== undefined) {
+            isProgrammaticScrolling.value = true;
+        }
+        scrollTimer = setInterval(() => {
+            const el = containerRef.value;
+            if (!el) return;
+            el.scrollTop += direction * SCROLL_SPEED;
+        }, SCROLL_INTERVAL);
+    }
+
+    function stopScroll() {
+        if (scrollTimer) {
+            clearInterval(scrollTimer);
+            scrollTimer = null;
+        }
+        if (isProgrammaticScrolling?.value !== undefined) {
+            isProgrammaticScrolling.value = false;
+        }
+    }
+
+    function onTouchMove(e) {
+        if (!isActive) return;
+
+        const touch = e.touches?.[0];
+        if (!touch) return;
+
+        const el = containerRef.value;
+        if (!el) return;
+
+        const rect = el.getBoundingClientRect();
+        const relY = touch.clientY - rect.top;
+        const height = rect.height;
+
+        if (relY < EDGE_ZONE) {
+            const factor = 1 - relY / EDGE_ZONE;
+            startScroll(-SCROLL_SPEED * factor);
+        } else if (relY > height - EDGE_ZONE) {
+            const factor = 1 - (height - relY) / EDGE_ZONE;
+            startScroll(SCROLL_SPEED * factor);
+        } else {
+            stopScroll();
+        }
+    }
+
+    function onTouchEnd() {
+        isActive = false;
+        stopScroll();
+    }
+
+    function onSelectionChange() {
+        const sel = window.getSelection();
+        if (sel && sel.toString().trim().length > 0) {
+            isActive = true;
+        } else {
+            isActive = false;
+            stopScroll();
+        }
+    }
+
+    onMounted(() => {
+        document.addEventListener('selectionchange', onSelectionChange, { passive: true });
+        document.addEventListener('touchend', onTouchEnd, { passive: true });
+        document.addEventListener('touchcancel', onTouchEnd, { passive: true });
+        const el = containerRef.value;
+        if (el) {
+            el.addEventListener('touchmove', onTouchMove, { passive: true });
+        }
+    });
+
+    onBeforeUnmount(() => {
+        stopScroll();
+        document.removeEventListener('selectionchange', onSelectionChange);
+        document.removeEventListener('touchend', onTouchEnd);
+        document.removeEventListener('touchcancel', onTouchEnd);
+        const el = containerRef.value;
+        if (el) {
+            el.removeEventListener('touchmove', onTouchMove);
+        }
+    });
+}

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -60,6 +60,7 @@ import { createNewSession as dbCreateSession, deleteSession as dbDeleteSession, 
 import { lorebookState, getActiveLorebooksForContext } from '@/core/states/lorebookState.js';
 import { presetState, getEffectivePreset, getEffectivePresetId } from '@/core/states/presetState.js';
 import { useVirtualScroll } from '@/composables/chat/useVirtualScroll.js';
+import { useSelectionAutoScroll } from '@/composables/chat/useSelectionAutoScroll.js';
 import { useGenerationRegistry } from '@/composables/chat/useGenerationRegistry.js';
 import { useTypingStateCleanup } from '@/composables/chat/useTypingStateCleanup.js';
 import { useSidebarResizer } from '@/composables/ui/useSidebarResizer.js';
@@ -452,6 +453,8 @@ const { visibleItems, paddingTop, paddingBottom, refresh: refreshVirtualScroll, 
     buffer: isBatterySaverUI.value ? 28 : 75,
     estimateHeight: 100
 });
+
+useSelectionAutoScroll(messagesContainer, isProgrammaticScrolling);
 
 const {
     asyncSaveCurrentSessionState,


### PR DESCRIPTION
## Summary

- **Token count fix**: tokenCount computed in ChatMessage.vue now always applies applyRegexes with ephemerality=2 (prompt-only) instead of conditioning on combinedMessageData.regexes which only contained ephemerality=1 (both) entries. This makes displayed per-message token counts accurately reflect text that will be stripped during actual prompt building.

- **Mobile selection auto-scroll**: New useSelectionAutoScroll.js composable (~80 lines). When user drags text selection handles near the viewport edge on mobile, the chat container auto-scrolls. Uses isProgrammaticScrolling guard from useVirtualScroll to prevent pointer-events:none from killing the selection handles during programmatic scroll.

## Files changed

| File | Change |
|------|--------|
| src/components/chat/ChatMessage.vue | Removed conditional regex gate in tokenCount; always apply prompt-only regexes |
| src/composables/chat/useSelectionAutoScroll.js | New composable - selection auto-scroll with isProgrammaticScrolling guard |
| src/views/ChatView.vue | Wire useSelectionAutoScroll(messagesContainer, isProgrammaticScrolling) |
| ARCHITECTURE.md | Document useSelectionAutoScroll and token count regex fix |