### PR TITLE
fix(chat): allow WebView bootstrap navigation

### DIFF
--- a/lib/features/chat/bridge/chat_webview_environment.dart
+++ b/lib/features/chat/bridge/chat_webview_environment.dart
@@ -88,6 +88,23 @@ URLRequest? chatWebViewInitialUrlRequest() {
   return null;
 }
 
+NavigationActionPolicy chatWebViewNavigationPolicy(WebUri? url) {
+  if (url == null) return NavigationActionPolicy.CANCEL;
+
+  final initialUrl = chatWebViewInitialUrlRequest()?.url;
+  if (initialUrl != null && url == initialUrl) {
+    return NavigationActionPolicy.ALLOW;
+  }
+
+  if (initialUrl == null &&
+      url.scheme == 'file' &&
+      url.path.endsWith('/assets/chat_webview/index.html')) {
+    return NavigationActionPolicy.ALLOW;
+  }
+
+  return NavigationActionPolicy.CANCEL;
+}
+
 String? chatWebViewResolveLocalFileUrl(String? source) {
   if (source == null || source.isEmpty) return source;
   if (source.startsWith('data:') ||

--- a/lib/features/chat/widgets/chat_webview_preload.dart
+++ b/lib/features/chat/widgets/chat_webview_preload.dart
@@ -46,7 +46,7 @@ class _ChatWebViewPreloaderState extends State<ChatWebViewPreloader> {
                     if (mounted) setState(() => _preloaded = true);
                   },
                   shouldOverrideUrlLoading: (controller, request) async {
-                    return NavigationActionPolicy.CANCEL;
+                    return chatWebViewNavigationPolicy(request.request.url);
                   },
                 ),
               ),

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -272,7 +272,7 @@ class ChatWebViewSurface extends ConsumerWidget {
                 await onInitWebView();
               },
               shouldOverrideUrlLoading: (controller, request) async {
-                return NavigationActionPolicy.CANCEL;
+                return chatWebViewNavigationPolicy(request.request.url);
               },
             ),
           ),

--- a/test/chat_webview_keep_alive_test.dart
+++ b/test/chat_webview_keep_alive_test.dart
@@ -148,5 +148,21 @@ void main() {
         'http://127.0.0.1:51234/index.html',
       );
     });
+
+    test('allows the loopback bootstrap navigation and blocks others', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      setChatWebViewAssetBaseUrlForTesting(WebUri('http://127.0.0.1:51234/'));
+
+      expect(
+        chatWebViewNavigationPolicy(
+          WebUri('http://127.0.0.1:51234/index.html'),
+        ),
+        NavigationActionPolicy.ALLOW,
+      );
+      expect(
+        chatWebViewNavigationPolicy(WebUri('https://example.com/')),
+        NavigationActionPolicy.CANCEL,
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- allow the exact chat WebView bootstrap URL through the native navigation guard
- keep blocking unrelated WebView navigations
- cover the iOS loopback bootstrap URL with a regression test

## Root cause
Commit 68495ec4 enabled shouldOverrideUrlLoading and unconditionally returned CANCEL. On iOS this also cancelled the initial http://127.0.0.1:<port>/index.html request, so the document and JS bridge never loaded. The later keep-alive init-race fix did not address this earlier navigation failure.

## Testing
- flutter test (1788 tests passed)
- flutter test test/chat_webview_keep_alive_test.dart
- flutter analyze on changed files (no issues)
- full flutter analyze (no errors; 17 pre-existing warnings/infos)

Trello: https://trello.com/c/aYsOe2Ol/95-ios-chat-sometimes-blank-on-open