### PR TITLE
feat: sync gallery images as raw binary files

### DIFF
--- a/src/core/services/adapters/dropboxAdapter.js
+++ b/src/core/services/adapters/dropboxAdapter.js
@@ -445,6 +445,8 @@ function stripAppFolderPrefix(path) {
     return path;
 }
 
+const _ensuredFolders = new Set();
+
 export async function ensureFolder(path) {
     const strippedPath = stripAppFolderPrefix(path);
     const parts = strippedPath.split('/').filter(Boolean);
@@ -452,10 +454,13 @@ export async function ensureFolder(path) {
     let currentPath = '';
     for (const part of parts) {
         currentPath = currentPath + '/' + part;
+        if (_ensuredFolders.has(currentPath)) continue;
         try {
             await apiCall('/files/create_folder_v2', { path: currentPath, autorename: false });
+            _ensuredFolders.add(currentPath);
         } catch (e) {
             if (e.status === 409 || e.message?.includes('conflict') || e.message?.includes('already_exists')) {
+                _ensuredFolders.add(currentPath);
                 continue;
             }
             throw e;
@@ -473,6 +478,95 @@ export async function listFolderContinue(cursor) {
 
 export async function upload(path, data) {
     return contentUpload(stripAppFolderPrefix(path), data);
+}
+
+export async function uploadBinary(path, arrayBuffer) {
+    const strippedPath = stripAppFolderPrefix(path);
+    if (!arrayBuffer) return null;
+    const tokens = await getTokens();
+    if (!tokens) throw new Error('Not connected to Dropbox');
+    const accessToken = tokens.access_token;
+
+    const response = await safeUploadFetch(`${CONTENT_BASE}/files/upload`, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${accessToken}`,
+            'Content-Type': 'application/octet-stream',
+            'Dropbox-API-Arg': JSON.stringify({
+                path: strippedPath,
+                mode: 'overwrite',
+                autorename: false,
+                mute: true
+            })
+        },
+        body: arrayBuffer
+    });
+
+    if (response.status === 401) {
+        if (tokens?.refresh_token) {
+            const refreshed = await refreshAccessToken(tokens.refresh_token);
+            const retry = await safeUploadFetch(`${CONTENT_BASE}/files/upload`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${refreshed.access_token}`,
+                    'Content-Type': 'application/octet-stream',
+                    'Dropbox-API-Arg': JSON.stringify({
+                        path: strippedPath,
+                        mode: 'overwrite',
+                        autorename: false,
+                        mute: true
+                    })
+                },
+                body: arrayBuffer
+            });
+            if (!retry.ok) throw Object.assign(new Error(`Binary upload failed ${retry.status}`), { status: retry.status });
+            return retry.json();
+        }
+        throw Object.assign(new Error('Session expired'), { status: 401 });
+    }
+
+    if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw Object.assign(new Error(err.error?.tag || err.error_summary || `Binary upload failed ${response.status}`), { status: response.status });
+    }
+
+    return response.json();
+}
+
+export async function downloadBinary(path) {
+    const strippedPath = stripAppFolderPrefix(path);
+    const tokens = await getTokens();
+    if (!tokens) throw new Error('Not connected to Dropbox');
+    const accessToken = tokens.access_token;
+
+    const response = await safeUploadFetch(`${CONTENT_BASE}/files/download`, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${accessToken}`,
+            'Dropbox-API-Arg': JSON.stringify({ path: strippedPath })
+        }
+    });
+
+    if (response.status === 401) {
+        if (tokens?.refresh_token) {
+            const refreshed = await refreshAccessToken(tokens.refresh_token);
+            const retry = await safeUploadFetch(`${CONTENT_BASE}/files/download`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${refreshed.access_token}`,
+                    'Dropbox-API-Arg': JSON.stringify({ path: strippedPath })
+                }
+            });
+            if (retry.status === 409) return null;
+            if (!retry.ok) throw Object.assign(new Error(`Binary download failed ${retry.status}`), { status: retry.status });
+            return retry.arrayBuffer();
+        }
+        throw Object.assign(new Error('Session expired'), { status: 401 });
+    }
+
+    if (response.status === 409) return null;
+    if (!response.ok) throw Object.assign(new Error(`Binary download failed ${response.status}`), { status: response.status });
+    return response.arrayBuffer();
 }
 
 export async function download(path) {

--- a/src/core/services/adapters/gdriveAdapter.js
+++ b/src/core/services/adapters/gdriveAdapter.js
@@ -799,6 +799,79 @@ export async function upload(path, data) {
     }
 }
 
