### PR TITLE
ci: gate PRs into nightly on analyze + test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI (PR checks)
+
+# Gate for pull requests into the release branches. Runs the two checks that can
+# be automated — the analyzer and the test suite — so a PR is never merged on a
+# broken tree just because nobody ran them locally.
+#
+# Only *errors* fail the analyzer here (`--no-fatal-infos --no-fatal-warnings`):
+# the project's lint set is strict, and infos/hints are not build-breaking. Same
+# filter as the diagnostic command documented in CLAUDE.md.
+
+on:
+  pull_request:
+    branches:
+      - nightly
+      - staging
+      - stable
+  workflow_dispatch:
+
+# A new push to the PR branch makes the in-flight run pointless.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-and-test:
+    name: Analyze + test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Cache pub
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: pub-${{ runner.os }}-
+
+      - name: Create placeholder .env
+        # .env is gitignored but declared as an asset in pubspec.yaml, so the
+        # asset bundle fails to build without it. The checks need no real
+        # credentials, only the file.
+        run: touch .env
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate code
+        # *.g.dart / *.freezed.dart are gitignored, so they must be built here.
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Analyze
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: Test
+        run: flutter test --reporter expanded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,7 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 
 - Branch (`feat/xxx`) off `nightly`, push to `origin`, open a PR — see `docs/WORKFLOW.md` for branching, Trello, and cleanup checklists.
 - Open PRs only against upstream repository `hydall/Glaze` (base: `hydall/Glaze:nightly`), not against fork repos.
+- PRs are squash-merged and gated on CI (`.github/workflows/ci.yml` — `flutter analyze` + `flutter test`); a red check blocks the merge.
 - Release branches are `nightly` → `staging` → `stable`, one per build channel; features enter at `nightly` and are promoted by merge. Channel semantics: `docs/RELEASE_CHANNELS.md`.
 - Run `dart run build_runner build` after changing any freezed/drift model.
 - Single responsibility: split a class before it grows past ~200-250 lines (thin orchestrators, fat specialists, constructor injection). Details: `docs/CODE_STYLE.md`.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -21,6 +21,8 @@ upstream `hydall/Glaze:nightly`.
 
 - **No direct commits to `nightly`, `staging` or `stable`** — always use a feature branch.
 - **Never PR straight into `staging` or `stable`** — features enter through `nightly` and are promoted.
+- **Squash-merge every PR** — one feature = one commit on `nightly`, so a regression found later is a single `git revert <sha>` instead of untangling a range.
+- **CI must be green before merge** — see below.
 - **Stack while catching up** — if a feature depends on another not-yet-merged branch, branch off that branch instead of `nightly`.
 - **Run `dart run build_runner build`** after changing any freezed/drift model.
 
@@ -32,6 +34,20 @@ git push -u origin feat/xxx
 ```
 
 Open the PR against `hydall/Glaze:nightly`, not a fork's branch. Use the **GitHub MCP tools** (`mcp__plugin_github_github__create_pull_request`) or the GitHub web UI. Do **not** use the `gh` CLI — GitHub operations go through GitHub MCP (project + global convention).
+
+## CI gate
+
+`.github/workflows/ci.yml` runs on every PR into `nightly`, `staging` or
+`stable` and does two things: `flutter analyze` and `flutter test`. A red check
+means the PR is not merged — no exceptions, no "it works on my machine".
+
+Only analyzer **errors** fail the run (`--no-fatal-infos --no-fatal-warnings`);
+infos and hints from the strict lint set are not build-breaking and must not be
+allowed to block every PR.
+
+Running `flutter analyze` locally before opening the PR is still useful — it is
+faster feedback — but it is not the gate. The gate is CI, because it cannot be
+skipped or forgotten.
 
 ## Before starting work
 
@@ -48,6 +64,20 @@ Open the PR against `hydall/Glaze:nightly`, not a fork's branch. Use the **GitHu
 - Sync nightly: `git checkout nightly && git pull`
 
 ## Promoting a release
+
+Promotion is a merge, not a PR. A `nightly → staging` diff is an aggregate of
+many features that nobody reads; opening a PR for it adds ceremony without
+adding a check.
+
+**`nightly → staging` is gated on a real device, not on the diff.** Promote only
+after a build of `nightly` (the *Build (Branch)* workflow) has been installed and
+actually used, and nothing obvious is broken. CI proves the code compiles and the
+tests pass; only a build on a phone or desktop proves the app still works.
+`staging` therefore means "someone held this in their hands", and `stable` means
+"that held up".
+
+When a promoted build turns out to be broken, revert the squashed commit of the
+offending feature on `nightly` and re-promote — that is what squash-merging buys.
 
 ```bash
 # nightly → staging (cut a release candidate)

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -70,16 +70,33 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
         widget.skipStartup || const bool.fromEnvironment('FLUTTER_TEST');
     GlazeApp._restart = widget.restart;
     WidgetsBinding.instance.addObserver(this);
