### PR TITLE
fix(ci): восстановить подпись Android APK после переезда репозитория

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -162,31 +162,41 @@ jobs:
 
       - name: Verify signing keystore
         env:
-          KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
-          KEYSTORE_PASSWORD: android
-          KEY_ALIAS: debug-key
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         run: |
           set -euo pipefail
           if [ -z "$(printf '%s' "${KEYSTORE_BASE64:-}" | tr -d '[:space:]')" ]; then
-            echo "::error::Secret DEBUG_KEYSTORE_BASE64 is empty or not set in this repository — the APK cannot be signed."
+            echo "::error::Secret ANDROID_KEYSTORE_BASE64 is empty or not set in this repository — the APK cannot be signed."
             echo "Add it in Settings -> Secrets and variables -> Actions. Value = base64 of the raw keystore file:"
-            echo '  [Convert]::ToBase64String([IO.File]::ReadAllBytes("debug-key.keystore")) | Set-Clipboard   # PowerShell'
-            echo '  base64 -w0 debug-key.keystore                                                              # bash'
-            echo "If the keystore was lost together with the old repository, generate a new one (this changes the"
-            echo "APK signature, so existing installs have to be reinstalled):"
-            echo '  keytool -genkeypair -v -keystore debug-key.keystore -storetype PKCS12 -alias debug-key \'
-            echo '    -storepass android -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Glaze"'
+            echo '  [Convert]::ToBase64String([IO.File]::ReadAllBytes("upload-key.keystore")) | Set-Clipboard   # PowerShell'
+            echo '  base64 -w0 upload-key.keystore                                                              # bash'
+            echo "If the keystore itself was lost, generate a new one (this changes the APK signature, so existing"
+            echo "installs have to be reinstalled) and update all four ANDROID_* secrets to match:"
+            echo '  keytool -genkeypair -v -keystore upload-key.keystore -storetype PKCS12 -alias <ANDROID_KEY_ALIAS> \'
+            echo '    -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Glaze"'
             exit 1
           fi
-          if ! printf '%s' "$KEYSTORE_BASE64" | tr -d '[:space:]' | base64 -d > android/debug-key.keystore; then
-            echo "::error::DEBUG_KEYSTORE_BASE64 is not valid base64 — re-create the secret from the raw keystore bytes."
+          for required in KEYSTORE_PASSWORD KEY_ALIAS; do
+            if [ -z "${!required:-}" ]; then
+              case "$required" in
+                KEYSTORE_PASSWORD) secret=ANDROID_STORE_PASSWORD ;;
+                KEY_ALIAS)         secret=ANDROID_KEY_ALIAS ;;
+              esac
+              echo "::error::Secret $secret is empty or not set — it is required to read the keystore."
+              exit 1
+            fi
+          done
+          if ! printf '%s' "$KEYSTORE_BASE64" | tr -d '[:space:]' | base64 -d > android/ci-signing.keystore; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not valid base64 — re-create the secret from the raw keystore bytes."
             exit 1
           fi
-          echo "Decoded keystore: $(stat -c%s android/debug-key.keystore) bytes," \
-               "header $(od -An -tx1 -N4 android/debug-key.keystore | tr -d ' ')," \
-               "sha256 $(sha256sum android/debug-key.keystore | cut -c1-16)..."
-          if ! keytool -list -keystore android/debug-key.keystore -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" > keytool.log 2>&1; then
-            echo "::error::Keystore decoded from DEBUG_KEYSTORE_BASE64 is unreadable or has no \"$KEY_ALIAS\" alias."
+          echo "Decoded keystore: $(stat -c%s android/ci-signing.keystore) bytes," \
+               "header $(od -An -tx1 -N4 android/ci-signing.keystore | tr -d ' ')," \
+               "sha256 $(sha256sum android/ci-signing.keystore | cut -c1-16)..."
+          if ! keytool -list -keystore android/ci-signing.keystore -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" > keytool.log 2>&1; then
+            echo "::error::Keystore decoded from ANDROID_KEYSTORE_BASE64 is unreadable or has no \"$KEY_ALIAS\" alias."
             echo "A 0-byte or text-mangled keystore shows up later as 'Tag number over 30 is not supported'."
             cat keytool.log
             rm -f keytool.log
