### PR TITLE
fix(windows): preserve preferences across app identity rename

### DIFF
--- a/lib/core/services/character_importer.dart
+++ b/lib/core/services/character_importer.dart
@@ -18,7 +18,12 @@ class CharacterImportResult {
   final Map<String, dynamic>? characterBookData;
   final List<GalleryImageData>? galleryImages;
 
-  CharacterImportResult({required this.character, required this.hadAvatar, this.characterBookData, this.galleryImages});
+  CharacterImportResult({
+    required this.character,
+    required this.hadAvatar,
+    this.characterBookData,
+    this.galleryImages,
+  });
 }
 
 class GalleryImageData {
@@ -26,7 +31,11 @@ class GalleryImageData {
   final Uint8List bytes;
   final String ext;
 
-  GalleryImageData({required this.label, required this.bytes, required this.ext});
+  GalleryImageData({
+    required this.label,
+    required this.bytes,
+    required this.ext,
+  });
 }
 
 class CharacterImporter {
@@ -49,7 +58,9 @@ class CharacterImporter {
   }
 
   Future<CharacterImportResult> importFromBytes(
-      Uint8List bytes, String fileName) async {
+    Uint8List bytes,
+    String fileName,
+  ) async {
     final ext = p.extension(fileName).toLowerCase();
 
     if (ext == '.png') {
@@ -71,8 +82,10 @@ class CharacterImporter {
     _logCharacterBook('png', data);
     final character = await _saveCharacterWithAvatar(data, pngBytes);
     return CharacterImportResult(
-        character: character, hadAvatar: true,
-        characterBookData: data['character_book'] as Map<String, dynamic>?);
+      character: character,
+      hadAvatar: true,
+      characterBookData: data['character_book'] as Map<String, dynamic>?,
+    );
   }
 
   Future<CharacterImportResult> _importJson(Uint8List jsonBytes) async {
@@ -89,12 +102,14 @@ class CharacterImporter {
 
     final character = await _saveCharacterWithAvatar(data, avatarBytes);
     return CharacterImportResult(
-        character: character, hadAvatar: avatarBytes != null,
-        characterBookData: data['character_book'] as Map<String, dynamic>?);
+      character: character,
+      hadAvatar: avatarBytes != null,
+      characterBookData: data['character_book'] as Map<String, dynamic>?,
+    );
   }
 
   Future<CharacterImportResult> _importCharX(Uint8List zipBytes) async {
-    final archive = ZipDecoder().decodeBytes(zipBytes);
+    final archive = ZipDecoder().decodeBytes(_charXZipBytes(zipBytes));
 
     String? cardJsonContent;
     final assetFiles = <String, Uint8List>{};
@@ -139,7 +154,7 @@ class CharacterImporter {
     if (avatarBytes == null) {
       final avatarSrc = data['avatar'] as String?;
       if (avatarSrc != null && avatarSrc.isNotEmpty) {
-      avatarBytes = dataUrlToBytes(avatarSrc);
+        avatarBytes = dataUrlToBytes(avatarSrc);
       }
     }
 
@@ -153,13 +168,16 @@ class CharacterImporter {
         final uri = gMap['uri'] as String?;
         if (uri != null) {
           final zipPath = _resolveEmbeddedUri(uri);
-          if (assetFiles.containsKey(zipPath) && assetFiles[zipPath]!.isNotEmpty) {
+          if (assetFiles.containsKey(zipPath) &&
+              assetFiles[zipPath]!.isNotEmpty) {
             final fileExt = p.extension(zipPath).replaceFirst('.', '');
-            galleryImages.add(GalleryImageData(
-              label: gMap['label'] as String? ?? '',
-              bytes: assetFiles[zipPath]!,
-              ext: fileExt.isEmpty ? 'png' : fileExt,
-            ));
+            galleryImages.add(
+              GalleryImageData(
+                label: gMap['label'] as String? ?? '',
+                bytes: assetFiles[zipPath]!,
+                ext: fileExt.isEmpty ? 'png' : fileExt,
+              ),
+            );
           }
         }
       }
@@ -172,13 +190,16 @@ class CharacterImporter {
         final uri = assetMap['uri'] as String?;
         if (type == 'gallery' && uri != null) {
           final zipPath = _resolveEmbeddedUri(uri);
-          if (assetFiles.containsKey(zipPath) && assetFiles[zipPath]!.isNotEmpty) {
+          if (assetFiles.containsKey(zipPath) &&
+              assetFiles[zipPath]!.isNotEmpty) {
             final fileExt = p.extension(zipPath).replaceFirst('.', '');
-            galleryImages.add(GalleryImageData(
-              label: assetMap['name'] as String? ?? '',
-              bytes: assetFiles[zipPath]!,
-              ext: fileExt.isEmpty ? 'png' : fileExt,
-            ));
+            galleryImages.add(
+              GalleryImageData(
+                label: assetMap['name'] as String? ?? '',
+                bytes: assetFiles[zipPath]!,
+                ext: fileExt.isEmpty ? 'png' : fileExt,
+              ),
+            );
           }
         }
       }
@@ -186,10 +207,40 @@ class CharacterImporter {
 
     final character = await _saveCharacterWithAvatar(data, avatarBytes);
     return CharacterImportResult(
-        character: character, hadAvatar: avatarBytes != null,
-        characterBookData: data['character_book'] as Map<String, dynamic>?,
-        galleryImages: galleryImages.isNotEmpty ? galleryImages : null);
+      character: character,
+      hadAvatar: avatarBytes != null,
+      characterBookData: data['character_book'] as Map<String, dynamic>?,
+      galleryImages: galleryImages.isNotEmpty ? galleryImages : null,
+    );
   }
+
+  Uint8List _charXZipBytes(Uint8List bytes) {
+    if (_hasZipSignature(bytes, 0)) return bytes;
+
+    final isJpeg =
+        bytes.length >= 3 &&
+        bytes[0] == 0xff &&
+        bytes[1] == 0xd8 &&
+        bytes[2] == 0xff;
+    if (!isJpeg) return bytes;
+
+    for (var i = 3; i <= bytes.length - 4; i++) {
+      if (_hasZipSignature(bytes, i) &&
+          i >= 2 &&
+          bytes[i - 2] == 0xff &&
+          bytes[i - 1] == 0xd9) {
+        return Uint8List.sublistView(bytes, i);
+      }
+    }
+    return bytes;
+  }
+
+  bool _hasZipSignature(Uint8List bytes, int offset) =>
+      offset + 4 <= bytes.length &&
+      bytes[offset] == 0x50 &&
+      bytes[offset + 1] == 0x4b &&
+      bytes[offset + 2] == 0x03 &&
+      bytes[offset + 3] == 0x04;
 
   Map<String, dynamic> _normalizeCharacterData(Map<String, dynamic> json) {
     final spec = json['spec'] as String?;
@@ -209,19 +260,23 @@ class CharacterImporter {
   void _logCharacterBook(String source, Map<String, dynamic> data) {
     final book = data['character_book'];
     if (book == null) {
-      debugPrint('[character_import] source=$source name=${data['name']} character_book=null');
+      debugPrint(
+        '[character_import] source=$source name=${data['name']} character_book=null',
+      );
       return;
     }
     if (book is! Map) {
-      debugPrint('[character_import] source=$source name=${data['name']} character_book_type=${book.runtimeType}');
+      debugPrint(
+        '[character_import] source=$source name=${data['name']} character_book_type=${book.runtimeType}',
+      );
       return;
     }
     final entries = book['entries'];
     final entryCount = entries is List
         ? entries.length
         : entries is Map
-            ? entries.length
-            : 0;
+        ? entries.length
+        : 0;
     debugPrint(
       '[character_import] source=$source name=${data['name']} '
       'book_name=${book['name']} entries_type=${entries.runtimeType} '
@@ -230,7 +285,9 @@ class CharacterImporter {
   }
 
   Future<Character> _saveCharacterWithAvatar(
-      Map<String, dynamic> data, Uint8List? avatarBytes) async {
+    Map<String, dynamic> data,
+    Uint8List? avatarBytes,
+  ) async {
     final id = generateId();
     String? avatarPath;
 
@@ -239,8 +296,7 @@ class CharacterImporter {
     } else {
       final avatarSrc = data['avatar'] as String?;
       if (avatarSrc != null && avatarSrc.isNotEmpty) {
-        avatarPath =
-            await _imageStorage.saveAvatarFromDataUrl(id, avatarSrc);
+        avatarPath = await _imageStorage.saveAvatarFromDataUrl(id, avatarSrc);
       }
     }
 
@@ -264,7 +320,9 @@ class CharacterImporter {
       createdAt: currentTimestampSeconds(),
       fav: data['fav'] as bool? ?? false,
       extensions: _extractExtensions(data),
-      characterVersion: data['character_version'] is String ? data['character_version'] as String : '1',
+      characterVersion: data['character_version'] is String
+          ? data['character_version'] as String
+          : '1',
       depthPrompt: _extractDepthPrompt(data),
       depthPromptDepth: _extractDepthPromptDepth(data),
       depthPromptRole: _extractDepthPromptRole(data),

--- a/lib/core/services/image_storage_service.dart
+++ b/lib/core/services/image_storage_service.dart
@@ -33,10 +33,16 @@ const String _kThumbMigrationKey = 'gz_thumb_v6_migrated';
 /// SharedPreferences flag guarding the one-time background thumbnail backfill.
 const String _kThumbBackfillKey = 'gz_thumb_v6_backfilled';
 
+const String _kThumbMigrationMarker = '.thumbnails-v6-migrated';
+const String _kThumbRefreshMarker = '.thumbnails-v6-refresh-required';
+
 /// Runs in a background isolate and scales without upscaling or changing the
 /// aspect ratio. Both axes are bounded to keep extreme images mobile-safe.
-Uint8List? resizeAvatarBytes(Uint8List imageBytes, int maxShortSide,
-    [int maxLongSide = kThumbnailLongSide]) {
+Uint8List? resizeAvatarBytes(
+  Uint8List imageBytes,
+  int maxShortSide, [
+  int maxLongSide = kThumbnailLongSide,
+]) {
   try {
     final image = img.decodeImage(imageBytes);
     if (image == null) return null;
@@ -52,7 +58,9 @@ Uint8List? resizeAvatarBytes(Uint8List imageBytes, int maxShortSide,
             height: (image.height * scale).round().clamp(1, maxLongSide),
           )
         : image;
-    return Uint8List.fromList(img.encodeJpg(scaled, quality: _kThumbnailQuality));
+    return Uint8List.fromList(
+      img.encodeJpg(scaled, quality: _kThumbnailQuality),
+    );
   } catch (_) {
     return null;
   }
@@ -66,23 +74,28 @@ class ImageStorageService implements SyncImageStore {
   static Future<ImageStorageService> create() async {
     final baseDir = await getAppDataDir();
     final service = ImageStorageService(baseDir);
-    await service._migrateOldThumbnails();
+    await service.migrateOldThumbnails();
     return service;
   }
 
-  Future<void> _migrateOldThumbnails([SharedPreferences? prefsArg]) async {
+  Future<void> migrateOldThumbnails([SharedPreferences? prefsArg]) async {
     final prefs = prefsArg ?? await SharedPreferences.getInstance();
-    if (prefs.getBool(_kThumbMigrationKey) == true) return;
+    final marker = File(p.join(baseDir, _kThumbMigrationMarker));
+    if (await marker.exists()) return;
 
-    final thumbDir = Directory(p.join(baseDir, 'thumbnails'));
-    if (await thumbDir.exists()) {
-      await thumbDir.delete(recursive: true);
+    // The Windows ProductName determines the preferences directory. A renamed
+    // executable must not replay a destructive thumbnail migration against the
+    // stable Glaze data directory just because its preference flag moved.
+    if (prefs.getBool(_kThumbMigrationKey) != true) {
+      await File(
+        p.join(baseDir, _kThumbRefreshMarker),
+      ).writeAsString('pending', flush: true);
     }
     await prefs.setBool(_kThumbMigrationKey, true);
-    // The wipe leaves existing characters without thumbnails until they are
-    // re-saved; clear the backfill flag so the next [backfillMissingThumbnails]
-    // pass regenerates them at the new resolution.
+    // Also repairs files removed by an interrupted legacy migration. Existing
+    // thumbnails are skipped unless a real schema refresh is pending.
     await prefs.setBool(_kThumbBackfillKey, false);
+    await marker.writeAsString('done', flush: true);
   }
 
   /// One-time background pass that regenerates thumbnails for any [avatarPaths]
@@ -93,7 +106,9 @@ class ImageStorageService implements SyncImageStore {
   /// Returns the number of thumbnails (re)generated.
   Future<int> backfillMissingThumbnails(Iterable<String?> avatarPaths) async {
     final prefs = await SharedPreferences.getInstance();
-    if (prefs.getBool(_kThumbBackfillKey) == true) return 0;
+    final refreshMarker = File(p.join(baseDir, _kThumbRefreshMarker));
+    final refreshExisting = await refreshMarker.exists();
+    if (!refreshExisting && prefs.getBool(_kThumbBackfillKey) == true) return 0;
 
     final dir = Directory(p.join(baseDir, 'thumbnails'));
     if (!await dir.exists()) await dir.create(recursive: true);
@@ -102,7 +117,7 @@ class ImageStorageService implements SyncImageStore {
     var complete = true;
     for (final avatarPath in avatarPaths) {
       if (avatarPath == null || avatarPath.isEmpty) continue;
-      if (thumbnailPath(avatarPath) != null) continue; // already has one
+      if (!refreshExisting && thumbnailPath(avatarPath) != null) continue;
 
       final resolvedPath = absolutePath(avatarPath) ?? avatarPath;
       final avatarFile = File(resolvedPath);
@@ -128,7 +143,10 @@ class ImageStorageService implements SyncImageStore {
       }
     }
 
-    if (complete) await prefs.setBool(_kThumbBackfillKey, true);
+    if (complete) {
+      await prefs.setBool(_kThumbBackfillKey, true);
+      if (await refreshMarker.exists()) await refreshMarker.delete();
+    }
     return made;
   }
 
@@ -145,14 +163,18 @@ class ImageStorageService implements SyncImageStore {
   }
 
   Future<String?> saveAvatarFromDataUrl(
-      String characterId, String dataUrl) async {
+    String characterId,
+    String dataUrl,
+  ) async {
     final bytes = dataUrlToBytes(dataUrl);
     if (bytes == null) return null;
     return saveAvatar(characterId, bytes);
   }
 
   Future<String?> saveThumbnail(
-      String characterId, Uint8List imageBytes) async {
+    String characterId,
+    Uint8List imageBytes,
+  ) async {
     final dir = Directory(p.join(baseDir, 'thumbnails'));
     if (!await dir.exists()) {
       await dir.create(recursive: true);
@@ -268,7 +290,9 @@ class ImageStorageService implements SyncImageStore {
     bool stripped = false;
     while (offset < pngBytes.length - 4) {
       final length = data.getUint32(offset, Endian.big);
-      final type = String.fromCharCodes(pngBytes.sublist(offset + 4, offset + 8));
+      final type = String.fromCharCodes(
+        pngBytes.sublist(offset + 4, offset + 8),
+      );
       if (type == 'tEXt' || type == 'zTXt' || type == 'iTXt') {
         stripped = true;
         offset += 12 + length;

--- a/lib/core/services/windows_preferences_migration.dart
+++ b/lib/core/services/windows_preferences_migration.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+const _legacyProductName = 'glaze_flutter';
+const _currentProductName = 'Glaze';
+const _migrationMarkerName = '.windows-prefs-product-name-v1';
+
+Future<void> migrateLegacyWindowsPreferences({
+  Map<String, String>? environment,
+}) async {
+  if (!Platform.isWindows && environment == null) return;
+
+  final appData = (environment ?? Platform.environment)['APPDATA'];
+  if (appData == null || appData.isEmpty) return;
+
+  final marker = File(p.join(appData, 'Glaze', _migrationMarkerName));
+  if (await marker.exists()) return;
+
+  final legacy = File(
+    p.join(appData, 'com.glaze', _legacyProductName, 'shared_preferences.json'),
+  );
+  final current = File(
+    p.join(
+      appData,
+      'com.glaze',
+      _currentProductName,
+      'shared_preferences.json',
+    ),
+  );
+
+  if (await legacy.exists()) {
+    final legacyValues = await _readPreferences(legacy);
+    final currentValues = await _readPreferences(current);
+    if (legacyValues != null) {
+      await current.parent.create(recursive: true);
+      await _replaceJsonFile(current, {...?currentValues, ...legacyValues});
+    }
+  }
+
+  await marker.parent.create(recursive: true);
+  await marker.writeAsString('done', flush: true);
+}
+
+Future<Map<String, dynamic>?> _readPreferences(File file) async {
+  if (!await file.exists()) return <String, dynamic>{};
+  try {
+    final decoded = jsonDecode(await file.readAsString());
+    return decoded is Map ? Map<String, dynamic>.from(decoded) : null;
+  } on FormatException {
+    return null;
+  }
+}
+
+Future<void> _replaceJsonFile(
+  File destination,
+  Map<String, dynamic> values,
+) async {
+  final temporary = File('${destination.path}.migration.tmp');
+  await temporary.writeAsString(jsonEncode(values), flush: true);
+
+  final backup = File('${destination.path}.before-product-name-migration');
+  if (await destination.exists()) {
+    if (await backup.exists()) await backup.delete();
+    await destination.rename(backup.path);
+  }
+  try {
+    await temporary.rename(destination.path);
+  } catch (_) {
+    if (await backup.exists() && !await destination.exists()) {
+      await backup.rename(destination.path);
+    }
+    rethrow;
+  }
+}

--- a/lib/features/presets/preset_editor_screen.dart
+++ b/lib/features/presets/preset_editor_screen.dart
@@ -97,18 +97,20 @@ class PresetEditorBody extends ConsumerStatefulWidget {
 }
 
 class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
-  late final _nameCtrl =
-      TextEditingController(text: widget.preset?.name ?? '');
+  late final _nameCtrl = TextEditingController(text: widget.preset?.name ?? '');
   late String _author = widget.preset?.author ?? '';
   late List<PresetBlock> _blocks;
   late List<PresetRegex> _regexes;
   late bool _parseInlineReasoning = widget.preset?.reasoningEnabled ?? false;
-  late final _reasoningStartCtrl =
-      TextEditingController(text: widget.preset?.reasoningStart ?? '');
-  late final _reasoningEndCtrl =
-      TextEditingController(text: widget.preset?.reasoningEnd ?? '');
-  late final _impersonationPromptCtrl =
-      TextEditingController(text: widget.preset?.impersonationPrompt ?? '');
+  late final _reasoningStartCtrl = TextEditingController(
+    text: widget.preset?.reasoningStart ?? '',
+  );
+  late final _reasoningEndCtrl = TextEditingController(
+    text: widget.preset?.reasoningEnd ?? '',
+  );
+  late final _impersonationPromptCtrl = TextEditingController(
+    text: widget.preset?.impersonationPrompt ?? '',
+  );
   late bool _mergePrompts = widget.preset?.mergePrompts ?? false;
   bool _showAdvanced = false;
   int? _expandedBlockIndex;
@@ -118,7 +120,8 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
 
   Timer? _saveTimer;
   late final String _currentId = widget.preset?.id ?? generateId();
-  late final int _createdAt = widget.preset?.createdAt ?? currentTimestampSeconds();
+  late final int _createdAt =
+      widget.preset?.createdAt ?? currentTimestampSeconds();
 
   @override
   void initState() {
@@ -168,7 +171,9 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
   }
 
   Future<void> _performSave() async {
-    final name = _nameCtrl.text.trim().isEmpty ? 'New Preset' : _nameCtrl.text.trim();
+    final name = _nameCtrl.text.trim().isEmpty
+        ? 'New Preset'
+        : _nameCtrl.text.trim();
     final presetToSave = Preset(
       id: _currentId,
       name: name,
@@ -279,7 +284,8 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
       key: const ValueKey('dashboard'),
       padding: EdgeInsets.only(
         top: MediaQuery.paddingOf(context).top,
-        bottom: MediaQuery.paddingOf(context).bottom +
+        bottom:
+            MediaQuery.paddingOf(context).bottom +
             MediaQuery.viewInsetsOf(context).bottom,
       ),
       child: Column(
@@ -297,8 +303,9 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
   // ─── Dashboard card ──────────────────────────────────────────────────────
 
   Widget _buildDashboard() {
-    final displayName =
-        _nameCtrl.text.trim().isEmpty ? 'New Preset' : _nameCtrl.text.trim();
+    final displayName = _nameCtrl.text.trim().isEmpty
+        ? 'New Preset'
+        : _nameCtrl.text.trim();
     final addBlockAtTop =
         ref.watch(appSettingsProvider).value?.addBlockAtTop ?? false;
 
@@ -338,8 +345,9 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
                                 style: TextStyle(
                                   fontSize: 12,
                                   fontWeight: FontWeight.w500,
-                                  color:
-                                      context.cs.primary.withValues(alpha: 0.8),
+                                  color: context.cs.primary.withValues(
+                                    alpha: 0.8,
+                                  ),
                                 ),
                               ),
                           ],
@@ -364,7 +372,10 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
                   const Spacer(),
                   _BlocksBadge(
                     count: _blocks
-                        .where((b) => b.enabled && !b.isStashed && b.content.isNotEmpty)
+                        .where(
+                          (b) =>
+                              b.enabled && !b.isStashed && b.content.isNotEmpty,
+                        )
                         .fold(0, (sum, b) => sum + estimateTokens(b.content)),
                   ),
                 ],
@@ -399,9 +410,11 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
           if (_expandedBlockIndex == oldIndex) {
             _expandedBlockIndex = newIndex;
           } else if (_expandedBlockIndex != null) {
-            if (oldIndex < _expandedBlockIndex! && newIndex >= _expandedBlockIndex!) {
+            if (oldIndex < _expandedBlockIndex! &&
+                newIndex >= _expandedBlockIndex!) {
               _expandedBlockIndex = _expandedBlockIndex! - 1;
-            } else if (oldIndex > _expandedBlockIndex! && newIndex <= _expandedBlockIndex!) {
+            } else if (oldIndex > _expandedBlockIndex! &&
+                newIndex <= _expandedBlockIndex!) {
               _expandedBlockIndex = _expandedBlockIndex! + 1;
             }
           }
@@ -449,21 +462,21 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
             children: [
               Text(
                 'Advanced Settings',
-                 style: TextStyle(
-                   fontSize: 14,
-                   fontWeight: FontWeight.w600,
-                   color: context.cs.onSurfaceVariant,
-                 ),
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: context.cs.onSurfaceVariant,
+                ),
               ),
               const Spacer(),
               AnimatedRotation(
                 turns: _showAdvanced ? 0.5 : 0,
                 duration: const Duration(milliseconds: 300),
-                 child: Icon(
-                   Icons.expand_more,
-                   color: context.cs.onSurfaceVariant,
-                   size: 20,
-                 ),
+                child: Icon(
+                  Icons.expand_more,
+                  color: context.cs.onSurfaceVariant,
+                  size: 20,
+                ),
               ),
             ],
           ),
@@ -755,8 +768,6 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
     _scheduleSave();
   }
 
-
-
   void _showRenameDialog() {
     GlazeBottomSheet.show<void>(
       context,
@@ -900,8 +911,9 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
   InputDecoration _inputDecoration(String hint) {
     return InputDecoration(
       hintText: hint,
-      hintStyle:
-          TextStyle(color: context.cs.onSurfaceVariant.withValues(alpha: 0.5)),
+      hintStyle: TextStyle(
+        color: context.cs.onSurfaceVariant.withValues(alpha: 0.5),
+      ),
       filled: true,
       fillColor: Colors.white.withValues(alpha: 0.04),
       border: OutlineInputBorder(
@@ -916,8 +928,7 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
         borderRadius: BorderRadius.circular(10),
         borderSide: BorderSide(color: context.cs.primary),
       ),
-      contentPadding:
-          const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
     );
   }
 }
@@ -965,11 +976,11 @@ class _AddBlockRow extends StatelessWidget {
               const SizedBox(width: 8),
               Text(
                 'Add Block',
-                 style: TextStyle(
-                   fontSize: 15,
-                   fontWeight: FontWeight.w600,
-                   color: context.cs.primary,
-                 ),
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  color: context.cs.primary,
+                ),
               ),
             ],
           ),
@@ -988,7 +999,7 @@ class _DotsButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-            color: context.cs.primary.withValues(alpha: 0.1),
+      color: context.cs.primary.withValues(alpha: 0.1),
       shape: const CircleBorder(),
       child: InkWell(
         onTap: onTap,
@@ -1013,8 +1024,11 @@ class _UtilButton extends StatelessWidget {
   final IconData icon;
   final int count;
   final VoidCallback onTap;
-  const _UtilButton(
-      {required this.icon, required this.count, required this.onTap});
+  const _UtilButton({
+    required this.icon,
+    required this.count,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -1116,7 +1130,10 @@ class _SectionLabel extends StatelessWidget {
     if (helpTerm == null) return label;
     return Row(
       mainAxisSize: MainAxisSize.min,
-      children: [label, HelpTip(term: helpTerm!)],
+      children: [
+        label,
+        HelpTip(term: helpTerm!),
+      ],
     );
   }
 }
@@ -1142,10 +1159,7 @@ class _SettingsToggle extends StatelessWidget {
   Widget build(BuildContext context) {
     final labelWidget = Text(
       label,
-      style: TextStyle(
-        fontSize: 14,
-        color: context.cs.onSurface,
-      ),
+      style: TextStyle(fontSize: 14, color: context.cs.onSurface),
     );
     return Row(
       children: [
@@ -1156,7 +1170,10 @@ class _SettingsToggle extends StatelessWidget {
               if (helpTerm != null)
                 Row(
                   mainAxisSize: MainAxisSize.min,
-                  children: [labelWidget, HelpTip(term: helpTerm!)],
+                  children: [
+                    labelWidget,
+                    HelpTip(term: helpTerm!),
+                  ],
                 )
               else
                 labelWidget,
@@ -1197,8 +1214,12 @@ class _BlockEditorInline extends StatelessWidget {
       GenericEditorSection(
         title: null,
         fields: [
-          const GenericEditorField(key: 'name', label: 'placeholder_block_name'.tr(), type: 'text'),
-          const GenericEditorField(
+          GenericEditorField(
+            key: 'name',
+            label: 'placeholder_block_name'.tr(),
+            type: 'text',
+          ),
+          GenericEditorField(
             key: 'role',
             label: 'label_role'.tr(),
             type: 'select',
@@ -1208,7 +1229,7 @@ class _BlockEditorInline extends StatelessWidget {
               {'label': 'Assistant', 'value': 'assistant'},
             ],
           ),
-          const GenericEditorField(
+          GenericEditorField(
             key: 'insertionMode',
             label: 'label_insertion'.tr(),
             type: 'select',
@@ -1221,10 +1242,13 @@ class _BlockEditorInline extends StatelessWidget {
             key: 'depth',
             label: 'label_depth'.tr(),
             type: 'select',
-            options: List.generate(20, (i) => {'label': '${i + 1}', 'value': i + 1}),
+            options: List.generate(
+              20,
+              (i) => {'label': '${i + 1}', 'value': i + 1},
+            ),
             showIf: (item) => item['insertionMode'] == 'depth',
           ),
-          const GenericEditorField(
+          GenericEditorField(
             key: 'appendToLastMessage',
             label: 'label_append_last_user'.tr(),
             type: 'select',
@@ -1233,7 +1257,7 @@ class _BlockEditorInline extends StatelessWidget {
               {'label': 'Yes', 'value': true},
             ],
           ),
-          const GenericEditorField(
+          GenericEditorField(
             key: 'content',
             label: 'section_content'.tr(),
             type: 'textarea',
@@ -1259,7 +1283,12 @@ class _BlockEditorInline extends StatelessWidget {
         ),
         // Delete button
         Padding(
-          padding: EdgeInsets.fromLTRB(16, 0, 16, MediaQuery.paddingOf(context).bottom + 16),
+          padding: EdgeInsets.fromLTRB(
+            16,
+            0,
+            16,
+            MediaQuery.paddingOf(context).bottom + 16,
+          ),
           child: Material(
             color: const Color(0xFFFF4444).withValues(alpha: 0.1),
             borderRadius: BorderRadius.circular(12),
@@ -1271,7 +1300,11 @@ class _BlockEditorInline extends StatelessWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Icon(Icons.delete_outlined, size: 20, color: Color(0xFFFF4444)),
+                    Icon(
+                      Icons.delete_outlined,
+                      size: 20,
+                      color: Color(0xFFFF4444),
+                    ),
                     SizedBox(width: 8),
                     Text(
                       'Delete Block',
@@ -1321,7 +1354,7 @@ class _AuthorsNoteBlockEditor extends ConsumerWidget {
       GenericEditorSection(
         title: null,
         fields: [
-          const GenericEditorField(
+          GenericEditorField(
             key: 'role',
             label: 'label_role'.tr(),
             type: 'select',
@@ -1331,7 +1364,7 @@ class _AuthorsNoteBlockEditor extends ConsumerWidget {
               {'label': 'Assistant', 'value': 'assistant'},
             ],
           ),
-          const GenericEditorField(
+          GenericEditorField(
             key: 'insertionMode',
             label: 'label_insertion'.tr(),
             type: 'select',
@@ -1344,7 +1377,10 @@ class _AuthorsNoteBlockEditor extends ConsumerWidget {
             key: 'depth',
             label: 'label_depth'.tr(),
             type: 'select',
-            options: List.generate(20, (i) => {'label': '${i + 1}', 'value': i + 1}),
+            options: List.generate(
+              20,
+              (i) => {'label': '${i + 1}', 'value': i + 1},
+            ),
             showIf: (item) => item['insertionMode'] == 'depth',
           ),
         ],
@@ -1410,7 +1446,7 @@ class _SummaryBlockEditor extends ConsumerWidget {
       GenericEditorSection(
         title: null,
         fields: [
-          const GenericEditorField(
+          GenericEditorField(
             key: 'role',
             label: 'label_role'.tr(),
             type: 'select',
@@ -1420,7 +1456,7 @@ class _SummaryBlockEditor extends ConsumerWidget {
               {'label': 'Assistant', 'value': 'assistant'},
             ],
           ),
-          const GenericEditorField(
+          GenericEditorField(
             key: 'insertionMode',
             label: 'label_insertion'.tr(),
             type: 'select',
@@ -1433,10 +1469,13 @@ class _SummaryBlockEditor extends ConsumerWidget {
             key: 'depth',
             label: 'label_depth'.tr(),
             type: 'select',
-            options: List.generate(20, (i) => {'label': '${i + 1}', 'value': i + 1}),
+            options: List.generate(
+              20,
+              (i) => {'label': '${i + 1}', 'value': i + 1},
+            ),
             showIf: (item) => item['insertionMode'] == 'depth',
           ),
-          const GenericEditorField(
+          GenericEditorField(
             key: 'prefix',
             label: 'label_prefix'.tr(),
             type: 'text',
@@ -1549,7 +1588,11 @@ Widget _linkedSessionContentCard(
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(Icons.edit_outlined, size: 18, color: context.cs.primary),
+                        Icon(
+                          Icons.edit_outlined,
+                          size: 18,
+                          color: context.cs.primary,
+                        ),
                         const SizedBox(width: 8),
                         Text(
                           'Edit content',
@@ -1571,4 +1614,3 @@ Widget _linkedSessionContentCard(
     ),
   );
 }
-

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,12 +5,25 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
 import 'core/debug/perf_debug.dart';
+import 'core/services/windows_preferences_migration.dart';
 
 final appRestartKey = GlobalKey();
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   PerfDebug.installFrameLoggerIfEnabled();
+  try {
+    await migrateLegacyWindowsPreferences();
+  } catch (error, stackTrace) {
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception: error,
+        stack: stackTrace,
+        library: 'startup',
+        context: ErrorDescription('Windows preferences migration failed'),
+      ),
+    );
+  }
   await EasyLocalization.ensureInitialized();
   try {
     await SystemChrome.setPreferredOrientations([

--- a/lib/shared/utils/avatar_image.dart
+++ b/lib/shared/utils/avatar_image.dart
@@ -14,7 +14,10 @@ final Map<String, String> _resolvedThumbCache = {};
 String? _resolveAvatarThumb(String? avatarPath) {
   if (avatarPath == null || avatarPath.isEmpty) return null;
   final cached = _resolvedThumbCache[avatarPath];
-  if (cached != null) return cached;
+  if (cached != null) {
+    if (File(cached).existsSync()) return cached;
+    _resolvedThumbCache.remove(avatarPath);
+  }
   final resolved = resolveGlazeThumbnailPath(avatarPath);
   if (resolved == null || resolved.isEmpty) return null;
   final sep = Platform.pathSeparator;

--- a/test/avatar_image_test.dart
+++ b/test/avatar_image_test.dart
@@ -1,0 +1,31 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:glaze_flutter/shared/utils/avatar_image.dart';
+
+void main() {
+  test('falls back when a memoized thumbnail is deleted', () async {
+    final root = await Directory.systemTemp.createTemp('glaze_avatar_cache_');
+    addTearDown(() async {
+      if (await root.exists()) await root.delete(recursive: true);
+    });
+
+    final avatar = File(p.join(root.path, 'avatars', 'character.png'));
+    final thumbnail = File(p.join(root.path, 'thumbnails', 'character.jpg'));
+    await avatar.parent.create(recursive: true);
+    await thumbnail.parent.create(recursive: true);
+    await avatar.writeAsBytes([1]);
+    await thumbnail.writeAsBytes([2]);
+
+    final first = glazeAvatarImage(avatar.path) as FileImage;
+    expect(first.file.path, thumbnail.path);
+
+    await thumbnail.delete();
+
+    final second = glazeAvatarImage(avatar.path) as FileImage;
+    expect(second.file.path, avatar.path);
+  });
+}

--- a/test/character_importer_test.dart
+++ b/test/character_importer_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/services/character_importer.dart';
+import 'package:glaze_flutter/core/services/image_storage_service.dart';
+
+class _TestImageStorage extends ImageStorageService {
+  _TestImageStorage()
+    : super(Directory.systemTemp.createTempSync('glaze_charx_test_').path);
+
+  Uint8List? avatarBytes;
+
+  @override
+  Future<String> saveAvatar(String characterId, Uint8List imageBytes) async {
+    avatarBytes = imageBytes;
+    return '/fake/avatars/$characterId.png';
+  }
+}
+
+void main() {
+  late _TestImageStorage imageStorage;
+  late CharacterImporter importer;
+
+  setUp(() {
+    imageStorage = _TestImageStorage();
+    importer = CharacterImporter(imageStorage);
+  });
+
+  test('imports a regular CharX ZIP', () async {
+    final result = await importer.importFromBytes(_charXBytes(), 'card.charx');
+
+    expect(result.character.name, 'Risu character');
+    expect(result.hadAvatar, isTrue);
+    expect(imageStorage.avatarBytes, _iconBytes);
+  });
+
+  test('imports a Risu JPEG-prefixed CharX', () async {
+    final zip = _charXBytes();
+    final polyglot = Uint8List.fromList([
+      0xff,
+      0xd8,
+      0xff,
+      0xe0,
+      0x00,
+      0x10,
+      0x4a,
+      0x46,
+      0x49,
+      0x46,
+      0x00,
+      0xff,
+      0xd9,
+      ...zip,
+    ]);
+
+    final result = await importer.importFromBytes(polyglot, 'card.charx');
+
+    expect(result.character.name, 'Risu character');
+    expect(result.hadAvatar, isTrue);
+    expect(imageStorage.avatarBytes, _iconBytes);
+  });
+
+  test('does not scan arbitrary prefixes for an embedded ZIP', () async {
+    final prefixed = Uint8List.fromList([0x00, 0x01, 0x02, ..._charXBytes()]);
+
+    expect(
+      () => importer.importFromBytes(prefixed, 'card.charx'),
+      throwsA(isA<FormatException>()),
+    );
+  });
+}
+
+final _iconBytes = Uint8List.fromList([1, 2, 3, 4]);
+
+Uint8List _charXBytes() {
+  final card = utf8.encode(
+    jsonEncode({
+      'spec': 'chara_card_v3',
+      'spec_version': '3.0',
+      'data': {
+        'name': 'Risu character',
+        'description': 'Test character',
+        'assets': [
+          {
+            'type': 'icon',
+            'name': 'main',
+            'uri': 'embeded://assets/icon.png',
+            'ext': 'png',
+          },
+        ],
+      },
+    }),
+  );
+  final archive = Archive()
+    ..addFile(ArchiveFile('card.json', card.length, card))
+    ..addFile(ArchiveFile('assets/icon.png', _iconBytes.length, _iconBytes));
+  return Uint8List.fromList(ZipEncoder().encode(archive));
+}

--- a/test/image_storage_service_test.dart
+++ b/test/image_storage_service_test.dart
@@ -184,6 +184,53 @@ void main() {
     expect(prefs.getBool('gz_thumb_v6_backfilled'), isTrue);
   });
 
+  test(
+    'thumbnail migration preserves existing files when prefs move',
+    () async {
+      final thumbDir = Directory(p.join(tmpDir.path, 'thumbnails'));
+      await thumbDir.create(recursive: true);
+      final thumbnail = File(p.join(thumbDir.path, 'existing.jpg'));
+      await thumbnail.writeAsBytes([1, 2, 3]);
+      final prefs = await SharedPreferences.getInstance();
+
+      await service.migrateOldThumbnails(prefs);
+
+      expect(await thumbnail.exists(), isTrue);
+      expect(prefs.getBool('gz_thumb_v6_migrated'), isTrue);
+      expect(
+        await File(p.join(tmpDir.path, '.thumbnails-v6-migrated')).exists(),
+        isTrue,
+      );
+      expect(
+        await File(
+          p.join(tmpDir.path, '.thumbnails-v6-refresh-required'),
+        ).exists(),
+        isTrue,
+      );
+    },
+  );
+
+  test(
+    'adopting an existing v6 library only backfills missing files',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        'gz_thumb_v6_migrated': true,
+        'gz_thumb_v6_backfilled': true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      await service.migrateOldThumbnails(prefs);
+
+      expect(prefs.getBool('gz_thumb_v6_backfilled'), isFalse);
+      expect(
+        await File(
+          p.join(tmpDir.path, '.thumbnails-v6-refresh-required'),
+        ).exists(),
+        isFalse,
+      );
+    },
+  );
+
   group('absolutePath rebasing (iOS sandbox UUID change)', () {
     test('relative path is joined onto baseDir', () {
       // Compare path-equivalently (separator-agnostic).
@@ -196,44 +243,48 @@ void main() {
       );
     });
 
-    test('existing absolute path is returned unchanged (Android/Windows)',
-        () async {
-      // Save a real avatar so the absolute path exists, then confirm
-      // absolutePath returns it verbatim — no rebasing when the file is valid.
-      final png = makePng(80, 80);
-      final abs = await service.saveAvatar('valid', png);
-      expect(File(abs).isAbsolute, isTrue);
-      expect(File(abs).existsSync(), isTrue);
-      expect(service.absolutePath(abs), equals(abs));
-    });
+    test(
+      'existing absolute path is returned unchanged (Android/Windows)',
+      () async {
+        // Save a real avatar so the absolute path exists, then confirm
+        // absolutePath returns it verbatim — no rebasing when the file is valid.
+        final png = makePng(80, 80);
+        final abs = await service.saveAvatar('valid', png);
+        expect(File(abs).isAbsolute, isTrue);
+        expect(File(abs).existsSync(), isTrue);
+        expect(service.absolutePath(abs), equals(abs));
+      },
+    );
 
-    test('stale absolute path under /Glaze/ is rebased onto current baseDir',
-        () async {
-      // Simulate an iOS path persisted under an OLD container UUID. The file
-      // does not exist at that absolute location, but the same sub-path
-      // exists under the current baseDir → should rebase.
-      //
-      // The rebasing only triggers when the input is recognised as absolute.
-      // On the Windows test host a unix path like /var/... is NOT absolute,
-      // so gate this assertion to POSIX hosts (where iOS-style paths apply).
-      final png = makePng(80, 80);
-      await service.saveAvatar('moved', png); // creates avatars/moved.png
+    test(
+      'stale absolute path under /Glaze/ is rebased onto current baseDir',
+      () async {
+        // Simulate an iOS path persisted under an OLD container UUID. The file
+        // does not exist at that absolute location, but the same sub-path
+        // exists under the current baseDir → should rebase.
+        //
+        // The rebasing only triggers when the input is recognised as absolute.
+        // On the Windows test host a unix path like /var/... is NOT absolute,
+        // so gate this assertion to POSIX hosts (where iOS-style paths apply).
+        final png = makePng(80, 80);
+        await service.saveAvatar('moved', png); // creates avatars/moved.png
 
-      const stale =
-          '/var/mobile/Containers/Data/Application/OLD-UUID/Documents/Glaze/avatars/moved.png';
-      final resolved = service.absolutePath(stale)!;
-      if (File(stale).isAbsolute) {
-        expect(
-          p.equals(resolved, p.join(tmpDir.path, 'avatars', 'moved.png')),
-          isTrue,
-          reason: 'stale /Glaze/ path should rebase onto current baseDir',
-        );
-        expect(File(resolved).existsSync(), isTrue);
-      } else {
-        // Non-absolute on this host → treated as relative, joined onto base.
-        expect(resolved, contains('moved.png'));
-      }
-    });
+        const stale =
+            '/var/mobile/Containers/Data/Application/OLD-UUID/Documents/Glaze/avatars/moved.png';
+        final resolved = service.absolutePath(stale)!;
+        if (File(stale).isAbsolute) {
+          expect(
+            p.equals(resolved, p.join(tmpDir.path, 'avatars', 'moved.png')),
+            isTrue,
+            reason: 'stale /Glaze/ path should rebase onto current baseDir',
+          );
+          expect(File(resolved).existsSync(), isTrue);
+        } else {
+          // Non-absolute on this host → treated as relative, joined onto base.
+          expect(resolved, contains('moved.png'));
+        }
+      },
+    );
 
     test('empty and null are passed through', () {
       expect(service.absolutePath(''), equals(''));
@@ -252,7 +303,9 @@ String base64Encode(Uint8List bytes) {
     final b2 = i + 2 < bytes.length ? bytes[i + 2] : 0;
     buf.write(chars[(b0 >> 2) & 0x3F]);
     buf.write(chars[((b0 << 4) | (b1 >> 4)) & 0x3F]);
-    buf.write(i + 1 < bytes.length ? chars[((b1 << 2) | (b2 >> 6)) & 0x3F] : '=');
+    buf.write(
+      i + 1 < bytes.length ? chars[((b1 << 2) | (b2 >> 6)) & 0x3F] : '=',
+    );
     buf.write(i + 2 < bytes.length ? chars[b2 & 0x3F] : '=');
   }
   return buf.toString();

--- a/test/windows_preferences_migration_test.dart
+++ b/test/windows_preferences_migration_test.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:glaze_flutter/core/services/windows_preferences_migration.dart';
+
+void main() {
+  late Directory appData;
+
+  setUp(() async {
+    appData = await Directory.systemTemp.createTemp('glaze_prefs_migration_');
+  });
+
+  tearDown(() async {
+    if (await appData.exists()) await appData.delete(recursive: true);
+  });
+
+  test('merges legacy values over current values once', () async {
+    final legacy = File(
+      p.join(
+        appData.path,
+        'com.glaze',
+        'glaze_flutter',
+        'shared_preferences.json',
+      ),
+    );
+    final current = File(
+      p.join(appData.path, 'com.glaze', 'Glaze', 'shared_preferences.json'),
+    );
+    await legacy.parent.create(recursive: true);
+    await current.parent.create(recursive: true);
+    await legacy.writeAsString(jsonEncode({'theme': 'legacy', 'old': true}));
+    await current.writeAsString(jsonEncode({'theme': 'default', 'new': true}));
+
+    await migrateLegacyWindowsPreferences(
+      environment: {'APPDATA': appData.path},
+    );
+
+    expect(jsonDecode(await current.readAsString()), {
+      'theme': 'legacy',
+      'old': true,
+      'new': true,
+    });
+
+    await legacy.writeAsString(jsonEncode({'theme': 'changed'}));
+    await migrateLegacyWindowsPreferences(
+      environment: {'APPDATA': appData.path},
+    );
+    expect(
+      (jsonDecode(await current.readAsString()) as Map)['theme'],
+      'legacy',
+    );
+  });
+
+  test(
+    'does not replace current preferences when legacy JSON is invalid',
+    () async {
+      final legacy = File(
+        p.join(
+          appData.path,
+          'com.glaze',
+          'glaze_flutter',
+          'shared_preferences.json',
+        ),
+      );
+      final current = File(
+        p.join(appData.path, 'com.glaze', 'Glaze', 'shared_preferences.json'),
+      );
+      await legacy.parent.create(recursive: true);
+      await current.parent.create(recursive: true);
+      await legacy.writeAsString('{invalid');
+      await current.writeAsString(jsonEncode({'theme': 'current'}));
+
+      await migrateLegacyWindowsPreferences(
+        environment: {'APPDATA': appData.path},
+      );
+
+      expect(jsonDecode(await current.readAsString()), {'theme': 'current'});
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- migrate legacy Windows SharedPreferences into the new Glaze product directory before startup consumers initialize
- replace destructive thumbnail migration with stable markers and safe background regeneration
- invalidate memoized thumbnail paths when files disappear
- restore Risu JPEG-prefixed CharX import support and preset editor localization compile fixes lost during the nightly rewrite

## Verification
- lutter test test/character_importer_test.dart test/windows_preferences_migration_test.dart test/image_storage_service_test.dart test/avatar_image_test.dart (29 tests)
- focused lutter analyze on all changed source and test files
- lutter build windows --debug`n
Full-repository analysis still reports three pre-existing errors in 	est/header_scroll_hider_test.dart.