### PR TITLE
feat(import): allow selecting multiple lorebooks and presets at once

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -415,6 +415,7 @@
   "context_limit_glossary_hint": "Learn more:",
   "context_limit_glossary_chip": "Context",
   "import_success": "Import successful",
+  "import_failed_count": "{} failed",
   "btn_reload": "Reload",
   "action_export_chat": "Export Chat (JSONL)",
   "action_export_st": "Export",
@@ -1910,6 +1911,10 @@
   "count_characters": {
     "one": "character",
     "other": "characters"
+  },
+  "count_lorebooks": {
+    "one": "lorebook",
+    "other": "lorebooks"
   },
   "count_sessions_format": {
     "one": "{} session",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -415,6 +415,7 @@
   "context_limit_glossary_hint": "Подробнее:",
   "context_limit_glossary_chip": "Контекст",
   "import_success": "Импорт завершен",
+  "import_failed_count": "с ошибкой: {}",
   "btn_reload": "Перезагрузить",
   "action_export_chat": "Экспорт чата (JSONL)",
   "action_export_st": "Экспорт",
@@ -1923,6 +1924,12 @@
     "few": "персонажа",
     "many": "персонажей",
     "other": "персонажей"
+  },
+  "count_lorebooks": {
+    "one": "лорбук",
+    "few": "лорбука",
+    "many": "лорбуков",
+    "other": "лорбуков"
   },
   "count_sessions_format": {
     "one": "{} сессия",

--- a/lib/features/lorebooks/lorebook_list_screen.dart
+++ b/lib/features/lorebooks/lorebook_list_screen.dart
@@ -193,39 +193,74 @@ class LorebookListScreen extends ConsumerWidget {
       type: FileType.custom,
       allowedExtensions: ['json'],
       dialogTitle: 'lorebook_import_st_dialog_title'.tr(),
+      allowMultiple: true,
       withData: true,
     );
     if (result == null || result.files.isEmpty) return;
-    final filePath = result.files.single.path;
-    if (filePath == null) return;
 
-    try {
-      final importResult = await importSTLorebookFromFile(filePath);
-      await ref
-          .read(lorebooksProvider.notifier)
-          .addLorebook(importResult.lorebook);
-      if (context.mounted) {
-        GlazeToast.show(
-          context,
-          'lorebook_imported'.tr(
-            args: [
-              importResult.lorebook.name,
-              importResult.entryCount.toString(),
-            ],
-          ),
-        );
-        await Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) =>
-                LorebookEditorScreen(lorebookId: importResult.lorebook.id),
-          ),
-        );
-      }
-    } catch (e) {
-      if (context.mounted) {
-        GlazeErrorDialog.show(context, e, prefix: 'Import failed: ');
+    final notifier = ref.read(lorebooksProvider.notifier);
+    final imported = <STLorebookImportResult>[];
+    Object? lastError;
+
+    for (final file in result.files) {
+      try {
+        final STLorebookImportResult importResult;
+        final bytes = file.bytes;
+        final filePath = file.path;
+        if (bytes != null && bytes.isNotEmpty) {
+          importResult = importSTLorebook(
+            jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>,
+            nameOverride: file.name,
+          );
+        } else if (filePath != null && filePath.isNotEmpty) {
+          importResult = await importSTLorebookFromFile(filePath);
+        } else {
+          continue;
+        }
+        await notifier.addLorebook(importResult.lorebook);
+        imported.add(importResult);
+      } catch (e) {
+        lastError = e;
       }
     }
+
+    if (!context.mounted) return;
+
+    if (imported.isEmpty) {
+      if (lastError != null) {
+        GlazeErrorDialog.show(context, lastError, prefix: 'Import failed: ');
+      }
+      return;
+    }
+
+    // A single picked file keeps the original flow: toast + open the editor.
+    if (result.files.length == 1) {
+      final single = imported.single;
+      GlazeToast.show(
+        context,
+        'lorebook_imported'.tr(
+          args: [single.lorebook.name, single.entryCount.toString()],
+        ),
+      );
+      await Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => LorebookEditorScreen(lorebookId: single.lorebook.id),
+        ),
+      );
+      return;
+    }
+
+    final failed = result.files.length - imported.length;
+    final summary = StringBuffer(
+      '${'import_success'.tr()}: ${imported.length} '
+      '${'count_lorebooks'.plural(imported.length)}',
+    );
+    if (failed > 0) {
+      summary.write(
+        ' — ${'import_failed_count'.tr(args: [failed.toString()])}',
+      );
+    }
+    GlazeToast.show(context, summary.toString());
   }
 
   void _lorebookMenu(BuildContext context, WidgetRef ref, Lorebook lb) {

--- a/lib/features/presets/preset_list_screen.dart
+++ b/lib/features/presets/preset_list_screen.dart
@@ -210,37 +210,65 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
       result = await FilePicker.pickFiles(
         type: Platform.isIOS ? FileType.any : FileType.custom,
         allowedExtensions: Platform.isIOS ? null : ['json'],
-        allowMultiple: false,
+        allowMultiple: true,
         withData: true,
       );
     } catch (_) {}
     if (!mounted) return;
     if (result == null || result.files.isEmpty) return;