@@ -197,10 +207,10 @@ jobs:
 
       - name: Build APK (arm64 only)
         env:
-          KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
-          KEYSTORE_PASSWORD: android
-          KEY_ALIAS: debug-key
-          KEY_PASSWORD: android
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: >
           flutter build apk --release --no-pub --target-platform android-arm64
           "--dart-define=APP_VERSION=${{ needs.metadata.outputs.version }}"

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -160,6 +160,41 @@ jobs:
       - name: Generate code
         run: dart run build_runner build --delete-conflicting-outputs
 
+      - name: Verify signing keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: android
+          KEY_ALIAS: debug-key
+        run: |
+          set -euo pipefail
+          if [ -z "$(printf '%s' "${KEYSTORE_BASE64:-}" | tr -d '[:space:]')" ]; then
+            echo "::error::Secret DEBUG_KEYSTORE_BASE64 is empty or not set in this repository — the APK cannot be signed."
+            echo "Add it in Settings -> Secrets and variables -> Actions. Value = base64 of the raw keystore file:"
+            echo '  [Convert]::ToBase64String([IO.File]::ReadAllBytes("debug-key.keystore")) | Set-Clipboard   # PowerShell'
+            echo '  base64 -w0 debug-key.keystore                                                              # bash'
+            echo "If the keystore was lost together with the old repository, generate a new one (this changes the"
+            echo "APK signature, so existing installs have to be reinstalled):"
+            echo '  keytool -genkeypair -v -keystore debug-key.keystore -storetype PKCS12 -alias debug-key \'
+            echo '    -storepass android -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Glaze"'
+            exit 1
+          fi
+          if ! printf '%s' "$KEYSTORE_BASE64" | tr -d '[:space:]' | base64 -d > android/debug-key.keystore; then
+            echo "::error::DEBUG_KEYSTORE_BASE64 is not valid base64 — re-create the secret from the raw keystore bytes."
+            exit 1
+          fi
+          echo "Decoded keystore: $(stat -c%s android/debug-key.keystore) bytes," \
+               "header $(od -An -tx1 -N4 android/debug-key.keystore | tr -d ' ')," \
+               "sha256 $(sha256sum android/debug-key.keystore | cut -c1-16)..."
+          if ! keytool -list -keystore android/debug-key.keystore -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" > keytool.log 2>&1; then
+            echo "::error::Keystore decoded from DEBUG_KEYSTORE_BASE64 is unreadable or has no \"$KEY_ALIAS\" alias."
+            echo "A 0-byte or text-mangled keystore shows up later as 'Tag number over 30 is not supported'."
+            cat keytool.log
+            rm -f keytool.log
+            exit 1
+          fi
+          rm -f keytool.log
+          echo "Keystore OK - alias \"$KEY_ALIAS\" is readable."
+
       - name: Build APK (arm64 only)
         env:
           KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -159,6 +159,41 @@ jobs:
       - name: Generate code
         run: dart run build_runner build --delete-conflicting-outputs
 
