### PR TITLE
fix: preset regex preservation during import/sync/onboarding

### DIFF
--- a/src/composables/app/usePresetCRUD.js
+++ b/src/composables/app/usePresetCRUD.js
@@ -19,7 +19,7 @@ export function usePresetCRUD({ currentPreset, currentPresetId, editingPresetId,
                 onConfirm: (name) => {
                     const id = Date.now().toString(36);
                     presetState.presets[id] = {
-                        id, createdAt: Date.now(), name, blocks: [], author: '', image: '',
+                        id, createdAt: Date.now(), name, blocks: [], regexes: [], author: '', image: '',
                         impersonationPrompt: '', reasoningEnabled: false, reasoningEffort: 'medium',
                         parseInlineReasoning: false, reasoningStart: R_START, reasoningEnd: R_END,
                         mergePrompts: false, mergeRole: 'system', noAssistant: false,

--- a/src/composables/app/usePresetLoader.js
+++ b/src/composables/app/usePresetLoader.js
@@ -28,6 +28,7 @@ export function usePresetLoader({ currentPreset }) {
             }
             if (preset.guidedGenerationPrompt === undefined) preset.guidedGenerationPrompt = '[Generate your next reply according to these instructions: {{guidance}}]';
             if (preset.guidedImpersonationPrompt === undefined) preset.guidedImpersonationPrompt = '[Instead of replying for {{char}}, impersonate {{user}} according to these instructions: {{guidance}}]';
+            if (preset.regexes === undefined) preset.regexes = [];
 
             ensureMandatoryBlocks(preset);
         }

--- a/src/composables/app/usePresetTokenPreview.js
+++ b/src/composables/app/usePresetTokenPreview.js
@@ -87,46 +87,86 @@ export function usePresetTokenPreview({
         return res;
     };
 
-    function getPresetTokens(preset) {
+    function getPresetTokens(preset, _log = false) {
         if (!preset) return 0;
-        let content = "";
+        let totalPresetTokens = 0;
+        const blockDetails = [];
         if (preset.blocks) {
             preset.blocks.forEach(b => {
-                if (b.enabled && !b.isStashed) {
-                    const blockContent = resolveBlockContent(b, { includeNonPreset: false });
-                    if (blockContent) {
-                        content += blockContent + "\n";
-                    }
+                if (!b.enabled || b.isStashed) {
+                    if (_log) blockDetails.push({ id: b.id, status: 'disabled/stashed', rawLen: 0, templateLen: 0, tokens: 0 });
+                    return;
                 }
+                const blockContent = resolveBlockContent(b, { includeNonPreset: false });
+                if (!blockContent) {
+                    if (_log) blockDetails.push({ id: b.id, status: 'no-content', rawLen: 0, templateLen: 0, tokens: 0 });
+                    return;
+                }
+
+                let literalTemplate = blockContent;
+                const sourceMacros = [
+                    /\{\{description\}\}/gi,
+                    /\{\{char_description\}\}/gi,
+                    /\{\{scenario\}\}/gi,
+                    /\{\{personality\}\}/gi,
+                    /\{\{char_personality\}\}/gi,
+                    /\{\{mesExamples\}\}/gi,
+                    /\{\{persona\}\}/gi,
+                    /\{\{summary\}\}/gi,
+                    /\{\{lorebooks\}\}/gi,
+                ];
+                for (const re of sourceMacros) {
+                    literalTemplate = literalTemplate.replace(re, '');
+                }
+
+                literalTemplate = literalTemplate
+                    .replace(/{{setvar::[\s\S]*?::[\s\S]*?}}/gi, '')
+                    .replace(/{{setglobalvar::[\s\S]*?::[\s\S]*?}}/gi, '');
+
+                const charId = activeChatChar?.value?.id || 'default';
+                const sessionId = activeChatChar?.value?.sessionId || 'current';
+                const varsKey = `gz_vars_${charId}_${sessionId}`;
+                let sessionVars = {};
+                try { sessionVars = JSON.parse(localStorage.getItem(varsKey)) || {}; } catch (e) {}
+                literalTemplate = literalTemplate.replace(/{{getvar::([\s\S]*?)}}/gi, (match, name) => {
+                    return sessionVars[name] !== undefined ? sessionVars[name] : '';
+                });
+                literalTemplate = literalTemplate.replace(/{{getglobalvar::([\s\S]*?)}}/gi, (match, name) => {
+                    try {
+                        const raw = localStorage.getItem('gz_global_vars');
+                        if (!raw) return '';
+                        const parsed = JSON.parse(raw);
+                        return parsed[name] !== undefined ? parsed[name] : '';
+                    } catch (e) { return ''; }
+                });
+
+                const charName = activeChatChar?.value ? (activeChatChar.value.macro_name || activeChatChar.value.name) : 'Character';
+                const userName = effectivePersona?.value ? effectivePersona.value.name : 'User';
+                literalTemplate = literalTemplate
+                    .replace(/{{char}}/gi, charName)
+                    .replace(/{{user}}/gi, userName);
+
+                const tokens = estimateTokens(literalTemplate);
+                if (_log) blockDetails.push({ id: b.id, status: 'counted', rawLen: blockContent.length, templateLen: literalTemplate.length, tokens });
+                totalPresetTokens += tokens;
             });
         }
-        const resolved = extendedReplaceMacros(content);
-
-        const macroReplacements = [
-            { regex: /\{\{description\}\}/gi, value: activeChatChar?.value?.description || activeChatChar?.value?.desc || '' },
-            { regex: /\{\{scenario\}\}/gi, value: activeChatChar?.value?.scenario || '' },
-            { regex: /\{\{personality\}\}/gi, value: activeChatChar?.value?.personality || '' },
-            { regex: /\{\{char_description\}\}/gi, value: activeChatChar?.value?.description || '' },
-            { regex: /\{\{char_personality\}\}/gi, value: activeChatChar?.value?.personality || '' },
-            { regex: /\{\{mesExamples\}\}/gi, value: activeChatChar?.value?.mes_example || '' },
-            { regex: /\{\{persona\}\}/gi, value: effectivePersona?.value?.prompt || '' },
-        ];
-
-        let templateOnly = resolved;
-        for (const mr of macroReplacements) {
-            templateOnly = templateOnly.replace(mr.regex, '');
+        if (_log) {
+            console.group('[getPresetTokens]', preset.name || preset.id);
+            console.log('total:', totalPresetTokens);
+            console.table(blockDetails);
+            console.groupEnd();
         }
-
-        return estimateTokens(templateOnly);
+        return totalPresetTokens;
     }
 
-    const editingPresetTokens = computed(() => getPresetTokens(currentPreset.value));
+    const editingPresetTokens = computed(() => getPresetTokens(currentPreset.value, true));
     const displayedEditingTokens = ref(0);
 
     const activePresetTokens = computed(() => {
         const id = effectivePresetId.value;
         const preset = presetState.presets[id] || presetState.presets.default_shino;
-        return getPresetTokens(preset);
+        return getPresetTokens(preset, true);
     });
     const displayedActiveTokens = ref(0);
 

--- a/src/core/services/presetImportService.js
+++ b/src/core/services/presetImportService.js
@@ -11,6 +11,7 @@ export function detectPresetFormat(data) {
 
 export function finalizeImportedPreset(preset) {
     if (!preset.blocks) preset.blocks = [];
+    if (!preset.regexes) preset.regexes = [];
 
     preset.blocks.forEach(b => {
         if (b.id !== 'authors_note' && b.id !== 'summary' && !b.insertion_mode) {

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -442,7 +442,31 @@ async function applyCloudEntry(adapter, entry, key) {
         await db.set('gz_theme_active_preset', entity);
     } else if (entry.type === ENTITY_TYPES.LOCAL_STORAGE) {
         for (const [lsKey, lsVal] of Object.entries(entity || {})) {
-            localStorage.setItem(lsKey, lsVal);
+            if (lsKey === 'silly_cradle_presets') {
+                try {
+                    const cloudPresets = JSON.parse(lsVal);
+                    const localRaw = localStorage.getItem('silly_cradle_presets');
+                    const localPresets = localRaw ? JSON.parse(localRaw) : {};
+                    for (const [pId, cloudPreset] of Object.entries(cloudPresets)) {
+                        const localRegexes = localPresets[pId]?.regexes;
+                        const cloudRegexes = cloudPreset.regexes;
+                        if (localRegexes?.length) {
+                            if (!cloudRegexes?.length) {
+                                cloudPreset.regexes = localRegexes;
+                            } else {
+                                const cloudIds = new Set(cloudRegexes.map(r => r.id));
+                                const localOnly = localRegexes.filter(r => !cloudIds.has(r.id));
+                                if (localOnly.length) cloudPreset.regexes = [...cloudRegexes, ...localOnly];
+                            }
+                        }
+                    }
+                    localStorage.setItem(lsKey, JSON.stringify({ ...localPresets, ...cloudPresets }));
+                } catch (e) {
+                    localStorage.setItem(lsKey, lsVal);
+                }
+            } else {
+                localStorage.setItem(lsKey, lsVal);
+            }
         }
     }
     return entity;

--- a/src/views/OnboardingView.vue
+++ b/src/views/OnboardingView.vue
@@ -322,6 +322,19 @@ function triggerPresetImport() {
                 if (data.blocks) {
                     preset = data;
                 } else {
+                    for (const [pId, importedPreset] of Object.entries(data)) {
+                        const localRegexes = presetState.presets[pId]?.regexes;
+                        const importedRegexes = importedPreset.regexes;
+                        if (localRegexes?.length) {
+                            if (!importedRegexes?.length) {
+                                importedPreset.regexes = localRegexes;
+                            } else {
+                                const importedIds = new Set(importedRegexes.map(r => r.id));
+                                const localOnly = localRegexes.filter(r => !importedIds.has(r.id));
+                                if (localOnly.length) importedPreset.regexes = [...importedRegexes, ...localOnly];
+                            }
+                        }
+                    }
                     Object.assign(presetState.presets, data);
                     savePresets();
                     next();

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -8,6 +8,7 @@ import Editor from '@/components/editors/GenericEditor.vue';
 import { presetState, initPresetState, getEffectivePresetId, flushPresetSave } from '@/core/states/presetState.js';
 import SheetView from '@/components/ui/SheetView.vue';
 import HelpTip from '@/components/ui/HelpTip.vue';
+import Tooltip from '@/components/ui/Tooltip.vue';
 import RegexSheet from '@/components/sheets/RegexSheet.vue';
 import { logger } from '@/utils/logger.js';
 import { getEffectivePersona } from '@/core/states/personaState.js';
@@ -250,6 +251,24 @@ defineExpose({ open, close, openAuthorsNoteSheet, openSummarySheet, openPreset }
 
 const regexSheetRef = ref(null);
 const presetRegexCount = computed(() => currentPreset.value?.regexes?.length || 0);
+const hasInflatingRegex = computed(() => {
+    const regexes = currentPreset.value?.regexes;
+    if (!regexes) return false;
+    return regexes.some(r => {
+        if (r.disabled) return false;
+        const rep = r.replacement || '';
+        return /[\u2000-\u200A\u202F\u205F\u3000\u00A0]/.test(rep);
+    });
+});
+
+function presetHasInflatingRegex(id) {
+    const regexes = presetState.presets[id]?.regexes;
+    if (!regexes) return false;
+    return regexes.some(r => {
+        if (r.disabled) return false;
+        return /[\u2000-\u200A\u202F\u205F\u3000\u00A0]/.test(r.replacement || '');
+    });
+}
 
 function openRegexSheetFromPreset() {
     if (openedFromRegex.value) close();
@@ -329,8 +348,11 @@ onBeforeUnmount(() => { unsubs.forEach(unsub => unsub()); });
 </div>
                         <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 4px;">
                             <div class="ps-card-badge" :class="{ 'ps-with-bg': !!preset.image }">
-                                <svg viewBox="0 0 24 24" class="ps-badge-icon"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
+                                <svg viewBox="0 0 24 24" class="ps-badge-icon"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c11 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
                                 {{ presetTokenCache[id] }}
+                                <Tooltip v-if="presetHasInflatingRegex(id)" text="This preset has regexes that inflate token count (rare Unicode spaces). Displayed count may be inaccurate." placement="top">
+                                    <span class="inflate-warning-card">&#x1F595;</span>
+                                </Tooltip>
                             </div>
                             <div class="ps-card-meta" :class="{ 'ps-with-bg': !!preset.image }">
                                 <span v-if="preset.author">by {{ preset.author }}</span>
@@ -411,6 +433,9 @@ by {{ currentPreset.author }}
                             <div class="active-tokens">
                                 <svg viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
                                 <span>{{ props.contextBreakdown?.preset || displayedEditingTokens }}</span>
+                                <Tooltip v-if="hasInflatingRegex" text="This preset has regexes that inflate token count (rare Unicode spaces). Displayed count may be inaccurate." placement="bottom">
+                                    <span class="inflate-warning">&#x1F595;</span>
+                                </Tooltip>
                             </div>
                         </div>
                     </div>
@@ -1318,6 +1343,17 @@ Add Block
     width: 14px;
     height: 14px;
     fill: currentColor;
+    opacity: 0.7;
+}
+
+.inflate-warning {
+    font-size: 14px;
+    opacity: 0.8;
+}
+
+.inflate-warning-card {
+    font-size: 12px;
+    margin-left: 2px;
     opacity: 0.7;
 }
 

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -251,24 +251,6 @@ defineExpose({ open, close, openAuthorsNoteSheet, openSummarySheet, openPreset }
 
 const regexSheetRef = ref(null);
 const presetRegexCount = computed(() => currentPreset.value?.regexes?.length || 0);
-const hasInflatingRegex = computed(() => {
-    const regexes = currentPreset.value?.regexes;
-    if (!regexes) return false;
-    return regexes.some(r => {
-        if (r.disabled) return false;
-        const rep = r.replacement || '';
-        return /[\u2000-\u200A\u202F\u205F\u3000\u00A0]/.test(rep);
-    });
-});
-
-function presetHasInflatingRegex(id) {
-    const regexes = presetState.presets[id]?.regexes;
-    if (!regexes) return false;
-    return regexes.some(r => {
-        if (r.disabled) return false;
-        return /[\u2000-\u200A\u202F\u205F\u3000\u00A0]/.test(r.replacement || '');
-    });
-}
 
 function openRegexSheetFromPreset() {
     if (openedFromRegex.value) close();
@@ -350,9 +332,6 @@ onBeforeUnmount(() => { unsubs.forEach(unsub => unsub()); });
                             <div class="ps-card-badge" :class="{ 'ps-with-bg': !!preset.image }">
                                 <svg viewBox="0 0 24 24" class="ps-badge-icon"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c11 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
                                 {{ presetTokenCache[id] }}
-                                <Tooltip v-if="presetHasInflatingRegex(id)" text="This preset has regexes that inflate token count (rare Unicode spaces). Displayed count may be inaccurate." placement="top">
-                                    <span class="inflate-warning-card">&#x26A0;&#xFE0F;</span>
-                                </Tooltip>
                             </div>
                             <div class="ps-card-meta" :class="{ 'ps-with-bg': !!preset.image }">
                                 <span v-if="preset.author">by {{ preset.author }}</span>
@@ -433,9 +412,6 @@ by {{ currentPreset.author }}
                             <div class="active-tokens">
                                 <svg viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
                                 <span>{{ props.contextBreakdown?.preset || displayedEditingTokens }}</span>
-                                <Tooltip v-if="hasInflatingRegex" text="This preset has regexes that inflate token count (rare Unicode spaces). Displayed count may be inaccurate." placement="bottom">
-                                    <span class="inflate-warning">&#x26A0;&#xFE0F;</span>
-                                </Tooltip>
                             </div>
                         </div>
                     </div>
@@ -1343,17 +1319,6 @@ Add Block
     width: 14px;
     height: 14px;
     fill: currentColor;
-    opacity: 0.7;
-}
-
-.inflate-warning {
-    font-size: 14px;
-    opacity: 0.8;
-}
-
-.inflate-warning-card {
-    font-size: 12px;
-    margin-left: 2px;
     opacity: 0.7;
 }
 

--- a/src/views/PresetView.vue
+++ b/src/views/PresetView.vue
@@ -351,7 +351,7 @@ onBeforeUnmount(() => { unsubs.forEach(unsub => unsub()); });
                                 <svg viewBox="0 0 24 24" class="ps-badge-icon"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c11 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
                                 {{ presetTokenCache[id] }}
                                 <Tooltip v-if="presetHasInflatingRegex(id)" text="This preset has regexes that inflate token count (rare Unicode spaces). Displayed count may be inaccurate." placement="top">
-                                    <span class="inflate-warning-card">&#x1F595;</span>
+                                    <span class="inflate-warning-card">&#x26A0;&#xFE0F;</span>
                                 </Tooltip>
                             </div>
                             <div class="ps-card-meta" :class="{ 'ps-with-bg': !!preset.image }">
@@ -434,7 +434,7 @@ by {{ currentPreset.author }}
                                 <svg viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
                                 <span>{{ props.contextBreakdown?.preset || displayedEditingTokens }}</span>
                                 <Tooltip v-if="hasInflatingRegex" text="This preset has regexes that inflate token count (rare Unicode spaces). Displayed count may be inaccurate." placement="bottom">
-                                    <span class="inflate-warning">&#x1F595;</span>
+                                    <span class="inflate-warning">&#x26A0;&#xFE0F;</span>
                                 </Tooltip>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary

- **Fix regexes being silently lost** during import, sync, and onboarding merge:
  - Backfill regexes: [] in finalizeImportedPreset, usePresetLoader, createNewPreset
  - Merge regexes by ID in syncEngine applyCloudEntry (local-only regexes preserved)
  - Merge regexes by ID in OnboardingView Object.assign path
- Remove debug logging from generationWorker