### PR TITLE
fix: backup file picker not opening on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 7
-        versionName "0.6.0.1-alpha"
+        versionName "0.6.1-alpha"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glaze",
-  "version": "0.6.0.1-alpha",
+  "version": "0.6.1-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glaze",
-      "version": "0.6.0.1-alpha",
+      "version": "0.6.1-alpha",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anuradev/capacitor-background-mode": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glaze",
   "private": true,
-  "version": "0.6.0.1-alpha",
+  "version": "0.6.1-alpha",
   "license": "AGPL-3.0-only",
   "author": "hydall <hydallatglaze@gmail.com>",
   "type": "module",

--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -46,7 +46,7 @@ const doUpdatePreview = (forcedCaretPos = null) => {
 };
 
 const {
-    attachedImage, imageInput,
+    attachedImage,
     isGuidanceMode, guidanceType, guidanceText, guidanceInput,
     isGuidanceFocused, isMainFocused,
     closeGuidance, toggleGuidanceMode,
@@ -325,7 +325,6 @@ defineExpose({
                 @request-preview="openRequestPreview"
                 @add-block="() => {}"
             />
-            <input type="file" ref="imageInput" accept="image/png, image/jpeg, image/webp" style="display: none" @change="onImageSelected" />
         </div>
     </div>
     <RequestPreviewSheet ref="requestPreviewSheet" />

--- a/src/components/editors/GenericEditor.vue
+++ b/src/components/editors/GenericEditor.vue
@@ -18,7 +18,6 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue', 'save', 'open-fs']);
 
 const item = ref({});
-const avatarInput = ref(null);
 const t = (key) => translations[currentLang.value]?.[key] || key;
 
 // Specific state for greetings cycling
@@ -165,7 +164,11 @@ onBeforeUnmount(() => {
 });
 
 function triggerAvatarUpload() {
-    if (avatarInput.value) avatarInput.value.click();
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.onchange = (e) => handleAvatarChange(e);
+    input.click();
 }
 
 function handleAvatarChange(e) {
@@ -261,7 +264,6 @@ function getSelectedLabel(field) {
 {{ t('hint_change_avatar') }}
 </div>
                 </div>
-                <input type="file" ref="avatarInput" accept="image/*" style="display: none;" @change="handleAvatarChange">
             </div>
             
             <!-- Dynamic Sections -->

--- a/src/components/sheets/BackupSheet.vue
+++ b/src/components/sheets/BackupSheet.vue
@@ -11,7 +11,6 @@ import { showBottomSheet, closeBottomSheet } from '@/core/states/bottomSheetStat
 import { flushDbWriteQueue } from '@/utils/db.js';
 
 const sheet = ref(null);
-const fileInput = ref(null);
 
 defineProps({
     zIndex: {
@@ -66,9 +65,11 @@ const performExport = async () => {
 };
 
 const triggerImport = () => {
-    if (fileInput.value) {
-        fileInput.value.click();
-    }
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '*/*';
+    input.onchange = (e) => handleRestoreFile(e);
+    input.click();
 };
 
 const stageMap = {
@@ -210,8 +211,6 @@ Export
 {{ t('backup_hint_export') || 'Create a full backup of your current application state.' }}
 </div>
                 </div>
-                
-                <input type="file" ref="fileInput" style="display: none" accept="*/*" @change="handleRestoreFile">
             </div>
 
             <!-- Importing View -->

--- a/src/components/sheets/RegexSheet.vue
+++ b/src/components/sheets/RegexSheet.vue
@@ -26,7 +26,6 @@ const t = (key) => translations[currentLang.value]?.[key] || key;
 const currentView = ref('list'); // list, edit
 const activeScript = ref(null);
 const isPresetScript = ref(false);
-const fileInput = ref(null);
 
 const presetRegexes = computed(() => {
     const charId = props.activeChatChar?.id;
@@ -188,7 +187,7 @@ function handleAddScript() {
                             {
                                 label: t('action_import') || 'Import from file',
                                 icon: '<svg viewBox="0 0 24 24"><path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM14 13v4h-4v-4H7l5-5 5 5h-3z"/></svg>',
-                                onClick: () => { closeBottomSheet(); importTargetPreset.value = true; fileInput.value?.click(); }
+                                onClick: () => { closeBottomSheet(); triggerFileImport(true); }
                             }
                         ]
                     });
@@ -210,7 +209,7 @@ function handleAddScript() {
                             {
                                 label: t('action_import') || 'Import from file',
                                 icon: '<svg viewBox="0 0 24 24"><path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM14 13v4h-4v-4H7l5-5 5 5h-3z"/></svg>',
-                                onClick: () => { closeBottomSheet(); importTargetPreset.value = false; fileInput.value?.click(); }
+                                onClick: () => { closeBottomSheet(); triggerFileImport(false); }
                             }
                         ]
                     });
@@ -219,6 +218,15 @@ function handleAddScript() {
         ]
     });
 }
+
+const triggerFileImport = (isPreset) => {
+    importTargetPreset.value = isPreset;
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.onchange = (e) => handleFileSelect(e);
+    input.click();
+};
 
 async function handleFileSelect(event) {
     const file = event.target.files?.[0];
@@ -438,7 +446,6 @@ defineExpose({ open, close });
             <HelpTip term="regex" />
         </template>
         <template #header>
-            <input type="file" ref="fileInput" accept=".json" style="display: none;" @change="handleFileSelect">
         </template>
 
         <div class="sheet-body">

--- a/src/composables/chat/useInputActions.js
+++ b/src/composables/chat/useInputActions.js
@@ -5,7 +5,6 @@ import { publishAppEvent } from '@/core/events/eventHub.js';
 
 export function useInputActions(props, emit, _chatInputRef, _isComposing, _updatePreview) {
     const attachedImage = ref(null);
-    const imageInput = ref(null);
     const isGuidanceMode = ref(false);
     const guidanceType = ref('send');
     const guidanceText = ref('');
@@ -32,7 +31,11 @@ export function useInputActions(props, emit, _chatInputRef, _isComposing, _updat
     };
 
     const triggerImageUpload = () => {
-        if (imageInput.value) imageInput.value.click();
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'image/png, image/jpeg, image/webp';
+        input.onchange = (e) => onImageSelected(e);
+        input.click();
     };
 
     const onImageSelected = (event) => {
@@ -44,7 +47,6 @@ export function useInputActions(props, emit, _chatInputRef, _isComposing, _updat
             };
             reader.readAsDataURL(file);
         }
-        if (imageInput.value) imageInput.value.value = '';
     };
 
     const clearImage = () => {
@@ -106,7 +108,6 @@ export function useInputActions(props, emit, _chatInputRef, _isComposing, _updat
 
     return {
         attachedImage,
-        imageInput,
         isGuidanceMode,
         guidanceType,
         guidanceText,

--- a/src/composables/theme/useThemePresets.js
+++ b/src/composables/theme/useThemePresets.js
@@ -10,7 +10,13 @@ const t = (key) => translations[currentLang.value]?.[key] || key;
 
 export function useThemePresets() {
     const presets = ref([]);
-    const themeImportInput = ref(null);
+    const triggerThemeImport = () => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = '.json';
+        input.onchange = (e) => onThemeFileSelected(e);
+        input.click();
+    };
 
     const activePresetName = computed(() => {
         const p = presets.value.find(x => x.id === themeState.activePresetId);
@@ -108,7 +114,7 @@ export function useThemePresets() {
                     icon: '<svg viewBox="0 0 24 24"><path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM14 13v4h-4v-4H7l5-5 5 5h-3z"/></svg>',
                     onClick: () => {
                         closeBottomSheet();
-                        themeImportInput.value?.click();
+                        triggerThemeImport();
                     }
                 }
             ]
@@ -281,7 +287,7 @@ export function useThemePresets() {
 
     return {
         presets,
-        themeImportInput,
+        triggerThemeImport,
         activePresetName,
         activePresetAuthor,
         loadPresetsList,

--- a/src/views/Menu/Settings/ThemeSettingsView.vue
+++ b/src/views/Menu/Settings/ThemeSettingsView.vue
@@ -72,15 +72,12 @@ const onColorSelected = (color) => {
     }
 };
 
-const bgInput = ref(null);
-const fontInput = ref(null);
-const chatFontInput = ref(null);
 const activeTab = ref('general');
 const activeChatSubTab = ref('font');
 
 const {
     presets,
-    themeImportInput,
+    triggerThemeImport,
     activePresetName,
     activePresetAuthor,
     loadPresetsList,
@@ -120,7 +117,6 @@ const getCustomColorStyle = (colorValue) => {
 
 const handleResetBackground = async () => {
     await setBackgroundImage(null);
-    if (bgInput.value) bgInput.value.value = '';
     
     const index = presets.value.findIndex(p => p.id === themeState.activePresetId);
     if (index !== -1) {
@@ -130,12 +126,10 @@ const handleResetBackground = async () => {
 
 const handleResetFont = async () => {
     await setCustomFont(null);
-    if (fontInput.value) fontInput.value.value = '';
 };
 
 const handleResetChatFont = async () => {
     await setChatFont(null);
-    if (chatFontInput.value) chatFontInput.value.value = '';
 };
 
 const checkIcon = '<svg viewBox="0 0 24 24" style="fill:currentColor"><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/></svg>';
@@ -174,7 +168,7 @@ const openUiFontSelector = () => {
             {
                 label: t('theme_font_custom') || 'Custom...',
                 icon: themeState.uiFontMode === 'custom' ? checkIcon : null,
-                onClick: () => { closeBottomSheet(); fontInput.value.click(); }
+                onClick: () => { closeBottomSheet(); const i = document.createElement('input'); i.type = 'file'; i.accept = '.ttf,.otf,.woff,.woff2'; i.onchange = (e) => setCustomFont(e.target.files[0]); i.click(); }
             }
         ]
     });
@@ -202,7 +196,7 @@ const openChatFontSelector = () => {
             {
                 label: t('theme_font_custom') || 'Custom...',
                 icon: themeState.chatFontMode === 'custom' ? checkIcon : null,
-                onClick: () => { closeBottomSheet(); chatFontInput.value.click(); }
+                onClick: () => { closeBottomSheet(); const i = document.createElement('input'); i.type = 'file'; i.accept = '.ttf,.otf,.woff,.woff2'; i.onchange = (e) => setChatFont(e.target.files[0]); i.click(); }
             }
         ]
     });
@@ -251,7 +245,6 @@ const chatPreviewStyle = computed(() => ({
                     <svg viewBox="0 0 24 24" style="width: 20px; height: 20px; fill: currentColor;"><path d="M7 10l5 5 5-5z"/></svg>
                 </div>
             </div>
-            <input type="file" ref="themeImportInput" accept=".json" style="display: none;" @change="onThemeFileSelected">
         </div>
 
         <!-- Tab Switcher -->
@@ -299,7 +292,6 @@ const chatPreviewStyle = computed(() => ({
 {{ t('theme_reset_font') || 'Reset Font' }}
 </div>
                     </div>
-                    <input type="file" ref="fontInput" accept=".ttf,.otf,.woff,.woff2" style="display: none;" @change="(e) => setCustomFont(e.target.files[0])">
 
                     <div class="menu-item color-item" @click="openColorPicker('uiText', t('theme_ui_text_color') || 'Text Color', themeState.uiTextColor, PRESET_UI_COLORS, true)">
                         <div class="menu-text" style="flex:1;">
@@ -433,7 +425,7 @@ const chatPreviewStyle = computed(() => ({
                     <div class="section-header">
 {{ t('theme_background_image') }}
 </div>
-                    <div class="menu-item" @click="bgInput.click()">
+                    <div class="menu-item" @click="() => { const i = document.createElement('input'); i.type = 'file'; i.accept = 'image/*'; i.onchange = (e) => onBackgroundImageSelected(e); i.click(); }">
                         <svg class="menu-icon" viewBox="0 0 24 24"><path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/></svg>
                         <div class="menu-text">
 {{ t('theme_select_image') }}
@@ -445,7 +437,6 @@ const chatPreviewStyle = computed(() => ({
 {{ t('theme_reset_background') }}
 </div>
                     </div>
-                    <input type="file" ref="bgInput" accept="image/*" style="display: none;" @change="onBackgroundImageSelected">
                     <div v-if="themeState.hasBackgroundImage">
                         <div style="height: 1px; background: rgba(128,128,128,0.1); margin: 0 16px;"></div>
                         <div style="padding: 16px;">
@@ -593,7 +584,6 @@ C
 {{ t('theme_reset_font') || 'Reset Font' }}
 </div>
                         </div>
-                        <input type="file" ref="chatFontInput" accept=".ttf,.otf,.woff,.woff2" style="display: none;" @change="(e) => setChatFont(e.target.files[0])">
 
                         <div style="height: 1px; background: rgba(128,128,128,0.1); margin: 0 16px;"></div>
 

--- a/src/views/OnboardingView.vue
+++ b/src/views/OnboardingView.vue
@@ -67,10 +67,12 @@ const personaConfig = reactive({
     avatar: null
 });
 
-const avatarInput = ref(null);
-
 function triggerAvatarUpload() {
-    if (avatarInput.value) avatarInput.value.click();
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.onchange = (e) => handleAvatarChange(e);
+    input.click();
 }
 
 function handleAvatarChange(e) {
@@ -428,7 +430,6 @@ async function finish() {
                                             <span class="hint-desktop">{{ t('hint_change_avatar_desktop') || 'Click to change' }}</span>
                                             <span class="hint-mobile">{{ t('hint_change_avatar_mobile') || t('hint_change_avatar') || 'Tap to change' }}</span>
                                         </div>
-                                        <input type="file" ref="avatarInput" accept="image/*" style="display: none;" @change="handleAvatarChange">
                                     </div>
                                     <div v-else class="icon-wrapper" v-html="slides[currentSlide].icon || introContent[0].icon"></div>
                                 </div>
@@ -658,7 +659,6 @@ async function finish() {
                                             </div>
                                             <div class="avatar-overlay-hint">{{ t('hint_change_avatar') || 'Tap to change' }}</div>
                                         </div>
-                                        <input type="file" ref="avatarInput" accept="image/*" style="display: none;" @change="handleAvatarChange">
                                     </div>
                                     <div class="settings-item">
                                         <label>{{ t('onboarding_label_name') }}</label>


### PR DESCRIPTION
## Summary

<imp><input type='file'> with style='display: none' failed to trigger the native file chooser on Capacitor Android WebView. Replaced with dynamic input creation (same pattern as chatImporter.pickChatFile) which works reliably on all platforms.

## Testing

- [x] Build passes
- [ ] Android: backup import file picker opens from Menu/ToolsView
- [ ] Web: backup import still works