### PR TITLE
feat(chat): block webview navigation while keeping external link opening

### DIFF
--- a/lib/features/chat/bridge/chat_webview_settings.dart
+++ b/lib/features/chat/bridge/chat_webview_settings.dart
@@ -87,6 +87,7 @@ InAppWebViewSettings chatWebViewInAppSettings({bool isInspectable = true}) {
     allowFileAccessFromFileURLs: chatWebViewAllowFileAccessFromFileUrls(),
     allowUniversalAccessFromFileURLs: false,
     mixedContentMode: chatWebViewMixedContentMode(),
+    useShouldOverrideUrlLoading: true,
     webViewAssetLoader: chatWebViewAssetLoader(),
   );
 }

--- a/lib/features/chat/widgets/chat_webview_preload.dart
+++ b/lib/features/chat/widgets/chat_webview_preload.dart
@@ -45,6 +45,9 @@ class _ChatWebViewPreloaderState extends State<ChatWebViewPreloader> {
                   onLoadStop: (_, _) {
                     if (mounted) setState(() => _preloaded = true);
                   },
+                  shouldOverrideUrlLoading: (controller, request) async {
+                    return ShouldOverrideUrlLoadingAction.CANCEL;
+                  },
                 ),
               ),
             ),

--- a/lib/features/chat/widgets/chat_webview_preload.dart
+++ b/lib/features/chat/widgets/chat_webview_preload.dart
@@ -46,7 +46,7 @@ class _ChatWebViewPreloaderState extends State<ChatWebViewPreloader> {
                     if (mounted) setState(() => _preloaded = true);
                   },
                   shouldOverrideUrlLoading: (controller, request) async {
-                    return ShouldOverrideUrlLoadingAction.CANCEL;
+                    return NavigationActionPolicy.CANCEL;
                   },
                 ),
               ),

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -272,7 +272,7 @@ class ChatWebViewSurface extends ConsumerWidget {
                 await onInitWebView();
               },
               shouldOverrideUrlLoading: (controller, request) async {
-                return ShouldOverrideUrlLoadingAction.CANCEL;
+                return NavigationActionPolicy.CANCEL;
               },
             ),
           ),

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -271,6 +271,9 @@ class ChatWebViewSurface extends ConsumerWidget {
                 // load stop wins the race, run init here.
                 await onInitWebView();
               },
+              shouldOverrideUrlLoading: (controller, request) async {
+                return ShouldOverrideUrlLoadingAction.CANCEL;
+              },
             ),
           ),
         ),


### PR DESCRIPTION
- Add useShouldOverrideUrlLoading: true to WebView settings
- Add shouldOverrideUrlLoading returning CANCEL in chat surface and preloader
- WebView never navigates away from chat; links still open in external browser