### PR TITLE
fix: GDrive gallery sync, sync conflict UI, iOS worker hang

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -1,0 +1,180 @@
+name: Build Branch
+
+on:
+  push:
+    branches:
+      - 'fix/**'
+      - 'feat/**'
+      - 'ci/**'
+  workflow_dispatch:
+
+jobs:
+  build-ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Web Project
+        env:
+          VITE_DROPBOX_APP_KEY: ${{ secrets.VITE_DROPBOX_APP_KEY }}
+          VITE_GDRIVE_CLIENT_ID: ${{ secrets.VITE_GDRIVE_IOS_CLIENT_ID }}
+        run: npx vite build
+
+      - name: Capacitor Sync
+        run: npx cap sync ios
+
+      - name: Build App Archive
+        run: |
+          xcodebuild -project ios/App/App.xcodeproj \
+                     -scheme App \
+                     -configuration Release \
+                     -destination 'generic/platform=iOS' \
+                     -archivePath App.xcarchive archive \
+                     CODE_SIGNING_ALLOWED=NO \
+                     CODE_SIGNING_REQUIRED=NO \
+                     CODE_SIGNING_METHOD=manual \
+                     -skipPackagePluginValidation
+
+      - name: Create IPA Structure
+        run: |
+          mkdir -p Payload
+          cp -r App.xcarchive/Products/Applications/App.app Payload/
+          zip -r App.ipa Payload
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SillyCradle-Unsigned-IPA
+          path: App.ipa
+
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Web Project
+        env:
+          VITE_DROPBOX_APP_KEY: ${{ secrets.VITE_DROPBOX_APP_KEY }}
+          VITE_DROPBOX_REDIRECT_NATIVE: ${{ secrets.VITE_DROPBOX_REDIRECT_NATIVE }}
+          VITE_GDRIVE_CLIENT_ID: ${{ secrets.VITE_GDRIVE_CLIENT_ID }}
+          VITE_GDRIVE_CLIENT_SECRET: ${{ secrets.VITE_GDRIVE_CLIENT_SECRET }}
+          VITE_GDRIVE_REDIRECT_NATIVE: https://hydall.github.io/Glaze/oauth/gdrive/redirect.html
+        run: npx vite build
+
+      - name: Capacitor Sync Android
+        run: npx cap sync android
+
+      - name: Decode Keystore
+        env:
+          KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: echo "$KEYSTORE_B64" | base64 --decode > "${{ github.workspace }}/glaze-release.jks"
+
+      - name: Build Signed Release APK
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/glaze-release.jks
+          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          chmod +x android/gradlew
+          cd android && ./gradlew assembleRelease --no-daemon
+
+      - name: Upload Signed APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: SillyCradle-Signed-APK
+          path: android/app/build/outputs/apk/release/*.apk
+
+      - name: Clean Up Keystore
+        if: always()
+        run: rm -f "${{ github.workspace }}/glaze-release.jks"
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Web Project
+        env:
+          VITE_DROPBOX_APP_KEY: ${{ secrets.VITE_DROPBOX_APP_KEY }}
+          VITE_GDRIVE_CLIENT_ID: ${{ secrets.VITE_GDRIVE_DESKTOP_CLIENT_ID }}
+          VITE_GDRIVE_CLIENT_SECRET: ${{ secrets.VITE_GDRIVE_DESKTOP_CLIENT_SECRET }}
+        run: npx vite build
+
+      - name: Build Electron App
+        run: npx electron-builder --win --publish never
+
+      - name: Upload Windows Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-Windows-Setup
+          path: dist_electron/*.exe
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y fakeroot dpkg rpm libarchive-tools
+          npm ci
+
+      - name: Build Web Project
+        env:
+          VITE_DROPBOX_APP_KEY: ${{ secrets.VITE_DROPBOX_APP_KEY }}
+          VITE_GDRIVE_CLIENT_ID: ${{ secrets.VITE_GDRIVE_DESKTOP_CLIENT_ID }}
+          VITE_GDRIVE_CLIENT_SECRET: ${{ secrets.VITE_GDRIVE_DESKTOP_CLIENT_SECRET }}
+        run: npx vite build
+
+      - name: Build Electron App
+        run: npx electron-builder --linux deb pacman AppImage --publish never
+
+      - name: Upload Linux Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-Linux-Packages
+          path: |
+            dist_electron/*.deb
+            dist_electron/*.pacman
+            dist_electron/*.AppImage

--- a/src/components/sheets/ConflictSheet.vue
+++ b/src/components/sheets/ConflictSheet.vue
@@ -79,6 +79,25 @@ const entityFields = (entity, type) => {
             const display = v?.length > 80 ? v.substring(0, 80) + '...' : String(v ?? '');
             fields.push({ key: k, label: k, value: display });
         }
+    } else if (type === 'lorebooks' && Array.isArray(entity)) {
+        fields.push({ key: 'count', label: t('sync_item_count') || 'Count', value: String(entity.length) });
+        for (const lb of entity.slice(0, 5)) {
+            fields.push({ key: lb.id, label: lb.name || lb.id, value: `${(lb.entries?.length || 0)} entries` });
+        }
+    } else if ((type === 'api_presets' || type === 'theme_presets') && typeof entity === 'object') {
+        const entries = Array.isArray(entity) ? entity : Object.values(entity);
+        fields.push({ key: 'count', label: t('sync_item_count') || 'Count', value: String(entries.length) });
+        for (const p of entries.slice(0, 5)) {
+            fields.push({ key: p.id, label: p.name || p.id, value: '' });
+        }
+    } else if (type === 'theme_state' && typeof entity === 'object') {
+        for (const [k, v] of Object.entries(entity)) {
+            if (typeof v === 'object' && v !== null) {
+                fields.push({ key: k, label: k, value: truncate(JSON.stringify(v), 120) });
+            } else if (v !== null && v !== undefined) {
+                fields.push({ key: k, label: k, value: truncate(String(v), 120) });
+            }
+        }
     } else if (typeof entity === 'object') {
         for (const [k, v] of Object.entries(entity)) {
             if (typeof v === 'object' && v !== null) {
@@ -228,6 +247,10 @@ defineExpose({ open, close });
                             <div class="cs-item-type">
 {{ typeLabel(conflict.type) }}
 </div>
+                            <div class="cs-item-time" v-if="conflict.localModified || conflict.cloudModified">
+                                <span class="cs-time-local" v-if="conflict.localModified">{{ t('sync_version_local') || 'Local' }}: {{ formatTimestamp(conflict.localModified) }}</span>
+                                <span class="cs-time-cloud" v-if="conflict.cloudModified">{{ t('sync_version_cloud') || 'Cloud' }}: {{ formatTimestamp(conflict.cloudModified) }}</span>
+                            </div>
                         </div>
                         <svg class="cs-chevron" viewBox="0 0 24 24" :class="{ rotated: expandedConflictId === conflict.id }"><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/></svg>
                     </div>
@@ -450,6 +473,21 @@ defineExpose({ open, close });
     font-size: 12px;
     color: var(--text-gray, #8e8e93);
     text-transform: capitalize;
+}
+
+.cs-item-time {
+    display: flex;
+    gap: 10px;
+    font-size: 10px;
+    margin-top: 2px;
+}
+
+.cs-time-local {
+    color: #FF9500;
+}
+
+.cs-time-cloud {
+    color: var(--vk-blue);
 }
 
 .cs-chevron {

--- a/src/components/sheets/ConflictSheet.vue
+++ b/src/components/sheets/ConflictSheet.vue
@@ -34,6 +34,11 @@ const typeLabel = (type) => {
     if (type === 'persona') return t('sync_type_persona') || 'Persona';
     if (type === 'chat') return t('sync_type_chat') || 'Chat';
     if (type === 'gallery') return t('sync_type_gallery') || 'Gallery';
+    if (type === 'lorebooks') return t('sync_type_lorebooks') || 'Lorebooks';
+    if (type === 'api_presets') return t('sync_type_api_presets') || 'API Presets';
+    if (type === 'theme_presets') return t('sync_type_theme_presets') || 'Theme Presets';
+    if (type === 'theme_state') return t('sync_type_theme_state') || 'Theme State';
+    if (type === 'local_storage') return t('sync_type_local_storage') || 'Local Storage';
     return type;
 };
 
@@ -69,6 +74,19 @@ const entityFields = (entity, type) => {
     } else if (type === 'gallery') {
         fields.push({ key: 'imgId', label: 'Image ID', value: entity.imgId || '—' });
         fields.push({ key: 'hash', label: 'Hash', value: truncate(entity.hash || '—', 16) });
+    } else if (type === 'local_storage' && typeof entity === 'object') {
+        for (const [k, v] of Object.entries(entity)) {
+            const display = v?.length > 80 ? v.substring(0, 80) + '...' : String(v ?? '');
+            fields.push({ key: k, label: k, value: display });
+        }
+    } else if (typeof entity === 'object') {
+        for (const [k, v] of Object.entries(entity)) {
+            if (typeof v === 'object' && v !== null) {
+                fields.push({ key: k, label: k, value: truncate(JSON.stringify(v), 120) });
+            } else if (v !== null && v !== undefined) {
+                fields.push({ key: k, label: k, value: truncate(String(v), 120) });
+            }
+        }
     }
     fields.push({ key: 'updatedAt', label: t('sync_modified') || 'Modified', value: formatTimestamp(entity.updatedAt) });
     return fields;

--- a/src/core/llm/usecases/promptWorkerLifecycle.js
+++ b/src/core/llm/usecases/promptWorkerLifecycle.js
@@ -1,33 +1,121 @@
-function getWorker() {
-    if (!globalThis._genWorker) {
-        globalThis._genWorker = new Worker(new URL('../../../workers/generationWorker.js', import.meta.url), { type: 'module' });
-        globalThis._workerQueue = new Map();
-        globalThis._msgIdCounter = 0;
+const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent || '');
+const PING_TIMEOUT = 2000;
 
-        globalThis._genWorker.onmessage = (e) => {
-            const { id, success, data, error } = e.data;
-            if (globalThis._workerQueue.has(id)) {
-                if (success) globalThis._workerQueue.get(id).resolve(data);
-                else globalThis._workerQueue.get(id).reject(new Error(error));
-                globalThis._workerQueue.delete(id);
-            }
-        };
+function createModuleWorker() {
+    return new Worker(
+        new URL('../../../workers/generationWorker.js', import.meta.url),
+        { type: 'module' }
+    );
+}
 
-        globalThis._genWorker.onerror = (e) => {
-            console.error('Generation worker crashed:', e);
-            for (const [, { reject }] of globalThis._workerQueue) {
-                reject(new Error('Worker crashed: ' + (e.message || 'Unknown error')));
-            }
-            globalThis._workerQueue.clear();
-            globalThis._genWorker.terminate();
-            globalThis._genWorker = null;
-        };
+async function createIosFallbackWorker() {
+    const workerUrl = new URL('../../../workers/generationWorker.js', import.meta.url);
+    try {
+        const response = await fetch(workerUrl.href);
+        let code = await response.text();
+        code = code.replace(/export\s*\{[^}]*\}/g, '');
+        code = code.replace(/export\s+(default\s+)?/g, '');
+        const blob = new Blob([code], { type: 'application/javascript' });
+        return new Worker(URL.createObjectURL(blob));
+    } catch (e) {
+        console.error('[Worker] Failed to create iOS Blob worker:', e);
+        return null;
     }
-    return globalThis._genWorker;
+}
+
+function pingWorker(worker) {
+    return new Promise((resolve) => {
+        const id = '_ping_' + Date.now();
+        const timer = setTimeout(() => resolve(false), PING_TIMEOUT);
+        const handler = (e) => {
+            if (e.data?.id === id) {
+                clearTimeout(timer);
+                worker.removeEventListener('message', handler);
+                resolve(true);
+            }
+        };
+        worker.addEventListener('message', handler);
+        worker.postMessage({ id, type: 'ping' });
+    });
+}
+
+function attachHandlers(worker) {
+    worker.onmessage = (e) => {
+        const { id, success, data, error } = e.data;
+        if (globalThis._workerQueue.has(id)) {
+            if (success) globalThis._workerQueue.get(id).resolve(data);
+            else globalThis._workerQueue.get(id).reject(new Error(error));
+            globalThis._workerQueue.delete(id);
+        }
+    };
+
+    worker.onerror = (e) => {
+        console.error('Generation worker crashed:', e);
+        for (const [, { reject }] of globalThis._workerQueue) {
+            reject(new Error('Worker crashed: ' + (e.message || 'Unknown error')));
+        }
+        globalThis._workerQueue.clear();
+        worker.terminate();
+        globalThis._genWorker = null;
+        globalThis._genWorkerInit = null;
+    };
+}
+
+async function initWorker() {
+    if (!isIOS) {
+        const worker = createModuleWorker();
+        attachHandlers(worker);
+        return worker;
+    }
+
+    const moduleWorker = createModuleWorker();
+    attachHandlers(moduleWorker);
+
+    const alive = await pingWorker(moduleWorker);
+    if (alive) {
+        console.log('[Worker] Module worker responding on iOS');
+        return moduleWorker;
+    }
+
+    console.warn('[Worker] Module worker unresponsive on iOS, trying Blob fallback');
+    moduleWorker.terminate();
+
+    const fallbackWorker = await createIosFallbackWorker();
+    if (fallbackWorker) {
+        attachHandlers(fallbackWorker);
+
+        const fallbackAlive = await pingWorker(fallbackWorker);
+        if (fallbackAlive) {
+            console.log('[Worker] Blob fallback worker responding on iOS');
+            return fallbackWorker;
+        }
+
+        console.error('[Worker] Blob fallback also unresponsive');
+        fallbackWorker.terminate();
+    }
+
+    throw new Error('Failed to initialize generation worker on iOS');
+}
+
+async function getWorker() {
+    if (globalThis._genWorker) return globalThis._genWorker;
+
+    if (!globalThis._genWorkerInit) {
+        globalThis._genWorkerInit = initWorker().then(worker => {
+            globalThis._genWorker = worker;
+            globalThis._workerQueue = globalThis._workerQueue || new Map();
+            globalThis._msgIdCounter = globalThis._msgIdCounter || 0;
+            return worker;
+        }).catch(err => {
+            globalThis._genWorkerInit = null;
+            throw err;
+        });
+    }
+
+    return globalThis._genWorkerInit;
 }
 
 function buildDiagnosticInfo(sentAt, payloadSize) {
-    const isIOS = typeof navigator !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent || '');
     const parts = [
         '--- Prompt Worker Timeout Diagnostic ---',
         `Time: ${new Date().toISOString()}`,
@@ -46,8 +134,8 @@ function buildDiagnosticInfo(sentAt, payloadSize) {
     return parts.join('\n');
 }
 
-export function processPromptAsync(payload) {
-    const worker = getWorker();
+export async function processPromptAsync(payload) {
+    const worker = await getWorker();
     const WORKER_TIMEOUT = 30000;
     const sentAt = Date.now();
     payload._sentAt = sentAt;

--- a/src/core/services/adapters/gdrive/gdriveFiles.js
+++ b/src/core/services/adapters/gdrive/gdriveFiles.js
@@ -196,29 +196,33 @@ export async function uploadBinary(path, arrayBuffer) {
     }
 
     const metadata = { name: fileName, parents: [parentId] };
-    const boundary = 'glaze_boundary_' + generateRandomString(16);
-    const metaPart = `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${JSON.stringify(metadata)}\r\n`;
-    const binaryBlob = new Blob([arrayBuffer]);
-    const multipartBody = new Blob([
-        new TextEncoder().encode(metaPart),
-        new TextEncoder().encode(`--${boundary}\r\nContent-Type: application/octet-stream\r\n\r\n`),
-        binaryBlob,
-        new TextEncoder().encode(`\r\n--${boundary}--`)
-    ]);
-
-    const response = await safeUploadFetch(
-        `${UPLOAD_BASE}/files?uploadType=multipart&fields=id&supportsAllDrives=true`,
+    const initResponse = await safeUploadFetch(
+        `${UPLOAD_BASE}/files?uploadType=resumable&supportsAllDrives=true&fields=id`,
         {
             method: 'POST',
             headers: {
                 'Authorization': `Bearer ${accessToken}`,
-                'Content-Type': `multipart/related; boundary=${boundary}`
+                'Content-Type': 'application/json; charset=UTF-8',
+                'X-Upload-Content-Type': 'application/octet-stream',
+                'X-Upload-Content-Length': String(arrayBuffer.byteLength)
             },
-            body: multipartBody
+            body: JSON.stringify(metadata)
         }
     );
-    if (!response.ok) throw new Error(`Binary upload failed ${response.status}`);
-    const result = await response.json();
+    if (!initResponse.ok) throw new Error(`Binary upload init failed ${initResponse.status}`);
+    const uploadUrl = initResponse.headers.get('Location');
+    if (!uploadUrl) throw new Error('Binary upload init returned no Location header');
+
+    const uploadResponse = await safeUploadFetch(uploadUrl, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/octet-stream',
+            'Content-Length': String(arrayBuffer.byteLength)
+        },
+        body: arrayBuffer
+    });
+    if (!uploadResponse.ok) throw new Error(`Binary upload failed ${uploadResponse.status}`);
+    const result = await uploadResponse.json();
     if (result?.id) cacheFileId(path, result.id);
     return result;
 }

--- a/src/core/services/sync/syncConflict.js
+++ b/src/core/services/sync/syncConflict.js
@@ -8,6 +8,45 @@ export async function getLocalConflictEntity(type, id, { getLocalCharacterWithIm
     if (type === 'character') return getLocalCharacterWithImages(id);
     if (type === 'persona') return getLocalPersona(id);
     if (type === 'chat') return getLocalChat(id);
+    if (type === 'lorebooks') return await db.get('gz_lorebooks');
+    if (type === 'api_presets') return await db.get('gz_api_connection_presets');
+    if (type === 'theme_presets') return await db.get('gz_theme_presets');
+    if (type === 'theme_state') return await db.get('gz_theme_active_preset');
+    if (type === 'local_storage') {
+        const lsKeys = [
+            'silly_cradle_presets', 'silly_cradle_current_preset_id', 'gz_preset_connections',
+            'regex_scripts', 'gz_active_persona_id', 'gz_persona_connections',
+            'gz_lang', 'gz_theme', 'gz_chat_padding_lr', 'gz_force_mobile_layout',
+            'gz_battery_saver_ui',
+            'api-endpoint', 'api-max-tokens', 'api-context',
+            'gz_api_provider', 'gz_api_endpoint_normalized',
+            'gz_api_temp', 'gz_api_topp', 'gz_api_stream',
+            'gz_api_auto_hide_images', 'gz_api_auto_hide_images_n',
+            'gz_api_request_reasoning', 'gz_api_reasoning_start', 'gz_api_reasoning_end', 'gz_api_reasoning_effort',
+            'gz_api_omit_temperature', 'gz_api_omit_top_p', 'gz_api_omit_reasoning', 'gz_api_omit_reasoning_effort',
+            'gz_api_connect_timeout', 'gz_api_stream_timeout',
+            'gz_embedding_use_same', 'gz_embedding_target', 'gz_embedding_scan_depth',
+            'gz_embedding_threshold', 'gz_embedding_top_k', 'gz_embedding_max_chunk_tokens',
+            'gz_embedding_enabled',
+            'gz_imggen_enabled', 'gz_imggen_api_type', 'gz_imggen_endpoint', 'gz_imggen_model',
+            'gz_imggen_size', 'gz_imggen_quality', 'gz_imggen_aspect_ratio', 'gz_imggen_image_size',
+            'gz_imggen_naistera_model', 'gz_imggen_naistera_aspect_ratio',
+            'gz_imggen_naistera_send_char_avatar', 'gz_imggen_naistera_send_user_avatar',
+            'gz_imggen_routmy_model', 'gz_imggen_routmy_aspect_ratio', 'gz_imggen_routmy_image_size',
+            'gz_imggen_routmy_quality', 'gz_imggen_routmy_send_char_avatar', 'gz_imggen_routmy_send_user_avatar',
+            'gz_imggen_image_context_enabled', 'gz_imggen_image_context_count',
+            'gz_imggen_additional_refs',
+            'gz_active_llm_profile_id', 'gz_service_profile_map', 'gz_provider_profiles_migrated',
+            'gz_sync_include_api_keys',
+            'api-key', 'api-model', 'gz_provider_profiles', 'gz_imggen_api_key', 'gz_imggen_naistera_api_key', 'gz_imggen_routmy_api_key'
+        ];
+        const data = {};
+        for (const k of lsKeys) {
+            const v = localStorage.getItem(k);
+            if (v !== null) data[k] = v;
+        }
+        return Object.keys(data).length > 0 ? data : null;
+    }
     return null;
 }
 
@@ -21,14 +60,35 @@ export function getConflictName(type, localEntity, cloudEntity, id) {
     if (type === 'gallery') {
         return `Gallery: ${id}`;
     }
-    const typeLabels = {
-        lorebooks: 'Lorebooks',
-        api_presets: 'API Presets',
-        theme_presets: 'Theme Presets',
-        theme_state: 'Theme State',
-        local_storage: 'Local Storage'
-    };
-    return typeLabels[type] || id;
+    if (type === 'lorebooks') {
+        const names = extractNames(localEntity, cloudEntity);
+        return names ? `Lorebooks: ${names}` : 'Lorebooks';
+    }
+    if (type === 'api_presets') {
+        const names = extractPresetNames(localEntity, cloudEntity);
+        return names ? `API Presets: ${names}` : 'API Presets';
+    }
+    if (type === 'theme_presets') {
+        const names = extractPresetNames(localEntity, cloudEntity);
+        return names ? `Theme Presets: ${names}` : 'Theme Presets';
+    }
+    if (type === 'theme_state') {
+        return 'Theme State';
+    }
+    if (type === 'local_storage') {
+        const localKeys = localEntity ? Object.keys(localEntity) : [];
+        const cloudKeys = cloudEntity ? Object.keys(cloudEntity) : [];
+        const diffKeys = [...new Set([...localKeys, ...cloudKeys])].filter(k => {
+            const lv = localEntity?.[k];
+            const cv = cloudEntity?.[k];
+            return lv !== cv;
+        });
+        if (diffKeys.length > 0 && diffKeys.length <= 3) {
+            return `Settings: ${diffKeys.join(', ')}`;
+        }
+        return diffKeys.length > 0 ? `Settings: ${diffKeys.length} changed` : 'Settings';
+    }
+    return id;
 }
 
 function getChatName(localChat, cloudChat, charId) {
@@ -40,6 +100,25 @@ function getChatName(localChat, cloudChat, charId) {
         return preview || charId;
     }
     return charId;
+}
+
+function extractNames(localEntity, cloudEntity) {
+    const items = localEntity || cloudEntity;
+    if (!Array.isArray(items)) return null;
+    const names = items.map(i => i.name || i.id).filter(Boolean).slice(0, 3);
+    if (names.length === 0) return null;
+    const suffix = items.length > 3 ? ` (+${items.length - 3})` : '';
+    return names.join(', ') + suffix;
+}
+
+function extractPresetNames(localEntity, cloudEntity) {
+    const obj = localEntity || cloudEntity;
+    if (!obj || typeof obj !== 'object') return null;
+    const entries = Array.isArray(obj) ? obj : Object.values(obj);
+    const names = entries.map(i => i.name || i.id).filter(Boolean).slice(0, 3);
+    if (names.length === 0) return null;
+    const suffix = entries.length > 3 ? ` (+${entries.length - 3})` : '';
+    return names.join(', ') + suffix;
 }
 
 export async function resolveConflict(conflict, choice, { ENTITY_TYPES, getLocalCharacterWithImages }) {

--- a/src/core/services/sync/syncConflict.js
+++ b/src/core/services/sync/syncConflict.js
@@ -18,7 +18,17 @@ export function getConflictName(type, localEntity, cloudEntity, id) {
     if (type === 'chat') {
         return getChatName(localEntity, cloudEntity, id);
     }
-    return id;
+    if (type === 'gallery') {
+        return `Gallery: ${id}`;
+    }
+    const typeLabels = {
+        lorebooks: 'Lorebooks',
+        api_presets: 'API Presets',
+        theme_presets: 'Theme Presets',
+        theme_state: 'Theme State',
+        local_storage: 'Local Storage'
+    };
+    return typeLabels[type] || id;
 }
 
 function getChatName(localChat, cloudChat, charId) {

--- a/src/core/services/sync/syncGallery.js
+++ b/src/core/services/sync/syncGallery.js
@@ -75,8 +75,23 @@ export async function applyGalleryEntriesForChar(adapter, entries, charId, local
 
         try {
             if (cloudEntry.deleted) {
-                char.images = char.images.filter(im => im.id !== cloudEntry.imgId);
-                applied++;
+                const localImg = char.images.find(im => im.id === cloudEntry.imgId);
+                if (localImg?.src && localEntry && !localEntry.deleted) {
+                    galleryConflicts.push({
+                        type: ENTITY_TYPES.GALLERY,
+                        id: cloudEntry.id,
+                        name: `Gallery: ${cloudEntry.imgId}`,
+                        charId,
+                        imgId: cloudEntry.imgId,
+                        local: { imgId: localEntry.imgId, hash: localEntry.hash, updatedAt: localEntry.updatedAt },
+                        cloud: { imgId: cloudEntry.imgId, hash: null, updatedAt: cloudEntry.updatedAt, deleted: true },
+                        cloudModified: cloudEntry.updatedAt
+                    });
+                    if (onConflict) onConflict(galleryConflicts[galleryConflicts.length - 1]);
+                } else {
+                    char.images = char.images.filter(im => im.id !== cloudEntry.imgId);
+                    applied++;
+                }
                 continue;
             }
 

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -322,7 +322,8 @@ async function pullManifestV2(adapter, key, onProgress, onConflict) {
                     name: getConflictName(cloudEntry.type, localEntity, cloudEntity, cloudEntry.id),
                     local: localEntity,
                     cloud: cloudEntity,
-                    cloudModified: cloudEntry.updatedAt
+                    cloudModified: cloudEntry.updatedAt,
+                    localModified: localEntry.updatedAt
                 };
                 conflicts.push(conflict);
                 if (onConflict) onConflict(conflict);

--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -181,8 +181,10 @@ async function pushManifestV2(adapter, key, onProgress) {
                         const binary = await dataUrlToBinary(img.src);
                         await adapter.uploadBinary(localEntry.path, binary);
                     } else {
-                        localManifest.entries[keyName] = { ...localEntry, deleted: true, updatedAt: Date.now() };
-                        await deleteCloudFileIfExists(adapter, localEntry);
+                        console.warn(`[sync] Gallery image ${localEntry.imgId} for char ${localEntry.charId} has no src, skipping push`);
+                        skipped++;
+                        if (onProgress) onProgress(phase, i + 1, allEntries.length);
+                        return;
                     }
                 }
 


### PR DESCRIPTION
## Summary

- **GDrive gallery sync**: Replace destructive delete-then-upload with resumable upload — no more silent image deletion if upload fails partway through
- **Sync conflict UI**: Show specific field names, entity names, and timestamps in conflict resolution dialog instead of generic `local/remote differ`
- **iOS worker hang**: On iOS WKWebView, module workers (`type: 'module'`) silently fail to initialize — no onmessage, no onerror. Added ping health-check at creation time and fallback to classic Blob worker built from fetched bundle code (Vite inlines all deps, no external imports)
- **CI**: Added `build-branch.yml` workflow that auto-triggers on push to `fix/**`, `feat/**`, `ci/**` branches

## Test plan

- [ ] Upload gallery images via GDrive sync on a character — verify images survive full sync cycle
- [ ] Trigger a sync conflict (modify same entity on two devices) — verify conflict dialog shows entity name, field names, timestamps
- [ ] On iOS: open a chat and send a message — verify prompt worker initializes (check console for `[Worker] Module worker responding on iOS` or fallback log)
- [ ] On desktop: verify prompt worker still works as before (no regression)