### PR TITLE
feat: свой package name и облачный корень у каждого канала — установка рядом

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -119,11 +119,31 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Create .env from secrets
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_KEY_STAGING: ${{ secrets.DROPBOX_APP_KEY_STAGING }}
+          DROPBOX_APP_KEY_NIGHTLY: ${{ secrets.DROPBOX_APP_KEY_NIGHTLY }}
+          DROPBOX_REDIRECT_NATIVE: ${{ secrets.DROPBOX_REDIRECT_NATIVE }}
+          GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
         run: |
-          echo "DROPBOX_APP_KEY=${{ secrets.DROPBOX_APP_KEY }}" >> .env
-          echo "DROPBOX_REDIRECT_NATIVE=${{ secrets.DROPBOX_REDIRECT_NATIVE }}" >> .env
-          echo "GDRIVE_CLIENT_ID=${{ secrets.GDRIVE_CLIENT_ID }}" >> .env
-          echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive" >> .env
+          set -euo pipefail
+          # A channel can be given its own Dropbox app, which gets it its own
+          # App folder in the user's Dropbox. While the channel secret is unset
+          # the build falls back to the shared key, and the channels are kept
+          # apart by a sub-folder inside that one App folder instead — see
+          # _channelSubfolder in dropbox_adapter.dart. Both layouts work.
+          case "$BUILD_CHANNEL" in
+            stable)  CHANNEL_DROPBOX_KEY="" ;;
+            staging) CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_STAGING" ;;
+            *)       CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_NIGHTLY" ;;
+          esac
+          {
+            echo "DROPBOX_APP_KEY=${CHANNEL_DROPBOX_KEY:-$DROPBOX_APP_KEY}"
+            echo "DROPBOX_REDIRECT_NATIVE=$DROPBOX_REDIRECT_NATIVE"
+            echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID"
+            echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive"
+          } >> .env
 
       - name: Set up Java 21
         uses: actions/setup-java@v4
@@ -243,11 +263,31 @@ jobs:
 
       - name: Create .env from secrets
         shell: bash
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_KEY_STAGING: ${{ secrets.DROPBOX_APP_KEY_STAGING }}
+          DROPBOX_APP_KEY_NIGHTLY: ${{ secrets.DROPBOX_APP_KEY_NIGHTLY }}
+          DROPBOX_REDIRECT_NATIVE: ${{ secrets.DROPBOX_REDIRECT_NATIVE }}
+          GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
         run: |
-          echo "DROPBOX_APP_KEY=${{ secrets.DROPBOX_APP_KEY }}" >> .env
-          echo "DROPBOX_REDIRECT_NATIVE=${{ secrets.DROPBOX_REDIRECT_NATIVE }}" >> .env
-          echo "GDRIVE_CLIENT_ID=${{ secrets.GDRIVE_CLIENT_ID }}" >> .env
-          echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive" >> .env
+          set -euo pipefail
+          # A channel can be given its own Dropbox app, which gets it its own
+          # App folder in the user's Dropbox. While the channel secret is unset
+          # the build falls back to the shared key, and the channels are kept
+          # apart by a sub-folder inside that one App folder instead — see
+          # _channelSubfolder in dropbox_adapter.dart. Both layouts work.
+          case "$BUILD_CHANNEL" in
+            stable)  CHANNEL_DROPBOX_KEY="" ;;
+            staging) CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_STAGING" ;;
+            *)       CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_NIGHTLY" ;;
+          esac
+          {
+            echo "DROPBOX_APP_KEY=${CHANNEL_DROPBOX_KEY:-$DROPBOX_APP_KEY}"
+            echo "DROPBOX_REDIRECT_NATIVE=$DROPBOX_REDIRECT_NATIVE"
+            echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID"
+            echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive"
+          } >> .env
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
@@ -294,11 +334,31 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Create .env from secrets
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_KEY_STAGING: ${{ secrets.DROPBOX_APP_KEY_STAGING }}
+          DROPBOX_APP_KEY_NIGHTLY: ${{ secrets.DROPBOX_APP_KEY_NIGHTLY }}
+          DROPBOX_REDIRECT_NATIVE: ${{ secrets.DROPBOX_REDIRECT_NATIVE }}
+          GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
         run: |
-          echo "DROPBOX_APP_KEY=${{ secrets.DROPBOX_APP_KEY }}" >> .env
-          echo "DROPBOX_REDIRECT_NATIVE=${{ secrets.DROPBOX_REDIRECT_NATIVE }}" >> .env
-          echo "GDRIVE_CLIENT_ID=${{ secrets.GDRIVE_CLIENT_ID }}" >> .env
-          echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive" >> .env
+          set -euo pipefail
+          # A channel can be given its own Dropbox app, which gets it its own
+          # App folder in the user's Dropbox. While the channel secret is unset
+          # the build falls back to the shared key, and the channels are kept
+          # apart by a sub-folder inside that one App folder instead — see
+          # _channelSubfolder in dropbox_adapter.dart. Both layouts work.
+          case "$BUILD_CHANNEL" in
+            stable)  CHANNEL_DROPBOX_KEY="" ;;
+            staging) CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_STAGING" ;;
+            *)       CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_NIGHTLY" ;;
+          esac
+          {
+            echo "DROPBOX_APP_KEY=${CHANNEL_DROPBOX_KEY:-$DROPBOX_APP_KEY}"
+            echo "DROPBOX_REDIRECT_NATIVE=$DROPBOX_REDIRECT_NATIVE"
+            echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID"
+            echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive"
+          } >> .env
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -211,6 +211,10 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          # Read by android/app/build.gradle.kts to derive the applicationId
+          # suffix and the launcher label, so the three channels co-install.
+          # Signing is unaffected — all channels use the same keystore above.
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
         run: >
           flutter build apk --release --no-pub --target-platform android-arm64
           "--dart-define=APP_VERSION=${{ needs.metadata.outputs.version }}"
@@ -324,6 +328,23 @@ jobs:
 
       - name: Install CocoaPods
         run: cd ios && pod install && cd ..
