### PR TITLE
fix(import): support Risu CharX archives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,8 +168,11 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 
 ## Workflow
 
-- Branch (`feat/xxx`) off `master`, push to `origin`, open a PR — see `docs/WORKFLOW.md` for branching, Trello, and cleanup checklists.
-- Open PRs only against upstream repository `hydall/Glaze` (base: `hydall/Glaze:master`), not against fork repos.
+- Repository: `hydall/Glaze`. Development uses three long-lived branches:
+  - `nightly` — active development (replaces the old `dev` branch).
+  - `staging` — changes promoted from `nightly` after verification; release candidates are built here.
+  - `stable` — stable versioned releases only (`0.7.0`, `0.7.1`, etc.), promoted from `staging`.
+- Branch (`feat/xxx`) off `nightly`, push to `origin`, and open the PR against `hydall/Glaze:nightly` — see `docs/WORKFLOW.md` for promotion, Trello, and cleanup checklists.
 - Run `dart run build_runner build` after changing any freezed/drift model.
 - Single responsibility: split a class before it grows past ~200-250 lines (thin orchestrators, fat specialists, constructor injection). Details: `docs/CODE_STYLE.md`.
 
@@ -181,7 +184,7 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 - Store API keys in plain text in Drift
 - Mutate state directly — use immutable patterns with freezed
 - Forget `ref.watch` select for streaming UI (causes full rebuild per chunk)
-- Commit directly to `master` — always use a feature branch
+- Commit directly to `nightly`, `staging`, or `stable` — use feature branches and promotion PRs
 - Use the `gh` CLI — GitHub operations go through GitHub MCP tools
 - Bypass `_requireCapability` in the JS bridge — every `glaze.*` method must enforce the matching capability (default-deny)
 - Run user JS in a same-origin iframe — panel/sandbox scripts go in `sandbox="allow-scripts"` (no `allow-same-origin`)

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -4,25 +4,31 @@ Git, branching, PR, and task-tracking conventions. Loaded on demand — `CLAUDE.
 
 ## Branching
 
-Each feature = a branch off `master`, pushed to `origin`, then a PR into upstream `hydall/Glaze:master`.
+The upstream repository is `hydall/Glaze` and has three long-lived branches:
 
-- **No direct commits to `master`** — always use a feature branch.
-- **Stack while catching up** — if a feature depends on another not-yet-merged branch, branch off that branch instead of `master`.
+- `nightly` — active development; this replaces the old `dev` branch.
+- `staging` — verified work promoted from `nightly`; release candidates are built here.
+- `stable` — stable versioned releases only (`0.7.0`, `0.7.1`, etc.), promoted from `staging`.
+
+Each feature = a branch off `nightly`, pushed to `origin`, then a PR into upstream `hydall/Glaze:nightly`.
+
+- **No direct commits to long-lived branches** — use feature branches and promotion PRs.
+- **Stack while catching up** — if a feature depends on another not-yet-merged branch, branch off that branch instead of `nightly`.
 - **Run `dart run build_runner build`** after changing any freezed/drift model.
 
 ```bash
