### PR TITLE
fix: block sync operations until DB is fully loaded

### DIFF
--- a/src/composables/app/useAppInit.js
+++ b/src/composables/app/useAppInit.js
@@ -6,17 +6,16 @@ import { loadPersonas } from '@/core/states/personaState.js';
 import { initLorebookState } from '@/core/states/lorebookState.js';
 import { initPresetState } from '@/core/states/presetState.js';
 import { initSyncState, syncProvider } from '@/core/states/syncState.js';
-import { checkSyncReadiness, fullPull } from '@/core/services/syncService.js';
+import { checkSyncReadiness, fullPull, isDbReady } from '@/core/services/syncService.js';
 import { startTracking } from '@/core/services/timeTracker.js';
 import { initThemeToggle, initHeaderDropdown, initViewportFix } from '@/core/services/ui.js';
 import { initRipple } from '@/core/services/interactionEffects.js';
 import { checkAndRequestNotifications, consumePendingNotificationData } from '@/core/services/notificationService.js';
 import { generateMissingThumbnails } from '@/utils/characterIO.js';
-import { migrateScToGz } from '@/utils/db.js';
+import { migrateScToGz, db } from '@/utils/db.js';
 import { seedDefaultCharacters } from '@/utils/seedDefaultCharacters.js';
 import { isKeyboardOpen, onKeyboardShow, onKeyboardHide } from '@/core/services/keyboardHandler.js';
 import { updateLanguage } from '@/utils/i18n.js';
-import { db } from '@/utils/db.js';
 import { publishAppEvent } from '@/core/events/eventHub.js';
 import { APP_EVENTS } from '@/core/events/eventNames.js';
 
@@ -45,6 +44,7 @@ export function useAppInit({
         }
         const wasHiddenMs = Date.now() - lastVisibilityHidden;
         if (wasHiddenMs < 5000) return;
+        if (!isDbReady.value) return;
 
         const skipPull = localStorage.getItem('gz_skip_sync_pull');
         if (skipPull) {
@@ -123,6 +123,7 @@ export function useAppInit({
 
         updateLanguage();
         isDataLoaded.value = true;
+        isDbReady.value = true;
 
         generateMissingThumbnails();
 

--- a/src/core/services/adapters/dropboxAdapter.js
+++ b/src/core/services/adapters/dropboxAdapter.js
@@ -156,6 +156,10 @@ async function contentDownload(path, accessToken) {
 
 const _ensuredFolders = new Set();
 
+export function invalidateFolderCache() {
+    _ensuredFolders.clear();
+}
+
 export async function ensureFolder(path) {
     const strippedPath = stripAppFolderPrefix(path);
     const parts = strippedPath.split('/').filter(Boolean);

--- a/src/core/services/sync/syncSerialization.js
+++ b/src/core/services/sync/syncSerialization.js
@@ -79,6 +79,9 @@ export async function applyCloudEntry(adapter, entry, key) {
     }
 
     const entity = await readCloudEntityByEntry(adapter, entry, key);
+    if (!entity) {
+        throw new Error(`Cloud file not found: ${entry.path}`);
+    }
     if (entry.type === 'character') {
         const existing = await db.get('characters', entry.id);
         if (existing?.images) {

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -409,6 +409,9 @@ export async function wipeCloudData(adapter, onProgress) {
     if (adapter.invalidateGlazeFolderCache) {
         adapter.invalidateGlazeFolderCache();
     }
+    if (adapter.invalidateFolderCache) {
+        adapter.invalidateFolderCache();
+    }
     if (onProgress) onProgress({ phase: 'deleting', message: 'Deleting cloud data...' });
     try {
         const result = await adapter.deleteFolder(CLOUD_BASE);

--- a/src/core/services/syncService.js
+++ b/src/core/services/syncService.js
@@ -6,6 +6,10 @@ import * as gdriveAdapter from '@/core/services/adapters/gdriveAdapter.js';
 import { pushEntities, pullEntities, detectEncryptionState, isEncryptionEnabled } from '@/core/services/syncEngine.js';
 import { flushLorebookSave } from '@/core/states/lorebookState.js';
 import { getSyncKey, hasSyncKey } from '@/core/services/crypto/keyManager.js';
+import { ref } from 'vue';
+
+const isDbReady = ref(false);
+export { isDbReady };
 
 function getAdapter() {
     if (syncProvider.value === PROVIDERS.DROPBOX) return dropboxAdapter;
@@ -14,6 +18,7 @@ function getAdapter() {
 }
 
 export async function fullPush() {
+    if (!isDbReady.value) return;
     if (syncStatus.value === SYNC_STATUS.SYNCING) return;
 
     syncStatus.value = SYNC_STATUS.SYNCING;
@@ -50,6 +55,7 @@ export async function fullPush() {
 }
 
 export async function fullPull() {
+    if (!isDbReady.value) return;
     if (syncStatus.value === SYNC_STATUS.SYNCING) return;
 
     syncStatus.value = SYNC_STATUS.SYNCING;
@@ -95,6 +101,7 @@ export async function fullSync() {
 }
 
 export async function checkSyncReadiness() {
+    if (!isDbReady.value) return { ready: false, reason: 'db_not_ready' };
     if (!syncProvider.value) return { ready: false, reason: 'no_provider' };
     return { ready: true };
 }

--- a/src/core/services/syncService.js
+++ b/src/core/services/syncService.js
@@ -6,6 +6,7 @@ import * as gdriveAdapter from '@/core/services/adapters/gdriveAdapter.js';
 import { pushEntities, pullEntities, detectEncryptionState, isEncryptionEnabled } from '@/core/services/syncEngine.js';
 import { flushLorebookSave } from '@/core/states/lorebookState.js';
 import { getSyncKey, hasSyncKey } from '@/core/services/crypto/keyManager.js';
+import { db } from '@/utils/db.js';
 import { ref } from 'vue';
 
 const isDbReady = ref(false);
@@ -20,6 +21,12 @@ function getAdapter() {
 export async function fullPush() {
     if (!isDbReady.value) return;
     if (syncStatus.value === SYNC_STATUS.SYNCING) return;
+
+    const chars = await db.getAll('characters');
+    if (!chars?.length) {
+        setSyncError('Cannot push: local database appears empty. If data was lost after wake, pull from cloud first.');
+        return;
+    }
 
     syncStatus.value = SYNC_STATUS.SYNCING;
     clearConflicts();


### PR DESCRIPTION
## Summary

IndexedDB can be empty after device wakes from sleep (Chromium bug). Without this guard, sync builds a manifest from empty DB and either overwrites cloud data (push) or shows false conflicts (pull).

- Add isDbReady ref in syncService, defaults to alse`n- ullPush, ullPull, checkSyncReadiness all check isDbReady before proceeding
- useAppInit sets isDbReady = true only after all init state loads complete
- onVisibilityChange also checks isDbReady before auto-pull

## Reproduction

Device goes to sleep with IndexedDB data, wakes up with empty IDB. Sync fires on visibility change or startup and sees empty local manifest vs cloud manifest with data.