+
+      - name: Configure iOS channel identity
+        # Overwrites the checked-in defaults in ios/Flutter/Channel.xcconfig so
+        # the bundle identifier and the home-screen name match the channel being
+        # built and the three IPAs can live on one device.
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+        run: |
+          set -euo pipefail
+          case "$BUILD_CHANNEL" in
+            stable)  SUFFIX="";         NAME="Glaze" ;;
+            staging) SUFFIX=".staging"; NAME="Glaze Staging" ;;
+            *)       SUFFIX=".nightly"; NAME="Glaze Nightly" ;;
+          esac
+          printf 'BUNDLE_ID_SUFFIX = %s\nAPP_DISPLAY_NAME = %s\n' \
+            "$SUFFIX" "$NAME" > ios/Flutter/Channel.xcconfig
+          cat ios/Flutter/Channel.xcconfig
 
       # === Reverted iOS IPA creation (the version that produced working sideload builds before PR 96) ===
       # We are reverting the "flutter build ipa" change introduced in 195b260 because it regressed the build

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -118,11 +118,31 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Create .env from secrets
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_KEY_STAGING: ${{ secrets.DROPBOX_APP_KEY_STAGING }}
+          DROPBOX_APP_KEY_NIGHTLY: ${{ secrets.DROPBOX_APP_KEY_NIGHTLY }}
+          DROPBOX_REDIRECT_NATIVE: ${{ secrets.DROPBOX_REDIRECT_NATIVE }}
+          GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
         run: |
-          echo "DROPBOX_APP_KEY=${{ secrets.DROPBOX_APP_KEY }}" >> .env
-          echo "DROPBOX_REDIRECT_NATIVE=${{ secrets.DROPBOX_REDIRECT_NATIVE }}" >> .env
-          echo "GDRIVE_CLIENT_ID=${{ secrets.GDRIVE_CLIENT_ID }}" >> .env
-          echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive" >> .env
+          set -euo pipefail
+          # A channel can be given its own Dropbox app, which gets it its own
+          # App folder in the user's Dropbox. While the channel secret is unset
+          # the build falls back to the shared key, and the channels are kept
+          # apart by a sub-folder inside that one App folder instead — see
+          # _channelSubfolder in dropbox_adapter.dart. Both layouts work.
+          case "$BUILD_CHANNEL" in
+            stable)  CHANNEL_DROPBOX_KEY="" ;;
+            staging) CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_STAGING" ;;
+            *)       CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_NIGHTLY" ;;
+          esac
+          {
+            echo "DROPBOX_APP_KEY=${CHANNEL_DROPBOX_KEY:-$DROPBOX_APP_KEY}"
+            echo "DROPBOX_REDIRECT_NATIVE=$DROPBOX_REDIRECT_NATIVE"
+            echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID"
+            echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive"
+          } >> .env
 
       - name: Set up Java 21
         uses: actions/setup-java@v4
@@ -242,11 +262,31 @@ jobs:
 
       - name: Create .env from secrets
         shell: bash
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_KEY_STAGING: ${{ secrets.DROPBOX_APP_KEY_STAGING }}
+          DROPBOX_APP_KEY_NIGHTLY: ${{ secrets.DROPBOX_APP_KEY_NIGHTLY }}
+          DROPBOX_REDIRECT_NATIVE: ${{ secrets.DROPBOX_REDIRECT_NATIVE }}
+          GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
         run: |
-          echo "DROPBOX_APP_KEY=${{ secrets.DROPBOX_APP_KEY }}" >> .env
-          echo "DROPBOX_REDIRECT_NATIVE=${{ secrets.DROPBOX_REDIRECT_NATIVE }}" >> .env
-          echo "GDRIVE_CLIENT_ID=${{ secrets.GDRIVE_CLIENT_ID }}" >> .env
-          echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive" >> .env
+          set -euo pipefail
+          # A channel can be given its own Dropbox app, which gets it its own
+          # App folder in the user's Dropbox. While the channel secret is unset
+          # the build falls back to the shared key, and the channels are kept
+          # apart by a sub-folder inside that one App folder instead — see
+          # _channelSubfolder in dropbox_adapter.dart. Both layouts work.
+          case "$BUILD_CHANNEL" in
+            stable)  CHANNEL_DROPBOX_KEY="" ;;
+            staging) CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_STAGING" ;;
+            *)       CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_NIGHTLY" ;;
+          esac
+          {
+            echo "DROPBOX_APP_KEY=${CHANNEL_DROPBOX_KEY:-$DROPBOX_APP_KEY}"
+            echo "DROPBOX_REDIRECT_NATIVE=$DROPBOX_REDIRECT_NATIVE"
+            echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID"
+            echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive"
+          } >> .env
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2
@@ -298,11 +338,31 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Create .env from secrets
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_KEY_STAGING: ${{ secrets.DROPBOX_APP_KEY_STAGING }}
+          DROPBOX_APP_KEY_NIGHTLY: ${{ secrets.DROPBOX_APP_KEY_NIGHTLY }}
+          DROPBOX_REDIRECT_NATIVE: ${{ secrets.DROPBOX_REDIRECT_NATIVE }}
+          GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
         run: |
-          echo "DROPBOX_APP_KEY=${{ secrets.DROPBOX_APP_KEY }}" >> .env
-          echo "DROPBOX_REDIRECT_NATIVE=${{ secrets.DROPBOX_REDIRECT_NATIVE }}" >> .env
-          echo "GDRIVE_CLIENT_ID=${{ secrets.GDRIVE_CLIENT_ID }}" >> .env
-          echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive" >> .env
+          set -euo pipefail
+          # A channel can be given its own Dropbox app, which gets it its own
+          # App folder in the user's Dropbox. While the channel secret is unset
+          # the build falls back to the shared key, and the channels are kept
+          # apart by a sub-folder inside that one App folder instead — see
+          # _channelSubfolder in dropbox_adapter.dart. Both layouts work.
+          case "$BUILD_CHANNEL" in
+            stable)  CHANNEL_DROPBOX_KEY="" ;;
+            staging) CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_STAGING" ;;
+            *)       CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_NIGHTLY" ;;
+          esac
+          {
+            echo "DROPBOX_APP_KEY=${CHANNEL_DROPBOX_KEY:-$DROPBOX_APP_KEY}"
+            echo "DROPBOX_REDIRECT_NATIVE=$DROPBOX_REDIRECT_NATIVE"
+            echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID"
+            echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive"
+          } >> .env
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -210,6 +210,10 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          # Read by android/app/build.gradle.kts to derive the applicationId
+          # suffix and the launcher label, so the three channels co-install.
+          # Signing is unaffected — all channels use the same keystore above.
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
         run: >
           flutter build apk --release --no-pub --target-platform android-arm64
           "--dart-define=APP_VERSION=${{ needs.metadata.outputs.version }}"
