### PR TITLE
fix: Author's Note persistence + regex conversion + mergePrompts regex gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ git checkout -b feat/memorybook-ui feat/multi-vector
 | `feat/character-gallery` | Character gallery tab, CharX/ZIP import-export, gallery composable, imageUtils dedup | #91 |
 | `fix/abort-empty-message-and-dropdown-scroll` | Abort pipeline onError propagation, desktop dropdown scroll (linear chain from feat/character-gallery) | Not yet |
 | `fix/preset-stackoverflow-and-chat-perf` | Preset token consistency, persona breakdown, stack overflow & chat perf (linear chain from fix/abort-empty-message-and-dropdown-scroll) | Not yet |
+| `fix/summary-deletion-and-context-cutoff` | Prevent summary object destruction by asyncSave/onVisibilityChange, invalidate context cache on context limit change | Not yet |
 
 ### Historical (merged & deleted)
 - `feat/refactor-phase1-event-hub` → merged into `feat/chat-persistence-and-reasoning-fixes`, then upstream/dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ git checkout -b feat/memorybook-ui feat/multi-vector
 | `fix/abort-empty-message-and-dropdown-scroll` | Abort pipeline onError propagation, desktop dropdown scroll (linear chain from feat/character-gallery) | Not yet |
 | `fix/preset-stackoverflow-and-chat-perf` | Preset token consistency, persona breakdown, stack overflow & chat perf (linear chain from fix/abort-empty-message-and-dropdown-scroll) | Not yet |
 | `fix/summary-deletion-and-context-cutoff` | Prevent summary object destruction by asyncSave/onVisibilityChange, invalidate context cache on context limit change | Not yet |
+| `fix/authornote-regex-prompt` | findRegex→regex conversion, mergePrompts regex gap, AN save on chat switch, context cache AN invalidation, native appState AN/summary save (linear chain from fix/summary-deletion-and-context-cutoff) | Not yet |
 
 ### Historical (merged & deleted)
 - `feat/refactor-phase1-event-hub` → merged into `feat/chat-persistence-and-reasoning-fixes`, then upstream/dev

