### PR TITLE
fix: summary deletion race, stale context cutoff, memory key extraction, embedding crash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ git checkout -b feat/memorybook-ui feat/multi-vector
 | `feat/character-gallery` | Character gallery tab, CharX/ZIP import-export, gallery composable, imageUtils dedup | #91 |
 | `fix/abort-empty-message-and-dropdown-scroll` | Abort pipeline onError propagation, desktop dropdown scroll (linear chain from feat/character-gallery) | Not yet |
 | `fix/preset-stackoverflow-and-chat-perf` | Preset token consistency, persona breakdown, stack overflow & chat perf (linear chain from fix/abort-empty-message-and-dropdown-scroll) | Not yet |
+| `fix/summary-deletion-and-context-cutoff` | Prevent summary object destruction by asyncSave/onVisibilityChange, invalidate context cache on context limit change | Not yet |
 
 ### Historical (merged & deleted)
 - `feat/refactor-phase1-event-hub` → merged into `feat/chat-persistence-and-reasoning-fixes`, then upstream/dev

--- a/src/composables/chat/useMemoryBooks.js
+++ b/src/composables/chat/useMemoryBooks.js
@@ -522,8 +522,20 @@ export function useMemoryBooks(deps) {
         reconcileSessionMemoryState(chatData, sessionId, currentMessages);
         chatData.sessions[sessionId] = currentMessages;
         await db.saveChat(activeChatChar.id, chatData);
-        await indexMemoryEntryIfNeeded(approvedEntry, activeChatChar.id, sessionId);
-        
+        try {
+            await indexMemoryEntryIfNeeded(approvedEntry, activeChatChar.id, sessionId);
+        } catch (e) {
+            console.warn('[memory] Embedding index failed for approved draft:', e?.message || e);
+            if (approvedEntry.vectorSearch) {
+                approvedEntry.vectorSearch = false;
+                await db.patchChatData(activeChatChar.id, (data) => {
+                    const mb = data.memoryBooks?.[sessionId];
+                    const entry = mb?.entries?.find(en => en.id === approvedEntry.id);
+                    if (entry) entry.vectorSearch = false;
+                });
+            }
+        }
+
         await updatePendingMemoryMessageIds(activeChatChar);
         await loadCurrentMemoryBook(activeChatChar);
         setTimeout(() => memoryBooksSheet.value?.open(), 50);

--- a/src/composables/chat/useSessionPersistence.js
+++ b/src/composables/chat/useSessionPersistence.js
@@ -92,7 +92,15 @@ export function useSessionPersistence({
                 }
                 if (charContext.summary !== undefined) {
                     if (!data.summaries) data.summaries = {};
-                    data.summaries[sessionId] = charContext.summary;
+                    let currentSum = data.summaries[sessionId];
+                    if (typeof currentSum === 'string') {
+                        currentSum = { content: currentSum, depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    } else if (!currentSum) {
+                        currentSum = { content: '', depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    }
+                    if (currentSum.content !== charContext.summary) {
+                        data.summaries[sessionId] = { ...currentSum, content: charContext.summary };
+                    }
                 }
             });
             savePromise.then(() => clearCrashBuffer(charContext.id, sessionId)).catch(() => {});
@@ -155,7 +163,15 @@ export function useSessionPersistence({
                 }
                 if (summary !== undefined) {
                     if (!data.summaries) data.summaries = {};
-                    data.summaries[sessionId] = summary;
+                    let currentSum = data.summaries[sessionId];
+                    if (typeof currentSum === 'string') {
+                        currentSum = { content: currentSum, depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    } else if (!currentSum) {
+                        currentSum = { content: '', depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    }
+                    if (currentSum.content !== summary) {
+                        data.summaries[sessionId] = { ...currentSum, content: summary };
+                    }
                 }
             });
             savePromise.then(() => clearCrashBuffer(charId, sessionId)).catch(() => {});

--- a/src/core/services/memoryBooksService.js
+++ b/src/core/services/memoryBooksService.js
@@ -469,12 +469,17 @@ export function parseMemoryDraftResponse(rawText, fallbackKeys = []) {
 
     for (const line of lines) {
         const trimmed = line.trim();
-        
-        if (trimmed.startsWith('TITLE:')) {
-            title = trimmed.substring(6).trim();
-        } else if (trimmed.startsWith('KEYS:')) {
-            const keyString = trimmed.substring(5).trim();
+        const upperTrimmed = trimmed.toUpperCase();
+
+        if (upperTrimmed.startsWith('TITLE:')) {
+            title = trimmed.substring(trimmed.indexOf(':') + 1).trim();
+        } else if (upperTrimmed.startsWith('KEYS:')) {
+            const keyString = trimmed.substring(trimmed.indexOf(':') + 1).trim();
             keys = parseMemoryKeyInput(keyString);
+        } else if (upperTrimmed.startsWith('MEMORY:')) {
+            inContent = true;
+            const rest = trimmed.substring(trimmed.indexOf(':') + 1).trim();
+            if (rest) content = rest;
         } else if (trimmed === 'CONTENT:') {
             inContent = true;
         } else if (inContent && trimmed) {
@@ -482,7 +487,6 @@ export function parseMemoryDraftResponse(rawText, fallbackKeys = []) {
         }
     }
 
-    // Fallback to raw text if parsing failed
     if (!content && rawText.length > 20) {
         content = rawText;
     }

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -1432,7 +1432,7 @@ onMounted(() => {
     unsubChatSearchToggle = subscribeAppEvent(APP_EVENTS.ui.chatSearchToggle, ({ detail }) => onChatSearchToggle({ detail }));
     unsubRegexChanged = subscribeAppEvent(APP_EVENTS.domain.lorebook.regexScriptsChanged, onRegexChanged);
     unsubChatSearch = subscribeAppEvent(APP_EVENTS.ui.chatSearch, ({ detail }) => onChatSearch({ detail }));
-    unsubApiContextChanged = subscribeAppEvent(APP_EVENTS.domain.settings.apiContextChanged, updateContextCutoff);
+    unsubApiContextChanged = subscribeAppEvent(APP_EVENTS.domain.settings.apiContextChanged, () => { invalidateContextCache(); updateContextCutoff(); });
     unsubSettingsChanged = subscribeAppEvent(APP_EVENTS.domain.settings.changed, restartVisibleGenerationTimers);
     unsubSyncDataRefreshed = subscribeAppEvent(APP_EVENTS.domain.sync.dataRefreshed, () => loadChats());
 });


### PR DESCRIPTION
## Summary

- **Summary keeps deleting**: `asyncSaveCurrentSessionState` and `onVisibilityChange` in `useSessionPersistence.js` were writing `charContext.summary` (a plain string) directly into `data.summaries[sessionId]`, overwriting the full object `{ content, depth, role, insertion_mode, prefix }`. The `activeChar` watcher correctly preserved the object structure, but the other two paths would race and destroy it. Now all paths use read-preserve-write.

- **Context cutoff separator not updating**: `apiContextChanged` handler called `updateContextCutoff` without invalidating the cache first. Now invalidates cache before recalculating.

- **Memory keys not extracted from LLM response**: `parseMemoryDraftResponse` checked for uppercase `KEYS:`/`TITLE:` but prompts instruct models to output `Keys:`/`Memory:`. Made matching case-insensitive and added `Memory:` as content start marker.

- **Embedding crash on draft approve**: `indexMemoryEntryIfNeeded` was unguarded — if embedding API was unavailable, the entire approve flow crashed and the entry was left with `vectorSearch: true` but no actual embedding. Now wrapped in try-catch with `vectorSearch` reset to `false` on failure.

## Changes

- `useSessionPersistence.js`: Both `asyncSaveCurrentSessionState` and `onVisibilityChange` now preserve summary object structure instead of overwriting with string
- `ChatView.vue`: `apiContextChanged` handler now calls `invalidateContextCache()` before `updateContextCutoff()`
- `memoryBooksService.js`: `parseMemoryDraftResponse` — case-insensitive matching for `KEYS:`/`TITLE:`/`MEMORY:`, added `Memory:` as content start marker
- `useMemoryBooks.js`: `indexMemoryEntryIfNeeded` wrapped in try-catch; on failure, `vectorSearch` reset to `false` via `db.patchChatData`

## Testing

- [ ] Manual: Edit summary, switch tabs (triggers `onVisibilityChange`), verify summary metadata (depth, role, prefix) is preserved after reload
- [ ] Manual: Change context size in API settings, verify "Context Limit" separator updates correctly
- [ ] Manual: Generate memory draft, verify keys are extracted (check entry in memory book editor)
- [ ] Manual: Approve memory draft with embedding API misconfigured, verify entry is approved with `vectorSearch: false` and no crash
