### PR TITLE
fix: eliminate memoryReserve double-counting, add actualPromptTokens, null guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ git checkout -b feat/memorybook-ui feat/multi-vector
 | `fix/abort-empty-message-and-dropdown-scroll` | Abort pipeline onError propagation, desktop dropdown scroll (linear chain from feat/character-gallery) | Not yet |
 | `fix/preset-stackoverflow-and-chat-perf` | Preset token consistency, persona breakdown, stack overflow & chat perf (linear chain from fix/abort-empty-message-and-dropdown-scroll) | Not yet |
 | `fix/summary-deletion-and-context-cutoff` | Prevent summary object destruction by asyncSave/onVisibilityChange, invalidate context cache on context limit change | Not yet |
+| `fix/authornote-regex-prompt` | findRegex→regex conversion, mergePrompts regex gap, AN save on chat switch, context cache AN invalidation, native appState AN/summary save (linear chain from fix/summary-deletion-and-context-cutoff) | Not yet |
 
 ### Historical (merged & deleted)
 - `feat/refactor-phase1-event-hub` → merged into `feat/chat-persistence-and-reasoning-fixes`, then upstream/dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ git checkout -b feat/memorybook-ui feat/multi-vector
 | `fix/preset-stackoverflow-and-chat-perf` | Preset token consistency, persona breakdown, stack overflow & chat perf (linear chain from fix/abort-empty-message-and-dropdown-scroll) | Not yet |
 | `fix/summary-deletion-and-context-cutoff` | Prevent summary object destruction by asyncSave/onVisibilityChange, invalidate context cache on context limit change | Not yet |
 | `fix/authornote-regex-prompt` | findRegex→regex conversion, mergePrompts regex gap, AN save on chat switch, context cache AN invalidation, native appState AN/summary save (linear chain from fix/summary-deletion-and-context-cutoff) | Not yet |
+| `fix/memory-reserve-double-count` | Eliminate memoryReserve double-counting, add actualPromptTokens to context breakdown, null guard in initHeaderScroll (linear chain from fix/authornote-regex-prompt) | Not yet |
 
 ### Historical (merged & deleted)
 - `feat/refactor-phase1-event-hub` → merged into `feat/chat-persistence-and-reasoning-fixes`, then upstream/dev
@@ -123,11 +124,10 @@ When in doubt, read all that apply before editing:
 When feature branches accumulate unmerged changes, they diverge and create merge conflicts when upstream accepts other PRs.
 
 ### The Solution: Strict Branch Hygiene
