### PR TITLE
fix(backup): quote column names in import INSERT to avoid SQL reserved-word clash

### DIFF
--- a/lib/core/services/backup/flutter_backup_importer.dart
+++ b/lib/core/services/backup/flutter_backup_importer.dart
@@ -212,8 +212,9 @@ class FlutterBackupImporter extends BackupHelpers {
           if (columns.isEmpty) continue;
 
           final placeholders = columns.map((_) => '?').join(', ');
+          final quotedColumns = columns.map((c) => '"$c"').join(', ');
           final sql =
-              'INSERT OR REPLACE INTO $tableName (${columns.join(', ')}) VALUES ($placeholders)';
+              'INSERT OR REPLACE INTO $tableName ($quotedColumns) VALUES ($placeholders)';
           final args = <dynamic>[];
           for (final c in columns) {
             final v = r[c];
@@ -275,8 +276,9 @@ class FlutterBackupImporter extends BackupHelpers {
               final columns = r.keys.where(knownCols.contains).toList();
               if (columns.isEmpty) continue;
               final placeholders = columns.map((_) => '?').join(', ');
+              final quotedColumns = columns.map((c) => '"$c"').join(', ');
               final sql =
-                  'INSERT OR REPLACE INTO $tableName (${columns.join(', ')}) VALUES ($placeholders)';
+                  'INSERT OR REPLACE INTO $tableName ($quotedColumns) VALUES ($placeholders)';
               final args = <dynamic>[];
               for (final c in columns) {
                 final v = r[c];


### PR DESCRIPTION
## Changes

- Quote column names in raw INSERT SQL generated by _importTableFromJsonl and _importTablesFromJson in FlutterBackupImporter

## Why

order is a SQLite reserved keyword. The raw INSERT OR REPLACE used
unquoted column names, which caused a syntax error when importing a backup
containing the info_blocks table (which has an order column). Every
column is now wrapped in double quotes, so reserved words are always safe.

## Verified

- lutter analyze passes locally