-    loadActiveSelections(ref);
-    loadLorebookActivations(ref);
-    loadLorebookSettings(ref);
-    seedDefaultPresets(ref);
-    seedFeaturedPresets(ref);
+    _initInBackground(loadActiveSelections(ref), 'active selections');
+    _initInBackground(loadLorebookActivations(ref), 'lorebook activations');
+    _initInBackground(loadLorebookSettings(ref), 'lorebook settings');
+    _initInBackground(seedDefaultPresets(ref), 'default preset seeding');
+    _initInBackground(seedFeaturedPresets(ref), 'featured preset seeding');
     if (!widget.skipStartup) {
       _warmInitialListProviders();
     }
     if (_startupReady) return;
     unawaited(_initializeStartup());
+  }
+
+  /// Runs a fire-and-forget init task and keeps its failure contained.
+  ///
+  /// These are started unawaited from [initState], so without a handler any
+  /// failure becomes an unhandled async error — and one that can outlive the
+  /// widget: in widget tests the task is still in flight when teardown closes
+  /// the database, and the late "Can't re-open a database after closing it"
+  /// then lands on whichever test happens to be running.
+  ///
+  /// None of these tasks is needed for the first frame — they hydrate state
+  /// that the UI already renders empty — so a failure is logged and dropped
+  /// rather than escalated.
+  void _initInBackground(Future<void> work, String what) {
+    unawaited(work.catchError((Object e) {
+      debugPrint('Glaze init: $what failed — $e');
+    }));
   }
 
   /// Starts the DB-backed providers behind the initial routes now, concurrently

--- a/test/characterization/ui_db_violations_test.dart
+++ b/test/characterization/ui_db_violations_test.dart
@@ -9,8 +9,8 @@ void main() {
       'lib/features/chat/widgets/authors_note_sheet.dart',
       'lib/features/chat/widgets/chat_stats_sheet.dart',
       'lib/features/chat/widgets/lorebook_coverage_sheet.dart',
-      'lib/features/chat/widgets/context_info_sheet.dart',
-      'lib/features/chat/widgets/chat_dialogs.dart',
+      // context_info_sheet.dart and chat_dialogs.dart were deleted in 0565341;
+      // they are intentionally absent from this list.
       'lib/features/chat/widgets/memory_books_sheet.dart',
       'lib/features/regex/regex_sheet.dart',
       'lib/features/personas/persona_list_screen.dart',
@@ -33,10 +33,21 @@ void main() {
       }
     });
 
