### PR TITLE
feat(ui): add BETA indicator to about screen and build watermark

### DIFF
--- a/lib/core/constants/app_version.dart
+++ b/lib/core/constants/app_version.dart
@@ -6,3 +6,10 @@ const buildBranch = String.fromEnvironment('BUILD_BRANCH');
 /// (`--dart-define=BUILD_COMMIT=<sha>`). Empty for local/dev builds, in which
 /// case the update checker cannot diff against the latest CI build.
 const buildCommit = String.fromEnvironment('BUILD_COMMIT');
+
+bool get isBetaVersion {
+  final parts = appVersion.split('.');
+  if (parts.isEmpty) return false;
+  final major = int.tryParse(parts.first);
+  return major != null && major == 0;
+}

--- a/lib/core/state/dev_mode_provider.dart
+++ b/lib/core/state/dev_mode_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../constants/app_version.dart';
 import '../constants/build_channel.dart';
 import 'shared_prefs_provider.dart';
 
@@ -48,7 +49,7 @@ class HideBuildWatermarkNotifier extends Notifier<bool> {
   @override
   bool build() {
     final prefs = ref.watch(sharedPreferencesProvider).value;
-    return prefs?.getBool(_prefsKey) ?? isStableChannel;
+    return prefs?.getBool(_prefsKey) ?? (isStableChannel && !isBetaVersion);
   }
 
   Future<void> set(bool value) async {

--- a/lib/features/menu/about_screen.dart
+++ b/lib/features/menu/about_screen.dart
@@ -97,7 +97,31 @@ class _HeroCard extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 4),
-                  const _VersionBadge(),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const _VersionBadge(),
+                      if (isBetaVersion) const SizedBox(width: 8),
+                      if (isBetaVersion)
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: Colors.orange.withValues(alpha: 0.15),
+                            borderRadius: BorderRadius.circular(5),
+                            border: Border.all(color: Colors.orange.withValues(alpha: 0.35)),
+                          ),
+                          child: const Text(
+                            'BETA',
+                            style: TextStyle(
+                              fontSize: 10,
+                              fontWeight: FontWeight.w700,
+                              color: Colors.orange,
+                              letterSpacing: 0.5,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
                   if (buildDate.isNotEmpty || buildBranch.isNotEmpty) ...[
                     const SizedBox(height: 6),
                     if (buildDate.isNotEmpty)

--- a/lib/shared/widgets/build_watermark.dart
+++ b/lib/shared/widgets/build_watermark.dart
@@ -47,6 +47,12 @@ class BuildWatermark extends ConsumerWidget {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
+                if (isBetaVersion)
+                  Text(
+                    'BETA',
+                    textAlign: TextAlign.right,
+                    style: style.copyWith(color: Colors.orange.withValues(alpha: 0.5)),
+                  ),
                 if (buildBranch.isNotEmpty)
                   Text(buildBranch, textAlign: TextAlign.right, style: style),
                 Text(_dateLabel, textAlign: TextAlign.right, style: style),


### PR DESCRIPTION
## Changes

- Added isBetaVersion getter in pp_version.dart — returns true while major version is 0 (pre-1.0)
- Added orange BETA chip next to the version badge in the About screen
- Added orange BETA text to the build watermark (bottom-right overlay)
- Changed watermark default visibility: visible even on stable channel during beta

## Verification

- dart analyze on all modified files — no issues