@@ -328,6 +332,23 @@ jobs:
 
       - name: Install CocoaPods
         run: cd ios && pod install && cd ..
+
+      - name: Configure iOS channel identity
+        # Overwrites the checked-in defaults in ios/Flutter/Channel.xcconfig so
+        # the bundle identifier and the home-screen name match the channel being
+        # built and the three IPAs can live on one device.
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+        run: |
+          set -euo pipefail
+          case "$BUILD_CHANNEL" in
+            stable)  SUFFIX="";         NAME="Glaze" ;;
+            staging) SUFFIX=".staging"; NAME="Glaze Staging" ;;
+            *)       SUFFIX=".nightly"; NAME="Glaze Nightly" ;;
+          esac
+          printf 'BUNDLE_ID_SUFFIX = %s\nAPP_DISPLAY_NAME = %s\n' \
+            "$SUFFIX" "$NAME" > ios/Flutter/Channel.xcconfig
+          cat ios/Flutter/Channel.xcconfig
 
       - name: Build iOS (release, no signing)
         run: |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,6 +7,31 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+// Release channel this APK is built for. CI exports it as an environment
+// variable holding the same value it passes to Dart through
+// --dart-define=BUILD_CHANNEL; a local build, which sets neither, falls back to
+// "nightly" exactly like lib/core/constants/build_channel.dart does.
+val buildChannel: String =
+    System.getenv("BUILD_CHANNEL")?.takeIf { it.isNotBlank() }?.trim()?.lowercase()
+        ?: "nightly"
+
+// Every channel gets its own applicationId so stable / staging / nightly can be
+// installed next to each other on one device. All three are still signed with
+// the same CI keystore — Android refuses to co-install packages that share an
+// applicationId, not ones that share a signing certificate.
+val channelApplicationIdSuffix = when (buildChannel) {
+    "stable" -> ""
+    "staging" -> ".staging"
+    else -> ".nightly"
+}
+
+// Launcher label, so three icons on the home screen are told apart.
+val channelAppLabel = when (buildChannel) {
+    "stable" -> "Glaze"
+    "staging" -> "Glaze Staging"
+    else -> "Glaze Nightly"
+}
+
 // CI signing: the keystore is passed in as base64 through KEYSTORE_BASE64.
 // An *unset* secret still reaches Gradle as an empty string, so blank must be
 // treated exactly like "no CI keystore" — otherwise we write a 0-byte file and