-git checkout master && git pull
+git checkout nightly && git pull
 git checkout -b feat/xxx
 # ... work ...
 git push -u origin feat/xxx
 ```
 
-Open the PR against `hydall/Glaze:master`, not a fork's `master`. Use the **GitHub MCP tools** (`mcp__plugin_github_github__create_pull_request`) or the GitHub web UI. Do **not** use the `gh` CLI — GitHub operations go through GitHub MCP (project + global convention).
+Open feature PRs against `hydall/Glaze:nightly`, not a fork's default branch. Promote verified work with PRs in this order: `nightly` -> `staging` -> `stable`. Use the **GitHub MCP tools** (`mcp__plugin_github_github__create_pull_request`) or the GitHub web UI. Do **not** use the `gh` CLI — GitHub operations go through GitHub MCP (project + global convention).
 
 ## Before starting work
 
 1. `git branch --show-current` — confirm the branch.
-2. `git checkout master && git pull` — sync.
+2. `git checkout nightly && git pull` — sync.
 3. `git checkout -b feat/xxx` — create the feature branch.
 4. `flutter analyze` — lint + typecheck.
 5. `flutter test` — run the test suite (one-shot, non-watch mode).
@@ -31,7 +37,7 @@ Open the PR against `hydall/Glaze:master`, not a fork's `master`. Use the **GitH
 
 - Delete local branch: `git branch -D feat/xxx`
 - Delete remote branch: `git push origin --delete feat/xxx`
-- Sync master: `git checkout master && git pull`
+- Sync nightly: `git checkout nightly && git pull`
 
 ## Trello board
 

--- a/lib/core/services/character_importer.dart
+++ b/lib/core/services/character_importer.dart
@@ -94,7 +94,7 @@ class CharacterImporter {
   }
 
   Future<CharacterImportResult> _importCharX(Uint8List zipBytes) async {
-    final archive = ZipDecoder().decodeBytes(zipBytes);
+    final archive = ZipDecoder().decodeBytes(_charXZipBytes(zipBytes));
 
     String? cardJsonContent;
     final assetFiles = <String, Uint8List>{};
@@ -190,6 +190,34 @@ class CharacterImporter {
         characterBookData: data['character_book'] as Map<String, dynamic>?,
         galleryImages: galleryImages.isNotEmpty ? galleryImages : null);
   }
+
+  Uint8List _charXZipBytes(Uint8List bytes) {
+    if (_hasZipSignature(bytes, 0)) return bytes;
+
+    final isJpeg =
+        bytes.length >= 3 &&
+        bytes[0] == 0xff &&
+        bytes[1] == 0xd8 &&
+        bytes[2] == 0xff;
+    if (!isJpeg) return bytes;
+
+    for (var i = 3; i <= bytes.length - 4; i++) {
+      if (_hasZipSignature(bytes, i) &&
+          i >= 2 &&
+          bytes[i - 2] == 0xff &&
+          bytes[i - 1] == 0xd9) {
+        return Uint8List.sublistView(bytes, i);
+      }
+    }
+    return bytes;
+  }
+
+  bool _hasZipSignature(Uint8List bytes, int offset) =>
+      offset + 4 <= bytes.length &&
+      bytes[offset] == 0x50 &&
+      bytes[offset + 1] == 0x4b &&
+      bytes[offset + 2] == 0x03 &&
+      bytes[offset + 3] == 0x04;
 
   Map<String, dynamic> _normalizeCharacterData(Map<String, dynamic> json) {
     final spec = json['spec'] as String?;

--- a/lib/core/services/update_check_service.dart
+++ b/lib/core/services/update_check_service.dart
@@ -7,7 +7,7 @@ import '../constants/app_version.dart';
 /// the new build's date plus the list of commit subjects since the installed
 /// build (see `.github/workflows/build-branch.yml`).
 class UpdateInfo {
-  /// Full git SHA of the latest successful `master` build.
+  /// Full git SHA of the latest successful `stable` build.
   final String headSha;
 
   /// When the CI run was created (UTC).
@@ -60,7 +60,7 @@ class UpdateCheckResult {
   const UpdateCheckResult(this.status, [this.info]);
 }
 
-/// Checks GitHub Actions for a `master` build newer than the installed one.
+/// Checks GitHub Actions for a `stable` build newer than the installed one.
 ///
 /// The repo is public, so the Actions REST API is reachable unauthenticated
 /// (60 req/h per IP — ample for an occasional check). No token is sent.
@@ -68,7 +68,7 @@ class UpdateCheckService {
   static const _owner = 'hydall';
   static const _repo = 'Glaze';
   static const _workflowFile = 'build-branch.yml';
-  static const _branch = 'master';
+  static const _branch = 'stable';
 
   /// Cap on commit subjects shown in the dialog — matches the bot's `head -10`.
   static const _commitCap = 10;
@@ -136,7 +136,7 @@ class UpdateCheckService {
     }
   }
 
-  /// Latest successful run of the release workflow on `master`, or null.
+  /// Latest successful run of the release workflow on `stable`, or null.
   Future<Map<String, dynamic>?> _latestSuccessfulRun() async {
     final res = await _dio.get<Map<String, dynamic>>(
       '/repos/$_owner/$_repo/actions/workflows/$_workflowFile/runs',

--- a/test/character_importer_test.dart
+++ b/test/character_importer_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/services/character_importer.dart';
+import 'package:glaze_flutter/core/services/image_storage_service.dart';
+
+class _TestImageStorage extends ImageStorageService {
+  _TestImageStorage()
+    : super(Directory.systemTemp.createTempSync('glaze_charx_test_').path);
+
+  Uint8List? avatarBytes;
+
+  @override
+  Future<String> saveAvatar(String characterId, Uint8List imageBytes) async {
+    avatarBytes = imageBytes;
+    return '/fake/avatars/$characterId.png';
+  }
+}
+
+void main() {
+  late _TestImageStorage imageStorage;
+  late CharacterImporter importer;
+
+  setUp(() {
+    imageStorage = _TestImageStorage();
+    importer = CharacterImporter(imageStorage);
+  });
+
+  test('imports a regular CharX ZIP', () async {
+    final result = await importer.importFromBytes(_charXBytes(), 'card.charx');
+
+    expect(result.character.name, 'Risu character');
+    expect(result.hadAvatar, isTrue);
+    expect(imageStorage.avatarBytes, _iconBytes);
+  });
+
+  test('imports a Risu JPEG-prefixed CharX', () async {
+    final zip = _charXBytes();
+    final polyglot = Uint8List.fromList([
+      0xff,
+      0xd8,
+      0xff,
+      0xe0,
+      0x00,
+      0x10,
+      0x4a,
+      0x46,
+      0x49,
+      0x46,
+      0x00,
+      0xff,
+      0xd9,
+      ...zip,
+    ]);
+
+    final result = await importer.importFromBytes(polyglot, 'card.charx');
+
+    expect(result.character.name, 'Risu character');
+    expect(result.hadAvatar, isTrue);
+    expect(imageStorage.avatarBytes, _iconBytes);
+  });
+
+  test('does not scan arbitrary prefixes for an embedded ZIP', () async {
+    final prefixed = Uint8List.fromList([0x00, 0x01, 0x02, ..._charXBytes()]);
+
+    expect(
+      () => importer.importFromBytes(prefixed, 'card.charx'),
+      throwsA(isA<FormatException>()),
+    );
+  });
+}
+
+final _iconBytes = Uint8List.fromList([1, 2, 3, 4]);
+
+Uint8List _charXBytes() {
+  final card = utf8.encode(
+    jsonEncode({
+      'spec': 'chara_card_v3',
+      'spec_version': '3.0',
+      'data': {
+        'name': 'Risu character',
+        'description': 'Test character',
+        'assets': [
+          {
+            'type': 'icon',
+            'name': 'main',
+            'uri': 'embeded://assets/icon.png',
+            'ext': 'png',
+          },
+        ],
+      },
+    }),
+  );
+  final archive = Archive()
+    ..addFile(ArchiveFile('card.json', card.length, card))
+    ..addFile(ArchiveFile('assets/icon.png', _iconBytes.length, _iconBytes));
+  return Uint8List.fromList(ZipEncoder().encode(archive));
+}


### PR DESCRIPTION
## Summary
- import Risu JPEG-prefixed CharX archives by decoding the ZIP payload after the JPEG end marker
- keep ordinary CharX ZIP behavior and reject arbitrary prefixed files
- add regression coverage for regular, Risu-prefixed, and invalid prefixed archives
- document the nightly -> staging -> stable branch workflow
- make update checks follow stable builds

## Verification
- `flutter test test/character_importer_test.dart`
- `flutter analyze lib/core/services/character_importer.dart lib/core/services/update_check_service.dart test/character_importer_test.dart`
- manually imported both reporter-provided Risu files, including the 52 MB archive