+export async function uploadBinary(path, arrayBuffer) {
+    if (!arrayBuffer) return null;
+    const { parentId, fileName } = await resolvePathToParent(path);
+    const existingFile = await findFileByName(fileName, parentId);
+    const accessToken = await getValidAccessToken();
+    if (!accessToken) throw new Error('Not connected to Google Drive');
+
+    if (existingFile) {
+        const response = await safeUploadFetch(
+            `${UPLOAD_BASE}/files/${existingFile.id}?uploadType=media&supportsAllDrives=true`,
+            {
+                method: 'PATCH',
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`,
+                    'Content-Type': 'application/octet-stream'
+                },
+                body: arrayBuffer
+            }
+        );
+        if (!response.ok) throw new Error(`Binary upload failed ${response.status}`);
+        return response.json();
+    }
+
+    const metadata = { name: fileName, parents: [parentId] };
+    const boundary = 'glaze_boundary_' + generateRandomString(16);
+    const metaPart = `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${JSON.stringify(metadata)}\r\n`;
+    const binaryBlob = new Blob([arrayBuffer]);
+    const multipartBody = new Blob([
+        new TextEncoder().encode(metaPart),
+        new TextEncoder().encode(`--${boundary}\r\nContent-Type: application/octet-stream\r\n\r\n`),
+        binaryBlob,
+        new TextEncoder().encode(`\r\n--${boundary}--`)
+    ]);
+
+    const response = await safeUploadFetch(
+        `${UPLOAD_BASE}/files?uploadType=multipart&fields=id&supportsAllDrives=true`,
+        {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+                'Content-Type': `multipart/related; boundary=${boundary}`
+            },
+            body: multipartBody
+        }
+    );
+    if (!response.ok) throw new Error(`Binary upload failed ${response.status}`);
+    return response.json();
+}
+
+export async function downloadBinary(path, _retry = false) {
+    const { parentId, fileName } = await resolvePathToParent(path);
+    const file = await findFileByName(fileName, parentId);
+
+    if (!file) {
+        if (!_retry && parentId === folderIdCache) {
+            invalidateGlazeFolderCache();
+            return downloadBinary(path, true);
+        }
+        return null;
+    }
+
+    const response = await apiRequest(
+        `${API_BASE}/files/${file.id}?alt=media&supportsAllDrives=true`
+    );
+
+    if (!response.ok) {
+        if (response.status === 404) return null;
+        throw new Error(`Binary download failed ${response.status}`);
+    }
+
+    return response.arrayBuffer();
+}
+
 export async function download(path, _retry = false) {
     const { parentId, fileName } = await resolvePathToParent(path);
     const file = await findFileByName(fileName, parentId);

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -16,7 +16,8 @@ const ENTITY_TYPES = {
     THEME_PRESETS: 'theme_presets',
     THEME_STATE: 'theme_state',
     LOCAL_STORAGE: 'local_storage',
-    MANIFEST: 'manifest'
+    MANIFEST: 'manifest',
+    GALLERY: 'gallery'
 };
 
 let _encryptionEnabled = false;
@@ -48,6 +49,23 @@ function cloudPath(type, id) {
         case ENTITY_TYPES.MANIFEST: return `${CLOUD_BASE}/manifest.json`;
         default: return `${CLOUD_BASE}/misc/${id}${e}`;
     }
+}
+
+function galleryCloudPath(charId, imgId, imgExt) {
+    return `${CLOUD_BASE}/gallery/${charId}/${imgId}.${imgExt}`;
+}
+
+async function dataUrlToBinary(dataUrl) {
+    const res = await fetch(dataUrl);
+    return await res.arrayBuffer();
+}
+
+function guessImageExt(dataUrl) {
+    const match = dataUrl.match(/^data:image\/([\w+]+)/);
+    if (!match) return 'png';
+    const raw = match[1].toLowerCase();
+    if (raw === 'jpeg') return 'jpg';
+    return raw;
 }
 
 function generateDeviceId() {
@@ -268,7 +286,8 @@ async function buildLocalManifestV2() {
     const characters = await db.getAll('characters');
     for (const char of characters) {
         if (!char?.id) continue;
-        const hash = await computeSyncHash(char);
+        const { images, ...charNoImages } = char;
+        const hash = await computeSyncHash(charNoImages);
         const previousEntry = previousEntries[entryKey(ENTITY_TYPES.CHARACTER, char.id)];
         manifest.entries[entryKey(ENTITY_TYPES.CHARACTER, char.id)] = {
             type: ENTITY_TYPES.CHARACTER,
@@ -278,6 +297,29 @@ async function buildLocalManifestV2() {
             hash,
             deleted: false
         };
+
+        if (Array.isArray(images)) {
+            for (const img of images) {
+                if (!img?.id || !img?.src) continue;
+                const imgExt = guessImageExt(img.src);
+                const imgHash = await computeSyncHash({ id: img.id, src: img.src });
+                const galleryKey = entryKey(ENTITY_TYPES.GALLERY, `${char.id}:${img.id}`);
+                const prevImgEntry = previousEntries[galleryKey];
+                manifest.entries[galleryKey] = {
+                    type: ENTITY_TYPES.GALLERY,
+                    id: `${char.id}:${img.id}`,
+                    charId: char.id,
+                    imgId: img.id,
+                    path: galleryCloudPath(char.id, img.id, imgExt),
+                    ext: imgExt,
+                    updatedAt: prevImgEntry?.hash === imgHash && !prevImgEntry?.deleted
+                        ? prevImgEntry.updatedAt
+                        : Date.now(),
+                    hash: imgHash,
+                    deleted: false
+                };
+            }
+        }
     }
 
     const personas = await db.getAll('personas');
@@ -376,6 +418,12 @@ async function applyCloudEntry(adapter, entry, key) {
 
     const entity = await readCloudEntityByEntry(adapter, entry, key);
     if (entry.type === ENTITY_TYPES.CHARACTER) {
+        const existing = await db.get('characters', entry.id);
+        if (existing?.images) {
+            entity.images = existing.images;
+        } else if (!entity.images) {
+            entity.images = [];
+        }
         await db.put('characters', entity);
         await clearSyncDeletedEntry(entry.type, entry.id);
     } else if (entry.type === ENTITY_TYPES.PERSONA) {
@@ -404,6 +452,7 @@ function getBreakdownBucket(type) {
     if (type === ENTITY_TYPES.CHARACTER) return 'characters';
     if (type === ENTITY_TYPES.PERSONA) return 'personas';
     if (type === ENTITY_TYPES.CHAT) return 'chats';
+    if (type === ENTITY_TYPES.GALLERY) return 'characters';
     return 'settings';
 }
 
@@ -412,7 +461,7 @@ function needsConflict(localEntry, cloudEntry) {
 }
 
 async function getLocalConflictEntity(type, id) {
-    if (type === ENTITY_TYPES.CHARACTER) return getLocalCharacter(id);
+    if (type === ENTITY_TYPES.CHARACTER) return getLocalCharacterWithImages(id);
     if (type === ENTITY_TYPES.PERSONA) return getLocalPersona(id);
     if (type === ENTITY_TYPES.CHAT) return getLocalChat(id);
     return null;
@@ -471,6 +520,16 @@ async function pushManifestV2(adapter, key, onProgress) {
 
     const singletonEntries = await collectSingletonEntries();
 
+    const galleryDirs = new Set();
+    for (const entry of Object.values(localManifest.entries)) {
+        if (entry.type === ENTITY_TYPES.GALLERY && !entry.deleted && adapter.ensureFolder) {
+            galleryDirs.add(`${CLOUD_BASE}/gallery/${entry.charId}`);
+        }
+    }
+    for (const dir of galleryDirs) {
+        await adapter.ensureFolder(dir);
+    }
+
     const tasks = allEntries.map((keyName, i) => {
         const localEntry = localManifest.entries[keyName];
         const cloudEntry = cloudEntries[keyName];
@@ -478,6 +537,34 @@ async function pushManifestV2(adapter, key, onProgress) {
 
         return async () => {
             if (!localEntry) {
+                if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                return;
+            }
+
+            if (localEntry.type === ENTITY_TYPES.GALLERY) {
+                const shouldUpload = !cloudEntry
+                    || localEntry.deleted !== cloudEntry.deleted
+                    || localEntry.hash !== cloudEntry.hash;
+
+                if (!shouldUpload) {
+                    skipped++;
+                    if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                    return;
+                }
+
+                if (localEntry.deleted) {
+                    await deleteCloudFileIfExists(adapter, localEntry);
+                } else {
+                    const char = await getLocalCharacterWithImages(localEntry.charId);
+                    const img = char?.images?.find(im => im.id === localEntry.imgId);
+                    if (img?.src) {
+                        const binary = await dataUrlToBinary(img.src);
+                        await adapter.uploadBinary(localEntry.path, binary);
+                    }
+                }
+
+                pushed++;
+                breakdown[phase]++;
                 if (onProgress) onProgress(phase, i + 1, allEntries.length);
                 return;
             }
@@ -567,6 +654,48 @@ async function pullManifestV2(adapter, key, onProgress, onConflict) {
 
             const cloudIsNewer = !localEntry || cloudEntry.hash !== localEntry.hash || cloudEntry.deleted !== localEntry.deleted;
             if (!cloudIsNewer) {
+                if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                return;
+            }
+
+            if (cloudEntry.type === ENTITY_TYPES.GALLERY) {
+                try {
+                    if (cloudEntry.deleted) {
+                        const char = await getLocalCharacterWithImages(cloudEntry.charId);
+                        if (char?.images) {
+                            char.images = char.images.filter(im => im.id !== cloudEntry.imgId);
+                            await db.put('characters', char);
+                        }
+                    } else {
+                        const binary = await adapter.downloadBinary(cloudEntry.path);
+                        if (binary) {
+                            const blob = new Blob([binary]);
+                            const dataUrl = await new Promise((resolve, reject) => {
+                                const reader = new FileReader();
+                                reader.onload = () => resolve(reader.result);
+                                reader.onerror = reject;
+                                reader.readAsDataURL(blob);
+                            });
+                            const char = await getLocalCharacterWithImages(cloudEntry.charId);
+                            if (char) {
+                                if (!Array.isArray(char.images)) char.images = [];
+                                const existingIdx = char.images.findIndex(im => im.id === cloudEntry.imgId);
+                                const imgEntry = { id: cloudEntry.imgId, src: dataUrl, name: '', thumbnail: null };
+                                if (existingIdx >= 0) {
+                                    imgEntry.name = char.images[existingIdx].name || '';
+                                    char.images[existingIdx] = imgEntry;
+                                } else {
+                                    char.images.push(imgEntry);
+                                }
+                                await db.put('characters', char);
+                            }
+                        }
+                    }
+                    pulled++;
+                    breakdown[phase]++;
+                } catch (e) {
+                    decryptErrors.push({ type: cloudEntry.type, id: cloudEntry.id, error: e.message });
+                }
                 if (onProgress) onProgress(phase, i + 1, allEntries.length);
                 return;
             }
@@ -687,8 +816,13 @@ async function getLocalCharacter(id) {
     const all = await db.getAll('characters');
     const char = all.find(c => c.id === id) || null;
     if (!char) return null;
-    const { images, ...rest } = char;
+    const { images: _images, ...rest } = char;
     return rest;
+}
+
+async function getLocalCharacterWithImages(id) {
+    const all = await db.getAll('characters');
+    return all.find(c => c.id === id) || null;
 }
 
 async function getLocalPersona(id) {
@@ -764,6 +898,10 @@ export async function resolveConflict(conflict, choice) {
         return null;
     }
     if (conflict.type === ENTITY_TYPES.CHARACTER) {
+        const existing = await db.get('characters', conflict.id);
+        if (existing?.images && !entity.images) {
+            entity.images = existing.images;
+        }
         await db.put('characters', entity);
     } else if (conflict.type === ENTITY_TYPES.PERSONA) {
         await db.put('personas', entity);


### PR DESCRIPTION
Gallery images are now synced as individual raw binary files under /Glaze/gallery/{charId}/{imgId}.{ext}, avoiding base64 overhead (33% size savings) and the 30MB JSON payload limit. Each image gets its own manifest entry with a per-image hash so unchanged images are skipped. Character JSON is synced without images but applyCloudEntry and resolveConflict now preserve local gallery images. Added uploadBinary/downloadBinary to both adapters. Dropbox ensureFolder now caches folders to prevent 409/429 errors during parallel uploads. GIF, animated WebP, APNG preserved without loss.