@@ -99,7 +124,8 @@ android {
     }
 
     defaultConfig {
-        applicationId = "app.glaze.flutter"
+        applicationId = "app.glaze.flutter$channelApplicationIdSuffix"
+        manifestPlaceholders["appLabel"] = channelAppLabel
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
          keeps every PopScope working; the only thing lost is the predictive-back
          peek animation. Re-enable only after verifying WebView back handling. -->
     <application
-        android:label="Glaze"
+        android:label="${appLabel}"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:enableOnBackInvokedCallback="false"

--- a/docs/RELEASE_CHANNELS.md
+++ b/docs/RELEASE_CHANNELS.md
@@ -71,10 +71,69 @@ If you ever need the watermark to be genuinely unreachable on `stable`, gate the
 widget itself on `!isStableChannel` in `lib/app.dart` rather than changing the
 default — that is a behaviour change, not a default change.
 
+## Side-by-side installs
+
+Each channel ships under its own package identity, so all three builds can sit
+on one device or one machine at the same time instead of upgrading over each
+other. `stable` keeps the bare identifiers it has always used, so existing
+installs are untouched.
+
+| Channel   | Android applicationId       | iOS bundle id                     | Launcher name    | Desktop data folder |
+|-----------|-----------------------------|-----------------------------------|------------------|---------------------|
+| `stable`  | `app.glaze.flutter`         | `com.glaze.glazeFlutter`          | `Glaze`          | `Glaze`             |
+| `staging` | `app.glaze.flutter.staging` | `com.glaze.glazeFlutter.staging`  | `Glaze Staging`  | `Glaze-staging`     |
+| `nightly` | `app.glaze.flutter.nightly` | `com.glaze.glazeFlutter.nightly`  | `Glaze Nightly`  | `Glaze-nightly`     |
+
+**Signing does not change.** All three channels are signed with the same CI
+keystore (`ANDROID_KEYSTORE_BASE64` and friends). Android only refuses to
+co-install packages that share an `applicationId`; a shared certificate is fine
+— and keeping it shared is what lets a build promoted from `nightly` to
+`stable` install as an update rather than a fresh app.
+
+### How each platform gets its identity
+
+- **Android** — CI exports `BUILD_CHANNEL` as an *environment variable* to the
+  "Build APK" step (`--dart-define` never reaches Gradle).
+  `android/app/build.gradle.kts` reads it with `System.getenv`, the same
+  mechanism the signing config already uses, and derives the `applicationId`
+  suffix plus the `appLabel` manifest placeholder. The `namespace` stays
+  `app.glaze.flutter`, so `.MainActivity` and the `MethodChannel` names are
+  unaffected.
+- **iOS** — xcconfig files cannot read the environment, so CI writes
+  `ios/Flutter/Channel.xcconfig` before building. It defines
+  `BUNDLE_ID_SUFFIX` (consumed by `PRODUCT_BUNDLE_IDENTIFIER` in the Runner
+  target) and `APP_DISPLAY_NAME` (consumed by `CFBundleDisplayName`). The file
+  is checked in with `nightly` defaults for local builds.
+- **Desktop** — Windows/Linux/macOS builds have no package manager to separate
+  them, so the channel goes into the data path instead:
+  `glazeDataFolderName` in `lib/core/constants/build_channel.dart` drives
+  `_desktopDataDir()` in `lib/core/utils/platform_paths.dart`. Without this the
+  three installs would share one `glaze.db`.
+
+### Known limitations
+
+- **The `com.hydall.glaze://` OAuth scheme is still shared.** All three Android
+  builds register it, so a Dropbox/Google Drive callback can raise an app
+  chooser. Making it per-channel means registering the extra redirect URIs
+  (`com.hydall.glaze.nightly://oauth/…`, `…staging…`) in the Google and Dropbox
+  consoles first, otherwise sync auth breaks outright on those channels.
+- **The Google Drive sync folder is shared** (`_folderName = 'Glaze'` in
+  `gdrive_folders.dart`), so two channels syncing the same account write into
+  one remote folder.
+- **macOS and Linux bundle identities are not split** — CI produces no builds
+  for them, so only the data folder is channel-aware there.
+- Switching an existing desktop install to `staging`/`nightly` starts from an
+  empty data folder; the old `%APPDATA%\Glaze` contents stay put and are picked
+  up again by a `stable` build. The same applies to a local `flutter run`,
+  which defaults to `nightly`.
+
 ## Adding a new channel
 
-1. Add the branch name to the `case` in the workflow's `metadata` job.
-2. If it needs different dev-tooling behaviour, extend
+1. Add the branch name to the `case` in the `metadata` job of **both**
+   `build-branch.yml` and `build-release.yml`.
+2. Add it to the `case` in the "Configure iOS channel identity" step of both
+   workflows, and to the two `when` blocks in `android/app/build.gradle.kts`.
+3. If it needs different dev-tooling behaviour, extend
    `build_channel.dart` — keep the derived flags `const` so they tree-shake.
 
 Do not read `buildChannel` directly in feature code; depend on the derived

--- a/docs/RELEASE_CHANNELS.md
+++ b/docs/RELEASE_CHANNELS.md
@@ -78,11 +78,11 @@ on one device or one machine at the same time instead of upgrading over each
 other. `stable` keeps the bare identifiers it has always used, so existing
 installs are untouched.
 
-| Channel   | Android applicationId       | iOS bundle id                     | Launcher name    | Desktop data folder |
-|-----------|-----------------------------|-----------------------------------|------------------|---------------------|
-| `stable`  | `app.glaze.flutter`         | `com.glaze.glazeFlutter`          | `Glaze`          | `Glaze`             |
-| `staging` | `app.glaze.flutter.staging` | `com.glaze.glazeFlutter.staging`  | `Glaze Staging`  | `Glaze-staging`     |
-| `nightly` | `app.glaze.flutter.nightly` | `com.glaze.glazeFlutter.nightly`  | `Glaze Nightly`  | `Glaze-nightly`     |
+| Channel   | Android applicationId       | iOS bundle id                     | Launcher name    | Desktop data folder | Cloud sync root |
+|-----------|-----------------------------|-----------------------------------|------------------|---------------------|-----------------|
+| `stable`  | `app.glaze.flutter`         | `com.glaze.glazeFlutter`          | `Glaze`          | `Glaze`             | `Glaze`         |
+| `staging` | `app.glaze.flutter.staging` | `com.glaze.glazeFlutter.staging`  | `Glaze Staging`  | `Glaze-staging`     | `Glaze-staging` |
+| `nightly` | `app.glaze.flutter.nightly` | `com.glaze.glazeFlutter.nightly`  | `Glaze Nightly`  | `Glaze-nightly`     | `Glaze-nightly` |
 
 **Signing does not change.** All three channels are signed with the same CI
 keystore (`ANDROID_KEYSTORE_BASE64` and friends). Android only refuses to
@@ -110,6 +110,70 @@ co-install packages that share an `applicationId`; a shared certificate is fine
   `_desktopDataDir()` in `lib/core/utils/platform_paths.dart`. Without this the
   three installs would share one `glaze.db`.
 
+## Cloud sync
+
+Local separation is only half the problem: two channels pointed at the same
+Dropbox or Google Drive account would still write through one shared manifest
+and overwrite each other's characters, chats and presets. So the cloud tree is
+split per channel too, named exactly like the desktop data folder.
+
+Everything hangs off one constant — `cloudBase` in
+`lib/features/cloud_sync/sync_models.dart`, which is `'/$cloudRootFolderName'`
+and reuses `glazeDataFolderName`. All ~50 cloud paths in the sync layer are
+built from it.
+
+### Google Drive
+
+Nothing else to do: the root folder is looked up by name under the Drive root,
+so `Glaze-nightly` simply becomes a sibling of `Glaze`. `GDriveFolders`
+takes its `_folderName` from `cloudRootFolderName`.
+
+### Dropbox
+
+Dropbox hands the app its **App folder** as the API root, which is why paths get
+stripped down to `''` rather than used as-is. That folder is named by the
+Dropbox app registration, not by us, so it cannot carry the channel — and a
+single `DROPBOX_APP_KEY` means all three channels land in the same place.
+
+Two configurations are therefore supported, and the code is correct under both:
+
+1. **Shared app key** (the default, and what happens until the extra secrets
+   exist). Each non-stable channel lives in a sub-folder of the shared App
+   folder: `/Apps/Glaze/nightly/…`. `stable` keeps the flat layout it has
+   always had, so its existing files never move.
+2. **Per-channel app key** — set `DROPBOX_APP_KEY_STAGING` /
+   `DROPBOX_APP_KEY_NIGHTLY` in the repository secrets and register a separate
+   Dropbox app for that channel. The channel then gets its own App folder, and
+   the sub-folder is just one harmless extra level inside it. CI falls back to
+   `DROPBOX_APP_KEY` whenever the channel secret is empty, so adding them is
+   safe to do one at a time.
+
+Three things in `dropbox_adapter.dart` make this work:
+
+- `_stripPrefix` maps a canonical path to the App-folder-relative one
+  (`/Glaze-nightly/characters/x.json` → `/nightly/characters/x.json`).
+- `_unmapChannelPath` is its inverse on the way back, so listings still reach
+  `normalizeCloudSyncPath` relative to the Glaze root — the invariant that lines
+  manifest entries up against `list_folder` results. Without it every entry
+  would look missing on a non-stable channel and each sync would re-upload the
+  whole library.
+- `_belongsToAnotherChannel` keeps one channel out of another's sub-tree. This
+  matters for exactly one operation: wiping cloud data from `stable` goes
+  through `_deleteAllInRoot`, which lists the App folder root *recursively* —
+  without the guard it would delete `nightly/` and `staging/` along with its
+  own files. It also hides sibling channel folders from `listFolder`, which is
+  what used to keep the post-wipe "waiting for cloud to finalize" poll spinning
+  until it timed out.
+
+### Migrating existing installs
+
+Cloud data written before this split stays where it is, under the `Glaze` root.
+A `stable` build keeps seeing it unchanged. A `staging` / `nightly` build starts
+against an empty root and pushes its local library up on the first sync — the
+old data is not touched or deleted, just no longer read by that channel. There
+is no automatic copy, and for a nightly channel that seems like the right
+trade rather than a gap worth closing.
+
 ### Known limitations
 
 - **The `com.hydall.glaze://` OAuth scheme is still shared.** All three Android
@@ -117,9 +181,6 @@ co-install packages that share an `applicationId`; a shared certificate is fine
   chooser. Making it per-channel means registering the extra redirect URIs
   (`com.hydall.glaze.nightly://oauth/…`, `…staging…`) in the Google and Dropbox
   consoles first, otherwise sync auth breaks outright on those channels.
-- **The Google Drive sync folder is shared** (`_folderName = 'Glaze'` in
-  `gdrive_folders.dart`), so two channels syncing the same account write into
-  one remote folder.
 - **macOS and Linux bundle identities are not split** — CI produces no builds
   for them, so only the data folder is channel-aware there.
 - Switching an existing desktop install to `staging`/`nightly` starts from an
@@ -133,7 +194,11 @@ co-install packages that share an `applicationId`; a shared certificate is fine
    `build-branch.yml` and `build-release.yml`.
 2. Add it to the `case` in the "Configure iOS channel identity" step of both
    workflows, and to the two `when` blocks in `android/app/build.gradle.kts`.
-3. If it needs different dev-tooling behaviour, extend
+3. Add it to the `case` in the "Create .env from secrets" step of both
+   workflows (all three build jobs each) if it gets its own Dropbox app key,
+   and to `_foreignChannelFolders` in `dropbox_adapter.dart` so a wipe from
+   `stable` leaves it alone.
+4. If it needs different dev-tooling behaviour, extend
    `build_channel.dart` — keep the derived flags `const` so they tree-shake.
 
 Do not read `buildChannel` directly in feature code; depend on the derived

--- a/ios/Flutter/Channel.xcconfig
+++ b/ios/Flutter/Channel.xcconfig
@@ -1,0 +1,14 @@
+// Per-channel identity for the iOS Runner target.
+//
+// Keeps stable / staging / nightly on distinct bundle identifiers so the three
+// builds can sit on one device at the same time instead of overwriting each
+// other. iOS keys an install on CFBundleIdentifier alone, so a shared signing
+// identity is fine — only the identifier has to differ.
+//
+// CI overwrites this file from the branch it is building (see the "Configure
+// iOS channel identity" step in .github/workflows/build-branch.yml). The values
+// committed here are the local-developer defaults and mirror the Dart default
+// in lib/core/constants/build_channel.dart, which is also `nightly`.
+
+BUNDLE_ID_SUFFIX = .nightly
+APP_DISPLAY_NAME = Glaze Nightly

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
+#include "Channel.xcconfig"
 #include? "Runner/Configs/Env.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
+#include "Channel.xcconfig"
 #include? "Runner/Configs/Env.xcconfig"
 #include "Generated.xcconfig"

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -376,7 +376,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.glaze.glazeFlutter;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.glaze.glazeFlutter$(BUNDLE_ID_SUFFIX)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -555,7 +555,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.glaze.glazeFlutter;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.glaze.glazeFlutter$(BUNDLE_ID_SUFFIX)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -577,7 +577,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.glaze.glazeFlutter;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.glaze.glazeFlutter$(BUNDLE_ID_SUFFIX)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Glaze</string>
+	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/core/constants/build_channel.dart
+++ b/lib/core/constants/build_channel.dart
@@ -26,3 +26,16 @@ const isStableChannel = buildChannel == 'stable';
 /// only — on every channel the user's own choice, once made, still wins, and
 /// the version-badge easter egg can unlock dev mode on a stable build too.
 const devToolingEnabledByDefault = !isStableChannel;
+
+/// Name of the Glaze data folder on desktop (`%APPDATA%\<name>` on Windows,
+/// `~/.local/share/<name>` on Linux, `~/Library/Application Support/<name>` on
+/// macOS).
+///
+/// Android and iOS get their separation from the per-channel applicationId /
+/// bundle identifier — each package already owns its own sandbox, so the folder
+/// inside it stays plain `Glaze`. Desktop builds have no such packaging, so the
+/// channel has to be part of the path or two installs would share one database.
+///
+/// `stable` deliberately keeps the bare `Glaze` name so existing installs are
+/// not orphaned by this split.
+const glazeDataFolderName = isStableChannel ? 'Glaze' : 'Glaze-$buildChannel';

--- a/lib/core/utils/platform_paths.dart
+++ b/lib/core/utils/platform_paths.dart
@@ -4,6 +4,8 @@ import 'package:path/path.dart' as p;
 // ignore: depend_on_referenced_packages
 import 'package:path_provider/path_provider.dart';
 
+import '../constants/build_channel.dart';
+
 /// Cached Glaze data root, populated on the first [getAppDataDir] call (which
 /// happens at startup via ImageStorageService.create / AppDatabase open).
 /// Used by [resolveGlazeFilePath] so widgets can rebase stale absolute paths
@@ -42,16 +44,22 @@ String? resolveGlazeFilePath(String? path) {
     return p.join(base, path);
   }
   // Absolute: if it already exists, keep it. Otherwise try to rebase onto the
-  // current base by the last "/Glaze/" marker.
+  // current base by the last data-root marker.
   if (File(path).existsSync()) return path;
 
   final normalized = path.replaceAll('\\', '/');
-  const marker = '/Glaze/';
-  final idx = normalized.lastIndexOf(marker);
-  if (idx < 0) return path;
-  final suffix = normalized.substring(idx + marker.length);
-  if (suffix.isEmpty) return path;
-  return p.join(base, suffix);
+  // This channel's folder first, then the bare "Glaze" root, so a path written
+  // by a stable build — or by any build from before the channels got their own
+  // desktop data folders — still rebases. The set collapses to one entry on
+  // stable and on mobile, where both names are the same.
+  for (final marker in {'/$glazeDataFolderName/', '/Glaze/'}) {
+    final idx = normalized.lastIndexOf(marker);
+    if (idx < 0) continue;
+    final suffix = normalized.substring(idx + marker.length);
+    if (suffix.isEmpty) continue;
+    return p.join(base, suffix);
+  }
+  return path;
 }
 
 /// Returns the on-disk path to the 512px thumbnail JPG for a stored avatar
