### PR TITLE
fix(lorebooks): scope imported character lorebooks to their character

### DIFF
--- a/lib/core/db/repositories/lorebook_repo.dart
+++ b/lib/core/db/repositories/lorebook_repo.dart
@@ -81,7 +81,7 @@ class LorebookRepo implements SyncLorebookStore {
     final lorebook = Lorebook(
       id: characterId,
       name: name.isNotEmpty ? name : 'Lorebook for $characterId',
-      enabled: true,
+      enabled: false,
       activationScope: 'character',
       activationTargetId: characterId,
       entries: entries,

--- a/lib/core/services/backup/js_lorebook_importer.dart
+++ b/lib/core/services/backup/js_lorebook_importer.dart
@@ -158,7 +158,7 @@ class JsLorebookImporter extends BackupHelpers {
               lorebookId: cbId,
               name: cbRaw['name'] as String? ??
                   '${char['name'] ?? 'Char'} Lorebook',
-              enabled: Value(cbRaw['enabled'] as bool? ?? true),
+              enabled: Value(cbRaw['enabled'] as bool? ?? false),
               activationScope: Value('character'),
               activationTargetId: Value(charId),
               entriesJson: jsonEncode(mappedEntries),

--- a/lib/core/services/character_book_converter.dart
+++ b/lib/core/services/character_book_converter.dart
@@ -44,7 +44,7 @@ Lorebook convertCharacterBook(
   return Lorebook(
     id: 'charbook_${characterId}_${DateTime.now().millisecondsSinceEpoch}',
     name: (bookData['name'] as String?) ?? 'Character Book',
-    enabled: true,
+    enabled: false,
     activationScope: 'character',
     activationTargetId: characterId,
     entries: entries,


### PR DESCRIPTION
## Changes

- Set \enabled: false\ for character-scoped lorebooks in \convertCharacterBook\, \createEntryFromCatalog\, and JS backup importer
- When \enabled=true\, a lorebook activates in every chat regardless of \ctivationScope\, making character-card lorebooks global
- With \enabled=false\, character-scoped lorebooks only activate when that specific character is in the chat (gate #4 in \lorebook_scanner.dart\)

## Verification

- \dart analyze\ on the 3 changed files passes with no errors