+    // Documented exception. chat_stats_sheet.dart reads sessions straight from
+    // chatRepoProvider on purpose — see the comment at its _initData(): the
+    // cached provider is not invalidated on message edits/deletions, so the
+    // stats counts would lag, and a plain repo future is guaranteed to complete
+    // where the provider may stay unresolved. Deliberate, so the rule below
+    // skips it rather than the rule being deleted for everyone else.
+    final directRepoExceptions = <String>{
+      'lib/features/chat/widgets/chat_stats_sheet.dart',
+    };
+
     test('no widget files directly import *RepoProvider', () {
       for (final path in widgetFiles) {
+        if (directRepoExceptions.contains(path)) continue;
         final source = File(path).readAsStringSync();
-        
+
         // Check that files don't directly use repo providers for data access
         // Note: Some files may still import db_provider.dart for other providers
         // like imageStorageProvider or characterImporterProvider
@@ -59,8 +70,8 @@ void main() {
       }
     });
 
-    test('total widget files count is 17', () {
-      expect(widgetFiles.length, 17);
+    test('total widget files count is 15', () {
+      expect(widgetFiles.length, 15);
     });
 
     test('no .put() calls on repos in widget code', () async {

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -708,7 +708,7 @@ void main() {
     test('scroll compensation is driven by the inset, not the padding', () {
       expect(
         bridgeControllerJs,
-        contains('container.scrollTop += insetDiff'),
+        contains('container.scrollTop + insetDiff'),
         reason:
             'The content must follow the input bar by the full inset delta '
             'regardless of how the inset was split between padding and shrink, '


### PR DESCRIPTION
Adds the automated PR gate the repo did not have, and clears the failures that stood between the tree and a green run.

Until now both workflows (`build-branch.yml`, `build-release.yml`) were `workflow_dispatch` only, so nothing ran automatically on a pull request — `flutter analyze` was invoked by hand before pushing and `flutter test` was not run at all.

## What is here

**`.github/workflows/ci.yml`** — runs on every PR into `nightly` / `staging` / `stable`: `flutter analyze` + `flutter test`. Code generation runs first (`*.g.dart` / `*.freezed.dart` are gitignored) and a placeholder `.env` is created (gitignored, but declared as an asset in `pubspec.yaml`, so the asset bundle will not build without it).

Only analyzer **errors** fail the run. On the current tree a plain `flutter analyze` exits 1 on three `unused_element_parameter` warnings, so a stricter gate would have been red from day one and quickly learned to be ignored. Same errors-only filter as the diagnostic command in `CLAUDE.md`.

**Two stale characterization tests repaired.** `ui_db_violations_test.dart` still listed `context_info_sheet.dart` and `chat_dialogs.dart`, deleted in 0565341; `readAsStringSync` threw on the missing paths and aborted the repo-provider scan before it reached the rest of the list, so the test had quietly stopped checking anything after them. With the list corrected, one real hit surfaced: `chat_stats_sheet.dart` reads `chatRepoProvider` directly. That is deliberate and documented at its `_initData()`, so it became an explicit exception set rather than a reason to delete the rule. `webview_assets_test.dart` asserted a literal `container.scrollTop += insetDiff` that a refactor turned into a ternary branch (`chat_bridge_controller.js:883`); the compensation it guards is intact.

**`app.dart` — fire-and-forget init tasks no longer leak failures.** The five hydration/seeding calls in `initState` ran unawaited, so a failure became an unhandled async error, and one that can outlive the widget: `seedFeaturedPresets` was still in flight when a widget test's teardown closed the in-memory database, and the late `Bad state: Can't re-open a database after closing it` was reported against whichever test happened to be running. They now go through `_initInBackground`, which logs and drops the failure. None of them is needed for the first frame.

**Docs** — `WORKFLOW.md` gains the CI gate, squash-merge (one feature = one revertable commit on `nightly`), and the rule that `nightly → staging` is promoted only after a build has been used on a real device.

## Verification

Flutter 3.44.8 (the version pinned in `CLAUDE.md`; Dart 3.12.2 matches `pubspec.yaml`), full pipeline run locally:

| | before | after |
|---|---|---|
| `flutter analyze --no-fatal-infos --no-fatal-warnings` | exit 0 — 18 issues, 0 errors | exit 0 — 18 issues, 0 errors |
| `flutter test` | 1741 passed, **6 failed** | **1747 passed, 0 failed** |

All six failures pre-dated this branch. The workflow YAML itself has not run on a runner yet — this PR is its first execution.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv99bkB9TbWMzPM2uRGxjC)_