### PR TITLE
feat: CharX/ZIP export in CardSheet + streaming/abort/imagegen/DB fixes

### DIFF
--- a/src/components/sheets/CharacterCardSheet.vue
+++ b/src/components/sheets/CharacterCardSheet.vue
@@ -7,7 +7,7 @@ import { translations } from '@/utils/i18n.js';
 import { currentLang } from '@/core/config/APPSettings.js';
 import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetState.js';
 import { db, markSyncDeletedEntry } from '@/utils/db.js';
-import { exportCharacterAsV2Json, exportCharacterAsV2Png } from '@/utils/characterIO.js';
+import { exportCharacterAsV2Json, exportCharacterAsV2Png, exportCharacterAsCharX } from '@/utils/characterIO.js';
 import { useSessionSheet } from '@/composables/character/useSessionSheet.js';
 import { useCharacterGallery } from '@/composables/character/useCharacterGallery.js';
 import { APP_EVENTS } from '@/core/events/eventNames.js';
@@ -147,6 +147,7 @@ const menuIcon = '<svg viewBox="0 0 24 24"><path d="M12 8a2 2 0 1 0 0-4 2 2 0 0 
 const plusIcon = '<svg viewBox="0 0 24 24"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>';
 const exportIcon = '<svg viewBox="0 0 24 24"><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>';
 const pngIcon = '<svg viewBox="0 0 24 24"><path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/></svg>';
+const archiveIcon = '<svg viewBox="0 0 24 24"><path d="M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-6 10H6v-2h8v2zm4-4H6v-2h12v2z"/></svg>';
 const editIcon = '<svg viewBox="0 0 24 24"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>';
 const deleteIcon = '<svg viewBox="0 0 24 24"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>';
 
@@ -212,6 +213,22 @@ function openExportSheet(char) {
                 icon: exportIcon,
                 onClick: () => {
                     exportCharacterAsV2Json(char);
+                    closeBottomSheet();
+                }
+            },
+            {
+                label: getTranslated('label_export_charx', 'CharX (with gallery)'),
+                icon: archiveIcon,
+                onClick: () => {
+                    exportCharacterAsCharX(char);
+                    closeBottomSheet();
+                }
+            },
+            {
+                label: getTranslated('label_export_zip', 'ZIP (with gallery)'),
+                icon: archiveIcon,
+                onClick: () => {
+                    exportCharacterAsCharX(char, true);
                     closeBottomSheet();
                 }
             }

--- a/src/locales/en/index.json
+++ b/src/locales/en/index.json
@@ -328,6 +328,8 @@
     "action_export_st": "Export",
     "label_export_png": "PNG (Character Card)",
     "label_export_json": "JSON (SillyTavern V2)",
+    "label_export_charx": "CharX (with gallery)",
+    "label_export_zip": "ZIP (with gallery)",
     "title_error": "Error",
     "msg_vector_generation_failed": "The embedding model did not respond during generation, so vector lorebook retrieval could not complete.",
     "msg_import_char_failed": "Failed to import character",

--- a/src/locales/ru/index.json
+++ b/src/locales/ru/index.json
@@ -328,6 +328,8 @@
     "action_export_st": "Экспорт",
     "label_export_png": "PNG (Карточка персонажа)",
     "label_export_json": "JSON (SillyTavern V2)",
+    "label_export_charx": "CharX (с галереей)",
+    "label_export_zip": "ZIP (с галереей)",
     "label_formatted": "Форматированный",
     "label_raw_json": "Сырой JSON",
     "export_success": "Экспорт завершен",


### PR DESCRIPTION
## Summary

- **CharX/ZIP export in CharacterCardSheet** - previously only available in CharacterList context menu; now the card detail sheet also offers CharX and ZIP export alongside PNG/JSON. Added locale keys for both formats (en/ru).
- **Streaming text flicker fix** - ShadowContent await nextTick() caused reactive messages to temporarily disappear; replaced with synchronous DOM measurement.
- **Streaming half-message disappear on chat switch** - closeChat() cleared currentMessages while restoreGenerationState was mid-save; patchChatData with JSON.parse(JSON.stringify) snapshot eliminates the race.
- **Phantom isTyping data loss** - onGenerationEnded handler now cleans phantom isTyping flags left by stale/aborted generations.
- **Inline image edit race** - imageGenState registry tracks in-flight image generations per message; enterEditMode/saveEdit abort any active generation; processMessageImages accepts abortSignal, guards onUpdate with abort/stale checks.
- **regex DB crash** - trimOut uses replaceAll instead of new RegExp (fixes crash on special chars); syncEngine merges regex_scripts by ID on cloud sync; RegexSheet subscribes to regexScriptsChanged; tavoBackupReader uses substituteRegex->macroRules.
- **ESLint rule no-abort-in-unmount** - enforces that onUnmounted/onBeforeUnmount never calls .abort() or clearGenerationState (per vue-components.md async lifecycle rule).
- **useGenerationAbort rule compliance** - reverted clearGenerationState from abort path; cleanup delegated to handleGenerationError -> finalizeGenerationState per generation.md.
- **RefactorPlan.md** - added Task 5: audit and migrate all getChatData+saveChat to patchChatData (41 patterns identified).

## Linear chain

This branch continues from PR #105 (merged), which included all previous feature branch commits.

## Testing

- [x] Build passes (npm run build)
- [ ] Desktop: generation + character switch + return
- [ ] Mobile: generation + minimize + return
- [ ] CharX/ZIP export from CharacterCardSheet
- [ ] Inline image edit abort on save
- [ ] Regex scripts survive cloud sync