### PR TITLE
fix(chat): prevent iOS WebView init race on keep-alive re-attach

### DIFF
--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -293,6 +293,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
   }
 
   Future<void> _initWebView() {
+    if (_bridge == null) return Future.value();
     return _initFuture ??= _initWebViewOnce();
   }
 


### PR DESCRIPTION
_onLoadStop can fire before onWebViewCreated on iOS keep-alive WebViews, consuming _initFuture while _bridge is still null. The early return inside _initWebViewOnce() skips the finally block that resets _initFuture on failure, leaving it permanently completed — real init never runs.

Move the null-bridge gate above the ??= assignment in _initWebView() so a call with no bridge never claims the future slot.