@@ -76,14 +84,14 @@ String? resolveGlazeThumbnailPath(String? avatarPath) {
 String _desktopDataDir() {
   if (Platform.isWindows) {
     final appData = Platform.environment['APPDATA']!;
-    return p.join(appData, 'Glaze');
+    return p.join(appData, glazeDataFolderName);
   } else if (Platform.isLinux) {
     final xdg = Platform.environment['XDG_DATA_HOME'] ??
         p.join(Platform.environment['HOME']!, '.local', 'share');
-    return p.join(xdg, 'Glaze');
+    return p.join(xdg, glazeDataFolderName);
   } else if (Platform.isMacOS) {
     return p.join(Platform.environment['HOME']!, 'Library',
-        'Application Support', 'Glaze');
+        'Application Support', glazeDataFolderName);
   }
   throw UnsupportedError('Platform not supported yet');
 }

--- a/lib/features/chat/bridge/chat_webview_environment.dart
+++ b/lib/features/chat/bridge/chat_webview_environment.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
+import '../../../core/constants/build_channel.dart';
 import '../../../core/utils/platform_paths.dart';
 import 'chat_webview_settings.dart';
 
@@ -362,7 +363,11 @@ Directory _glazeDataDirectory() {
   if (Platform.isWindows) {
     final appData = Platform.environment['APPDATA'];
     if (appData != null && appData.isNotEmpty) {
-      return Directory('$appData${Platform.pathSeparator}Glaze');
+      // Must track the same per-channel folder as getAppDataDir(), or the
+      // file-serving root would point at another channel's install.
+      return Directory(
+        '$appData${Platform.pathSeparator}$glazeDataFolderName',
+      );
     }
   }
   return Directory.current;

--- a/lib/features/cloud_sync/services/dropbox/dropbox_adapter.dart
+++ b/lib/features/cloud_sync/services/dropbox/dropbox_adapter.dart
@@ -3,14 +3,33 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 
+import '../../../../core/constants/build_channel.dart';
 import '../../cloud_adapter.dart';
+import '../../sync_models.dart';
 import 'dropbox_auth.dart';
 
 class DropboxAdapter implements CloudAdapter {
   static const _apiBase = 'https://api.dropboxapi.com/2';
   static const _contentBase = 'https://content.dropboxapi.com/2';
-  static const _appFolderPrefix = '/Glaze';
   static const _deleteBatchPolls = 30;
+
+  // Dropbox hands the app its own App folder as the API root, so the Glaze root
+  // itself collapses to '' — that is why paths are stripped rather than used
+  // as-is. The name of that App folder comes from the Dropbox app registration,
+  // not from us, so it cannot carry the channel.
+  //
+  // Each channel therefore lives in a sub-folder of the App folder, with stable
+  // keeping the flat layout it has always had. This is correct under both
+  // configurations: with one shared DROPBOX_APP_KEY the sub-folder is what
+  // keeps the channels apart, and with a per-channel app key (separate App
+  // folders) it is merely one harmless extra level.
+  static const _channelSubfolder = isStableChannel ? '' : '/$buildChannel';
+
+  // Sub-folder names reserved by the *other* channels. Only reachable from
+  // stable, whose wipe is the one operation that touches the App folder root.
+  static const _foreignChannelFolders = isStableChannel
+      ? {'staging', 'nightly'}
+      : <String>{};
 
   final DropboxAuth _auth;
   final Dio _dio = Dio(
@@ -24,11 +43,43 @@ class DropboxAdapter implements CloudAdapter {
 
   DropboxAdapter(this._auth);
 
+  /// Canonical Glaze path (`/Glaze-nightly/characters/x.json`) to the
+  /// App-folder-relative path Dropbox expects (`/nightly/characters/x.json`).
   String _stripPrefix(String path) {
-    if (path.startsWith(_appFolderPrefix)) {
-      return path.substring(_appFolderPrefix.length);
+    if (path.startsWith(cloudBase)) {
+      return '$_channelSubfolder${path.substring(cloudBase.length)}';
     }
     return path;
+  }
+
+  /// Inverse of [_stripPrefix] for paths coming back from the API.
+  ///
+  /// Drops the channel sub-folder so the rest of the sync layer keeps seeing
+  /// listings relative to the Glaze root — the invariant
+  /// [normalizeCloudSyncPath] relies on to line manifest entries up against
+  /// `list_folder` results. Without this, every entry would look missing on a
+  /// non-stable channel and sync would re-upload the whole library each run.
+  String _unmapChannelPath(String path) {
+    if (_channelSubfolder.isEmpty) return path;
+    if (path == _channelSubfolder) return '/';
+    if (path.startsWith('$_channelSubfolder/')) {
+      return path.substring(_channelSubfolder.length);
+    }
+    return path;
+  }
+
+  /// Whether a root-relative path belongs to a channel that is not this build.
+  ///
+  /// Guards the App-folder-root wipe: with a shared DROPBOX_APP_KEY the other
+  /// channels sit next to us in the same folder, and "delete cloud data" must
+  /// not reach across into them.
+  bool _belongsToAnotherChannel(String? path) {
+    if (_foreignChannelFolders.isEmpty) return false;
+    if (path == null || path.isEmpty) return false;
+    final first = path
+        .split('/')
+        .firstWhere((segment) => segment.isNotEmpty, orElse: () => '');
+    return _foreignChannelFolders.contains(first.toLowerCase());
   }
 
   Future<Map<String, String>> _headers() async {
@@ -209,6 +260,13 @@ class DropboxAdapter implements CloudAdapter {
       hasMore = result['has_more'] as bool? ?? false;
     }
 
+    // Leave the other channels' sub-trees alone — see _belongsToAnotherChannel.
+    entries.removeWhere(
+      (e) => _belongsToAnotherChannel(
+        (e['path_lower'] ?? e['path_display']) as String?,
+      ),
+    );
+
     if (entries.isEmpty) return;
 
     try {
@@ -288,9 +346,18 @@ class DropboxAdapter implements CloudAdapter {
   List<CloudFileInfo> _parseEntries(List<Object?> entries) {
     return entries
         .whereType<Map<String, dynamic>>()
+        // Another channel's sub-folder is not ours to see. Listing the App
+        // folder root from stable would otherwise surface `nightly/` as cloud
+        // content — which, among other things, kept the post-wipe
+        // "waiting for cloud to finalize" poll spinning until it timed out.
+        .where(
+          (e) => !_belongsToAnotherChannel(
+            (e['path_lower'] ?? e['path_display']) as String?,
+          ),
+        )
         .map(
           (e) => CloudFileInfo(
-            path: e['path_display'] as String? ?? '',
+            path: _unmapChannelPath(e['path_display'] as String? ?? ''),
             name: e['name'] as String? ?? '',
             isFolder: e['.tag'] == 'folder',
           ),

--- a/lib/features/cloud_sync/services/gdrive/gdrive_adapter.dart
+++ b/lib/features/cloud_sync/services/gdrive/gdrive_adapter.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:dio/dio.dart';
 
 import '../../cloud_adapter.dart';
+import '../../sync_models.dart';
 import 'gdrive_auth.dart';
 import 'gdrive_files.dart';
 import 'gdrive_folders.dart';
@@ -28,8 +29,8 @@ class GDriveAdapter implements CloudAdapter {
 
   @override
   Future<void> ensureFolder(String path) async {
-    if (!path.startsWith('/Glaze')) {
-      path = '/Glaze/$path';
+    if (!path.startsWith(cloudBase)) {
+      path = '$cloudBase/$path';
     }
     await _folders.ensureFolder(path);
   }

--- a/lib/features/cloud_sync/services/gdrive/gdrive_folders.dart
+++ b/lib/features/cloud_sync/services/gdrive/gdrive_folders.dart
@@ -2,8 +2,12 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 
+import '../../sync_models.dart';
+
 class GDriveFolders {
-  static const _folderName = 'Glaze';
+  // Per-channel, so stable / staging / nightly get sibling folders in the
+  // user's Drive root instead of writing into one shared tree.
+  static const _folderName = cloudRootFolderName;
 
   final Dio _dio = Dio(
     BaseOptions(

--- a/lib/features/cloud_sync/sync_models.dart
+++ b/lib/features/cloud_sync/sync_models.dart
@@ -1,3 +1,5 @@
+import '../../core/constants/build_channel.dart';
+
 enum SyncProvider { dropbox, gdrive }
 
 enum SyncStatus { idle, syncing, error, conflict }
@@ -170,7 +172,21 @@ class SyncManifest {
 
 String entryKey(String type, String id) => '$type:$id';
 
-const String cloudBase = '/Glaze';
+/// Name of the Glaze root folder in the cloud provider.
+///
+/// Reuses [glazeDataFolderName] so the cloud tree is named exactly like the
+/// desktop data folder: `Glaze` on stable, `Glaze-staging` / `Glaze-nightly`
+/// elsewhere. Keeping the channels apart matters as soon as two of them are
+/// installed side by side and pointed at the same cloud account — otherwise
+/// they overwrite each other's entities through a shared manifest.
+const String cloudRootFolderName = glazeDataFolderName;
+
+/// Root of the Glaze tree in the cloud provider, as an absolute path.
+///
+/// Every cloud path in the sync layer is built from this, so the channel split
+/// is a single-constant change for Google Drive. Dropbox needs one extra step
+/// — see `_channelSubfolder` in `dropbox_adapter.dart`.
+const String cloudBase = '/$cloudRootFolderName';
 
 const int maxSyncPayloadBytes = 30 * 1024 * 1024;
 
@@ -226,7 +242,9 @@ String cloudPath(String type, String id) {
 }
 
 /// Canonical path for comparing manifest entry paths with cloud list_folder results.
-/// Dropbox app-folder listings omit the `/Glaze` prefix; GDrive uses full paths.
+/// Dropbox app-folder listings omit the [cloudBase] prefix; GDrive uses full
+/// paths. (`DropboxAdapter` strips its own channel sub-folder before returning
+/// listings, so both providers reach this function Glaze-root-relative.)
 String normalizeCloudSyncPath(String path) {
   var p = path.trim();
   if (p.isEmpty) return p;

--- a/test/ext_blocks_sync_test.dart
+++ b/test/ext_blocks_sync_test.dart
@@ -547,19 +547,19 @@ void main() {
     () {
       expect(
         cloudPath('extension_preset', 'ep-123'),
-        equals('/Glaze/extension_presets/ep-123.json'),
+        equals('$cloudBase/extension_presets/ep-123.json'),
       );
       expect(
         cloudPath('extensions_settings', 'extensions_settings'),
-        equals('/Glaze/extensions_settings.json'),
+        equals('$cloudBase/extensions_settings.json'),
       );
       expect(
         cloudPath('info_block', 'session-abc'),
-        equals('/Glaze/info_blocks/session-abc.json'),
+        equals('$cloudBase/info_blocks/session-abc.json'),
       );
       expect(
         cloudPath('tracker_value', 'session-abc'),
-        equals('/Glaze/tracker_values/session-abc.json'),
+        equals('$cloudBase/tracker_values/session-abc.json'),
       );
     },
   );
@@ -660,7 +660,7 @@ void main() {
     await deviceA.engine.pushEntities(onProgress: (_) {});
 
     expect(
-      deviceA.cloud.files.containsKey('/Glaze/extensions_settings.json'),
+      deviceA.cloud.files.containsKey('$cloudBase/extensions_settings.json'),
       isTrue,
       reason: 'ExtensionsSettings should be uploaded to cloud',
     );
@@ -866,17 +866,17 @@ void main() {
       // Verify paths are correct
       expect(
         manifest.entries[entryKey('extension_preset', 'ep1')]!.path,
-        equals('/Glaze/extension_presets/ep1.json'),
+        equals('$cloudBase/extension_presets/ep1.json'),
       );
       expect(
         manifest
             .entries[entryKey('extensions_settings', 'extensions_settings')]!
             .path,
-        equals('/Glaze/extensions_settings.json'),
+        equals('$cloudBase/extensions_settings.json'),
       );
       expect(
         manifest.entries[entryKey('info_block', 'session1')]!.path,
-        equals('/Glaze/info_blocks/session1.json'),
+        equals('$cloudBase/info_blocks/session1.json'),
       );
     },
   );


### PR DESCRIPTION
Три канала теперь можно держать на одном устройстве одновременно: у каждого свой package name, своя папка данных и свой корень облачной синхронизации. `stable` сохраняет все идентификаторы, которые у него были, — существующие установки не осиротеют.

| Канал | Android applicationId | iOS bundle id | Ярлык | Папка данных | Облачный корень |
|---|---|---|---|---|---|
| `stable` | `app.glaze.flutter` | `com.glaze.glazeFlutter` | Glaze | `Glaze` | `Glaze` |
| `staging` | `app.glaze.flutter.staging` | `…glazeFlutter.staging` | Glaze Staging | `Glaze-staging` | `Glaze-staging` |
| `nightly` | `app.glaze.flutter.nightly` | `…glazeFlutter.nightly` | Glaze Nightly | `Glaze-nightly` | `Glaze-nightly` |

## Подпись не меняется

Все три канала подписываются тем же CI-keystore. Android отказывается ставить рядом пакеты с одинаковым `applicationId`, а не с одинаковым сертификатом — и общий сертификат как раз нужен, чтобы билд, промотированный из `nightly` в `stable`, встал как обновление, а не как новое приложение.

## Как канал доезжает до сборки

- **Android** — `--dart-define` до Gradle не доходит, поэтому CI отдаёт `BUILD_CHANNEL` в окружение шага сборки, а `build.gradle.kts` читает его через `System.getenv` (тем же способом, что и конфиг подписи). `namespace` остаётся `app.glaze.flutter`, так что `.MainActivity` и имена `MethodChannel` не затронуты.
- **iOS** — xcconfig не умеет читать окружение, поэтому CI пишет `ios/Flutter/Channel.xcconfig` перед сборкой: `BUNDLE_ID_SUFFIX` уходит в `PRODUCT_BUNDLE_IDENTIFIER`, `APP_DISPLAY_NAME` — в `CFBundleDisplayName`. Файл закоммичен с дефолтами `nightly` для локальных сборок.
- **Десктоп** — пакетного менеджера нет, поэтому канал попадает в путь к данным (`glazeDataFolderName`). Иначе три установки делили бы один `glaze.db`. Тот же суффикс подхватывает и Windows-корень WebView.

## Облачная синхронизация

Разделения на устройстве мало: два канала на одном аккаунте Dropbox или Google Drive писали бы через общий манифест и затирали друг другу персонажей, чаты и пресеты. Всё висит на одной константе `cloudBase` в `sync_models.dart`, из которой строятся все ~50 облачных путей.

**Google Drive** — больше ничего не нужно, корневая папка ищется по имени в корне Drive, `Glaze-nightly` просто становится соседкой `Glaze`.

**Dropbox** — приложение получает свою App folder как корень API, поэтому пути и срезаются до пустой строки. Имя этой папки задаётся регистрацией приложения, а не нами, так что канал в него не положить. Поддержаны две конфигурации, и код корректен в обеих:

1. **Общий ключ** (по умолчанию, работает уже сейчас) — неstable-канал живёт в подпапке общей App folder: `/Apps/Glaze/nightly/…`. Stable сохраняет плоскую раскладку, его файлы не двигаются.
2. **Ключ на канал** — секреты `DROPBOX_APP_KEY_STAGING` / `DROPBOX_APP_KEY_NIGHTLY` плюс отдельная регистрация приложения. CI откатывается на `DROPBOX_APP_KEY`, пока секрет канала пуст, поэтому добавлять их можно по одному и в любой момент.

Три вещи в `dropbox_adapter.dart` делают это рабочим:

- `_stripPrefix` переводит канонический путь в путь относительно App folder;
- `_unmapChannelPath` — обратное преобразование для ответов API, чтобы листинги доходили до `normalizeCloudSyncPath` относительно корня Glaze. Без него на неstable-канале каждая запись манифеста выглядела бы отсутствующей и синк перезаливал бы всю библиотеку на каждом прогоне;
- `_belongsToAnotherChannel` не пускает канал в чужое поддерево. Критично ровно для одной операции: стирание облачных данных из `stable` идёт через `_deleteAllInRoot`, который листает корень App folder **рекурсивно** — без охраны он снёс бы `nightly/` и `staging/` вместе со своими файлами. Он же прячет чужие папки от `listFolder`, из-за чего опрос «ожидание финализации облака» после стирания крутился бы до таймаута.

## Миграция

Намеренно автоматической миграции нет. Локальные и облачные данные, записанные до разделения, остаются на месте; `stable` продолжает их видеть без изменений, `staging`/`nightly` стартуют с пустого корня и заливают своё локальное. Старое не трогается и не удаляется. Локальный `flutter run` по умолчанию идёт как `nightly`, то есть тоже начнёт с чистой папки — прежние данные подхватит `stable`-сборка.

## Проверка

- `flutter analyze --no-fatal-infos --no-fatal-warnings` — проходит (17 замечаний, все info/warning, ни одного в изменённых файлах).
- `flutter test` — 1765 тестов, все зелёные. Три ассерта в `ext_blocks_sync_test.dart` хардкодили `/Glaze/` как корень; переведены на `cloudBase`, потому что проверяют маршрутизацию путей, а не имя корневой папки.
- Отдельно прогнана арифметика путей по всем трём каналам: главный инвариант (путь из манифеста и тот же файл, как его вернул Dropbox, нормализуются в одну строку), отсутствие коллизий между каналами внутри общей App folder, изоляция стирания.

Живой синк не проверялся — нужны реальные аккаунты Google и Dropbox.

## Известные ограничения

- OAuth-схема `com.hydall.glaze://` пока общая: на Android при подключении облака появится диалог выбора приложения. Развести её по каналам можно только после регистрации дополнительных redirect URI в консолях Google и Dropbox, иначе авторизация на этих каналах сломается совсем. PKCE и проверка `state` на месте, так что это неудобство, а не дыра.
- Bundle id для macOS и Linux не разделены — CI их не собирает, там канало-зависима только папка данных.

Подробности — в `docs/RELEASE_CHANNELS.md` (новые разделы «Side-by-side installs», «Cloud sync» и обновлённый чек-лист добавления канала).

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5uFFZqF3onWvgbU5rmocw)_