-1. **One feature per branch** — Never combine unrelated work in a single branch
-2. **Always branch from `origin/dev`** (or previous feature if dependent)
-3. **Never branch from local `dev`** that has unmerged feature commits
-4. **Delete merged branches immediately** — both local and remote
-5. **Keep `origin/dev` in sync** with upstream before creating new branches
+1. **Always branch from `origin/dev`** (or previous feature if dependent)
+2. **Never branch from local `dev`** that has unmerged feature commits
+3. **Delete merged branches immediately** — both local and remote
+4. **Keep `origin/dev` in sync** with upstream before creating new branches
 
 ### Visual Workflow
 ```

--- a/src/components/chat/MagicDrawer.vue
+++ b/src/components/chat/MagicDrawer.vue
@@ -343,11 +343,7 @@ const cardTokens = computed(() => props.contextBreakdown?.character || 0);
 
 const personaTokens = computed(() => props.contextBreakdown?.persona || 0);
 
-const generationTokens = computed(() => {
-    const prompt = getLastRequestPreviewSnapshot().prompt;
-    if (!prompt || !prompt.messages) return 0;
-    return prompt.messages.reduce((acc, m) => acc + estimateTokens(m.content), 0);
-});
+const generationTokens = computed(() => props.contextBreakdown?.actualPromptTokens || 0);
 
 const imageGenEnabled = computed(() => getImageGenSettings().enabled);
 

--- a/src/components/sheets/RegexSheet.vue
+++ b/src/components/sheets/RegexSheet.vue
@@ -222,11 +222,11 @@ async function handleFileSelect(event) {
             const regex = item.findRegex || item.regex || '';
             const replacement = item.replaceString || item.replacement || '';
             const trimOut = Array.isArray(item.trimStrings) ? item.trimStrings.join('\n') : (item.trimOut || '');
-            const placement = item.placement || [2];
+            const placement = Array.isArray(item.placement) ? item.placement : (typeof item.placement === 'number' ? [item.placement] : [2]);
             
             // Ephemerality: ST's promptOnly means it's ONLY for prompt (2)
             // If promptOnly is false, it's for both display (1) and prompt (2)
-            let ephemerality = item.ephemerality;
+            let ephemerality = Array.isArray(item.ephemerality) ? item.ephemerality : null;
             if (!ephemerality) {
                 if (item.markdownOnly === true && item.promptOnly === false) ephemerality = [1];
                 else if (item.markdownOnly === false && item.promptOnly === true) ephemerality = [2];

--- a/src/components/ui/DragDropOverlay.vue
+++ b/src/components/ui/DragDropOverlay.vue
@@ -104,11 +104,11 @@ const onDrop = async (e) => {
                             regex: item.findRegex || item.regex || '',
                             replacement: item.replaceString || item.replacement || '',
                             trimOut: Array.isArray(item.trimStrings) ? item.trimStrings.join('\\n') : (item.trimOut || ''),
-                            placement: item.placement || [2],
+                            placement: Array.isArray(item.placement) ? item.placement : (typeof item.placement === 'number' ? [item.placement] : [2]),
                             disabled: item.disabled ?? false,
                             runOnEdit: item.runOnEdit ?? false,
                             macroRules: (item.substituteRegex ?? 0).toString(),
-                            ephemerality: item.ephemerality || (item.promptOnly === true ? [2] : [1, 2]),
+                            ephemerality: Array.isArray(item.ephemerality) ? item.ephemerality : (item.promptOnly === true ? [2] : [1, 2]),
                             minDepth: item.minDepth ?? null,
                             maxDepth: item.maxDepth ?? null
                         });

--- a/src/components/ui/ShadowContent.vue
+++ b/src/components/ui/ShadowContent.vue
@@ -284,6 +284,14 @@ const getStyles = () => `
     font-style: italic;
   }
 