+      - name: Verify signing keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: android
+          KEY_ALIAS: debug-key
+        run: |
+          set -euo pipefail
+          if [ -z "$(printf '%s' "${KEYSTORE_BASE64:-}" | tr -d '[:space:]')" ]; then
+            echo "::error::Secret DEBUG_KEYSTORE_BASE64 is empty or not set in this repository — the APK cannot be signed."
+            echo "Add it in Settings -> Secrets and variables -> Actions. Value = base64 of the raw keystore file:"
+            echo '  [Convert]::ToBase64String([IO.File]::ReadAllBytes("debug-key.keystore")) | Set-Clipboard   # PowerShell'
+            echo '  base64 -w0 debug-key.keystore                                                              # bash'
+            echo "If the keystore was lost together with the old repository, generate a new one (this changes the"
+            echo "APK signature, so existing installs have to be reinstalled):"
+            echo '  keytool -genkeypair -v -keystore debug-key.keystore -storetype PKCS12 -alias debug-key \'
+            echo '    -storepass android -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Glaze"'
+            exit 1
+          fi
+          if ! printf '%s' "$KEYSTORE_BASE64" | tr -d '[:space:]' | base64 -d > android/debug-key.keystore; then
+            echo "::error::DEBUG_KEYSTORE_BASE64 is not valid base64 — re-create the secret from the raw keystore bytes."
+            exit 1
+          fi
+          echo "Decoded keystore: $(stat -c%s android/debug-key.keystore) bytes," \
+               "header $(od -An -tx1 -N4 android/debug-key.keystore | tr -d ' ')," \
+               "sha256 $(sha256sum android/debug-key.keystore | cut -c1-16)..."
+          if ! keytool -list -keystore android/debug-key.keystore -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" > keytool.log 2>&1; then
+            echo "::error::Keystore decoded from DEBUG_KEYSTORE_BASE64 is unreadable or has no \"$KEY_ALIAS\" alias."
+            echo "A 0-byte or text-mangled keystore shows up later as 'Tag number over 30 is not supported'."
+            cat keytool.log
+            rm -f keytool.log
+            exit 1
+          fi
+          rm -f keytool.log
+          echo "Keystore OK - alias \"$KEY_ALIAS\" is readable."
+
       - name: Build APK (arm64 only)
         env:
           KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -161,31 +161,41 @@ jobs:
 
       - name: Verify signing keystore
         env:
-          KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
-          KEYSTORE_PASSWORD: android
-          KEY_ALIAS: debug-key
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         run: |
           set -euo pipefail
           if [ -z "$(printf '%s' "${KEYSTORE_BASE64:-}" | tr -d '[:space:]')" ]; then
-            echo "::error::Secret DEBUG_KEYSTORE_BASE64 is empty or not set in this repository — the APK cannot be signed."
+            echo "::error::Secret ANDROID_KEYSTORE_BASE64 is empty or not set in this repository — the APK cannot be signed."
             echo "Add it in Settings -> Secrets and variables -> Actions. Value = base64 of the raw keystore file:"
-            echo '  [Convert]::ToBase64String([IO.File]::ReadAllBytes("debug-key.keystore")) | Set-Clipboard   # PowerShell'
-            echo '  base64 -w0 debug-key.keystore                                                              # bash'
-            echo "If the keystore was lost together with the old repository, generate a new one (this changes the"
-            echo "APK signature, so existing installs have to be reinstalled):"
-            echo '  keytool -genkeypair -v -keystore debug-key.keystore -storetype PKCS12 -alias debug-key \'
-            echo '    -storepass android -keypass android -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Glaze"'
+            echo '  [Convert]::ToBase64String([IO.File]::ReadAllBytes("upload-key.keystore")) | Set-Clipboard   # PowerShell'
+            echo '  base64 -w0 upload-key.keystore                                                              # bash'
+            echo "If the keystore itself was lost, generate a new one (this changes the APK signature, so existing"
+            echo "installs have to be reinstalled) and update all four ANDROID_* secrets to match:"
+            echo '  keytool -genkeypair -v -keystore upload-key.keystore -storetype PKCS12 -alias <ANDROID_KEY_ALIAS> \'
+            echo '    -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Glaze"'
             exit 1
           fi
-          if ! printf '%s' "$KEYSTORE_BASE64" | tr -d '[:space:]' | base64 -d > android/debug-key.keystore; then
-            echo "::error::DEBUG_KEYSTORE_BASE64 is not valid base64 — re-create the secret from the raw keystore bytes."
+          for required in KEYSTORE_PASSWORD KEY_ALIAS; do
+            if [ -z "${!required:-}" ]; then
+              case "$required" in
+                KEYSTORE_PASSWORD) secret=ANDROID_STORE_PASSWORD ;;
+                KEY_ALIAS)         secret=ANDROID_KEY_ALIAS ;;
+              esac
+              echo "::error::Secret $secret is empty or not set — it is required to read the keystore."
+              exit 1
+            fi
+          done
+          if ! printf '%s' "$KEYSTORE_BASE64" | tr -d '[:space:]' | base64 -d > android/ci-signing.keystore; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not valid base64 — re-create the secret from the raw keystore bytes."
             exit 1
           fi
