### PR TITLE
fix(chat): anchor the markdown image options menu to the image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 ## Workflow
 
 - Branch (`feat/xxx`) off `nightly`, push to `origin`, open a PR — see `docs/WORKFLOW.md` for branching, Trello, and cleanup checklists.
+- **Feature branches are always based on `nightly`** — `stable` is the default branch, so a fresh clone starts there; check the base first, and `git rebase origin/nightly` a branch that was cut from the wrong one before opening the PR.
 - Open PRs only against upstream repository `hydall/Glaze` (base: `hydall/Glaze:nightly`), not against fork repos.
 - PR title and body are **in English**, and the body lists the changes as bullets (one bullet per change, `##` headings when a PR carries several independent fixes) plus how it was verified. Full rules: `docs/WORKFLOW.md` § PR title and body.
 - PRs are squash-merged and gated on CI (`.github/workflows/ci.yml` — `flutter analyze` + `flutter test`); a red check blocks the merge.

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -129,9 +129,22 @@ export class Formatter {
     });
 
     // 5b. Janitor images: ![alt](url) → <span class="janitor-img-wrapper"> with options button
+    //
+    // The card is stashed as ONE atomic placeholder and restored at the very
+    // end (step 12c). Emitting its raw HTML here instead would hand it to the
+    // tag extraction in step 6, which classifies <img>/<svg>/<path> as *block*
+    // tags — step 11 then isolates every block placeholder in its own
+    // paragraph, so `<span class="janitor-img-wrapper">`, the `<img>` and the
+    // options `<button>` end up in three different <p> elements. The button
+    // would lose its positioned wrapper and its `position: absolute` would
+    // resolve against the message container, pinning the 3-dot menu to the top
+    // of the whole message instead of the top of the image.
+    const mdImages = [];
     html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, url) => {
       const safeUrl = this._escapeHtml(this._normalizeMdUrl(url));
-      return `<span class="janitor-img-wrapper"><img src="${safeUrl}" alt="${this._escapeHtml(alt)}" class="janitor-img" loading="lazy" data-action="image-click" data-src="${safeUrl}"><button class="janitor-options-btn" type="button" data-action="img-options" data-src="${safeUrl}" title="Options">${OPTIONS_SVG}</button></span>`;
+      const id = this._ph('MI_', mdImages.length);
+      mdImages.push(`<span class="janitor-img-wrapper"><img src="${safeUrl}" alt="${this._escapeHtml(alt)}" class="janitor-img" loading="lazy" data-action="image-click" data-src="${safeUrl}"><button class="janitor-options-btn" type="button" data-action="img-options" data-src="${safeUrl}" title="Options">${OPTIONS_SVG}</button></span>`);
+      return id;
     });
 
     // 5c. Glaze image gen tags