+  .chat-blockquote {
+    border-left: 3px solid var(--current-italic-color, var(--char-italic-color, #888));
+    margin: 4px 0;
+    padding: 2px 8px;
+    color: var(--current-italic-color, var(--char-italic-color, #888));
+    font-style: italic;
+  }
+
   /* RollingNumber styles */
   .rolling-number { display: inline-flex; align-items: center; vertical-align: middle; height: 1.2em; font-variant-numeric: tabular-nums; }
   .rolling-number-inner { display: inline-flex; align-items: center; }

--- a/src/composables/chat/useContextCutoff.js
+++ b/src/composables/chat/useContextCutoff.js
@@ -87,7 +87,11 @@ export function useContextCutoff({
             const runtime = getApiRuntimeStorage();
             const contextSize = String(runtime.contextSize || 32000);
             const maxTokens = String(runtime.maxTokens || 8000);
-            const cacheKey = `${currentCharId}_${sessionId}_${messageCount}_${contextSize}_${maxTokens}`;
+            let anForCache = cutoffChatData.authorsNotes?.[sessionId];
+            if (typeof anForCache === 'object' && anForCache !== null) anForCache = anForCache.content || '';
+            else if (typeof anForCache !== 'string') anForCache = '';
+            const sumForCache = typeof cutoffChatData.summaries?.[sessionId] === 'string' ? cutoffChatData.summaries[sessionId] : (cutoffChatData.summaries?.[sessionId]?.content || '');
+            const cacheKey = `${currentCharId}_${sessionId}_${messageCount}_${contextSize}_${maxTokens}_${anForCache}_${sumForCache}`;
 
             if (contextCutoffCache && contextCutoffCache.hash === cacheKey) {
                 cutoffIndex.value = contextCutoffCache.result?.cutoffIndex ?? 0;

--- a/src/composables/chat/useSessionPersistence.js
+++ b/src/composables/chat/useSessionPersistence.js
@@ -204,7 +204,7 @@ export function useSessionPersistence({
             const summary = newVal.summary;
             const authorsNote = newVal.authors_note;
             await db.patchChatData(newVal.id, (data) => {
-                const sessionId = data.currentId;
+                const sessionId = newVal.sessionId || data.currentId;
                 if (summary !== undefined) {
                     if (!data.summaries) data.summaries = {};
                     let currentSum = data.summaries[sessionId];

--- a/src/core/llm/pipeline/steps.js
+++ b/src/core/llm/pipeline/steps.js
@@ -1,6 +1,7 @@
 import { publishAppEvent } from '@/core/events/eventHub.js';
 import { APP_EVENTS } from '@/core/events/eventNames.js';
 import { PipelineContext } from './pipelineContext.js';
+import { estimateTokens } from '@/utils/tokenizer.js';
 
 export async function stepVectorSearch(ctx, deps) {
     const { vectorSearchLorebooks, mergeLateVectorLoreEntries } = deps;
@@ -96,10 +97,13 @@ export async function stepPromptReady(ctx, deps) {
 
     if (ctx.isAborted) return;
 
+    const actualPromptTokens = ctx.messages.reduce((acc, m) => acc + estimateTokens(m.content), 0);
+
     ctx.contextBreakdown = buildMergedContextBreakdown(ctx.result.contextBreakdown, {
         vectorLoreTokens: ctx.vectorLoreTokens,
         memoryTokens: ctx.memoryTokens,
-        memoryReserve: ctx.memoryReserve
+        memoryReserve: ctx.memoryReserve,
+        actualPromptTokens
     });
 
     const { onPromptReady } = ctx.callbacks;

--- a/src/core/llm/usecases/calculateContext.js
+++ b/src/core/llm/usecases/calculateContext.js
@@ -17,7 +17,7 @@ import { vectorSearchLorebooks } from '@/core/states/lorebookState.js';
 import { mergeLateVectorLoreEntries, estimateVectorLoreTokens } from '@/core/llm/usecases/vectorLoreInjection.js';
 import { executeChatContextCalculation } from './contextCalculation.js';
 
-function buildContextCalculationResult(result, { vectorLoreTokens = 0, memoryTokens = 0, memoryReserve = 0 } = {}) {
+function buildContextCalculationResult(result, { vectorLoreTokens = 0, memoryTokens = 0, memoryReserve = 0, actualPromptTokens = 0 } = {}) {
     if (!result?.contextBreakdown) {
         return { cutoffIndex: result?.cutoffIndex ?? -1, contextBreakdown: null };
     }
@@ -44,7 +44,8 @@ function buildContextCalculationResult(result, { vectorLoreTokens = 0, memoryTok
             fixedBase: newFixedBase,
             fixedTotal: newFixedTotal,
             totalUsed: newTotalUsed,
-            remaining: Math.max(0, contextSize - newTotalUsed)
+            remaining: Math.max(0, contextSize - newTotalUsed),
+            actualPromptTokens
         }
     };
 }

--- a/src/core/llm/usecases/calculateContext.js
+++ b/src/core/llm/usecases/calculateContext.js
@@ -21,21 +21,30 @@ function buildContextCalculationResult(result, { vectorLoreTokens = 0, memoryTok
     if (!result?.contextBreakdown) {
         return { cutoffIndex: result?.cutoffIndex ?? -1, contextBreakdown: null };
     }
-    const actualMemory = memoryTokens || memoryReserve;
+    const hasMemoryInjection = memoryTokens > 0;
+    const actualMemory = hasMemoryInjection ? memoryTokens : 0;
+    const effectiveReserve = hasMemoryInjection ? 0 : (memoryReserve || result.contextBreakdown.memoryReserve || 0);
+
+    const newFixedBase = (result.contextBreakdown.fixedBase || 0) + actualMemory;
+    const newFixedTotal = newFixedBase + (result.contextBreakdown.lorebookReserve || 0) + effectiveReserve;
+    const newHistory = result.contextBreakdown.history || 0;
+    const newTotalUsed = newFixedBase + (result.contextBreakdown.lorebookReserve || 0) + effectiveReserve + newHistory;
+    const contextSize = result.contextBreakdown.contextSize || result.contextBreakdown.safeContext || 0;
+
     return {
         cutoffIndex: result.cutoffIndex ?? -1,
         cutoffOriginalIndex: result.cutoffOriginalIndex ?? result.cutoffIndex ?? -1,
         contextBreakdown: {
             ...result.contextBreakdown,
-            memory: memoryTokens,
-            memoryReserve: memoryReserve || result.contextBreakdown.memoryReserve || 0,
+            memory: memoryTokens || 0,
+            memoryReserve: effectiveReserve,
             vectorLore: (result.contextBreakdown.vectorLore || 0) + vectorLoreTokens,
             summaryBase: result.contextBreakdown.summary || 0,
             summary: (result.contextBreakdown.summary || 0) + actualMemory,
-            fixedBase: (result.contextBreakdown.fixedBase || 0) + actualMemory,
-            fixedTotal: result.contextBreakdown.fixedTotal || 0,
-            totalUsed: result.contextBreakdown.totalUsed || 0,
-            remaining: Math.max(0, result.contextBreakdown.remaining || 0)
+            fixedBase: newFixedBase,
+            fixedTotal: newFixedTotal,
+            totalUsed: newTotalUsed,
+            remaining: Math.max(0, contextSize - newTotalUsed)
         }
     };
 }

--- a/src/core/llm/usecases/contextCalculation.js
+++ b/src/core/llm/usecases/contextCalculation.js
@@ -1,3 +1,5 @@
+import { estimateTokens } from '@/utils/tokenizer.js';
+
 export async function executeChatContextCalculation({
     char,
     history,
@@ -68,10 +70,14 @@ export async function executeChatContextCalculation({
             console.warn('[calculateContext] Vector search failed:', e);
         }
 
+        const memoryMsgTokens = (memoryInjection.messages || []).reduce((acc, m) => acc + estimateTokens(m.content || ''), 0);
+        const actualPromptTokens = result.messages.reduce((acc, m) => acc + estimateTokens(m.content), 0) + memoryMsgTokens;
+
         return buildContextCalculationResult(result, {
             vectorLoreTokens,
             memoryTokens: memoryInjection.tokens || 0,
-            memoryReserve
+            memoryReserve,
+            actualPromptTokens
         });
     } catch (e) {
         console.error('Calculate context worker error', e);

--- a/src/core/llm/usecases/promptConfigReaders.js
+++ b/src/core/llm/usecases/promptConfigReaders.js
@@ -48,5 +48,13 @@ export function loadSessionVars(char) {
 export function loadGlobalRegexes() {
     let globalRegexes = [];
     try { globalRegexes = JSON.parse(localStorage.getItem('regex_scripts')) || []; } catch (e) { }
+    for (const script of globalRegexes) {
+        if (script.findRegex && !script.regex) {
+            script.regex = script.findRegex;
+        }
+        if (script.replaceString !== undefined && script.replacement === undefined) {
+            script.replacement = script.replaceString;
+        }
+    }
     return globalRegexes;
 }

--- a/src/core/llm/usecases/promptConfigReaders.js
+++ b/src/core/llm/usecases/promptConfigReaders.js
@@ -55,6 +55,8 @@ export function loadGlobalRegexes() {
         if (script.replaceString !== undefined && script.replacement === undefined) {
             script.replacement = script.replaceString;
         }
+        if (typeof script.placement === 'number') script.placement = [script.placement];
+        if (typeof script.ephemerality === 'number') script.ephemerality = [script.ephemerality];
     }
     return globalRegexes;
 }

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -24,7 +24,7 @@ function buildDebugKey(prefix, ...parts) {
 
 // --- Helpers ---
 
-function buildMergedContextBreakdown(contextBreakdown, { vectorLoreTokens = 0, memoryTokens = 0, memoryReserve = 0 } = {}) {
+function buildMergedContextBreakdown(contextBreakdown, { vectorLoreTokens = 0, memoryTokens = 0, memoryReserve = 0, actualPromptTokens = 0 } = {}) {
     if (!contextBreakdown) return null;
 
     const hasMemoryInjection = memoryTokens > 0;
@@ -47,7 +47,8 @@ function buildMergedContextBreakdown(contextBreakdown, { vectorLoreTokens = 0, m
         fixedBase: newFixedBase,
         fixedTotal: newFixedTotal,
         totalUsed: newTotalUsed,
-        remaining: Math.max(0, contextSize - newTotalUsed)
+        remaining: Math.max(0, contextSize - newTotalUsed),
+        actualPromptTokens
     };
 }
 

--- a/src/core/services/generationService.js
+++ b/src/core/services/generationService.js
@@ -27,19 +27,27 @@ function buildDebugKey(prefix, ...parts) {
 function buildMergedContextBreakdown(contextBreakdown, { vectorLoreTokens = 0, memoryTokens = 0, memoryReserve = 0 } = {}) {
     if (!contextBreakdown) return null;
 
-    const actualMemory = memoryTokens || memoryReserve;
+    const hasMemoryInjection = memoryTokens > 0;
+    const actualMemory = hasMemoryInjection ? memoryTokens : 0;
+    const effectiveReserve = hasMemoryInjection ? 0 : (memoryReserve || contextBreakdown.memoryReserve || 0);
+
+    const newFixedBase = (contextBreakdown.fixedBase || 0) + actualMemory;
+    const newFixedTotal = newFixedBase + (contextBreakdown.lorebookReserve || 0) + effectiveReserve;
+    const newHistory = contextBreakdown.history || 0;
+    const newTotalUsed = newFixedBase + (contextBreakdown.lorebookReserve || 0) + effectiveReserve + newHistory;
+    const contextSize = contextBreakdown.contextSize || contextBreakdown.safeContext || 0;
 
     return {
         ...contextBreakdown,
-        memory: memoryTokens,
-        memoryReserve: memoryReserve || contextBreakdown.memoryReserve || 0,
+        memory: memoryTokens || 0,
+        memoryReserve: effectiveReserve,
         vectorLore: (contextBreakdown.vectorLore || 0) + vectorLoreTokens,
         summaryBase: contextBreakdown.summary || 0,
         summary: (contextBreakdown.summary || 0) + actualMemory,
-        fixedBase: (contextBreakdown.fixedBase || 0) + actualMemory,
-        fixedTotal: (contextBreakdown.fixedTotal || 0),
-        totalUsed: (contextBreakdown.totalUsed || 0),
-        remaining: Math.max(0, (contextBreakdown.remaining || 0))
+        fixedBase: newFixedBase,
+        fixedTotal: newFixedTotal,
+        totalUsed: newTotalUsed,
+        remaining: Math.max(0, contextSize - newTotalUsed)
     };
 }
 

--- a/src/core/services/presetImportService.js
+++ b/src/core/services/presetImportService.js
@@ -165,13 +165,13 @@ export function convertSTPreset(data, fileName) {
         regex: r.findRegex || '',
         replacement: r.replaceString || '',
         trimOut: Array.isArray(r.trimStrings) ? r.trimStrings.join('\n') : (r.trimStrings || ''),
-        placement: r.placement || [2],
+        placement: Array.isArray(r.placement) ? r.placement : (typeof r.placement === 'number' ? [r.placement] : [2]),
         disabled: r.disabled !== undefined ? r.disabled : false,
         markdownOnly: r.markdownOnly || false,
         promptOnly: r.promptOnly || false,
         runOnEdit: r.runOnEdit || false,
         macroRules: (r.substituteRegex || 0).toString(),
-        ephemerality: r.ephemerality || (r.markdownOnly === true && r.promptOnly === false ? [1] : r.markdownOnly === false && r.promptOnly === true ? [2] : [1, 2]),
+        ephemerality: Array.isArray(r.ephemerality) ? r.ephemerality : (r.markdownOnly === true && r.promptOnly === false ? [1] : r.markdownOnly === false && r.promptOnly === true ? [2] : [1, 2]),
         minDepth: r.minDepth || null,
         maxDepth: r.maxDepth || null
     })) : [];

--- a/src/core/services/regexService.js
+++ b/src/core/services/regexService.js
@@ -33,6 +33,8 @@ function _loadGlobalScripts(providedGlobalScripts) {
             if (script.replaceString !== undefined && script.replacement === undefined) {
                 script.replacement = script.replaceString;
             }
+            if (typeof script.placement === 'number') script.placement = [script.placement];
+            if (typeof script.ephemerality === 'number') script.ephemerality = [script.ephemerality];
         }
     } catch (e) {
         console.error('Failed to load global regex scripts', e);
@@ -62,6 +64,10 @@ export function applyRegexes(text, placementFilter, ephemeralityFilter, options 
         const preset = getEffectivePreset(charId, chatId);
         if (preset && preset.regexes) {
             presetRegexes = preset.regexes;
+            for (const script of presetRegexes) {
+                if (typeof script.placement === 'number') script.placement = [script.placement];
+                if (typeof script.ephemerality === 'number') script.ephemerality = [script.ephemerality];
+            }
         }
     }
 
@@ -70,9 +76,11 @@ export function applyRegexes(text, placementFilter, ephemeralityFilter, options 
     for (const script of allScripts) {
         if (script.disabled) continue;
 
-        if (script.placement && !script.placement.includes(placementFilter)) continue;
+        const sPlacement = Array.isArray(script.placement) ? script.placement : (typeof script.placement === 'number' ? [script.placement] : null);
+        if (sPlacement && !sPlacement.includes(placementFilter)) continue;
 
-        if (script.ephemerality && !script.ephemerality.includes(ephemeralityFilter)) continue;
+        const sEphemerality = Array.isArray(script.ephemerality) ? script.ephemerality : (typeof script.ephemerality === 'number' ? [script.ephemerality] : null);
+        if (sEphemerality && !sEphemerality.includes(ephemeralityFilter)) continue;
 
         if (depth !== undefined && depth !== null) {
             const minD = script.minDepth ?? null;

--- a/src/core/services/regexService.js
+++ b/src/core/services/regexService.js
@@ -26,6 +26,14 @@ function _loadGlobalScripts(providedGlobalScripts) {
         if (raw === _globalScriptsCacheKey && _globalScriptsCache) return _globalScriptsCache;
         _globalScriptsCacheKey = raw;
         _globalScriptsCache = raw ? JSON.parse(raw) : [];
+        for (const script of _globalScriptsCache) {
+            if (script.findRegex && !script.regex) {
+                script.regex = script.findRegex;
+            }
+            if (script.replaceString !== undefined && script.replacement === undefined) {
+                script.replacement = script.replaceString;
+            }
+        }
     } catch (e) {
         console.error('Failed to load global regex scripts', e);
         _globalScriptsCache = [];

--- a/src/core/services/ui.js
+++ b/src/core/services/ui.js
@@ -396,6 +396,7 @@ export function animateOdometer(element, target) {
 }
 
 export function initHeaderScroll(messagesContainer, initialScrollTop, isGeneratingCallback) {
+    if (!messagesContainer) return () => {};
     let lastScrollTop = initialScrollTop || 0;
     let ticking = false;
     let isHidden = false;

--- a/src/utils/textFormatter.js
+++ b/src/utils/textFormatter.js
@@ -152,6 +152,12 @@ export function formatText(text, isUser = false, options = {}) {
     });
 
     // 4. Markdown Parsing (in order of precedence)
+    // Blockquote: > text at start of line
+    html = html.replace(/^>\s?(.*)$/gm, '<blockquote class="chat-blockquote">$1</blockquote>');
+
+    // Collapse consecutive blockquotes into one
+    html = html.replace(/<\/blockquote>\n*<blockquote class="chat-blockquote">/g, '<br>');
+
     // Horizontal Rule on its own line
     html = html.replace(/^(_{3,}|-{3,}|\*{3,})$/gm, '<hr>');
 

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -673,6 +673,10 @@ async function openChat(char, onBack, force = false) {
     isLoading.value = true;
     resetCutoffState();
 
+    if (activeChatChar) {
+        await asyncSaveCurrentSessionState();
+    }
+
     try {
     // Attempt to migrate legacy stats locally
     await migrateStatsIfNeeded();
@@ -1412,11 +1416,29 @@ onMounted(() => {
                 const sessionId = activeChatChar.sessionId;
                 const messagesSnapshot = currentMessages.value;
                 const draft = inputValue.value;
+                const authorsNote = activeChatChar.authors_note;
+                const summary = activeChatChar.summary;
                 db.patchChatData(charId, (data) => {
                     if (sessionId) {
                         data.sessions[sessionId] = JSON.parse(JSON.stringify(messagesSnapshot));
                     }
                     data.draft = draft;
+                    if (authorsNote !== undefined) {
+                        if (!data.authorsNotes) data.authorsNotes = {};
+                        data.authorsNotes[sessionId] = authorsNote;
+                    }
+                    if (summary !== undefined) {
+                        if (!data.summaries) data.summaries = {};
+                        let currentSum = data.summaries[sessionId];
+                        if (typeof currentSum === 'string') {
+                            currentSum = { content: currentSum, depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                        } else if (!currentSum) {
+                            currentSum = { content: '', depth: 4, role: 'system', insertion_mode: 'relative', prefix: 'Summary: ' };
+                        }
+                        if (currentSum.content !== summary) {
+                            data.summaries[sessionId] = { ...currentSum, content: summary };
+                        }
+                    }
                 });
             }
         }).then(handle => { _appStateListener = handle; });

--- a/src/views/Menu/Settings/ThemeSettingsView.vue
+++ b/src/views/Menu/Settings/ThemeSettingsView.vue
@@ -861,6 +861,14 @@ C
     font-style: italic;
 }
 
+:deep(.chat-blockquote) {
+    border-left: 3px solid var(--current-italic-color, #888);
+    margin: 4px 0;
+    padding: 2px 8px;
+    color: var(--current-italic-color, #888);
+    font-style: italic;
+}
+
 .msg-footer {
     display: grid;
     grid-template-columns: 1fr auto 1fr;

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -90,8 +90,10 @@ function applyRegexes(text, placementFilter, ephemeralityFilter, allScripts, opt
 
     for (const script of allScripts) {
         if (script.disabled) continue;
-        if (script.placement && !script.placement.includes(placementFilter)) continue;
-        if (script.ephemerality && !script.ephemerality.includes(ephemeralityFilter)) continue;
+        const sPlacement = Array.isArray(script.placement) ? script.placement : (typeof script.placement === 'number' ? [script.placement] : null);
+        if (sPlacement && !sPlacement.includes(placementFilter)) continue;
+        const sEphemerality = Array.isArray(script.ephemerality) ? script.ephemerality : (typeof script.ephemerality === 'number' ? [script.ephemerality] : null);
+        if (sEphemerality && !sEphemerality.includes(ephemeralityFilter)) continue;
 
         if (depth !== undefined && depth !== null) {
             const minD = script.minDepth ?? null;

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -384,12 +384,24 @@ function buildPromptMessagesWorker(args) {
 
     const flushMergeBuffer = () => {
         if (mergeContentBuffer.length > 0) {
-            const content = mergeContentBuffer.join('\n');
+            let content = mergeContentBuffer.join('\n');
             const sources = [];
             for (const s of mergeSourcesBuffer) {
                 const existing = sources.find(x => x.source === s.source);
                 if (existing) existing.tokens += s.tokens;
                 else sources.push({ ...s });
+            }
+            const preRegexTokens = estimateTokens(content);
+            content = applyRegexes(content, 4, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj });
+            const postRegexTokens = estimateTokens(content);
+            if (preRegexTokens > 0 && postRegexTokens > 0 && sources.length > 0) {
+                const scale = postRegexTokens / preRegexTokens;
+                for (const s of sources) s.tokens = Math.max(0, Math.round(s.tokens * scale));
+            } else if (postRegexTokens > 0) {
+                sources.length = 0;
+                sources.push({ source: 'merged prompt', tokens: postRegexTokens });
+            } else {
+                sources.length = 0;
             }
             messages.push({
                 role: mergeRole || 'system',

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -408,7 +408,7 @@ function buildPromptMessagesWorker(args) {
                 content,
                 blockName: 'merged prompt',
                 sources,
-                _allSources: mergeSourcesBuffer.slice()
+                _allSources: sources
             });
             mergeContentBuffer = [];
             mergeSourcesBuffer = [];
@@ -791,25 +791,36 @@ function buildPromptMessagesWorker(args) {
         });
         if (mergePrompts) flushMergeBuffer();
     } else {
-        const fallbackTokens = estimateTokens("You are a helpful assistant.");
+        let fbContent = "You are a helpful assistant.";
+        const fbPreTokens = estimateTokens(fbContent);
+        fbContent = applyRegexes(fbContent, 4, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj });
+        const fbPostTokens = estimateTokens(fbContent);
         messages.push({
             role: "system",
-            content: "You are a helpful assistant.",
-            sources: fallbackTokens > 0 ? [{ source: 'preset', tokens: fallbackTokens }] : [],
-            _allSources: fallbackTokens > 0 ? [{ source: 'preset', tokens: fallbackTokens }] : []
+            content: fbContent,
+            sources: fbPostTokens > 0 ? [{ source: 'preset', tokens: fbPostTokens }] : [],
+            _allSources: fbPostTokens > 0 ? [{ source: 'preset', tokens: fbPostTokens }] : []
         });
         if (summaryText) {
-            const sTokens = estimateTokens(summaryText);
+            let sContent = summaryText;
+            const sPreTokens = estimateTokens(sContent);
+            sContent = applyRegexes(sContent, 4, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj });
+            const sPostTokens = estimateTokens(sContent);
             messages.push({
                 role: "system",
-                content: summaryText,
-                sources: sTokens > 0 ? [{ source: 'summary', tokens: sTokens }] : [],
-                _allSources: sTokens > 0 ? [{ source: 'summary', tokens: sTokens }] : []
+                content: sContent,
+                sources: sPostTokens > 0 ? [{ source: 'summary', tokens: sPostTokens }] : [],
+                _allSources: sPostTokens > 0 ? [{ source: 'summary', tokens: sPostTokens }] : []
             });
         }
         if (history) {
-            for (const m of history) {
-                const content = m.content !== undefined ? m.content : (m.text || m.mes || "");
+            for (let i = 0; i < history.length; i++) {
+                const m = history[i];
+                let content = m.content !== undefined ? m.content : (m.text || m.mes || "");
+                content = replaceMacros(content, char, personaObj, sessionVars, notifyObj);
+                const placement = m.role === 'user' ? 1 : 2;
+                const depth = history.length - 1 - i;
+                content = applyRegexes(content, placement, 2, allScripts, { char, persona: personaObj, sessionVars, charId, sessionId, notifyObj, depth });
                 const tokens = estimateTokens(content);
                 messages.push({
                     ...m,


### PR DESCRIPTION
## Summary

- **Eliminate memoryReserve double-counting**: When memory injection is active (`memoryTokens > 0`), `memoryReserve` was still added to `totalUsed` alongside the actual memory tokens, inflating the reported context usage. Now `memoryReserve` is zeroed when memory is injected, and `totalUsed` is recalculated correctly.
- **Add `actualPromptTokens` to context breakdown**: Token count of the actual prompt messages (worker messages + memory injection messages) is now computed in both `calculateContext` (tokenizer) and pipeline `stepPromptReady` (generation). MagicDrawer reads this field instead of computing from the request preview snapshot, so tokens are always available even without a prior generation.
- **Null guard in `initHeaderScroll`**: Prevents `TypeError: Cannot read properties of null (reading 'addEventListener')` when `messagesContainer` is null at call time.
- **AGENTS.md cleanup**: Removed "one feature per branch" rule, keeping only the linear chain workflow guidance.

## Linear chain

This branch continues from `fix/authornote-regex-prompt`, which continues from `fix/summary-deletion-and-context-cutoff`, etc. All previous fixes are included.

## Testing

- [x] Tokenizer shows `actualPromptTokens` matching request preview token count (within ~50 token delta from preset suffix expansion)
- [x] `memoryReserve` is 0 when memory is injected, `totalUsed` no longer double-counts
- [x] MagicDrawer displays generation tokens from breakdown without requiring a prior generation
- [x] No crash on `initHeaderScroll` with null container
- [x] Build passes
