### PR TITLE
fix(chat): optimistic message delete and typing-bubble placement

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -699,7 +699,14 @@ export class Bridge {
     const el = document.querySelector(`[data-message-id="${messageId}"]`);
     if (el && this.renderer) {
       this.renderer.animateRemoveSection(el, () => {
-        this.virtualList.remove(messageId);
+        // The exit animation runs for ~340ms and the id can be re-registered
+        // in the meantime — the streaming placeholder reuses one constant id,
+        // and `append` already evicted the node we animated out. Dropping the
+        // id here regardless would delete the *new* bubble.
+        const item = this.virtualList.itemMap?.get(messageId);
+        if (!item || item.el === el) {
+          this.virtualList.remove(messageId);
+        }
         this._pruneOrphanSeparators();
       });
     } else {

--- a/assets/chat_webview/useVirtualScroll.js
+++ b/assets/chat_webview/useVirtualScroll.js
@@ -291,8 +291,13 @@ class UseVirtualScroll {
 
     append(id, el) {
         if (this.itemMap.has(id)) {
-            this.update(id, el);
-            return;
+            // An append must land at the tail even when the id is already
+            // known. The streaming placeholder reuses one constant id and the
+            // bridge defers its removal behind a ~340ms exit animation, so a
+            // message sent inside that window used to re-render the
+            // placeholder in place — at the slot it held *before* the user
+            // message that had just been appended. Evict first, then append.
+            this.remove(id);
         }
         const idx = this.items.length;
         el.dataset.index = idx;

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -348,7 +348,11 @@ when newer rows are deleted.
 
 Code refs: `lib/core/db/repositories/tracker_snapshot_repo.dart`,
 `lib/core/llm/studio_ledger_service.dart`,
-`lib/features/chat/chat_message_service.dart:deleteMessage` → `deleteForMessage`.
+`lib/features/chat/chat_message_service.dart:commitDeleteMessages` →
+`deleteForMessages`. The UI publishes the shortened message list before this
+commit runs (`ChatMessageOpsController.deleteMessages` is optimistic), so the
+snapshot rollback is *not* observable state — it lands with the transaction,
+and a failed commit restores the pre-delete session in the UI.
 
 ### INV-TS2: Sentinel anchor survives per-message deletes ✅ ENFORCED (Phase 7)
 

--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -95,14 +95,36 @@ class ChatMessageService {
   }
 
   /// Deletes multiple messages with one session write and one cleanup pass.
+  ///
+  /// Convenience wrapper over [planDeleteMessages] + [commitDeleteMessages] for
+  /// callers that do not need to paint the removal before the writes land. The
+  /// chat UI uses the two halves directly so the bubbles disappear on the frame
+  /// of the tap (see `ChatMessageOpsController.deleteMessages`).
   Future<ChatSession> deleteMessages(
     ChatSession session,
     Set<int> indices,
   ) async {
+    final plan = planDeleteMessages(session, indices);
+    if (plan == null) return session;
+    return commitDeleteMessages(session, plan);
+  }
+
+  /// Synchronous half of a message deletion: the session as it will look once
+  /// the delete lands, plus everything [commitDeleteMessages] needs to clean up
+  /// the dependent tables. Returns null when [indices] selects nothing, so a
+  /// caller can bail out before touching any state.
+  ///
+  /// Split out of [deleteMessages] so the UI can publish the shortened message
+  /// list immediately — the commit below runs a multi-table transaction whose
+  /// latency is visible as a stuck Delete button on long chats.
+  MessageDeletionPlan? planDeleteMessages(
+    ChatSession session,
+    Set<int> indices,
+  ) {
     final validIndices = indices
         .where((index) => index >= 0 && index < session.messages.length)
         .toSet();
-    if (validIndices.isEmpty) return session;
+    if (validIndices.isEmpty) return null;
 
     final earliestDeletedIndex = validIndices.reduce((a, b) => a < b ? a : b);
     final invalidatedMessageIds = session.messages
@@ -115,14 +137,6 @@ class ChatMessageService {
         if (!validIndices.contains(i)) session.messages[i],
     ];
 
-    final snapshotRepo = _ref.read(trackerSnapshotRepoProvider);
-    final trackerRepo = _ref.read(trackerRepoProvider);
-    final memoryBookRepo = _ref.read(memoryBookRepoProvider);
-    final knowledgeRepo = _ref.read(characterKnowledgeFactRepoProvider);
-    final checkpointRepo = _ref.read(
-      ledgerReconciliationCheckpointRepoProvider,
-    );
-    final chatRepo = _ref.read(chatRepoProvider);
     // Track the running count of deleted messages so the chat statistics can
     // report it after the messages themselves are gone. Every per-message
     // delete path (single + bulk, native menu, selection mode) funnels through
@@ -131,17 +145,45 @@ class ChatMessageService {
     final updatedVars = Map<String, String>.from(session.sessionVars)
       ..[ChatSessionX.deletedMessagesVarKey] =
           (session.deletedMessageCount + validIndices.length).toString();
-    final updated = session.copyWith(
-      messages: newMessages,
-      sessionVars: updatedVars,
-      updatedAt: currentTimestampSeconds(),
+
+    return MessageDeletionPlan(
+      session: session.copyWith(
+        messages: newMessages,
+        sessionVars: updatedVars,
+        updatedAt: currentTimestampSeconds(),
+      ),
+      deletedIndices: validIndices,
+      earliestDeletedIndex: earliestDeletedIndex,
+      invalidatedMessageIds: invalidatedMessageIds,
     );
+  }
+
+  /// Persists [plan] and rolls back everything anchored at or after the
+  /// earliest deleted message. [session] is the *pre-delete* session — the
+  /// snapshot search walks its surviving prefix to pick a rollback base.
+  ///
+  /// Throws whatever the transaction throws; the caller owns the decision to
+  /// restore [session] in the UI.
+  Future<ChatSession> commitDeleteMessages(
+    ChatSession session,
+    MessageDeletionPlan plan,
+  ) async {
+    final snapshotRepo = _ref.read(trackerSnapshotRepoProvider);
+    final trackerRepo = _ref.read(trackerRepoProvider);
+    final memoryBookRepo = _ref.read(memoryBookRepoProvider);
+    final knowledgeRepo = _ref.read(characterKnowledgeFactRepoProvider);
+    final checkpointRepo = _ref.read(
+      ledgerReconciliationCheckpointRepoProvider,
+    );
+    final chatRepo = _ref.read(chatRepoProvider);
+    final updated = plan.session;
+    final invalidatedMessageIds = plan.invalidatedMessageIds;
 
     // Select the rollback base by chat order. Snapshot timestamps have
     // second-level precision and cannot reliably order adjacent turns.
     TrackerSnapshot? fallbackSnapshot;
     for (final message
-        in session.messages.take(earliestDeletedIndex).toList().reversed) {
+        in session.messages.take(plan.earliestDeletedIndex).toList().reversed) {
       final candidate = await snapshotRepo.getByAnchor(
         sessionId: session.id,
         messageId: message.id,
@@ -892,6 +934,37 @@ class ChatMessageService {
     ChatSessionService.updateCache(updated);
     return updated;
   }
+}
+
+/// Everything a message deletion needs, computed synchronously by
+/// [ChatMessageService.planDeleteMessages] and consumed by
+/// [ChatMessageService.commitDeleteMessages].
+///
+/// Splitting the plan from the commit lets the chat publish [session] (and its
+/// bumped deleted-message counter) before the DB work starts, so the bubbles
+/// leave the list on the frame of the tap instead of after the transaction.
+class MessageDeletionPlan {
+  /// The session as it looks once the deletion lands: messages removed,
+  /// `deletedMessages` session var bumped, `updatedAt` restamped.
+  final ChatSession session;
+
+  /// Indices that were actually in range — the ones this plan deletes.
+  final Set<int> deletedIndices;
+
+  /// Lowest index in [deletedIndices]. Everything from here on is invalidated.
+  final int earliestDeletedIndex;
+
+  /// Ids of every message at or after [earliestDeletedIndex] in the *original*
+  /// session, including the deleted ones. Snapshots, memory entries, knowledge
+  /// facts and ext blocks anchored to these ids no longer describe the chat.
+  final Set<String> invalidatedMessageIds;
+
+  const MessageDeletionPlan({
+    required this.session,
+    required this.deletedIndices,
+    required this.earliestDeletedIndex,
+    required this.invalidatedMessageIds,
+  });
 }
 
 /// Result of [ChatMessageService.changeSwipe].

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -1811,11 +1811,19 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                         if (mounted) setState(() {});
                                       },
                                       onDeleteSelected: () async {
-                                        await _selectionCtrl.deleteSelected(
-                                          ref,
-                                          widget.charId,
-                                          widget.state.messages,
-                                        );
+                                        // deleteSelected drops the selection
+                                        // synchronously; rebuild before
+                                        // awaiting so the toolbar closes with
+                                        // the messages instead of after the
+                                        // DB cleanup finishes.
+                                        final pending = _selectionCtrl
+                                            .deleteSelected(
+                                              ref,
+                                              widget.charId,
+                                              widget.state.messages,
+                                            );
+                                        if (mounted) setState(() {});
+                                        await pending;
                                         if (mounted) setState(() {});
                                       },
                                       isDrawerOpen:

--- a/lib/features/chat/controllers/chat_message_ops_controller.dart
+++ b/lib/features/chat/controllers/chat_message_ops_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/chat_message.dart';
@@ -10,6 +11,7 @@ import '../state/token_breakdown_cache.dart';
 import '../state/cached_token_breakdown.dart';
 import '../../../core/llm/regex_service.dart';
 import '../../../core/state/active_selection_provider.dart';
+import '../../../shared/widgets/glaze_toast.dart';
 import '../../personas/persona_list_provider.dart';
 
 class ChatMessageOpsController {
@@ -28,6 +30,13 @@ class ChatMessageOpsController {
   });
 
   ChatMessageService get _messageSvc => ChatMessageService(_ref);
+
+  /// Tail of the in-flight delete commits. Publishing the shortened list before
+  /// the write makes it easy to fire a second delete while the first is still
+  /// in its transaction; unserialized, the two session writes interleave and
+  /// whichever lands last wins — which can put back messages the later delete
+  /// already took off screen. Chaining keeps the DB in UI order.
+  Future<void> _deleteCommits = Future<void>.value();
 
   Future<void> editMessage(
     int index,
@@ -122,11 +131,50 @@ class ChatMessageOpsController {
   Future<void> deleteMessages(Set<int> indices) async {
     if (!_ref.mounted) return;
     final current = _getState().value;
-    if (current == null || current.session == null) return;
-    final updated = await _messageSvc.deleteMessages(current.session!, indices);
+    final original = current?.session;
+    if (current == null || original == null) return;
+
+    final svc = _messageSvc;
+    final plan = svc.planDeleteMessages(original, indices);
+    if (plan == null) return;
+
+    // Optimistic: drop the bubbles on the frame of the tap. The commit below
+    // runs a multi-table transaction (knowledge rollback, memory, snapshots,
+    // ledger, embedding index) plus a full session re-encode, which is long
+    // enough on a big chat to read as an unresponsive Delete button.
+    ChatSessionService.updateCache(plan.session);
+    _setState(AsyncData(current.copyWith(session: plan.session)));
+    _invalidateHistory();
+
+    final commit = _deleteCommits.then(
+      (_) => svc.commitDeleteMessages(original, plan),
+    );
+    // Keep the chain usable after a failed commit.
+    _deleteCommits = commit.then<void>((_) {}, onError: (Object _) {});
+
+    try {
+      await commit;
+    } catch (e) {
+      debugPrint('[ChatMessageOps] delete failed, restoring messages: $e');
+      if (!_ref.mounted) return;
+      final after = _getState().value;
+      // Only undo the optimistic write when nothing else has touched the
+      // session since — a newer edit/generation owns the state by then, and
+      // restoring the pre-delete session would resurrect more than the failure.
+      if (after != null && identical(after.session, plan.session)) {
+        ChatSessionService.updateCache(original);
+        _setState(AsyncData(after.copyWith(session: original)));
+        _invalidateHistory();
+      }
+      GlazeToast.showWithoutContext(
+        'Failed to delete message: $e',
+        isError: true,
+        duration: 5000,
+      );
+      return;
+    }
     if (!_ref.mounted) return;
     _invalidateHistory();
-    _setState(AsyncData(current.copyWith(session: updated)));
   }
 
   Future<void> toggleMessageHidden(int index) async {

--- a/lib/features/chat/controllers/chat_message_selection_controller.dart
+++ b/lib/features/chat/controllers/chat_message_selection_controller.dart
@@ -39,18 +39,24 @@ class ChatMessageSelectionController {
     clearSelection();
   }
 
+  /// Deletes every selected message and leaves selection mode.
+  ///
+  /// Deliberately not `async`: the indices are resolved and the selection is
+  /// dropped synchronously, so a caller that rebuilds before awaiting the
+  /// returned future sees the toolbar gone on the frame of the tap. The delete
+  /// itself is optimistic (see `ChatMessageOpsController.deleteMessages`) — a
+  /// toolbar that outlived the bubbles would be the only thing still lagging.
   Future<void> deleteSelected(
     WidgetRef ref,
     String charId,
     List<ChatMessage> messages,
-  ) async {
+  ) {
     final indices = selectedMessageIds
         .map((id) => messages.indexWhere((m) => m.id == id))
         .where((idx) => idx >= 0)
         .toSet();
-    if (indices.isNotEmpty) {
-      await ref.read(chatProvider(charId).notifier).deleteMessages(indices);
-    }
     clearSelection();
+    if (indices.isEmpty) return Future<void>.value();
+    return ref.read(chatProvider(charId).notifier).deleteMessages(indices);
   }
 }

--- a/lib/features/chat/widgets/chat_message_sync.dart
+++ b/lib/features/chat/widgets/chat_message_sync.dart
@@ -14,8 +14,9 @@ import '../bridge/chat_bridge_controller.dart';
 ///   * Cleared (new empty) → `clearAll`.
 ///   * Head prepend → `prependMessages` for the prefix.
 ///   * Tail append → `appendMessages`.
-///   * Head truncation → `removeMessage` per removed id.
-///   * Tail truncation → `removeMessage` for trimmed ids.
+///   * Any pure removal — head truncation, tail truncation, mid-chat
+///     delete, scattered bulk delete → `removeMessage` per removed id.
+///   * Shorter with a reorder → `clearAll` + `setMessages`.
 ///   * Same length with at least one swap → `clearAll` + `setMessages`.
 ///   * Same length, per-index change → `updateMessage` if the
 ///     content / swipe / hidden / typing / error / guidance / greeting
@@ -89,19 +90,17 @@ class ChatMessageSync {
     }
 
     if (newIds.length < oldIds.length) {
-      final newFirstId = newIds.first;
-      final oldIdx = oldIds.indexOf(newFirstId);
-      if (oldIdx > 0) {
-        for (int i = 0; i < oldIdx; i++) {
-          await bridge.removeMessage(oldIds[i]);
-        }
-        return;
-      }
-      final newLastId = newIds.last;
-      final oldLastIdx = oldIds.indexOf(newLastId);
-      if (oldLastIdx >= 0 && newIds.length == oldLastIdx + 1) {
-        for (int i = oldIds.length - 1; i > oldLastIdx; i--) {
-          await bridge.removeMessage(oldIds[i]);
+      // Every shrink that keeps the surviving ids in order — a head trim from
+      // scrollback windowing, a tail trim from a branch/abort, a delete from
+      // the middle, a bulk delete of scattered messages — is a plain list of
+      // removals. Emitting them one by one keeps the WebView's exit animation
+      // and its scroll position; the `clearAll` + `setMessages` fallback below
+      // flashes the loading screen and re-renders the whole window instead,
+      // which is what made a delete land late and with a visible stall.
+      final removed = _removedIdsIfSubsequence(oldIds, newIds);
+      if (removed != null) {
+        for (final id in removed) {
+          await bridge.removeMessage(id);
         }
         if (!isGenerating) {
           await bridge.setLastMessage(
@@ -193,6 +192,31 @@ class ChatMessageSync {
       );
     }
   }
+}
+
+/// Returns the ids present in [oldIds] but not in [newIds] when [newIds] is a
+/// subsequence of [oldIds] — i.e. the diff is a pure removal with no reorder,
+/// no insert and no id reuse. Returns null otherwise, so the caller falls back
+/// to a full re-render.
+///
+/// Both lists are id lists in chat order. Runs a single linear walk: every
+/// `newIds` entry must be matched, in order, against the remaining `oldIds`.
+List<String>? _removedIdsIfSubsequence(
+  List<String> oldIds,
+  List<String> newIds,
+) {
+  final removed = <String>[];
+  var newIdx = 0;
+  for (final oldId in oldIds) {
+    if (newIdx < newIds.length && newIds[newIdx] == oldId) {
+      newIdx++;
+    } else {
+      removed.add(oldId);
+    }
+  }
+  // Some new id never matched → the lists diverge by more than deletions.
+  if (newIdx != newIds.length) return null;
+  return removed;
 }
 
 /// Appends the virtual streaming message only after persisted message changes

--- a/test/chat_delete_plan_test.dart
+++ b/test/chat_delete_plan_test.dart
@@ -1,0 +1,103 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:glaze_flutter/features/chat/chat_message_service.dart';
+
+final _messageServiceProvider = Provider(ChatMessageService.new);
+
+ChatSession _session(int messageCount) => ChatSession(
+  id: 's1',
+  characterId: 'c1',
+  sessionIndex: 0,
+  messages: [
+    for (var i = 0; i < messageCount; i++)
+      ChatMessage(
+        id: 'm$i',
+        role: i.isEven ? 'user' : 'assistant',
+        content: 'message $i',
+      ),
+  ],
+);
+
+void main() {
+  test('planDeleteMessages shortens the session without a write', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+
+    final session = _session(5);
+    await container.read(chatRepoProvider).put(session);
+
+    final plan = container
+        .read(_messageServiceProvider)
+        .planDeleteMessages(session, {1, 3});
+
+    expect(plan, isNotNull);
+    expect(plan!.session.messages.map((m) => m.id), ['m0', 'm2', 'm4']);
+    expect(plan.session.deletedMessageCount, 2);
+    expect(plan.deletedIndices, unorderedEquals([1, 3]));
+    expect(plan.earliestDeletedIndex, 1);
+    // Everything from the earliest deletion on is causally invalidated.
+    expect(
+      plan.invalidatedMessageIds,
+      unorderedEquals(['m1', 'm2', 'm3', 'm4']),
+    );
+
+    // Planning is pure: the row on disk is untouched until the commit runs.
+    final persisted = await container.read(chatRepoProvider).getById('s1');
+    expect(persisted?.messages.map((m) => m.id), [
+      'm0',
+      'm1',
+      'm2',
+      'm3',
+      'm4',
+    ]);
+  });
+
+  test('planDeleteMessages returns null when nothing is in range', () {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+
+    final service = container.read(_messageServiceProvider);
+    expect(service.planDeleteMessages(_session(3), const <int>{}), isNull);
+    expect(service.planDeleteMessages(_session(3), const {7, -1}), isNull);
+  });
+
+  test('commitDeleteMessages persists exactly the planned session', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+
+    final session = _session(5);
+    await container.read(chatRepoProvider).put(session);
+
+    final service = container.read(_messageServiceProvider);
+    final plan = service.planDeleteMessages(session, {1, 3})!;
+    final committed = await service.commitDeleteMessages(session, plan);
+
+    expect(identical(committed, plan.session), isTrue);
+    final persisted = await container.read(chatRepoProvider).getById('s1');
+    expect(persisted?.messages.map((m) => m.id), ['m0', 'm2', 'm4']);
+    expect(persisted?.deletedMessageCount, 2);
+  });
+}

--- a/test/chat_message_sync_removal_test.dart
+++ b/test/chat_message_sync_removal_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/features/chat/bridge/chat_bridge_controller.dart';
+import 'package:glaze_flutter/features/chat/widgets/chat_message_sync.dart';
+
+void main() {
+  group('ChatMessageSync removals', () {
+    test('mid-chat delete removes only the deleted id', () async {
+      final bridge = _RecordingBridge();
+      final a = _msg('a1', 'assistant');
+      final u = _msg('u1', 'user');
+      final b = _msg('a2', 'assistant');
+
+      await const ChatMessageSync().sync(
+        bridge: bridge,
+        oldMsgs: [a, u, b],
+        newMsgs: [a, b],
+        visibleStartIndex: 0,
+        isGenerating: false,
+        sessionSwitching: false,
+      );
+
+      expect(bridge.removedIds, ['u1']);
+      expect(bridge.clearAllCalls, 0);
+      expect(bridge.setMessagesCalls, isEmpty);
+    });
+
+    test('bulk delete of non-adjacent messages removes each id', () async {
+      final bridge = _RecordingBridge();
+      final msgs = [
+        for (var i = 0; i < 6; i++)
+          _msg('m$i', i.isEven ? 'user' : 'assistant'),
+      ];
+
+      await const ChatMessageSync().sync(
+        bridge: bridge,
+        oldMsgs: msgs,
+        newMsgs: [msgs[0], msgs[3], msgs[5]],
+        visibleStartIndex: 0,
+        isGenerating: false,
+        sessionSwitching: false,
+      );
+
+      expect(bridge.removedIds, ['m1', 'm2', 'm4']);
+      expect(bridge.clearAllCalls, 0);
+    });
+
+    test('head truncation still removes the dropped prefix', () async {
+      final bridge = _RecordingBridge();
+      final msgs = [for (var i = 0; i < 4; i++) _msg('m$i', 'user')];
+
+      await const ChatMessageSync().sync(
+        bridge: bridge,
+        oldMsgs: msgs,
+        newMsgs: msgs.sublist(2),
+        visibleStartIndex: 2,
+        isGenerating: false,
+        sessionSwitching: false,
+      );
+
+      expect(bridge.removedIds, ['m0', 'm1']);
+      expect(bridge.clearAllCalls, 0);
+    });
+
+    test('head trim and a mid-chat delete in one diff remove both', () async {
+      final bridge = _RecordingBridge();
+      final msgs = [for (var i = 0; i < 6; i++) _msg('m$i', 'user')];
+
+      // The scrollback window moved forward (m0 left the window) while m3 was
+      // deleted. Handling only the prefix would leave m3 stuck in the DOM.
+      await const ChatMessageSync().sync(
+        bridge: bridge,
+        oldMsgs: msgs,
+        newMsgs: [msgs[1], msgs[2], msgs[4], msgs[5]],
+        visibleStartIndex: 1,
+        isGenerating: false,
+        sessionSwitching: false,
+      );
+
+      expect(bridge.removedIds, ['m0', 'm3']);
+      expect(bridge.clearAllCalls, 0);
+    });
+
+    test('a reorder still falls back to a full re-render', () async {
+      final bridge = _RecordingBridge();
+      final a1 = _msg('a1', 'assistant');
+      final u1 = _msg('u1', 'user');
+      final a2 = _msg('a2', 'assistant');
+      final u2 = _msg('u2', 'user');
+
+      // Shorter *and* reordered: not a pure removal, so the ids the WebView
+      // holds cannot be reconciled one by one.
+      await const ChatMessageSync().sync(
+        bridge: bridge,
+        oldMsgs: [a1, u1, a2, u2],
+        newMsgs: [a1, a2, u1],
+        visibleStartIndex: 0,
+        isGenerating: false,
+        sessionSwitching: false,
+      );
+
+      expect(bridge.removedIds, isEmpty);
+      expect(bridge.clearAllCalls, 1);
+      expect(bridge.setMessagesCalls, [
+        ['a1', 'a2', 'u1'],
+      ]);
+    });
+
+    test('an unrelated shorter list falls back to a full re-render', () async {
+      final bridge = _RecordingBridge();
+
+      await const ChatMessageSync().sync(
+        bridge: bridge,
+        oldMsgs: [_msg('a1', 'assistant'), _msg('u1', 'user')],
+        newMsgs: [_msg('x9', 'assistant')],
+        visibleStartIndex: 0,
+        isGenerating: false,
+        sessionSwitching: false,
+      );
+
+      expect(bridge.removedIds, isEmpty);
+      expect(bridge.clearAllCalls, 1);
+    });
+  });
+}
+
+ChatMessage _msg(String id, String role) =>
+    ChatMessage(id: id, role: role, content: role, timestamp: 1);
+
+class _RecordingBridge implements ChatBridgeController {
+  final List<String> removedIds = [];
+  final List<List<String>> setMessagesCalls = [];
+  final List<String?> lastMessageIds = [];
+  int clearAllCalls = 0;
+
+  @override
+  Future<void> removeMessage(String messageId) async {
+    removedIds.add(messageId);
+  }
+
+  @override
+  Future<void> clearAll() async {
+    clearAllCalls++;
+  }
+
+  @override
+  Future<void> setMessages(
+    List<ChatMessage> messages, {
+    int visibleStartIndex = 0,
+    bool preserveScroll = false,
+  }) async {
+    setMessagesCalls.add(messages.map((m) => m.id).toList());
+  }
+
+  @override
+  Future<void> setLastMessage(String? messageId) async {
+    lastMessageIds.add(messageId);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}


### PR DESCRIPTION
Two reported chat issues: deleting a message did not remove it right away, and the "generating" bubble sometimes rendered *above* the user message it was replying to.

## Optimistic delete

- Split `ChatMessageService.deleteMessages` into a synchronous `planDeleteMessages` (shortened session, invalidated message ids, bumped deleted-message counter) and an async `commitDeleteMessages` (snapshot rollback base, knowledge/memory/checkpoint cleanup, session write, embedding index drop). `deleteMessages` stays as a thin wrapper over both, so existing callers and tests are unchanged.
- `ChatMessageOpsController.deleteMessages` publishes the planned session and refreshes the `ChatSessionService` cache *before* the commit runs. Previously it awaited the whole multi-table transaction plus a full session re-encode before touching state, which is what made the Delete button look stuck on long chats.
- A failed commit restores the pre-delete session and toasts the error — but only when nothing else has touched the session since (`identical(after.session, plan.session)`), so a newer edit or generation is never clobbered by a rollback.
- Delete commits are chained per controller (`_deleteCommits`). Publishing state before the write makes it easy to fire a second delete while the first is still in its transaction; unserialized, the two session writes interleave and whichever lands last wins, which could put back messages the later delete already took off screen.
- `ChatMessageSelectionController.deleteSelected` is no longer `async`: it resolves the indices and leaves selection mode synchronously, and `_ChatBody`'s `onDeleteSelected` rebuilds before awaiting, so the selection toolbar closes with the messages instead of after the DB cleanup.

## Faster WebView delete diff

- `ChatMessageSync` now treats **any** shrink whose surviving ids stay in order as a plain list of removals — head trim from scrollback windowing, tail trim from a branch/abort, a delete from the middle, a scattered bulk delete — and emits one `removeMessage` per removed id.
- Previously only pure head/tail truncations were special-cased; a mid-chat delete fell through to `clearAll` + `setMessages`, and `Bridge.clearAll` shows the loading screen and re-renders the whole window. That re-render was a large part of the perceived delete latency.
- The old head-truncation branch also returned early after removing the prefix, so a diff that both shifted the scrollback window *and* deleted a message left the deleted message stuck in the DOM. The general branch fixes that.

## Typing placeholder ordering

- `Bridge.removeMessage` defers `virtualList.remove` into `animateRemoveSection`'s callback, i.e. ~340 ms after the call. The streaming placeholder reuses one constant id (`__streaming__`), so during that window the id was still registered. Sending a message inside it made `UseVirtualScroll.append` fall back to an in-place `update()`, re-rendering the placeholder at the slot it held *before* the user message that had just been appended — the reported "generating above the user message".
- `UseVirtualScroll.append` now evicts an existing entry with the same id before appending, so an append always lands at the tail.
- `Bridge.removeMessage`'s animation callback only drops the id when the virtual list still holds the node it animated out (`item.el === el`), so a re-added placeholder is not deleted by the previous generation's pending removal.

## Verification

- Added `test/chat_delete_plan_test.dart` — planning is pure (the row on disk is untouched), the commit persists exactly the planned session, and out-of-range/empty index sets plan nothing.
- Added `test/chat_message_sync_removal_test.dart` — mid-chat delete, scattered bulk delete, head trim, head trim combined with a mid-chat delete, plus the reorder and unrelated-list cases that must still fall back to `clearAll` + `setMessages`.
- Replayed the placeholder-reuse sequence against the real `UseVirtualScroll` with a DOM stub under Node. Before the fix the resulting order is `a1, __streaming__, a2, u1`; after it is `a1, a2, u1, __streaming__`.
- Both changed JS modules were parsed by Node to confirm they still load.
- **`flutter analyze` and `flutter test` were NOT run** — the agent environment has no Flutter SDK. This PR's CI run is the first execution of these changes.
- Not verified at runtime: the actual feel of the delete and the bubble order under a fast send need a manual `flutter run` (hot **restart** required, `assets/chat_webview/` changed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ln3a8kG3rx2fmSJ38KjQZ4)_