### PR TITLE
fix(onboarding): persona button shows Next when configured; theme init handles errors gracefully

### DIFF
--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -9,6 +9,7 @@ import '../../shared/theme/theme_provider.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../core/services/onboarding_service.dart';
 import '../backup/backup_screen.dart';
+import '../../core/state/active_selection_provider.dart';
 import '../settings/api_list_provider.dart';
 import '../settings/api_settings_screen.dart';
 import '../settings/widgets/chat_layout_picker.dart';
@@ -132,7 +133,12 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     if (_isLastSlide) return 'onboarding_btn_start'.tr();
     switch (_slides[_currentSlide].type) {
       case OnboardingSlideType.dataImport:
+        return 'onboarding_btn_skip'.tr();
       case OnboardingSlideType.persona:
+        final personaId = ref.watch(activePersonaIdProvider);
+        if (personaId != null) {
+          return 'onboarding_btn_next'.tr();
+        }
         return 'onboarding_btn_skip'.tr();
       case OnboardingSlideType.api:
         final apiConfig = ref.watch(activeApiConfigProvider);

--- a/lib/shared/theme/theme_provider.dart
+++ b/lib/shared/theme/theme_provider.dart
@@ -45,9 +45,12 @@ class ThemeNotifier extends StateNotifier<ThemeSettings> {
   }
 
   Future<void> _init() async {
-    _storage = await ThemePresetStorage.create();
-    await _load();
-    _ready.complete();
+    try {
+      _storage = await ThemePresetStorage.create();
+      await _load();
+    } finally {
+      _ready.complete();
+    }
   }
 
   Future<void> _load() async {
@@ -126,7 +129,7 @@ class ThemeNotifier extends StateNotifier<ThemeSettings> {
       accentColor: preset.accent,
       presets: updated,
     );
-    await _storage!.saveAll(updated);
+    await _storage?.saveAll(updated);
   }
 
   Future<void> reload() async {


### PR DESCRIPTION
## Changes

### Persona slide button label (onboarding_screen.dart)
- The persona slide in onboarding now checks whether a persona has been configured (via activePersonaIdProvider), matching the pattern already used for the API slide.
- If a persona is active, the button shows Next instead of Skip.

### Theme provider error resilience (theme_provider.dart)
- Wrapped _init() in a try-finally so _ready always completes, even if SharedPreferences initialization throws. This prevents updatePreset (and thus the onboarding layout picker) from hanging indefinitely.
- Changed _storage! to _storage? in updatePreset as a defensive measure for failed init scenarios.

## Verification
- dart analyze passed on both modified files
- No freezed models were changed, so build_runner is not required