-    final picked = result.files.first;
 
-    try {
-      String jsonString;
-      if (picked.bytes != null && picked.bytes!.isNotEmpty) {
-        jsonString = utf8.decode(picked.bytes!);
-      } else if (picked.path != null && picked.path!.isNotEmpty) {
-        jsonString = await File(picked.path!).readAsString();
-      } else {
-        if (ctx.mounted) GlazeToast.show(ctx, 'Cannot read file');
-        return;
-      }
+    final notifier = ref.read(presetListProvider.notifier);
+    final imported = <Preset>[];
+    Object? lastError;
+    var unreadable = 0;
 
-      final json = jsonDecode(jsonString) as Map<String, dynamic>;
-      final preset = parseSillyTavernPreset(json, picked.name);
-      await ref.read(presetListProvider.notifier).add(preset);
-      if (ctx.mounted) {
-        GlazeToast.show(
-          ctx,
-          'Imported "${preset.name}" (${preset.blocks.length} blocks)',
-        );
+    for (final picked in result.files) {
+      try {
+        String jsonString;
+        if (picked.bytes != null && picked.bytes!.isNotEmpty) {
+          jsonString = utf8.decode(picked.bytes!);
+        } else if (picked.path != null && picked.path!.isNotEmpty) {
+          jsonString = await File(picked.path!).readAsString();
+        } else {
+          unreadable++;
+          continue;
+        }
+
+        final json = jsonDecode(jsonString) as Map<String, dynamic>;
+        final preset = parseSillyTavernPreset(json, picked.name);
+        await notifier.add(preset);
+        imported.add(preset);
+      } catch (e) {
+        lastError = e;
       }
-    } catch (e) {
-      if (ctx.mounted) GlazeErrorDialog.show(ctx, e, prefix: 'Import failed: ');
     }
+
+    if (!ctx.mounted) return;
+
+    if (imported.isEmpty) {
+      if (lastError != null) {
+        GlazeErrorDialog.show(ctx, lastError, prefix: 'Import failed: ');
+      } else if (unreadable > 0) {
+        GlazeToast.show(ctx, 'Cannot read file');
+      }
+      return;
+    }
+
+    if (imported.length == 1 && result.files.length == 1) {
+      final preset = imported.single;
+      GlazeToast.show(
+        ctx,
+        'Imported "${preset.name}" (${preset.blocks.length} blocks)',
+      );
+      return;
+    }
+
+    final failed = result.files.length - imported.length;
+    GlazeToast.show(
+      ctx,
+      'Imported ${imported.length} presets'
+      '${failed > 0 ? ' — $failed failed' : ''}',
+    );
   }
 }
 


### PR DESCRIPTION
## Lorebook import

- File picker now uses `allowMultiple: true`; every picked file is parsed and saved in a loop, so one bad file no longer aborts the rest.
- Each file falls back from in-memory bytes to its path, replacing the old `files.single.path` read that returned `null` on Android/iOS picks without a filesystem path.
- Picking exactly one file keeps the previous behaviour: toast with name + entry count, then push the lorebook editor. Picking several shows one aggregated toast and does not open any editor.

## Preset import

- File picker now uses `allowMultiple: true`; each JSON is parsed and added individually, so a malformed file no longer cancels the whole import.
- One file keeps the previous `Imported "<name>" (N blocks)` toast; several files report `Imported N presets`.

## Shared behaviour

- The error dialog is only shown when nothing at all could be imported; a partial success appends the failure count to the success toast instead.
- Added `count_lorebooks` (with Russian plural forms) and `import_failed_count` to `assets/translations/en.json` and `ru.json`.

## Verification

- `flutter analyze` / `flutter test` were **not** run — the agent container for this session has no Dart/Flutter SDK (`Z:\GlazeProject\flutter` is not reachable from it), so CI on this PR is the first analyzer/test run.
- Translation files validated with a JSON parser; en/ru key sets confirmed identical (1900 keys each).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KBtnZnvp5BJ9zcFjpu9tdv)_