-          echo "Decoded keystore: $(stat -c%s android/debug-key.keystore) bytes," \
-               "header $(od -An -tx1 -N4 android/debug-key.keystore | tr -d ' ')," \
-               "sha256 $(sha256sum android/debug-key.keystore | cut -c1-16)..."
-          if ! keytool -list -keystore android/debug-key.keystore -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" > keytool.log 2>&1; then
-            echo "::error::Keystore decoded from DEBUG_KEYSTORE_BASE64 is unreadable or has no \"$KEY_ALIAS\" alias."
+          echo "Decoded keystore: $(stat -c%s android/ci-signing.keystore) bytes," \
+               "header $(od -An -tx1 -N4 android/ci-signing.keystore | tr -d ' ')," \
+               "sha256 $(sha256sum android/ci-signing.keystore | cut -c1-16)..."
+          if ! keytool -list -keystore android/ci-signing.keystore -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" > keytool.log 2>&1; then
+            echo "::error::Keystore decoded from ANDROID_KEYSTORE_BASE64 is unreadable or has no \"$KEY_ALIAS\" alias."
             echo "A 0-byte or text-mangled keystore shows up later as 'Tag number over 30 is not supported'."
             cat keytool.log
             rm -f keytool.log
@@ -196,10 +206,10 @@ jobs:
 
       - name: Build APK (arm64 only)
         env:
