### PR TITLE
feat(catalog): default to JanitorAI only, migrate existing users

### DIFF
--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -49,7 +49,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 77;
+  int get schemaVersion => 78;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1388,6 +1388,15 @@ class AppDatabase extends _$AppDatabase {
       }
       if (from < 77) {
         await m.createTable(ledgerReconciliationCleanupJournals);
+      }
+      if (from < 78) {
+        final prefs = await SharedPreferences.getInstance();
+        if (!prefs.containsKey('gz_disabled_third_party_providers')) {
+          await prefs.setStringList(
+            'gz_disabled_third_party_providers',
+            <String>[],
+          );
+        }
       }
     },
   );

--- a/lib/features/catalog/third_party_providers_provider.dart
+++ b/lib/features/catalog/third_party_providers_provider.dart
@@ -24,15 +24,15 @@ extension ThirdPartyProviderX on ThirdPartyProvider {
 }
 
 /// Holds the set of DISABLED third-party providers (a provider absent from the
-/// set is enabled). Persisted so the choice survives launches; defaults to all
-/// enabled (empty set).
+/// set is enabled). Persisted so the choice survives launches; defaults to
+/// janitor enabled (all others disabled).
 class ThirdPartyProvidersNotifier extends Notifier<Set<ThirdPartyProvider>> {
   static const _key = 'gz_disabled_third_party_providers';
 
   @override
   Set<ThirdPartyProvider> build() {
     _load();
-    return const {};
+    return {ThirdPartyProvider.janny, ThirdPartyProvider.datacat, ThirdPartyProvider.chub, ThirdPartyProvider.saucepan};
   }
 
   Future<void> _load() async {
@@ -46,7 +46,7 @@ class ThirdPartyProvidersNotifier extends Notifier<Set<ThirdPartyProvider>> {
       );
       if (match != null) disabled.add(match);
     }
-    if (disabled.isNotEmpty) state = disabled;
+    state = disabled;
   }
 
   bool isEnabled(ThirdPartyProvider p) => !state.contains(p);


### PR DESCRIPTION
## Changes

- **Default third-party providers changed to JanitorAI only** — \ThirdPartyProvidersNotifier.build()\ now returns all providers except janitor as disabled
- **DB migration (v77→v78)** — persists old default (all enabled) for existing users before the new default takes effect. Fresh installs get the new janitor-only default
- **Fixed \_load()\** — updates state even when the saved disabled set is empty, so the migration's persisted empty list correctly restores all-providers-enabled for existing users

## Verified

- \dart analyze\ passes on both changed files