@@ -286,6 +299,10 @@ export class Formatter {
 
     // 12b. Restore list blocks
     html = html.replace(/\x01LB_BLOCK_(\d+)\x01/g, (_, i) => listBlocks[parseInt(i)]);
+
+    // 12c. Restore markdown image cards — kept whole so the options button
+    //      stays inside its positioned .janitor-img-wrapper (see step 5b).
+    html = html.replace(/\x01MI_(\d+)\x01/g, (_, i) => mdImages[parseInt(i)]);
 
     // 13. Restore CSS comments
     html = html.replace(/\x01CC_(\d+)\x01/g, (_, i) => cssComments[parseInt(i)]);

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -19,6 +19,7 @@ build settings automatically as it is promoted — see `docs/RELEASE_CHANNELS.md
 Each feature = a branch off `nightly`, pushed to `origin`, then a PR into
 upstream `hydall/Glaze:nightly`.
 
+- **Always base a feature branch on `nightly`** — never on `stable` or `staging`, and never on whatever happened to be checked out. `stable` is the repository's *default* branch, so a fresh clone (and every agent session started from one) lands there: check the base before the first commit. If a branch was already cut from the wrong base, rebase it before opening the PR — `git fetch origin nightly && git rebase origin/nightly` — so the PR carries only its own commits.
 - **No direct commits to `nightly`, `staging` or `stable`** — always use a feature branch.
 - **Never PR straight into `staging` or `stable`** — features enter through `nightly` and are promoted.
 - **Squash-merge every PR** — one feature = one commit on `nightly`, so a regression found later is a single `git revert <sha>` instead of untangling a range.

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -770,8 +770,12 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
   /// Options sheet for a generated/janitor image (Imagen UI, ported from
   /// Glaze useMessageImageGen.js): Expand → fullscreen, Save → share/save,
   /// Regenerate → re-run image generation for the owning message. The
-  /// Regenerate entry is hidden when there is no owning message (e.g. inline
-  /// janitor `![](url)` images, which carry no messageId).
+  /// Regenerate entry is hidden when the owning message can't be resolved in
+  /// the current list (no messageId, or the message is already gone).
+  ///
+  /// Uses [GlazeBottomSheet] so the sheet matches every other action sheet in
+  /// the app (glass surface, handle bar, haptics) instead of a bare Material
+  /// `showModalBottomSheet`.
   void _showImageOptionsSheet(
     String src,
     String instruction,
@@ -782,57 +786,37 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
         ? -1
         : messages.indexWhere((m) => m.id == messageId);
 
-    showModalBottomSheet<void>(
-      context: context,
-      backgroundColor: context.cs.surfaceContainerHigh,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
-      builder: (sheetCtx) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const SizedBox(height: 8),
-            Container(
-              width: 32,
-              height: 4,
-              decoration: BoxDecoration(
-                color: context.cs.outlineVariant.withValues(alpha: 0.4),
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-            const SizedBox(height: 8),
-            ListTile(
-              leading: const Icon(Icons.fullscreen),
-              title: Text('imggen_expand_image'.tr()),
-              onTap: () {
-                Navigator.pop(sheetCtx);
-                _showImageViewer(context, src);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.save_alt),
-              title: Text('action_save_image'.tr()),
-              onTap: () {
-                Navigator.pop(sheetCtx);
-                _downloadImage(src);
-              },
-            ),
-            if (idx >= 0)
-              ListTile(
-                leading: const Icon(Icons.refresh),
-                title: Text('action_regenerate'.tr()),
-                onTap: () {
-                  Navigator.pop(sheetCtx);
-                  ref
-                      .read(chatProvider(widget.charId).notifier)
-                      .retryImageGenerationForMessage(messageId);
-                },
-              ),
-            const SizedBox(height: 8),
-          ],
+    GlazeBottomSheet.show<void>(
+      context,
+      items: [
+        BottomSheetItem(
+          icon: Icons.fullscreen,
+          label: 'imggen_expand_image'.tr(),
+          onTap: () {
+            Navigator.of(context, rootNavigator: true).pop();
+            _showImageViewer(context, src);
+          },
         ),
-      ),
+        BottomSheetItem(
+          icon: Icons.save_alt,
+          label: 'action_save_image'.tr(),
+          onTap: () {
+            Navigator.of(context, rootNavigator: true).pop();
+            _downloadImage(src);
+          },
+        ),
+        if (idx >= 0)
+          BottomSheetItem(
+            icon: Icons.refresh,
+            label: 'action_regenerate'.tr(),
+            onTap: () {
+              Navigator.of(context, rootNavigator: true).pop();
+              ref
+                  .read(chatProvider(widget.charId).notifier)
+                  .retryImageGenerationForMessage(messageId);
+            },
+          ),
+      ],
     );
   }
 

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -240,6 +240,87 @@ void main() {
     });
   });
 
+  // ─── markdown image options button ────────────────────────────────────────
+  group('markdown image card (formatter/formatter.js)', () {
+    test('the card is stashed whole, not emitted as raw HTML mid-pipeline', () {
+      // Raw HTML emitted before the tag extraction gets torn apart: <img>,
+      // <svg> and <path> are *block* tags, so the paragraph step isolates each
+      // of them and the wrapper <span>, the image and the options <button> end
+      // up in three different <p> elements. The button then loses its
+      // positioned wrapper and its `position: absolute` resolves against the
+      // message container — the 3-dot menu jumps to the top of the message.
+      expect(formatterFormatterJs, contains('const mdImages = []'));
+      expect(formatterFormatterJs, contains('mdImages.push('));
+
+      final pushIdx = formatterFormatterJs.indexOf('mdImages.push(');
+      final tagExtractIdx = formatterFormatterJs.indexOf(
+        '// 6. Extract HTML Tags',
+      );
+      expect(tagExtractIdx, isNot(-1));
+      expect(
+        pushIdx < tagExtractIdx,
+        isTrue,
+        reason: 'the image card must be stashed before tag extraction runs',
+      );
+    });
+
+    test('wrapper, image and options button live in one atomic chunk', () {
+      final pushIdx = formatterFormatterJs.indexOf('mdImages.push(');
+      final chunk = formatterFormatterJs.substring(
+        pushIdx,
+        formatterFormatterJs.indexOf('\n', pushIdx),
+      );
+      expect(chunk, contains('janitor-img-wrapper'));
+      expect(chunk, contains('class="janitor-img"'));
+      expect(chunk, contains('janitor-options-btn'));
+      expect(chunk, contains(r'data-action="img-options"'));
+    });
+
+    test('the card is restored after paragraph splitting', () {
+      final restoreIdx = formatterFormatterJs.indexOf(
+        r'html = html.replace(/\x01MI_(\d+)\x01/g',
+      );
+      expect(
+        restoreIdx,
+        isNot(-1),
+        reason: 'markdown image placeholders must be restored',
+      );
+      final paragraphIdx = formatterFormatterJs.indexOf('// 11. Paragraphs');
+      expect(paragraphIdx, isNot(-1));
+      expect(
+        restoreIdx > paragraphIdx,
+        isTrue,
+        reason:
+            'restoring before the paragraph step would expose the card to the '
+            'block-placeholder isolation again',
+      );
+    });
+
+    test('options button is positioned against the image wrapper', () {
+      final wrapperIdx = rendererJs.indexOf('.janitor-img-wrapper {');
+      expect(wrapperIdx, isNot(-1));
+      final wrapperBlock = rendererJs.substring(
+        wrapperIdx,
+        rendererJs.indexOf('}', wrapperIdx) + 1,
+      );
+      expect(
+        wrapperBlock,
+        contains('position: relative'),
+        reason: 'the wrapper is the containing block of the options button',
+      );
+
+      final btnIdx = rendererJs.indexOf('.janitor-options-btn,');
+      expect(btnIdx, isNot(-1));
+      final btnBlock = rendererJs.substring(
+        btnIdx,
+        rendererJs.indexOf('}', btnIdx) + 1,
+      );
+      expect(btnBlock, contains('position: absolute'));
+      expect(btnBlock, contains('top: 8px'));
+      expect(btnBlock, contains('right: 8px'));
+    });
+  });
+
   // ─── Headless engine (Phase 6.1) ────────────────────────────────────────────
   group('headless engine (headless.html)', () {
     test('loads glaze_sdk.js', () {


### PR DESCRIPTION
## Fixes

- **The 3-dot options button of a markdown image (`[alt](url)`) rendered at the top of the message container instead of the top of the image.** The CSS was fine (`.janitor-img-wrapper { position: relative }`, button `position: absolute; top: 8px; right: 8px`) — the HTML was broken. `Formatter._processText` step 5b emitted the image card as raw HTML *before* the tag extraction in step 6, which classifies `<img>`, `<svg>` and `<path>` as **block** tags; step 11 then isolates every block placeholder in its own paragraph, so the wrapper `<span>`, the `<img>` and the options `<button>` ended up in three different `<p>` elements:

  ```html
  <p>Hello <span class="janitor-img-wrapper"></p><img ...><p><button class="janitor-options-btn" ...></p>…
  ```

  With the button torn out of its positioned wrapper, `position: absolute` resolved against the message container. The card is now stashed as one atomic placeholder (`\x01MI_n\x01`) and restored after the paragraph step (12c), so wrapper, image and button stay together.
- **The image options sheet used a bare Material `showModalBottomSheet`.** `_ChatBodyState._showImageOptionsSheet` now uses `GlazeBottomSheet.show` with `BottomSheetItem`s, matching every other action sheet in the app (glass surface, handle bar, haptics). The entries and the condition that hides "Regenerate" are unchanged.
- **Corrected a misleading doc comment** on `_showImageOptionsSheet`: it claimed "Regenerate" is hidden for markdown images because they carry no `messageId`, but `InteractionDispatch._extractImgInstruction` reads the id from the enclosing message section. Behaviour unchanged, wording now matches it.

## Docs

- **`docs/WORKFLOW.md` / `CLAUDE.md`: feature branches must be based on `nightly`.** `stable` is the repository's default branch, so a fresh clone — and every agent session started from one — lands there and a branch cut without checking the base ends up rooted on `stable`. The rule and the recovery (`git rebase origin/nightly`) are now written down. This branch itself hit exactly that and was rebased onto `nightly` before the PR was opened.

## Tests

- `test/webview_assets_test.dart`: the image card is stashed before tag extraction, wrapper + image + button live in one atomic chunk, the placeholder is restored after the paragraph step, and the wrapper/button positioning rules are present in `shadow_style.js`.

## Verification

- The formatter was run through node on the real asset, before and after the fix: before produced the torn HTML above, after keeps the card intact — inline in a sentence, alone on its own line, inside a list item, and inside `**bold**`.
- `flutter analyze` and `flutter test` could **not** be run locally (the agent container has no Flutter SDK) — relying on the `Analyze + test` CI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sc8CGiJsN2w2pyw5YNvcfz