### PR TITLE
fix: db.put durability and Tavo backup data loss after restart

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 7
-        versionName "0.6.1-alpha"
+        versionName "0.6.2-alpha"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "glaze",
-  "version": "0.6.1-alpha",
+  "version": "0.6.2-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glaze",
-      "version": "0.6.1-alpha",
+      "version": "0.6.2-alpha",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@anuradev/capacitor-background-mode": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glaze",
   "private": true,
-  "version": "0.6.1-alpha",
+  "version": "0.6.2-alpha",
   "license": "AGPL-3.0-only",
   "author": "hydall <hydallatglaze@gmail.com>",
   "type": "module",

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -305,8 +305,12 @@ export const db = {
             const tx = database.transaction(storeName, 'readwrite');
             const store = tx.objectStore(storeName);
             const req = store.put(toPlain(value));
-            req.onsuccess = () => {
+            tx.oncomplete = () => {
                 resolve();
+                database.close();
+            };
+            tx.onerror = () => {
+                reject(tx.error);
                 database.close();
             };
             req.onerror = () => {

--- a/src/utils/tavoBackupReader.js
+++ b/src/utils/tavoBackupReader.js
@@ -3,9 +3,11 @@
  * Uses FlatBuffer format for structured field extraction.
  */
 import JSZip from 'jszip';
-import { db } from '@/utils/db.js';
+import { db, flushDbWriteQueue } from '@/utils/db.js';
 import { importSillyTavernChat } from '@/core/services/chatImporter.js';
 import { convertSTPreset } from '@/core/services/presetImportService.js';
+import { initLorebookState, flushLorebookSave } from '@/core/states/lorebookState.js';
+import { initPresetState, flushPresetSave } from '@/core/states/presetState.js';
 
 const TYPE_NAMES = {
     0x0000: "_meta",
@@ -833,6 +835,27 @@ export async function importTavoBackupFromZip(zipFile, onProgress) {
             }
         }
     }
+
+    progress('finalizing');
+    await flushDbWriteQueue();
+
+    flushPresetSave();
+    await initPresetState(true);
+
+    flushLorebookSave();
+    await initLorebookState(true);
+
+    const keysToRemove = [];
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith('gz_chat_recovery_')) {
+            keysToRemove.push(key);
+        }
+    }
+    keysToRemove.forEach(key => localStorage.removeItem(key));
+
+    localStorage.setItem('gz_skip_sync_pull', Date.now().toString());
+    localStorage.setItem('gz_backup_restored', Date.now().toString());
 
     return result;
 }


### PR DESCRIPTION
## Summary

- **Fix `db.put()` durability**: resolved on `req.onsuccess` instead of `tx.oncomplete`, causing characters and personas to be lost on page reload before the IDB transaction committed
- **Fix Tavo backup data loss after restart**: reactive watches (`presetState`, `lorebookState`) with debounced saves could overwrite freshly imported data with stale in-memory state; added flush + re-init after import
- **Fix missing `gz_skip_sync_pull` flag in Tavo importer**: on restart, `fullPull()` would overwrite imported data with stale cloud data; now matches Glaze importer behavior

## Bugs Fixed

### Bug 1 — `db.put()` not durable (`db.js:302-316`)
Characters and personas were written via `db.put()` which resolved on `req.onsuccess` (write requested) instead of `tx.oncomplete` (write committed to disk). If the user reloaded or the app was killed before the transaction committed, data was silently lost. This is why only the API key survived Tavo backup imports — `db.set()` (used for API presets) already waited for `tx.oncomplete`.

### Bug 2 — Reactive watches overwrite imported data (`tavoBackupReader.js`)
`presetState` watch (1s debounce → `localStorage.setItem`) and `lorebookState` watch (500ms debounce → `db.queuedSet`) could fire during/after Tavo import, overwriting freshly written data with stale pre-import reactive state. `flushDbWriteQueue()` only drains the IDB promise chain — it does NOT cancel `setTimeout`-based debounce timers.

**Fix**: After import, flush debounce timers (`flushPresetSave()`, `flushLorebookSave()`) and re-initialize reactive state from IDB (`initPresetState(true)`, `initLorebookState(true)`).

### Bug 3 — Missing sync-pull guard (`tavoBackupReader.js`)
The Glaze importer sets `gz_skip_sync_pull` and `gz_backup_restored` in localStorage (backupService.js:202-203) to prevent `fullPull()` from overwriting imported data on restart. The Tavo importer did not set these flags.

**Fix**: Added `gz_skip_sync_pull`, `gz_backup_restored`, and crash recovery key cleanup (matching Glaze importer behavior).

## Test plan
- [ ] Import a Tavo `.tbk` backup, reload app — characters, personas, presets, lorebooks should persist
- [ ] Import a Glaze `.glz` backup, reload app — verify same behavior as before (regression check)
- [ ] Create a character, reload app — verify character persists (db.put durability)
- [ ] Import Tavo backup with cloud sync enabled — verify `fullPull()` does not overwrite imported data on restart
