### PR TITLE
feat: add worker timeout diagnostics with copyable bottom sheet

### DIFF
--- a/src/core/llm/usecases/chatPreparedPromptExecution.js
+++ b/src/core/llm/usecases/chatPreparedPromptExecution.js
@@ -60,6 +60,19 @@ export async function executePreparedChatPrompt({
         ({ result } = await runPreparedChatPrompt(preparedRequest));
     } catch (e) {
         console.error('Worker error:', e);
+        if (e.message?.includes('Prompt building timed out') && e._diagnostic) {
+            showBottomSheet({
+                title: t('prompt_timeout_title') || 'Prompt Building Timeout',
+                bigInfo: {
+                    icon: '<svg viewBox="0 0 24 24" style="fill:currentColor;width:100%;height:100%;"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>',
+                    description: e._diagnostic,
+                    buttonText: t('btn_copy') || 'Copy',
+                    onButtonClick: () => {
+                        try { navigator.clipboard.writeText(e._diagnostic); } catch (__e) {}
+                    }
+                }
+            });
+        }
         if (onError) onError(e);
         return null;
     }

--- a/src/core/llm/usecases/promptWorkerLifecycle.js
+++ b/src/core/llm/usecases/promptWorkerLifecycle.js
@@ -26,15 +26,42 @@ function getWorker() {
     return globalThis._genWorker;
 }
 
+function buildDiagnosticInfo(sentAt, payloadSize) {
+    const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent || '');
+    const parts = [
+        '--- Prompt Worker Timeout Diagnostic ---',
+        `Time: ${new Date().toISOString()}`,
+        `Message sent at: ${sentAt ? new Date(sentAt).toISOString() : 'N/A'}`,
+        `Elapsed: ${sentAt ? Date.now() - sentAt : 'N/A'}ms`,
+        `Payload size: ${(payloadSize / 1024).toFixed(1)}KB`,
+        `Worker exists: ${!!globalThis._genWorker}`,
+        `Queue size: ${globalThis._workerQueue?.size || 0}`,
+        `Main thread UA: ${typeof navigator !== 'undefined' ? navigator.userAgent : 'N/A'}`,
+        `Main thread platform: ${typeof navigator !== 'undefined' ? navigator.platform : 'N/A'}`,
+        `Main thread isIOS: ${isIOS}`,
+        `Device memory: ${navigator?.deviceMemory || 'N/A'}GB`,
+        `Hardware concurrency: ${navigator?.hardwareConcurrency || 'N/A'}`,
+        '--- End Diagnostic ---'
+    ];
+    return parts.join('\n');
+}
+
 export function processPromptAsync(payload) {
     const worker = getWorker();
     const WORKER_TIMEOUT = 30000;
+    const sentAt = Date.now();
+    payload._sentAt = sentAt;
+    const payloadSize = JSON.stringify(payload).length;
+
     return new Promise((resolve, reject) => {
         const id = ++globalThis._msgIdCounter;
 
         const timer = setTimeout(() => {
             globalThis._workerQueue.delete(id);
-            reject(new Error('Prompt building timed out (worker did not respond within 30s)'));
+            const diagInfo = buildDiagnosticInfo(sentAt, payloadSize);
+            const err = new Error('Prompt building timed out (worker did not respond within 30s)\n\n' + diagInfo);
+            err._diagnostic = diagInfo;
+            reject(err);
         }, WORKER_TIMEOUT);
 
         globalThis._workerQueue.set(id, {

--- a/src/workers/generationWorker.js
+++ b/src/workers/generationWorker.js
@@ -846,16 +846,39 @@ function buildPromptMessagesWorker(args) {
 self.onmessage = async function (e) {
     const { id, type, payload } = e.data;
 
-    if (type === 'calculateContext' || type === 'generateChatResponse') {
-        try {
-            if (tokenizerReady) await tokenizerReady;
+    if (type === 'ping') {
+        self.postMessage({ id, success: true, data: { pong: true, ts: Date.now(), isIOS, ua: (typeof navigator !== 'undefined' ? navigator.userAgent : 'N/A') } });
+        return;
+    }
 
+    if (type === 'calculateContext' || type === 'generateChatResponse') {
+        const diag = {
+            receivedAt: Date.now(),
+            sentAt: payload?._sentAt || null,
+            tokenizerReadyAt: null,
+            buildStart: null,
+            buildEnd: null,
+            calcStart: null,
+            calcEnd: null,
+            isIOS,
+            workerUa: typeof navigator !== 'undefined' ? navigator.userAgent : 'N/A'
+        };
+        try {
+            if (tokenizerReady) {
+                await tokenizerReady;
+                diag.tokenizerReadyAt = Date.now();
+            }
+
+            diag.buildStart = Date.now();
             const { messages, loreEntries, notifyObj } = buildPromptMessagesWorker(payload);
+            diag.buildEnd = Date.now();
 
             const { apiConfig } = payload;
             const maxTokens = apiConfig.maxTokens || 8000;
             const contextSize = apiConfig.contextSize || 32000;
             const safeContext = Math.max(1000, contextSize - maxTokens);
+
+            diag.calcStart = Date.now();
 
             const staticMessages = messages.filter(m => !m.isHistory);
             const historyMessages = messages.filter(m => m.isHistory);
@@ -903,8 +926,8 @@ self.onmessage = async function (e) {
                 historyMessagesHiddenByContext: 0
             };
 
-            // Lorebook and vectorLore are inside reserve, not in fixedBase
             breakdown.fixedBase = breakdown.character + breakdown.preset + breakdown.persona + breakdown.summary + breakdown.authorsNote;
+            // Lorebook and vectorLore are inside reserve, not in fixedBase
             breakdown.fixedTotal = breakdown.fixedBase + breakdown.lorebookReserve + breakdown.memoryReserve;
 
             const availableForHistory = safeContext - breakdown.fixedTotal;
@@ -952,6 +975,8 @@ self.onmessage = async function (e) {
             breakdown.totalUsed = breakdown.fixedBase + breakdown.lorebookReserve + breakdown.memoryReserve + breakdown.history;
             breakdown.remaining = Math.max(0, contextSize - breakdown.totalUsed);
 
+            diag.calcEnd = Date.now();
+
             self.postMessage({
                 id,
                 success: true,
@@ -963,11 +988,12 @@ self.onmessage = async function (e) {
                     staticTokens,
                     contextBreakdown: breakdown,
                     needsVarsSave: notifyObj.varsChanged,
-                    sessionVars: payload.sessionVars
+                    sessionVars: payload.sessionVars,
+                    _diagnostic: diag
                 }
             });
         } catch (error) {
-            self.postMessage({ id, success: false, error: error.message });
+            self.postMessage({ id, success: false, error: error.message, _diagnostic: diag });
         }
     }
 };


### PR DESCRIPTION
## Summary

- When the prompt building worker times out (30s), show a bottom sheet with diagnostic info (timestamps, payload size, UA, iOS detection, device memory, worker alive status) and a Copy button so users on iOS can report the issue
- Worker now responds to ping messages for liveness checks and includes timing metadata (_diagnostic) in every response
- Main thread enriches timeout errors with diagnostic info: elapsed time, payload size, worker exists, queue size, UA, platform, isIOS, device memory, hardware concurrency

## Why

Some iOS users hit the timeout error with no way to debug - no access to console logs. This gives them a copyable diagnostic report to send us, so we can identify the root cause (worker not loading, tokenizer hanging, module worker unsupported, etc.).