-          KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
-          KEYSTORE_PASSWORD: android
-          KEY_ALIAS: debug-key
-          KEY_PASSWORD: android
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: >
           flutter build apk --release --no-pub --target-platform android-arm64
           "--dart-define=APP_VERSION=${{ needs.metadata.outputs.version }}"

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,9 +1,61 @@
+import java.security.KeyStore
 import java.util.Base64
 
 plugins {
     id("com.android.application")
     id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// CI signing: the keystore is passed in as base64 through KEYSTORE_BASE64.
+// An *unset* secret still reaches Gradle as an empty string, so blank must be
+// treated exactly like "no CI keystore" — otherwise we write a 0-byte file and
+// AGP fails deep inside the DER parser ("Tag number over 30 is not supported")
+// with no hint about the real cause.
+val ciKeystoreBase64: String? =
+    System.getenv("KEYSTORE_BASE64")?.filterNot { it.isWhitespace() }?.ifEmpty { null }
+val ciStorePassword: String = System.getenv("KEYSTORE_PASSWORD") ?: "android"
+val ciKeyAlias: String = System.getenv("KEY_ALIAS") ?: "debug-key"
+
+fun decodeCiKeystore(base64: String): ByteArray {
+    val bytes = try {
+        Base64.getMimeDecoder().decode(base64)
+    } catch (e: IllegalArgumentException) {
+        throw GradleException(
+            "KEYSTORE_BASE64 is not valid base64 (${e.message}). Re-create the secret with:\n" +
+                "  [Convert]::ToBase64String([IO.File]::ReadAllBytes(\"debug-key.keystore\")) | Set-Clipboard",
+        )
+    }
+    if (bytes.isEmpty()) {
+        throw GradleException("KEYSTORE_BASE64 decodes to 0 bytes — the secret is empty or truncated.")
+    }
+    return bytes
+}
+
+fun verifyCiKeystore(ksFile: File, storePassword: String, keyAlias: String) {
+    var lastError: Exception? = null
+    // PKCS12 first (keytool's default since JDK 9), JKS for older keystores.
+    val store = listOf("pkcs12", "jks").firstNotNullOfOrNull { type ->
+        try {
+            KeyStore.getInstance(type).also { ks ->
+                ksFile.inputStream().use { ks.load(it, storePassword.toCharArray()) }
+            }
+        } catch (e: Exception) {
+            lastError = e
+            null
+        }
+    } ?: throw GradleException(
+        "Cannot read the keystore decoded from KEYSTORE_BASE64 (${ksFile.length()} bytes): ${lastError?.message}\n" +
+            "The secret is either corrupted (re-encoded as text instead of raw bytes) or was created " +
+            "with a different store password than KEYSTORE_PASSWORD.",
+        lastError,
+    )
+    if (!store.containsAlias(keyAlias)) {
+        throw GradleException(
+            "Keystore has no alias \"$keyAlias\". Available aliases: " +
+                store.aliases().toList().joinToString(", ").ifEmpty { "<none>" },
+        )
+    }
 }
 
 android {
@@ -23,16 +75,15 @@ android {
 
     signingConfigs {
         create("ci") {
-            val ks = System.getenv("KEYSTORE_BASE64")
-            if (ks != null) {
+            val base64 = ciKeystoreBase64
+            if (base64 != null) {
                 val ksFile = rootProject.file("debug-key.keystore")
-                if (!ksFile.exists()) {
-                    ksFile.writeBytes(Base64.getDecoder().decode(ks))
-                }
+                ksFile.writeBytes(decodeCiKeystore(base64))
                 storeFile = ksFile
-                storePassword = System.getenv("KEYSTORE_PASSWORD") ?: "android"
-                keyAlias = System.getenv("KEY_ALIAS") ?: "debug-key"
+                storePassword = ciStorePassword
+                keyAlias = ciKeyAlias
                 keyPassword = System.getenv("KEY_PASSWORD") ?: "android"
+                verifyCiKeystore(ksFile, ciStorePassword, ciKeyAlias)
             }
         }
     }
@@ -47,14 +98,14 @@ android {
 
     buildTypes {
         debug {
-            signingConfig = if (System.getenv("KEYSTORE_BASE64") != null) {
+            signingConfig = if (ciKeystoreBase64 != null) {
                 signingConfigs.getByName("ci")
             } else {
                 signingConfigs.getByName("debug")
             }
         }
         release {
-            signingConfig = if (System.getenv("KEYSTORE_BASE64") != null) {
+            signingConfig = if (ciKeystoreBase64 != null) {
                 signingConfigs.getByName("ci")
             } else {
                 signingConfigs.getByName("debug")

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,16 +14,24 @@ plugins {
 // with no hint about the real cause.
 val ciKeystoreBase64: String? =
     System.getenv("KEYSTORE_BASE64")?.filterNot { it.isWhitespace() }?.ifEmpty { null }
-val ciStorePassword: String = System.getenv("KEYSTORE_PASSWORD") ?: "android"
-val ciKeyAlias: String = System.getenv("KEY_ALIAS") ?: "debug-key"
+
+// Store password, key alias and key password come from secrets too, so they are
+// subject to the same empty-string-instead-of-null trap.
+fun requireCiEnv(name: String): String =
+    System.getenv(name)?.takeIf { it.isNotBlank() } ?: throw GradleException(
+        "KEYSTORE_BASE64 is set but $name is empty — CI signing needs the store password, " +
+            "key alias and key password (secrets ANDROID_STORE_PASSWORD, ANDROID_KEY_ALIAS, " +
+            "ANDROID_KEY_PASSWORD).",
+    )
 
 fun decodeCiKeystore(base64: String): ByteArray {
     val bytes = try {
         Base64.getMimeDecoder().decode(base64)
     } catch (e: IllegalArgumentException) {
         throw GradleException(
-            "KEYSTORE_BASE64 is not valid base64 (${e.message}). Re-create the secret with:\n" +
-                "  [Convert]::ToBase64String([IO.File]::ReadAllBytes(\"debug-key.keystore\")) | Set-Clipboard",
+            "KEYSTORE_BASE64 is not valid base64 (${e.message}). Re-create the ANDROID_KEYSTORE_BASE64 " +
+                "secret from the raw keystore bytes:\n" +
+                "  [Convert]::ToBase64String([IO.File]::ReadAllBytes(\"<keystore>\")) | Set-Clipboard",
         )
     }
     if (bytes.isEmpty()) {
@@ -77,13 +85,15 @@ android {
         create("ci") {
             val base64 = ciKeystoreBase64
             if (base64 != null) {
-                val ksFile = rootProject.file("debug-key.keystore")
+                val ksPassword = requireCiEnv("KEYSTORE_PASSWORD")
+                val ksAlias = requireCiEnv("KEY_ALIAS")
+                val ksFile = rootProject.file("ci-signing.keystore")
                 ksFile.writeBytes(decodeCiKeystore(base64))
+                verifyCiKeystore(ksFile, ksPassword, ksAlias)
                 storeFile = ksFile
-                storePassword = ciStorePassword
-                keyAlias = ciKeyAlias
-                keyPassword = System.getenv("KEY_PASSWORD") ?: "android"
-                verifyCiKeystore(ksFile, ciStorePassword, ciKeyAlias)
+                storePassword = ksPassword
+                keyAlias = ksAlias
+                keyPassword = requireCiEnv("KEY_PASSWORD")
             }
         }
     }

--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -79,39 +79,54 @@ Windows 2025 image settle.
 **Symptom:** `flutter build apk --release` in CI fails at `:app:packageRelease`:
 
 ```text
-com.android.ide.common.signing.KeytoolException: Failed to read key debug-key
-from store ".../android/debug-key.keystore": Tag number over 30 is not supported
+com.android.ide.common.signing.KeytoolException: Failed to read key <alias>
+from store ".../android/<name>.keystore": Tag number over 30 is not supported
 ```
 
-**Cause:** the signing keystore is passed to Gradle as the base64 secret
-`DEBUG_KEYSTORE_BASE64`. A secret that does not exist in the repository (e.g.
-after moving the project to a new GitHub repo — secrets do not travel with the
-code) still reaches the build as an **empty string**, not as an unset variable.
-The old `if (ks != null)` check in `android/app/build.gradle.kts` therefore
-passed, `Base64.decode("")` produced 0 bytes, and a 0-byte keystore was written
-and handed to AGP. Loading an empty file as PKCS12 makes the JDK DER parser read
-tag `-1`, and `-1 and 0x1f == 0x1f` is reported as *"Tag number over 30 is not
-supported"* — the message says nothing about the file being empty.
+**Cause:** the signing keystore is passed to Gradle as a base64 secret. A secret
+that does not exist in the repository (e.g. after moving the project to a new
+GitHub repo — secrets do not travel with the code, and the new repo used
+different secret names) still reaches the build as an **empty string**, not as an
+unset variable. The old `if (ks != null)` check in `android/app/build.gradle.kts`
+therefore passed, `Base64.decode("")` produced 0 bytes, and a 0-byte keystore was
+written and handed to AGP. Loading an empty file as PKCS12 makes the JDK DER
+parser read tag `-1`, and `-1 and 0x1f == 0x1f` is reported as *"Tag number over
+30 is not supported"* — the message says nothing about the file being empty.
+
+**Signing secrets (repository → Settings → Secrets and variables → Actions):**
+
+| Secret | Gradle env | Purpose |
+|---|---|---|
+| `ANDROID_KEYSTORE_BASE64` | `KEYSTORE_BASE64` | keystore file, base64 of the raw bytes |
+| `ANDROID_STORE_PASSWORD` | `KEYSTORE_PASSWORD` | keystore password |
+| `ANDROID_KEY_ALIAS` | `KEY_ALIAS` | alias of the signing key |
+| `ANDROID_KEY_PASSWORD` | `KEY_PASSWORD` | password of that key |
+
+All four are required together; the decoded keystore is written to
+`android/ci-signing.keystore` (gitignored). Without `KEYSTORE_BASE64` the build
+falls back to the local debug signing config, which is what local builds use.
 
 **Fix (applied 2026-07-26):**
 - `android/app/build.gradle.kts` treats a blank `KEYSTORE_BASE64` as "no CI
-  keystore" (falls back to the local debug signing config), tolerates wrapped
-  base64, always rewrites the keystore file, and verifies that the decoded store
-  loads and contains `KEY_ALIAS` — failing with an explicit message otherwise.
-- Both Android workflows gained a `Verify signing keystore` step that runs
-  before the ~8-minute Gradle build and reports a missing, non-base64 or
-  unreadable secret immediately, including the commands to re-create it.
+  keystore", tolerates wrapped base64, always rewrites the keystore file,
+  requires the other three values to be non-blank, and verifies that the decoded
+  store loads and contains `KEY_ALIAS` — failing with an explicit message
+  otherwise.
+- Both Android workflows read the `ANDROID_*` secrets (they previously looked
+  for a `DEBUG_KEYSTORE_BASE64` secret that no longer exists, with alias and
+  passwords hardcoded to `debug-key`/`android`) and gained a `Verify signing
+  keystore` step that runs before the ~8-minute Gradle build and reports a
+  missing, non-base64 or unreadable secret immediately.
 
-**If the secret is missing,** add it under *Settings → Secrets and variables →
-Actions*, with the value produced from the raw keystore bytes:
+**To (re-)create the base64 secret** from the keystore file:
 
 ```powershell
-[Convert]::ToBase64String([IO.File]::ReadAllBytes("debug-key.keystore")) | Set-Clipboard
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("upload-key.keystore")) | Set-Clipboard
 ```
 
 Do not paste the output of `certutil -encode` or a file that was re-saved as
 text — either mangles the bytes. If the keystore itself is gone, generate a new
-one (`keytool -genkeypair -keystore debug-key.keystore -storetype PKCS12 -alias
-debug-key -storepass android -keypass android -keyalg RSA -keysize 2048
--validity 10000 -dname "CN=Glaze"`); note that a new key changes the APK
-signature, so existing installs must be uninstalled before updating.
+one (`keytool -genkeypair -keystore upload-key.keystore -storetype PKCS12 -alias
+<ANDROID_KEY_ALIAS> -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Glaze"`)
+and update all four secrets; note that a new key changes the APK signature, so
+existing installs must be uninstalled before updating.

--- a/docs/BUILD_NOTES.md
+++ b/docs/BUILD_NOTES.md
@@ -73,3 +73,45 @@ image. The Flutter setup/cache step is not reliable there yet for this workflow.
 **Workaround (active):** `.github/workflows/build-branch.yml` pins the Windows
 job to `windows-2022`. Revisit after `subosito/flutter-action` and the GitHub
 Windows 2025 image settle.
+
+## Android release APK: `Tag number over 30 is not supported`
+
+**Symptom:** `flutter build apk --release` in CI fails at `:app:packageRelease`:
+
+```text
+com.android.ide.common.signing.KeytoolException: Failed to read key debug-key
+from store ".../android/debug-key.keystore": Tag number over 30 is not supported
+```
+
+**Cause:** the signing keystore is passed to Gradle as the base64 secret
+`DEBUG_KEYSTORE_BASE64`. A secret that does not exist in the repository (e.g.
+after moving the project to a new GitHub repo — secrets do not travel with the
+code) still reaches the build as an **empty string**, not as an unset variable.
+The old `if (ks != null)` check in `android/app/build.gradle.kts` therefore
+passed, `Base64.decode("")` produced 0 bytes, and a 0-byte keystore was written
+and handed to AGP. Loading an empty file as PKCS12 makes the JDK DER parser read
+tag `-1`, and `-1 and 0x1f == 0x1f` is reported as *"Tag number over 30 is not
+supported"* — the message says nothing about the file being empty.
+
+**Fix (applied 2026-07-26):**
+- `android/app/build.gradle.kts` treats a blank `KEYSTORE_BASE64` as "no CI
+  keystore" (falls back to the local debug signing config), tolerates wrapped
+  base64, always rewrites the keystore file, and verifies that the decoded store
+  loads and contains `KEY_ALIAS` — failing with an explicit message otherwise.
+- Both Android workflows gained a `Verify signing keystore` step that runs
+  before the ~8-minute Gradle build and reports a missing, non-base64 or
+  unreadable secret immediately, including the commands to re-create it.
+
+**If the secret is missing,** add it under *Settings → Secrets and variables →
+Actions*, with the value produced from the raw keystore bytes:
+
+```powershell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("debug-key.keystore")) | Set-Clipboard
+```
+
+Do not paste the output of `certutil -encode` or a file that was re-saved as
+text — either mangles the bytes. If the keystore itself is gone, generate a new
+one (`keytool -genkeypair -keystore debug-key.keystore -storetype PKCS12 -alias
+debug-key -storepass android -keypass android -keyalg RSA -keysize 2048
+-validity 10000 -dname "CN=Glaze"`); note that a new key changes the APK
+signature, so existing installs must be uninstalled before updating.


### PR DESCRIPTION
## Проблема

Сборка APK падала на `:app:packageRelease`:

```text
com.android.ide.common.signing.KeytoolException: Failed to read key debug-key
from store ".../android/debug-key.keystore": Tag number over 30 is not supported
```

Workflow запрашивал секрет `DEBUG_KEYSTORE_BASE64`, которого в новом репозитории нет (секреты не переезжают вместе с кодом; здесь они называются `ANDROID_*`). Несуществующий секрет приходит в Gradle **не как `null`, а как пустая строка**, поэтому проверка `if (ks != null)` проходила, `Base64.decode("")` давал 0 байт, и в keystore записывался пустой файл.

Чтение пустого файла как PKCS12 заставляет DER-парсер JDK прочитать тег `-1`, а `-1 and 0x1f == 0x1f` рапортуется как «Tag number over 30 is not supported» — о пустом файле сообщение не говорит ничего. Воспроизведено локально на JDK 21:

```text
pkcs12: IOException: Tag number over 30 is not supported
jks:    EOFException: null
```

Вдобавок алиас и пароли были захардкожены как `debug-key` / `android`, что с реальным ключом всё равно не сработало бы.

## Изменения

**`.github/workflows/build-branch.yml`, `.github/workflows/build-release.yml`**
- Android-джобы читают секреты репозитория: `ANDROID_KEYSTORE_BASE64` → `KEYSTORE_BASE64`, `ANDROID_STORE_PASSWORD` → `KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS` → `KEY_ALIAS`, `ANDROID_KEY_PASSWORD` → `KEY_PASSWORD`.
- Новый шаг `Verify signing keystore` перед сборкой: проверяет наличие всех четырёх секретов, декодирует base64, печатает размер/заголовок/sha256 файла и проверяет `keytool -list` по алиасу. Отсутствующий, не-base64 или нечитаемый секрет виден за секунды, а не после ~8 минут Gradle.

**`android/app/build.gradle.kts`**
- Пустой или пробельный `KEYSTORE_BASE64` трактуется как «CI-ключа нет» (локальные сборки падают обратно на debug-подпись).
- base64 с переносами строк принимается (MIME-декодер), файл keystore перезаписывается всегда.
- Пароль хранилища, алиас и пароль ключа обязательны и не могут быть пустыми, если keystore передан.
- Декодированное хранилище проверяется на загрузку (PKCS12, затем JKS) и наличие алиаса — с явным сообщением вместо ошибки DER-парсера. Пишется в `android/ci-signing.keystore` (покрыт `.gitignore`).

**`docs/BUILD_NOTES.md`** — разбор ошибки, таблица «секрет → env» и порядок пересоздания секрета.

## Проверка

- Kotlin-хелперы прогнаны через настоящий Gradle Kotlin DSL: без секрета → debug-подпись; пустой пароль хранилища → явная ошибка; неверный пароль → «keystore password was incorrect»; неверный алиас → список доступных алиасов; валидный keystore → OK.
- Shell-шаг прогнан на кейсах: секрета нет, пустой `ANDROID_KEY_ALIAS`, не-base64, испорченные байты, неверный алиас, валидный keystore с переносами строк на 76 колонок.
- Dart-код не менялся, поэтому `flutter analyze` / `flutter test` не запускались.

## После мержа

Секреты уже заведены в репозитории — дополнительных действий не требуется. Стоит проверить, переехали ли остальные секреты, которые используют workflow: `DROPBOX_APP_KEY`, `DROPBOX_REDIRECT_NATIVE`, `GDRIVE_CLIENT_ID`, `TG_BOT_TOKEN`, `TG_CHAT_ID`, `TG_DEV_CHAT_IDS`, `TG_MENTIONS` — без них сборка пройдёт, но OAuth и отправка в Telegram работать не будут.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FH6HhXoKfrLc6Neyjk4s3H)_