### PR TITLE
fix(chat): equalize row height for Quick Access / Quick Replies cards

### DIFF
--- a/lib/features/chat/widgets/magic_drawer.dart
+++ b/lib/features/chat/widgets/magic_drawer.dart
@@ -825,10 +825,9 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
                 12,
                 16 + MediaQuery.of(context).padding.bottom,
               ),
-              child: Wrap(
-                spacing: 6,
-                runSpacing: 8,
-                children: List.generate(items.length, (index) {
+              child: MagicCardGrid(
+                columns: 3,
+                cells: List.generate(items.length, (index) {
                   final item = items[index];
                   final card = MagicCard(
                     item: item,

--- a/lib/features/chat/widgets/magic_drawer_widgets.dart
+++ b/lib/features/chat/widgets/magic_drawer_widgets.dart
@@ -336,6 +336,50 @@ class MagicDrawerAddList extends StatelessWidget {
   }
 }
 
+/// Lays out fixed-width cells left-to-right in rows of [columns], like
+/// [Wrap], but stretches every cell in a row to match the tallest cell in
+/// that row so cards with a status line and cards without one stay level.
+class MagicCardGrid extends StatelessWidget {
+  final List<Widget> cells;
+  final int columns;
+  final double spacing;
+  final double runSpacing;
+
+  const MagicCardGrid({
+    super.key,
+    required this.cells,
+    required this.columns,
+    this.spacing = 6,
+    this.runSpacing = 8,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = <Widget>[];
+    for (var i = 0; i < cells.length; i += columns) {
+      final rowCells = cells.skip(i).take(columns).toList();
+      if (rows.isNotEmpty) rows.add(SizedBox(height: runSpacing));
+      rows.add(
+        IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (var j = 0; j < rowCells.length; j++) ...[
+                if (j > 0) SizedBox(width: spacing),
+                rowCells[j],
+              ],
+            ],
+          ),
+        ),
+      );
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: rows,
+    );
+  }
+}
+
 class AddMagicCard extends StatelessWidget {
   final VoidCallback onTap;
 

--- a/lib/features/chat/widgets/quick_replies_panel.dart
+++ b/lib/features/chat/widgets/quick_replies_panel.dart
@@ -243,10 +243,9 @@ class _QuickRepliesPanelState extends ConsumerState<QuickRepliesPanel> {
                 12,
                 16 + MediaQuery.of(context).padding.bottom,
               ),
-              child: Wrap(
-                spacing: 6,
-                runSpacing: 8,
-                children: List.generate(cards.length, (index) {
+              child: MagicCardGrid(
+                columns: 3,
+                cells: List.generate(cards.length, (index) {
                   final item = cards[index];
                   if (item.isAddButton) {
                     return SizedBox(


### PR DESCRIPTION
## Summary
- Cards in the Quick Access drawer and Quick Replies panel used `Wrap`, so each card sized itself by its own intrinsic height — a card with a status line (e.g. "3 sessions") ended up taller than a card without one in the same row.
- Added `MagicCardGrid` (`lib/features/chat/widgets/magic_drawer_widgets.dart`), which groups cells into fixed-column rows and stretches every cell in a row to the tallest one's height.
- Swapped `Wrap` for `MagicCardGrid` in both `magic_drawer.dart` and `quick_replies_panel.dart`, keeping the existing drag-and-drop reordering, spacing, and column width behavior unchanged.

## Test plan
- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] Manually open the Quick Access drawer and Quick Replies panel and confirm cards in the same row now share equal height, with and without status lines, in both normal and edit/drag modes


---
_Generated by [Claude Code](https://claude.ai/code/session_01TXMDTjPaFM3pN4sqDQ6zHt)_