### PR TITLE
fix: gallery sync re-upload on reconnect

### DIFF
--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -60,6 +60,12 @@ async function dataUrlToBinary(dataUrl) {
     return await res.arrayBuffer();
 }
 
+async function computeImageHash(dataUrl) {
+    const binary = await dataUrlToBinary(dataUrl);
+    const digest = await crypto.subtle.digest('SHA-256', binary);
+    return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
 function guessImageExt(dataUrl) {
     const match = dataUrl.match(/^data:image\/([\w+]+)/);
     if (!match) return 'png';
@@ -302,7 +308,7 @@ async function buildLocalManifestV2() {
             for (const img of images) {
                 if (!img?.id || !img?.src) continue;
                 const imgExt = guessImageExt(img.src);
-                const imgHash = await computeSyncHash({ id: img.id, src: img.src });
+                const imgHash = await computeImageHash(img.src);
                 const galleryKey = entryKey(ENTITY_TYPES.GALLERY, `${char.id}:${img.id}`);
                 const prevImgEntry = previousEntries[galleryKey];
                 manifest.entries[galleryKey] = {


### PR DESCRIPTION
## Summary

Gallery images were re-uploaded on every disconnect+reconnect or pull+push cycle because computeSyncHash({id, src}) hashed the data URL string. Data URLs change when binary is round-tripped through Blob/FileReader (different MIME formatting, base64 normalization), causing hash mismatches even for identical images.

Fixed by introducing computeImageHash() that converts the data URL to raw binary first, then hashes only the binary bytes with SHA-256. Same image binary = same hash regardless of data URL encoding.

## Testing

- [x] Build passes
- [ ] Import char with gallery on PC, import same char on phone, push from PC, pull on phone — gallery should be skipped (not re-uploaded)