### PR TITLE
fix: sync deleted chars & theme background reset

### DIFF
--- a/src/core/services/syncEngine.js
+++ b/src/core/services/syncEngine.js
@@ -276,6 +276,8 @@ async function pullManifestV2(adapter, key, onProgress, onConflict) {
 
         if (!cloudEntry) continue;
 
+        if (localEntry?.deleted && !cloudEntry.deleted) continue;
+
         const cloudIsNewer = !localEntry || cloudEntry.hash !== localEntry.hash || cloudEntry.deleted !== localEntry.deleted;
         if (!cloudIsNewer) continue;
 

--- a/src/core/states/themePersistence.js
+++ b/src/core/states/themePersistence.js
@@ -26,14 +26,22 @@ export async function presetFromStateWithBlobs(state) {
     const preset = presetFromState(state);
     if (state.hasBackgroundImage) {
         preset.bgImage = await db.get('gz_theme_bg');
+    } else {
+        preset.bgImage = null;
     }
     if (state.customFontName) {
         preset.customFont = await db.get('gz_theme_font');
         preset.customFontName = await db.get('gz_theme_font_name');
+    } else {
+        preset.customFont = null;
+        preset.customFontName = null;
     }
     if (state.chatFontName) {
         preset.chatFont = await db.get('gz_theme_chat_font');
         preset.chatFontName = await db.get('gz_theme_chat_font_name');
+    } else {
+        preset.chatFont = null;
+        preset.chatFontName = null;
     }
     return preset;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
   plugins: [vue()],
   base: './', // Это ГЛАВНОЕ: заставляет пути быть относительными
   server: {
+    host: true,
     proxy: {
       '/dc-proxy': {
         target: 'https://datacat.run',


### PR DESCRIPTION
## Summary
- **Cloud sync**: deleted characters were being pulled back from cloud because the pull logic didn't check for local tombstones. Now `pullManifestV2` skips cloud entries when `localEntry.deleted && !cloudEntry.deleted` — the next push will propagate the deletion.
- **Theme background reset**: `presetFromStateWithBlobs` never set `bgImage: null` when `hasBackgroundImage` was false, so the spread merge in `saveStateToActivePreset` preserved the stale data URL. Added `else` branches for `bgImage`, `customFont`, and `chatFont` fields.
- **Dev server**: added `host: true` to vite config so the dev server binds on `0.0.0.0` instead of only `[::1]`.