--- a/src/components/sheets/RegexSheet.vue
+++ b/src/components/sheets/RegexSheet.vue
@@ -222,11 +222,11 @@ async function handleFileSelect(event) {
             const regex = item.findRegex || item.regex || '';
             const replacement = item.replaceString || item.replacement || '';
             const trimOut = Array.isArray(item.trimStrings) ? item.trimStrings.join('\n') : (item.trimOut || '');
-            const placement = item.placement || [2];
+            const placement = Array.isArray(item.placement) ? item.placement : (typeof item.placement === 'number' ? [item.placement] : [2]);
             
             // Ephemerality: ST's promptOnly means it's ONLY for prompt (2)
             // If promptOnly is false, it's for both display (1) and prompt (2)
-            let ephemerality = item.ephemerality;
+            let ephemerality = Array.isArray(item.ephemerality) ? item.ephemerality : null;
             if (!ephemerality) {
                 if (item.markdownOnly === true && item.promptOnly === false) ephemerality = [1];
                 else if (item.markdownOnly === false && item.promptOnly === true) ephemerality = [2];

--- a/src/components/ui/DragDropOverlay.vue
+++ b/src/components/ui/DragDropOverlay.vue
@@ -104,11 +104,11 @@ const onDrop = async (e) => {
                             regex: item.findRegex || item.regex || '',
                             replacement: item.replaceString || item.replacement || '',
                             trimOut: Array.isArray(item.trimStrings) ? item.trimStrings.join('\\n') : (item.trimOut || ''),
-                            placement: item.placement || [2],
+                            placement: Array.isArray(item.placement) ? item.placement : (typeof item.placement === 'number' ? [item.placement] : [2]),
                             disabled: item.disabled ?? false,
                             runOnEdit: item.runOnEdit ?? false,
                             macroRules: (item.substituteRegex ?? 0).toString(),
-                            ephemerality: item.ephemerality || (item.promptOnly === true ? [2] : [1, 2]),
+                            ephemerality: Array.isArray(item.ephemerality) ? item.ephemerality : (item.promptOnly === true ? [2] : [1, 2]),
                             minDepth: item.minDepth ?? null,
                             maxDepth: item.maxDepth ?? null
                         });

--- a/src/components/ui/ShadowContent.vue
+++ b/src/components/ui/ShadowContent.vue
@@ -284,6 +284,14 @@ const getStyles = () => `
     font-style: italic;
   }
 
+  .chat-blockquote {
+    border-left: 3px solid var(--current-italic-color, var(--char-italic-color, #888));
+    margin: 4px 0;
+    padding: 2px 8px;
+    color: var(--current-italic-color, var(--char-italic-color, #888));
+    font-style: italic;
+  }
+
   /* RollingNumber styles */
   .rolling-number { display: inline-flex; align-items: center; vertical-align: middle; height: 1.2em; font-variant-numeric: tabular-nums; }
   .rolling-number-inner { display: inline-flex; align-items: center; }

--- a/src/composables/chat/useContextCutoff.js
+++ b/src/composables/chat/useContextCutoff.js
@@ -87,7 +87,11 @@ export function useContextCutoff({
             const runtime = getApiRuntimeStorage();
             const contextSize = String(runtime.contextSize || 32000);
             const maxTokens = String(runtime.maxTokens || 8000);
-            const cacheKey = `${currentCharId}_${sessionId}_${messageCount}_${contextSize}_${maxTokens}`;
+            let anForCache = cutoffChatData.authorsNotes?.[sessionId];
+            if (typeof anForCache === 'object' && anForCache !== null) anForCache = anForCache.content || '';
+            else if (typeof anForCache !== 'string') anForCache = '';
+            const sumForCache = typeof cutoffChatData.summaries?.[sessionId] === 'string' ? cutoffChatData.summaries[sessionId] : (cutoffChatData.summaries?.[sessionId]?.content || '');
+            const cacheKey = `${currentCharId}_${sessionId}_${messageCount}_${contextSize}_${maxTokens}_${anForCache}_${sumForCache}`;
 
             if (contextCutoffCache && contextCutoffCache.hash === cacheKey) {
                 cutoffIndex.value = contextCutoffCache.result?.cutoffIndex ?? 0;

--- a/src/composables/chat/useMemoryBooks.js
+++ b/src/composables/chat/useMemoryBooks.js
@@ -522,8 +522,20 @@ export function useMemoryBooks(deps) {
         reconcileSessionMemoryState(chatData, sessionId, currentMessages);
         chatData.sessions[sessionId] = currentMessages;
         await db.saveChat(activeChatChar.id, chatData);
-        await indexMemoryEntryIfNeeded(approvedEntry, activeChatChar.id, sessionId);
-        
+        try {
+            await indexMemoryEntryIfNeeded(approvedEntry, activeChatChar.id, sessionId);
+        } catch (e) {
+            console.warn('[memory] Embedding index failed for approved draft:', e?.message || e);
+            if (approvedEntry.vectorSearch) {
+                approvedEntry.vectorSearch = false;
+                await db.patchChatData(activeChatChar.id, (data) => {
+                    const mb = data.memoryBooks?.[sessionId];
+                    const entry = mb?.entries?.find(en => en.id === approvedEntry.id);
+                    if (entry) entry.vectorSearch = false;
+                });
+            }
+        }
+
         await updatePendingMemoryMessageIds(activeChatChar);
         await loadCurrentMemoryBook(activeChatChar);
         setTimeout(() => memoryBooksSheet.value?.open(), 50);

--- a/src/composables/chat/useSessionPersistence.js
+++ b/src/composables/chat/useSessionPersistence.js
@@ -92,7 +92,15 @@ export function useSessionPersistence({
                 }
                 if (charContext.summary !== undefined) {
                     if (!data.summaries) data.summaries = {};
-                    data.summaries[sessionId] = charContext.summary;
+                    let currentSum = data.summaries[sessionId];
+                    if (typeof currentSum === 'string') {
+                        currentSum = { content: currentSum, depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    } else if (!currentSum) {
+                        currentSum = { content: '', depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    }
+                    if (currentSum.content !== charContext.summary) {
+                        data.summaries[sessionId] = { ...currentSum, content: charContext.summary };
+                    }
                 }
             });
             savePromise.then(() => clearCrashBuffer(charContext.id, sessionId)).catch(() => {});
@@ -155,7 +163,15 @@ export function useSessionPersistence({
                 }
                 if (summary !== undefined) {
                     if (!data.summaries) data.summaries = {};
-                    data.summaries[sessionId] = summary;
+                    let currentSum = data.summaries[sessionId];
+                    if (typeof currentSum === 'string') {
+                        currentSum = { content: currentSum, depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    } else if (!currentSum) {
+                        currentSum = { content: '', depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                    }
+                    if (currentSum.content !== summary) {
+                        data.summaries[sessionId] = { ...currentSum, content: summary };
+                    }
                 }
             });
             savePromise.then(() => clearCrashBuffer(charId, sessionId)).catch(() => {});

--- a/src/composables/chat/useSessionPersistence.js
+++ b/src/composables/chat/useSessionPersistence.js
@@ -204,7 +204,7 @@ export function useSessionPersistence({
             const summary = newVal.summary;
             const authorsNote = newVal.authors_note;
             await db.patchChatData(newVal.id, (data) => {
-                const sessionId = data.currentId;
+                const sessionId = newVal.sessionId || data.currentId;
                 if (summary !== undefined) {
                     if (!data.summaries) data.summaries = {};
                     let currentSum = data.summaries[sessionId];

--- a/src/core/llm/usecases/promptConfigReaders.js
+++ b/src/core/llm/usecases/promptConfigReaders.js
@@ -48,5 +48,13 @@ export function loadSessionVars(char) {
 export function loadGlobalRegexes() {
     let globalRegexes = [];
     try { globalRegexes = JSON.parse(localStorage.getItem('regex_scripts')) || []; } catch (e) { }
+    for (const script of globalRegexes) {
+        if (script.findRegex && !script.regex) {
+            script.regex = script.findRegex;
+        }
+        if (script.replaceString !== undefined && script.replacement === undefined) {
+            script.replacement = script.replaceString;
+        }
+    }
     return globalRegexes;
 }

--- a/src/core/llm/usecases/promptConfigReaders.js
+++ b/src/core/llm/usecases/promptConfigReaders.js
@@ -55,6 +55,8 @@ export function loadGlobalRegexes() {
         if (script.replaceString !== undefined && script.replacement === undefined) {
             script.replacement = script.replaceString;
         }
+        if (typeof script.placement === 'number') script.placement = [script.placement];
+        if (typeof script.ephemerality === 'number') script.ephemerality = [script.ephemerality];
     }
     return globalRegexes;
 }

--- a/src/core/services/memoryBooksService.js
+++ b/src/core/services/memoryBooksService.js
@@ -469,12 +469,17 @@ export function parseMemoryDraftResponse(rawText, fallbackKeys = []) {
 
     for (const line of lines) {
         const trimmed = line.trim();
-        
-        if (trimmed.startsWith('TITLE:')) {
-            title = trimmed.substring(6).trim();
-        } else if (trimmed.startsWith('KEYS:')) {
-            const keyString = trimmed.substring(5).trim();
+        const upperTrimmed = trimmed.toUpperCase();
+
+        if (upperTrimmed.startsWith('TITLE:')) {
+            title = trimmed.substring(trimmed.indexOf(':') + 1).trim();
+        } else if (upperTrimmed.startsWith('KEYS:')) {
+            const keyString = trimmed.substring(trimmed.indexOf(':') + 1).trim();
             keys = parseMemoryKeyInput(keyString);
+        } else if (upperTrimmed.startsWith('MEMORY:')) {
+            inContent = true;
+            const rest = trimmed.substring(trimmed.indexOf(':') + 1).trim();
+            if (rest) content = rest;
         } else if (trimmed === 'CONTENT:') {
             inContent = true;
         } else if (inContent && trimmed) {
@@ -482,7 +487,6 @@ export function parseMemoryDraftResponse(rawText, fallbackKeys = []) {
         }
     }
 
-    // Fallback to raw text if parsing failed
     if (!content && rawText.length > 20) {
         content = rawText;
     }

--- a/src/core/services/presetImportService.js
+++ b/src/core/services/presetImportService.js
@@ -165,13 +165,13 @@ export function convertSTPreset(data, fileName) {
         regex: r.findRegex || '',
         replacement: r.replaceString || '',
         trimOut: Array.isArray(r.trimStrings) ? r.trimStrings.join('\n') : (r.trimStrings || ''),
-        placement: r.placement || [2],
+        placement: Array.isArray(r.placement) ? r.placement : (typeof r.placement === 'number' ? [r.placement] : [2]),
         disabled: r.disabled !== undefined ? r.disabled : false,
         markdownOnly: r.markdownOnly || false,
         promptOnly: r.promptOnly || false,
         runOnEdit: r.runOnEdit || false,
         macroRules: (r.substituteRegex || 0).toString(),
-        ephemerality: r.ephemerality || (r.markdownOnly === true && r.promptOnly === false ? [1] : r.markdownOnly === false && r.promptOnly === true ? [2] : [1, 2]),
+        ephemerality: Array.isArray(r.ephemerality) ? r.ephemerality : (r.markdownOnly === true && r.promptOnly === false ? [1] : r.markdownOnly === false && r.promptOnly === true ? [2] : [1, 2]),
         minDepth: r.minDepth || null,
         maxDepth: r.maxDepth || null
     })) : [];

--- a/src/core/services/regexService.js
+++ b/src/core/services/regexService.js
@@ -33,6 +33,8 @@ function _loadGlobalScripts(providedGlobalScripts) {
             if (script.replaceString !== undefined && script.replacement === undefined) {
                 script.replacement = script.replaceString;
             }
+            if (typeof script.placement === 'number') script.placement = [script.placement];
+            if (typeof script.ephemerality === 'number') script.ephemerality = [script.ephemerality];
         }
     } catch (e) {
         console.error('Failed to load global regex scripts', e);
@@ -62,6 +64,10 @@ export function applyRegexes(text, placementFilter, ephemeralityFilter, options 
         const preset = getEffectivePreset(charId, chatId);
         if (preset && preset.regexes) {
             presetRegexes = preset.regexes;
+            for (const script of presetRegexes) {
+                if (typeof script.placement === 'number') script.placement = [script.placement];
+                if (typeof script.ephemerality === 'number') script.ephemerality = [script.ephemerality];
+            }
         }
     }
 
@@ -70,9 +76,11 @@ export function applyRegexes(text, placementFilter, ephemeralityFilter, options 
     for (const script of allScripts) {
         if (script.disabled) continue;
 
-        if (script.placement && !script.placement.includes(placementFilter)) continue;
+        const sPlacement = Array.isArray(script.placement) ? script.placement : (typeof script.placement === 'number' ? [script.placement] : null);
+        if (sPlacement && !sPlacement.includes(placementFilter)) continue;
 
-        if (script.ephemerality && !script.ephemerality.includes(ephemeralityFilter)) continue;
+        const sEphemerality = Array.isArray(script.ephemerality) ? script.ephemerality : (typeof script.ephemerality === 'number' ? [script.ephemerality] : null);
+        if (sEphemerality && !sEphemerality.includes(ephemeralityFilter)) continue;
 
         if (depth !== undefined && depth !== null) {
             const minD = script.minDepth ?? null;

--- a/src/core/services/regexService.js
+++ b/src/core/services/regexService.js
@@ -26,6 +26,14 @@ function _loadGlobalScripts(providedGlobalScripts) {
         if (raw === _globalScriptsCacheKey && _globalScriptsCache) return _globalScriptsCache;
         _globalScriptsCacheKey = raw;
         _globalScriptsCache = raw ? JSON.parse(raw) : [];
+        for (const script of _globalScriptsCache) {
+            if (script.findRegex && !script.regex) {
+                script.regex = script.findRegex;
+            }
+            if (script.replaceString !== undefined && script.replacement === undefined) {
+                script.replacement = script.replaceString;
+            }
+        }
     } catch (e) {
         console.error('Failed to load global regex scripts', e);
         _globalScriptsCache = [];

--- a/src/utils/textFormatter.js
+++ b/src/utils/textFormatter.js
@@ -152,6 +152,12 @@ export function formatText(text, isUser = false, options = {}) {
     });
 
     // 4. Markdown Parsing (in order of precedence)
+    // Blockquote: > text at start of line
+    html = html.replace(/^>\s?(.*)$/gm, '<blockquote class="chat-blockquote">$1</blockquote>');
+
+    // Collapse consecutive blockquotes into one
+    html = html.replace(/<\/blockquote>\n*<blockquote class="chat-blockquote">/g, '<br>');
+
     // Horizontal Rule on its own line
     html = html.replace(/^(_{3,}|-{3,}|\*{3,})$/gm, '<hr>');
 

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -673,6 +673,10 @@ async function openChat(char, onBack, force = false) {
     isLoading.value = true;
     resetCutoffState();
 
+    if (activeChatChar) {
+        await asyncSaveCurrentSessionState();
+    }
+
     try {
     // Attempt to migrate legacy stats locally
     await migrateStatsIfNeeded();
@@ -1412,11 +1416,29 @@ onMounted(() => {
                 const sessionId = activeChatChar.sessionId;
                 const messagesSnapshot = currentMessages.value;
                 const draft = inputValue.value;
+                const authorsNote = activeChatChar.authors_note;
+                const summary = activeChatChar.summary;
                 db.patchChatData(charId, (data) => {
                     if (sessionId) {
                         data.sessions[sessionId] = JSON.parse(JSON.stringify(messagesSnapshot));
                     }
                     data.draft = draft;
+                    if (authorsNote !== undefined) {
+                        if (!data.authorsNotes) data.authorsNotes = {};
+                        data.authorsNotes[sessionId] = authorsNote;
+                    }
+                    if (summary !== undefined) {
+                        if (!data.summaries) data.summaries = {};
+                        let currentSum = data.summaries[sessionId];
+                        if (typeof currentSum === 'string') {
+                            currentSum = { content: currentSum, depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                        } else if (!currentSum) {
+                            currentSum = { content: '', depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                        }
+                        if (currentSum.content !== summary) {
+                            data.summaries[sessionId] = { ...currentSum, content: summary };
+                        }
+                    }
                 });
             }
         }).then(handle => { _appStateListener = handle; });

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -1432,7 +1432,7 @@ onMounted(() => {
     unsubChatSearchToggle = subscribeAppEvent(APP_EVENTS.ui.chatSearchToggle, ({ detail }) => onChatSearchToggle({ detail }));
     unsubRegexChanged = subscribeAppEvent(APP_EVENTS.domain.lorebook.regexScriptsChanged, onRegexChanged);
     unsubChatSearch = subscribeAppEvent(APP_EVENTS.ui.chatSearch, ({ detail }) => onChatSearch({ detail }));
-    unsubApiContextChanged = subscribeAppEvent(APP_EVENTS.domain.settings.apiContextChanged, updateContextCutoff);
+    unsubApiContextChanged = subscribeAppEvent(APP_EVENTS.domain.settings.apiContextChanged, () => { invalidateContextCache(); updateContextCutoff(); });
     unsubSettingsChanged = subscribeAppEvent(APP_EVENTS.domain.settings.changed, restartVisibleGenerationTimers);
     unsubSyncDataRefreshed = subscribeAppEvent(APP_EVENTS.domain.sync.dataRefreshed, () => loadChats());
 });

--- a/src/views/Menu/Settings/ThemeSettingsView.vue
+++ b/src/views/Menu/Settings/ThemeSettingsView.vue
@@ -861,6 +861,14 @@ C
     font-style: italic;
 }
 
+:deep(.chat-blockquote) {
+    border-left: 3px solid var(--current-italic-color, #888);
+    margin: 4px 0;
+    padding: 2px 8px;
+    color: var(--current-italic-color, #888);
+    font-style: italic;
+}
+
 .msg-footer {
     display: grid;
     grid-template-columns: 1fr auto 1fr;

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -90,8 +90,10 @@ function applyRegexes(text, placementFilter, ephemeralityFilter, allScripts, opt
 
     for (const script of allScripts) {
         if (script.disabled) continue;
-        if (script.placement && !script.placement.includes(placementFilter)) continue;
-        if (script.ephemerality && !script.ephemerality.includes(ephemeralityFilter)) continue;
+        const sPlacement = Array.isArray(script.placement) ? script.placement : (typeof script.placement === 'number' ? [script.placement] : null);
+        if (sPlacement && !sPlacement.includes(placementFilter)) continue;
+        const sEphemerality = Array.isArray(script.ephemerality) ? script.ephemerality : (typeof script.ephemerality === 'number' ? [script.ephemerality] : null);
+        if (sEphemerality && !sEphemerality.includes(ephemeralityFilter)) continue;
 
         if (depth !== undefined && depth !== null) {
             const minD = script.minDepth ?? null;

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -384,12 +384,24 @@ function buildPromptMessagesWorker(args) {
 
     const flushMergeBuffer = () => {
         if (mergeContentBuffer.length > 0) {
-            const content = mergeContentBuffer.join('\n');
+            let content = mergeContentBuffer.join('\n');
             const sources = [];
             for (const s of mergeSourcesBuffer) {
                 const existing = sources.find(x => x.source === s.source);
                 if (existing) existing.tokens += s.tokens;
                 else sources.push({ ...s });
+            }
+            const preRegexTokens = estimateTokens(content);
+            content = applyRegexes(content, 4, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj });
+            const postRegexTokens = estimateTokens(content);
+            if (preRegexTokens > 0 && postRegexTokens > 0 && sources.length > 0) {
+                const scale = postRegexTokens / preRegexTokens;
+                for (const s of sources) s.tokens = Math.max(0, Math.round(s.tokens * scale));
+            } else if (postRegexTokens > 0) {
+                sources.length = 0;
+                sources.push({ source: 'merged prompt', tokens: postRegexTokens });
+            } else {
+                sources.length = 0;
             }
             messages.push({
                 role: mergeRole || 'system',

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -408,7 +408,7 @@ function buildPromptMessagesWorker(args) {
                 content,
                 blockName: 'merged prompt',
                 sources,
-                _allSources: mergeSourcesBuffer.slice()
+                _allSources: sources
             });
             mergeContentBuffer = [];
             mergeSourcesBuffer = [];
@@ -791,25 +791,36 @@ function buildPromptMessagesWorker(args) {
         });
         if (mergePrompts) flushMergeBuffer();
     } else {
-        const fallbackTokens = estimateTokens("You are a helpful assistant.");
+        let fbContent = "You are a helpful assistant.";
+        const fbPreTokens = estimateTokens(fbContent);
+        fbContent = applyRegexes(fbContent, 4, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj });
+        const fbPostTokens = estimateTokens(fbContent);
         messages.push({
             role: "system",
-            content: "You are a helpful assistant.",
-            sources: fallbackTokens > 0 ? [{ source: 'preset', tokens: fallbackTokens }] : [],
-            _allSources: fallbackTokens > 0 ? [{ source: 'preset', tokens: fallbackTokens }] : []
+            content: fbContent,
+            sources: fbPostTokens > 0 ? [{ source: 'preset', tokens: fbPostTokens }] : [],
+            _allSources: fbPostTokens > 0 ? [{ source: 'preset', tokens: fbPostTokens }] : []
         });
         if (summaryText) {
-            const sTokens = estimateTokens(summaryText);
+            let sContent = summaryText;
+            const sPreTokens = estimateTokens(sContent);
+            sContent = applyRegexes(sContent, 4, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj });
+            const sPostTokens = estimateTokens(sContent);
             messages.push({
                 role: "system",
-                content: summaryText,
-                sources: sTokens > 0 ? [{ source: 'summary', tokens: sTokens }] : [],
-                _allSources: sTokens > 0 ? [{ source: 'summary', tokens: sTokens }] : []
+                content: sContent,
+                sources: sPostTokens > 0 ? [{ source: 'summary', tokens: sPostTokens }] : [],
+                _allSources: sPostTokens > 0 ? [{ source: 'summary', tokens: sPostTokens }] : []
             });
         }
         if (history) {
-            for (const m of history) {
-                const content = m.content !== undefined ? m.content : (m.text || m.mes || "");
+            for (let i = 0; i < history.length; i++) {
+                const m = history[i];
+                let content = m.content !== undefined ? m.content : (m.text || m.mes || "");
+                content = replaceMacros(content, char, personaObj, sessionVars, notifyObj);
+                const placement = m.role === 'user' ? 1 : 2;
+                const depth = history.length - 1 - i;
+                content = applyRegexes(content, placement, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj, depth });
                 const tokens = estimateTokens(content);
                 messages.push({
                     ...m,


### PR DESCRIPTION
## Summary

- **findRegex to regex conversion**: Global regex scripts imported from SillyTavern store their pattern as `findRegex`/`replaceString`, but the engine only reads `script.regex`/`script.replacement`. Both `loadGlobalRegexes()` (worker path) and `_loadGlobalScripts()` (display path) now normalize these legacy field names on load.
- **mergePrompts regex gap**: When merge mode is active, system/user block content was buffered and flushed without regex processing. `flushMergeBuffer()` now applies `applyRegexes()` to the merged content before pushing to messages, with token scaling.
- **AN save on character switch**: `openChat()` now calls `await asyncSaveCurrentSessionState()` before switching `activeChatChar`, preventing Author's Note and summary loss when changing characters.
- **Watcher sessionId fix**: The deep watcher in `useSessionPersistence.js` used `data.currentId` from DB instead of `newVal.sessionId`, which could write AN/summary to the wrong session. Now uses `newVal.sessionId || data.currentId`.
- **Context cache AN/summary invalidation**: Cache key now includes Author's Note and summary content so the context breakdown recalculates when either changes.
- **Native appStateChange AN/summary save**: The Capacitor `appStateChange` handler only saved messages and draft, missing Author's Note and summary. Now persists both on background.

## Test plan

- [ ] Import a SillyTavern regex script (with `findRegex` field) and verify it applies to outgoing prompts
- [ ] Enable mergePrompts and verify regex scripts process the merged system block
- [ ] Edit Author's Note, switch to another character, switch back - AN should be preserved
- [ ] Edit Author's Note and verify context breakdown updates immediately
- [ ] On native: edit AN/summary, background the app, foreground - verify AN/summary persisted
