### PR TITLE
ci: post builds to a group topic with per-platform toggles

### DIFF
--- a/.github/scripts/telegram_post.sh
+++ b/.github/scripts/telegram_post.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Posts one build announcement plus its artifacts to a single Telegram chat.
+#
+# Used by both build workflows for the public group post and for the developer
+# DMs, so the topic handling, the upload size limit and the API error reporting
+# live in one place.
+#
+# Usage: telegram_post.sh <chat_id> [topic_id]
+#
+#   chat_id   numeric id or @username of the target chat.
+#   topic_id  message thread id of a forum topic. Optional: a plain (non-forum)
+#             chat rejects the field, so it is only sent when non-empty.
+#
+# Environment:
+#   TG_BOT_TOKEN  bot token (required)
+#   TEXT          announcement text, HTML parse mode (required)
+#   FILES_DIR     directory whose files are uploaded as replies (default: artifacts)
+#   PIN           "true" to pin the announcement (default: false)
+#   RUN_URL       workflow run URL, referenced when a file is too large to upload
+#
+# Exits non-zero when the Telegram API rejects a call. A file that exceeds the
+# Bot API upload limit is not an API failure: it is announced in the chat as a
+# reply pointing at the workflow run, and the script keeps going.
+set -euo pipefail
+
+CHAT_ID="${1:?chat id required}"
+TOPIC_ID="${2:-}"
+
+: "${TG_BOT_TOKEN:?TG_BOT_TOKEN is required}"
+: "${TEXT:?TEXT is required}"
+FILES_DIR="${FILES_DIR:-artifacts}"
+PIN="${PIN:-false}"
+RUN_URL="${RUN_URL:-}"
+
+API="https://api.telegram.org/bot${TG_BOT_TOKEN}"
+# The Bot API caps a sendDocument upload at 50 MB.
+MAX_BYTES=$((50 * 1024 * 1024))
+
+FAILED=0
+
+html_escape() {
+  printf '%s' "$1" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
+}
+
+# Base payload every call shares: the chat and, in a forum, the topic to post in.
+target_json() {
+  jq -n --arg cid "$CHAT_ID" --arg tid "$TOPIC_ID" \
+    '{chat_id: $cid}
+     + (if $tid == "" then {} else {message_thread_id: ($tid | tonumber)} end)'
+}
+
+api_failed() { # $1 = method, $2 = response body
+  echo "::warning::$1 to chat $CHAT_ID failed: $(jq -r '.description // "unknown error"' <<<"$2")"
+}
+
+# $1 = HTML text, $2 = optional message id to reply to. Prints the new message id.
+send_message() {
+  local payload response
+  payload=$(target_json | jq --arg text "$1" --arg reply "${2:-}" \
+    '. + {text: $text, parse_mode: "HTML"}
+       + (if $reply == "" then {} else {reply_to_message_id: ($reply | tonumber)} end)')
+
+  response=$(curl -sS -X POST "$API/sendMessage" \
+    -H 'Content-Type: application/json' -d "$payload")
+
+  if [ "$(jq -r '.ok' <<<"$response")" != "true" ]; then
+    api_failed sendMessage "$response"
+    return 1
+  fi
+  jq -r '.result.message_id' <<<"$response"
+}
+
+# ── announcement ───────────────────────────────────────────────────────────────
+if ! MSG_ID=$(send_message "$TEXT"); then
+  echo "::error::Could not post the build announcement to chat $CHAT_ID."
+  exit 1
+fi
+echo "Announcement posted to chat $CHAT_ID${TOPIC_ID:+ (topic $TOPIC_ID)} as message $MSG_ID."
+
+# A pin needs can_pin_messages, which the bot only has in a group it administers.
+# Losing the pin must not fail the build, so this one is a warning.
+if [ "$PIN" = "true" ]; then
+  PIN_RESPONSE=$(curl -sS -X POST "$API/pinChatMessage" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -n --arg cid "$CHAT_ID" --arg mid "$MSG_ID" \
+      '{chat_id: $cid, message_id: ($mid | tonumber), disable_notification: true}')")
+  if [ "$(jq -r '.ok' <<<"$PIN_RESPONSE")" != "true" ]; then
+    api_failed pinChatMessage "$PIN_RESPONSE"
+  fi
+fi
+
+# ── artifacts ──────────────────────────────────────────────────────────────────
+shopt -s nullglob
+FILES=("$FILES_DIR"/*)
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "::warning::No files found in $FILES_DIR — only the announcement was posted."
+fi
+
+for FILE in "${FILES[@]}"; do
+  [ -f "$FILE" ] || continue
+  NAME=$(basename "$FILE")
+  SIZE=$(stat -c%s "$FILE")
+
+  if [ "$SIZE" -gt "$MAX_BYTES" ]; then
+    MB=$((SIZE / 1024 / 1024))
+    echo "::warning::$NAME is ${MB} MB, over the 50 MB Telegram upload limit — posting a link instead."
+    NOTE="⚠️ $(html_escape "$NAME") — ${MB} МБ, больше лимита Telegram (50 МБ)."
+    if [ -n "$RUN_URL" ]; then
+      NOTE="$NOTE"$'\n'"Скачать: $(html_escape "$RUN_URL")"
+    fi
+    send_message "$NOTE" "$MSG_ID" >/dev/null || FAILED=1
+    continue
+  fi
+
+  ARGS=(-F "chat_id=$CHAT_ID" -F "reply_to_message_id=$MSG_ID" -F "document=@$FILE")
+  [ -n "$TOPIC_ID" ] && ARGS+=(-F "message_thread_id=$TOPIC_ID")
+
+  RESPONSE=$(curl -sS -X POST "$API/sendDocument" "${ARGS[@]}")
+  if [ "$(jq -r '.ok' <<<"$RESPONSE")" != "true" ]; then
+    api_failed sendDocument "$RESPONSE"
+    FAILED=1
+  else
+    echo "Uploaded $NAME ($((SIZE / 1024 / 1024)) MB)."
+  fi
+done
+
+exit "$FAILED"

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       # Platform selection. Each toggle gates both the build job and the upload,
       # so an unchecked platform costs no runner time and simply does not appear
-      # in the Telegram post. Unchecking all three leaves nothing to post.
+      # in the Telegram post. Unchecking every platform leaves nothing to post.
       build_android:
         description: 'Android (APK)'
         required: false
@@ -22,6 +22,11 @@ on:
         type: boolean
       build_ios:
         description: 'iOS (IPA)'
+        required: false
+        default: true
+        type: boolean
+      build_linux:
+        description: 'Linux (DEB + pacman)'
         required: false
         default: true
         type: boolean
@@ -475,9 +480,118 @@ jobs:
           name: Glaze-release-iOS
           path: "${{ needs.metadata.outputs.file_slug }}.ipa"
 
+  # ── linux ──────────────────────────────────────────────────────────────────
+  build-linux:
+    needs: metadata
+    if: ${{ github.event.inputs.build_linux == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Create .env from secrets
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_KEY_STAGING: ${{ secrets.DROPBOX_APP_KEY_STAGING }}
+          DROPBOX_APP_KEY_NIGHTLY: ${{ secrets.DROPBOX_APP_KEY_NIGHTLY }}
+          DROPBOX_REDIRECT_NATIVE: ${{ secrets.DROPBOX_REDIRECT_NATIVE }}
+          GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
+        run: |
+          set -euo pipefail
+          case "$BUILD_CHANNEL" in
+            stable)  CHANNEL_DROPBOX_KEY="" ;;
+            staging) CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_STAGING" ;;
+            *)       CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_NIGHTLY" ;;
+          esac
+          {
+            echo "DROPBOX_APP_KEY=${CHANNEL_DROPBOX_KEY:-$DROPBOX_APP_KEY}"
+            echo "DROPBOX_REDIRECT_NATIVE=$DROPBOX_REDIRECT_NATIVE"
+            echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID"
+            echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive"
+          } >> .env
+
+      - name: Install Linux dependencies
+        # pacman-package-manager brings makepkg, which the packaging script uses
+        # for the Arch/CachyOS package; the rest is the standard Flutter Linux
+        # desktop toolchain.
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev pacman-package-manager
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Cache pub
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: pub-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate code
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Build Linux packages (release)
+        run: >
+          ./scripts/build_linux_packages.sh
+          "--dart-define=APP_VERSION=${{ needs.metadata.outputs.version }}"
+          "--dart-define=BUILD_DATE=${{ needs.metadata.outputs.build_date }}"
+          "--dart-define=BUILD_BRANCH=${{ needs.metadata.outputs.build_branch }}"
+          "--dart-define=BUILD_COMMIT=${{ needs.metadata.outputs.git_sha }}"
+          "--dart-define=BUILD_CHANNEL=${{ needs.metadata.outputs.build_channel }}"
+
+      - name: Rename Linux packages
+        # The script skips a format whose tooling is missing instead of failing,
+        # so the rename reports what actually came out and only fails when
+        # neither package was produced.
+        env:
+          SLUG: ${{ needs.metadata.outputs.file_slug }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          DEB=(build/linux/deb/*.deb)
+          PKG=(build/linux/arch/*.pkg.tar.zst)
+
+          if [ ${#DEB[@]} -gt 0 ]; then
+            mv "${DEB[0]}" "build/linux/deb/${SLUG}-linux.deb"
+          else
+            echo "::warning::No .deb was produced — dpkg-deb missing or the build failed."
+          fi
+
+          if [ ${#PKG[@]} -gt 0 ]; then
+            mv "${PKG[0]}" "build/linux/arch/${SLUG}-linux.pkg.tar.zst"
+          else
+            echo "::warning::No pacman package was produced — makepkg missing or the build failed."
+          fi
+
+          if [ ${#DEB[@]} -eq 0 ] && [ ${#PKG[@]} -eq 0 ]; then
+            echo "::error::build_linux_packages.sh produced no package at all."
+            exit 1
+          fi
+
+      - name: Upload DEB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-release-DEB
+          path: "build/linux/deb/${{ needs.metadata.outputs.file_slug }}-linux.deb"
+
+      - name: Upload Pacman artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-release-Pacman
+          path: "build/linux/arch/${{ needs.metadata.outputs.file_slug }}-linux.pkg.tar.zst"
+
   # ── telegram notify ────────────────────────────────────────────────────────
   notify:
-    needs: [metadata, build-android, build-windows, build-ios]
+    needs: [metadata, build-android, build-windows, build-ios, build-linux]
     runs-on: ubuntu-latest
     # Run when either delivery toggle is on: the group post and/or the direct
     # messages to developers. Each individual step is gated on its own toggle.
@@ -491,7 +605,8 @@ jobs:
       !contains(needs.*.result, 'cancelled') &&
       (github.event.inputs.build_android == 'true' ||
        github.event.inputs.build_windows == 'true' ||
-       github.event.inputs.build_ios == 'true') &&
+       github.event.inputs.build_ios == 'true' ||
+       github.event.inputs.build_linux == 'true') &&
       (github.event.inputs.post_to_telegram == 'true' ||
        github.event.inputs.dm_developers == 'true') }}
     steps:

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -7,6 +7,24 @@ on:
     # exposed as github.ref_name and used for checkout, the in-app build label
     # and the Telegram message.
     inputs:
+      # Platform selection. Each toggle gates both the build job and the upload,
+      # so an unchecked platform costs no runner time and simply does not appear
+      # in the Telegram post. Unchecking all three leaves nothing to post.
+      build_android:
+        description: 'Android (APK)'
+        required: false
+        default: true
+        type: boolean
+      build_windows:
+        description: 'Windows (ZIP)'
+        required: false
+        default: true
+        type: boolean
+      build_ios:
+        description: 'iOS (IPA)'
+        required: false
+        default: true
+        type: boolean
       post_to_telegram:
         description: 'Post build to Telegram'
         required: false
@@ -21,8 +39,8 @@ on:
         default: false
         type: boolean
       dm_developers:
-        # Sends the APK + IPA straight to each developer's private Telegram chat
-        # (@frostake, @All_Systems_Go). Independent of "Post build to Telegram":
+        # Sends the selected builds straight to each developer's private Telegram
+        # chat (@frostake, @All_Systems_Go). Independent of "Post build to Telegram":
         # it can be used on its own for an internal test share. Requires the
         # TG_DEV_CHAT_IDS secret (numeric chat IDs) — see the "Send build to
         # developers (DM)" step below for why @usernames can't be used.
@@ -112,6 +130,7 @@ jobs:
   # ── android ────────────────────────────────────────────────────────────────
   build-android:
     needs: metadata
+    if: ${{ github.event.inputs.build_android == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -255,6 +274,7 @@ jobs:
   # ── windows ────────────────────────────────────────────────────────────────
   build-windows:
     needs: metadata
+    if: ${{ github.event.inputs.build_windows == 'true' }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -317,16 +337,24 @@ jobs:
           "--dart-define=BUILD_COMMIT=${{ needs.metadata.outputs.git_sha }}"
           "--dart-define=BUILD_CHANNEL=${{ needs.metadata.outputs.build_channel }}"
 
+      - name: Zip Windows build
+        # The Release directory has to become one file before it can be sent to
+        # Telegram, so the zip is built here and uploaded as the artifact.
+        shell: pwsh
+        run: |
+          Compress-Archive -Path build/windows/x64/runner/Release/* `
+            -DestinationPath "${{ needs.metadata.outputs.file_slug }}-windows.zip"
+
       - name: Upload Windows
         uses: actions/upload-artifact@v4
         with:
           name: Glaze-release-Windows
-          path: build/windows/x64/runner/Release/**
-          include-hidden-files: true
+          path: "${{ needs.metadata.outputs.file_slug }}-windows.zip"
 
   # ── ios ────────────────────────────────────────────────────────────────────
   build-ios:
     needs: metadata
+    if: ${{ github.event.inputs.build_ios == 'true' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -449,12 +477,21 @@ jobs:
 
   # ── telegram notify ────────────────────────────────────────────────────────
   notify:
-    needs: [metadata, build-android, build-ios]
+    needs: [metadata, build-android, build-windows, build-ios]
     runs-on: ubuntu-latest
     # Run when either delivery toggle is on: the group post and/or the direct
     # messages to developers. Each individual step is gated on its own toggle.
+    #
+    # An unselected platform leaves its build job "skipped", which would block a
+    # plain success() gate, so the results are checked explicitly instead: no
+    # failure among the needs, and at least one platform actually built.
     if: >-
-      ${{ success() &&
+      ${{ !cancelled() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      (github.event.inputs.build_android == 'true' ||
+       github.event.inputs.build_windows == 'true' ||
+       github.event.inputs.build_ios == 'true') &&
       (github.event.inputs.post_to_telegram == 'true' ||
        github.event.inputs.dm_developers == 'true') }}
     steps:
@@ -462,30 +499,23 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - name: Download APK
+      - name: Download built artifacts
+        # Picks up whichever of the three platform artifacts exist, so the
+        # platform toggles alone decide what gets posted.
         uses: actions/download-artifact@v4
         with:
-          name: Glaze-release-APK
+          pattern: Glaze-release-*
+          merge-multiple: true
           path: artifacts/
 
-      - name: Download IPA
-        uses: actions/download-artifact@v4
-        with:
-          name: Glaze-release-iOS
-          path: artifacts/
-
-      - name: Send to Telegram
-        # Group post — only when the "Post build to Telegram" toggle is on.
-        if: ${{ github.event.inputs.post_to_telegram == 'true' }}
+      - name: Compose announcement
+        id: text
         env:
-          TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
-          TG_CHAT_ID:   ${{ secrets.TG_CHAT_ID }}
           TG_MENTIONS:  ${{ secrets.TG_MENTIONS }}
           NOTIFY_PEOPLE: ${{ github.event.inputs.notify_people || 'true' }}
           VERSION:      ${{ needs.metadata.outputs.version }}
           BUILD_DATE:   ${{ needs.metadata.outputs.build_date }}
           BUILD_BRANCH: ${{ needs.metadata.outputs.build_branch }}
-          FILE_SLUG:    ${{ needs.metadata.outputs.file_slug }}
           COMMITS:      ${{ needs.metadata.outputs.commits }}
         run: |
           COMMITS_SECTION=""
@@ -498,34 +528,39 @@ jobs:
             MENTIONS_SECTION=$(printf '\n\n<tg-spoiler>%s</tg-spoiler>' "$TG_MENTIONS")
           fi
 
-          TEXT=$(printf 'Новый дев-билд:\n\n%s\n%s\n%s%s%s' \
-            "$VERSION" "$BUILD_DATE" "$BUILD_BRANCH" \
-            "$COMMITS_SECTION" "$MENTIONS_SECTION")
+          # The group post carries the mentions; the DM version does not, since
+          # its only reader is already the person being notified.
+          {
+            echo "group<<DELIM"
+            printf 'Новый дев-билд:\n\n%s\n%s\n%s%s%s\n' \
+              "$VERSION" "$BUILD_DATE" "$BUILD_BRANCH" \
+              "$COMMITS_SECTION" "$MENTIONS_SECTION"
+            echo "DELIM"
+            echo "dm<<DELIM"
+            printf 'Новый дев-билд (в ЛС):\n\n%s\n%s\n%s%s\n' \
+              "$VERSION" "$BUILD_DATE" "$BUILD_BRANCH" "$COMMITS_SECTION"
+            echo "DELIM"
+          } >> $GITHUB_OUTPUT
 
-          MSG_ID=$(curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -n --arg cid "$TG_CHAT_ID" --arg text "$TEXT" \
-              '{chat_id: $cid, text: $text, parse_mode: "HTML"}')" \
-            | jq -r '.result.message_id')
-
-          curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/pinChatMessage" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -n --arg cid "$TG_CHAT_ID" --arg mid "$MSG_ID" \
-              '{chat_id: $cid, message_id: ($mid | tonumber), disable_notification: true}')"
-
-          curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendDocument" \
-            -F "chat_id=${TG_CHAT_ID}" \
-            -F "reply_to_message_id=${MSG_ID}" \
-            -F "document=@artifacts/${FILE_SLUG}.ipa"
-
-          curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendDocument" \
-            -F "chat_id=${TG_CHAT_ID}" \
-            -F "reply_to_message_id=${MSG_ID}" \
-            -F "document=@artifacts/${FILE_SLUG}.apk"
+      - name: Send to Telegram
+        # Group post — only when the "Post build to Telegram" toggle is on.
+        if: ${{ github.event.inputs.post_to_telegram == 'true' }}
+        env:
+          TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
+          # Chat id of the public group the builds are announced in.
+          TG_CHAT_ID:   ${{ secrets.TG_CHAT_ID }}
+          # Message thread id of the topic inside that group. Leave the secret
+          # unset for a group without topics — the post then goes to the chat
+          # itself, which is the pre-topic behaviour.
+          TG_TOPIC_ID:  ${{ secrets.TG_TOPIC_ID }}
+          TEXT:         ${{ steps.text.outputs.group }}
+          PIN:          'true'
+          RUN_URL:      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/telegram_post.sh "$TG_CHAT_ID" "$TG_TOPIC_ID"
 
       - name: Send build to developers (DM)
-        # Direct-message the APK + IPA to each developer's private chat when the
-        # "Отправить в ЛС разработчикам" toggle is on.
+        # Direct-message the selected builds to each developer's private chat
+        # when the "Отправить в ЛС разработчикам" toggle is on.
         if: ${{ github.event.inputs.dm_developers == 'true' }}
         env:
           TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
@@ -534,45 +569,20 @@ jobs:
           # start a private chat by @username, so each developer must have sent
           # /start to the bot once and their numeric id stored in this secret.
           TG_DEV_CHAT_IDS: ${{ secrets.TG_DEV_CHAT_IDS }}
-          VERSION:      ${{ needs.metadata.outputs.version }}
-          BUILD_DATE:   ${{ needs.metadata.outputs.build_date }}
-          BUILD_BRANCH: ${{ needs.metadata.outputs.build_branch }}
-          FILE_SLUG:    ${{ needs.metadata.outputs.file_slug }}
-          COMMITS:      ${{ needs.metadata.outputs.commits }}
+          TEXT:         ${{ steps.text.outputs.dm }}
+          RUN_URL:      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           if [ -z "$TG_DEV_CHAT_IDS" ]; then
             echo "::warning::TG_DEV_CHAT_IDS secret is empty — skipping developer DMs."
             exit 0
           fi
 
-          COMMITS_SECTION=""
-          if [ -n "$COMMITS" ]; then
-            COMMITS_SECTION=$(printf '\n\n%s' "$COMMITS")
-          fi
-
-          TEXT=$(printf 'Новый дев-билд (в ЛС):\n\n%s\n%s\n%s%s' \
-            "$VERSION" "$BUILD_DATE" "$BUILD_BRANCH" "$COMMITS_SECTION")
-
-          # Accept commas or whitespace as separators between chat IDs.
+          # Accept commas or whitespace as separators between chat IDs. A private
+          # chat has no topics, so no thread id is passed.
           IDS=$(printf '%s' "$TG_DEV_CHAT_IDS" | tr ',' ' ')
           for CID in $IDS; do
             [ -z "$CID" ] && continue
-
-            MSG_ID=$(curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage" \
-              -H "Content-Type: application/json" \
-              -d "$(jq -n --arg cid "$CID" --arg text "$TEXT" \
-                '{chat_id: $cid, text: $text, parse_mode: "HTML"}')" \
-              | jq -r '.result.message_id')
-
-            curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendDocument" \
-              -F "chat_id=${CID}" \
-              -F "reply_to_message_id=${MSG_ID}" \
-              -F "document=@artifacts/${FILE_SLUG}.ipa"
-
-            curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendDocument" \
-              -F "chat_id=${CID}" \
-              -F "reply_to_message_id=${MSG_ID}" \
-              -F "document=@artifacts/${FILE_SLUG}.apk"
+            bash .github/scripts/telegram_post.sh "$CID"
           done
 
       - name: Advance build/last tag

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,6 +13,24 @@ on:
         required: false
         type: string
         default: ''
+      # Platform selection. Each toggle gates its build job, the GitHub Release
+      # asset and the Telegram post, so an unchecked platform is simply absent
+      # from the release.
+      build_android:
+        description: 'Android (APK)'
+        required: false
+        default: true
+        type: boolean
+      build_windows:
+        description: 'Windows (ZIP)'
+        required: false
+        default: true
+        type: boolean
+      build_ios:
+        description: 'iOS (IPA)'
+        required: false
+        default: true
+        type: boolean
       post_to_telegram:
         description: 'Post build to Telegram'
         required: false
@@ -111,6 +129,7 @@ jobs:
   # ── android ────────────────────────────────────────────────────────────────
   build-android:
     needs: metadata
+    if: ${{ github.event.inputs.build_android == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -254,6 +273,7 @@ jobs:
   # ── windows ────────────────────────────────────────────────────────────────
   build-windows:
     needs: metadata
+    if: ${{ github.event.inputs.build_windows == 'true' }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
@@ -317,20 +337,23 @@ jobs:
           "--dart-define=BUILD_CHANNEL=${{ needs.metadata.outputs.build_channel }}"
 
       - name: Zip Windows build
+        # Written outside the directory being archived so the zip cannot end up
+        # inside itself.
         shell: pwsh
         run: |
-          cd build/windows/x64/runner/Release
-          Compress-Archive -Path * -DestinationPath "${{ needs.metadata.outputs.tag_name }}-windows.zip"
+          Compress-Archive -Path build/windows/x64/runner/Release/* `
+            -DestinationPath "${{ needs.metadata.outputs.tag_name }}-windows.zip"
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
           name: Glaze-release-Windows
-          path: "build/windows/x64/runner/Release/${{ needs.metadata.outputs.tag_name }}-windows.zip"
+          path: "${{ needs.metadata.outputs.tag_name }}-windows.zip"
 
   # ── ios ────────────────────────────────────────────────────────────────────
   build-ios:
     needs: metadata
+    if: ${{ github.event.inputs.build_ios == 'true' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -440,28 +463,29 @@ jobs:
   release:
     needs: [metadata, build-android, build-windows, build-ios]
     runs-on: ubuntu-latest
+    # An unselected platform leaves its build job "skipped", which would block
+    # the implicit success() gate, so the results are checked explicitly: no
+    # failure among the needs, and at least one platform actually built.
+    if: >-
+      ${{ !cancelled() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      (github.event.inputs.build_android == 'true' ||
+       github.event.inputs.build_windows == 'true' ||
+       github.event.inputs.build_ios == 'true') }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
 
-      - name: Download APK
+      - name: Download built artifacts
+        # Picks up whichever of the three platform artifacts exist, so the
+        # platform toggles alone decide which assets the release carries.
         uses: actions/download-artifact@v4
         with:
-          name: Glaze-release-APK
-          path: release-assets/
-
-      - name: Download Windows
-        uses: actions/download-artifact@v4
-        with:
-          name: Glaze-release-Windows
-          path: release-assets/
-
-      - name: Download IPA
-        uses: actions/download-artifact@v4
-        with:
-          name: Glaze-release-iOS
+          pattern: Glaze-release-*
+          merge-multiple: true
           path: release-assets/
 
       - name: Prepare release notes
@@ -493,10 +517,13 @@ jobs:
 
   # ── telegram notify ────────────────────────────────────────────────────────
   notify:
-    needs: [metadata, build-android, build-ios, release]
+    needs: [metadata, build-android, build-windows, build-ios, release]
     runs-on: ubuntu-latest
     if: >-
-      ${{ success() &&
+      ${{ !cancelled() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      needs.release.result == 'success' &&
       (github.event.inputs.post_to_telegram == 'true' ||
        github.event.inputs.dm_developers == 'true') }}
     steps:
@@ -504,30 +531,22 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      - name: Download APK
+      - name: Download built artifacts
         uses: actions/download-artifact@v4
         with:
-          name: Glaze-release-APK
+          pattern: Glaze-release-*
+          merge-multiple: true
           path: artifacts/
 
-      - name: Download IPA
-        uses: actions/download-artifact@v4
-        with:
-          name: Glaze-release-iOS
-          path: artifacts/
-
-      - name: Send to Telegram
-        if: ${{ github.event.inputs.post_to_telegram == 'true' }}
+      - name: Compose announcement
+        id: text
         env:
-          TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
-          TG_CHAT_ID:   ${{ secrets.TG_CHAT_ID }}
           TG_MENTIONS:  ${{ secrets.TG_MENTIONS }}
           NOTIFY_PEOPLE: ${{ github.event.inputs.notify_people || 'true' }}
           VERSION:      ${{ needs.metadata.outputs.version }}
           TAG_NAME:     ${{ needs.metadata.outputs.tag_name }}
           BUILD_DATE:   ${{ needs.metadata.outputs.build_date }}
           BUILD_BRANCH: ${{ needs.metadata.outputs.build_branch }}
-          FILE_SLUG:    ${{ needs.metadata.outputs.file_slug }}
           COMMITS:      ${{ needs.metadata.outputs.commits }}
         run: |
           COMMITS_SECTION=""
@@ -540,69 +559,54 @@ jobs:
             MENTIONS_SECTION=$(printf '\n\n<tg-spoiler>%s</tg-spoiler>' "$TG_MENTIONS")
           fi
 
-          TEXT=$(printf 'Новый релиз: %s\n\n%s\n%s\n%s%s%s' \
-            "$TAG_NAME" "$VERSION" "$BUILD_DATE" "$BUILD_BRANCH" \
-            "$COMMITS_SECTION" "$MENTIONS_SECTION")
+          # The group post carries the mentions; the DM version does not, since
+          # its only reader is already the person being notified.
+          {
+            echo "group<<DELIM"
+            printf 'Новый релиз: %s\n\n%s\n%s\n%s%s%s\n' \
+              "$TAG_NAME" "$VERSION" "$BUILD_DATE" "$BUILD_BRANCH" \
+              "$COMMITS_SECTION" "$MENTIONS_SECTION"
+            echo "DELIM"
+            echo "dm<<DELIM"
+            printf 'Новый релиз (в ЛС): %s\n\n%s\n%s\n%s%s\n' \
+              "$TAG_NAME" "$VERSION" "$BUILD_DATE" "$BUILD_BRANCH" "$COMMITS_SECTION"
+            echo "DELIM"
+          } >> $GITHUB_OUTPUT
 
-          MSG_ID=$(curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -n --arg cid "$TG_CHAT_ID" --arg text "$TEXT" \
-              '{chat_id: $cid, text: $text, parse_mode: "HTML"}')" \
-            | jq -r '.result.message_id')
-
-          curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/pinChatMessage" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -n --arg cid "$TG_CHAT_ID" --arg mid "$MSG_ID" \
-              '{chat_id: $cid, message_id: ($mid | tonumber), disable_notification: true}')"
-
-          for f in artifacts/*; do
-            curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendDocument" \
-              -F "chat_id=${TG_CHAT_ID}" \
-              -F "reply_to_message_id=${MSG_ID}" \
-              -F "document=@${f}"
-          done
+      - name: Send to Telegram
+        if: ${{ github.event.inputs.post_to_telegram == 'true' }}
+        env:
+          TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
+          # Chat id of the public group the releases are announced in.
+          TG_CHAT_ID:   ${{ secrets.TG_CHAT_ID }}
+          # Message thread id of the topic inside that group. Leave the secret
+          # unset for a group without topics — the post then goes to the chat
+          # itself, which is the pre-topic behaviour.
+          TG_TOPIC_ID:  ${{ secrets.TG_TOPIC_ID }}
+          TEXT:         ${{ steps.text.outputs.group }}
+          PIN:          'true'
+          RUN_URL:      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/telegram_post.sh "$TG_CHAT_ID" "$TG_TOPIC_ID"
 
       - name: Send build to developers (DM)
         if: ${{ github.event.inputs.dm_developers == 'true' }}
         env:
           TG_BOT_TOKEN: ${{ secrets.TG_BOT_TOKEN }}
           TG_DEV_CHAT_IDS: ${{ secrets.TG_DEV_CHAT_IDS }}
-          VERSION:      ${{ needs.metadata.outputs.version }}
-          TAG_NAME:     ${{ needs.metadata.outputs.tag_name }}
-          BUILD_DATE:   ${{ needs.metadata.outputs.build_date }}
-          BUILD_BRANCH: ${{ needs.metadata.outputs.build_branch }}
-          FILE_SLUG:    ${{ needs.metadata.outputs.file_slug }}
-          COMMITS:      ${{ needs.metadata.outputs.commits }}
+          TEXT:         ${{ steps.text.outputs.dm }}
+          RUN_URL:      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           if [ -z "$TG_DEV_CHAT_IDS" ]; then
             echo "::warning::TG_DEV_CHAT_IDS secret is empty — skipping developer DMs."
             exit 0
           fi
 
-          COMMITS_SECTION=""
-          if [ -n "$COMMITS" ]; then
-            COMMITS_SECTION=$(printf '\n\n%s' "$COMMITS")
-          fi
-
-          TEXT=$(printf 'Новый релиз (в ЛС): %s\n\n%s\n%s\n%s%s' \
-            "$TAG_NAME" "$VERSION" "$BUILD_DATE" "$BUILD_BRANCH" "$COMMITS_SECTION")
-
+          # Accept commas or whitespace as separators between chat IDs. A private
+          # chat has no topics, so no thread id is passed.
           IDS=$(printf '%s' "$TG_DEV_CHAT_IDS" | tr ',' ' ')
           for CID in $IDS; do
             [ -z "$CID" ] && continue
-
-            MSG_ID=$(curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage" \
-              -H "Content-Type: application/json" \
-              -d "$(jq -n --arg cid "$CID" --arg text "$TEXT" \
-                '{chat_id: $cid, text: $text, parse_mode: "HTML"}')" \
-              | jq -r '.result.message_id')
-
-            for f in artifacts/*; do
-              curl -s -X POST "https://api.telegram.org/bot${TG_BOT_TOKEN}/sendDocument" \
-                -F "chat_id=${CID}" \
-                -F "reply_to_message_id=${MSG_ID}" \
-                -F "document=@${f}"
-            done
+            bash .github/scripts/telegram_post.sh "$CID"
           done
 
       - name: Advance build/last tag

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: true
         type: boolean
+      build_linux:
+        description: 'Linux (DEB + pacman)'
+        required: false
+        default: true
+        type: boolean
       post_to_telegram:
         description: 'Post build to Telegram'
         required: false
@@ -459,9 +464,118 @@ jobs:
           name: Glaze-release-iOS
           path: "${{ needs.metadata.outputs.tag_name }}.ipa"
 
+  # ── linux ──────────────────────────────────────────────────────────────────
+  build-linux:
+    needs: metadata
+    if: ${{ github.event.inputs.build_linux == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Create .env from secrets
+        env:
+          BUILD_CHANNEL: ${{ needs.metadata.outputs.build_channel }}
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_KEY_STAGING: ${{ secrets.DROPBOX_APP_KEY_STAGING }}
+          DROPBOX_APP_KEY_NIGHTLY: ${{ secrets.DROPBOX_APP_KEY_NIGHTLY }}
+          DROPBOX_REDIRECT_NATIVE: ${{ secrets.DROPBOX_REDIRECT_NATIVE }}
+          GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
+        run: |
+          set -euo pipefail
+          case "$BUILD_CHANNEL" in
+            stable)  CHANNEL_DROPBOX_KEY="" ;;
+            staging) CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_STAGING" ;;
+            *)       CHANNEL_DROPBOX_KEY="$DROPBOX_APP_KEY_NIGHTLY" ;;
+          esac
+          {
+            echo "DROPBOX_APP_KEY=${CHANNEL_DROPBOX_KEY:-$DROPBOX_APP_KEY}"
+            echo "DROPBOX_REDIRECT_NATIVE=$DROPBOX_REDIRECT_NATIVE"
+            echo "GDRIVE_CLIENT_ID=$GDRIVE_CLIENT_ID"
+            echo "GDRIVE_REDIRECT_NATIVE=com.hydall.glaze://oauth/gdrive"
+          } >> .env
+
+      - name: Install Linux dependencies
+        # pacman-package-manager brings makepkg, which the packaging script uses
+        # for the Arch/CachyOS package; the rest is the standard Flutter Linux
+        # desktop toolchain.
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev pacman-package-manager
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Cache pub
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: pub-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate code
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Build Linux packages (release)
+        run: >
+          ./scripts/build_linux_packages.sh
+          "--dart-define=APP_VERSION=${{ needs.metadata.outputs.version }}"
+          "--dart-define=BUILD_DATE=${{ needs.metadata.outputs.build_date }}"
+          "--dart-define=BUILD_BRANCH=${{ needs.metadata.outputs.build_branch }}"
+          "--dart-define=BUILD_COMMIT=${{ needs.metadata.outputs.git_sha }}"
+          "--dart-define=BUILD_CHANNEL=${{ needs.metadata.outputs.build_channel }}"
+
+      - name: Rename Linux packages
+        # The script skips a format whose tooling is missing instead of failing,
+        # so the rename reports what actually came out and only fails when
+        # neither package was produced.
+        env:
+          SLUG: ${{ needs.metadata.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          DEB=(build/linux/deb/*.deb)
+          PKG=(build/linux/arch/*.pkg.tar.zst)
+
+          if [ ${#DEB[@]} -gt 0 ]; then
+            mv "${DEB[0]}" "build/linux/deb/${SLUG}-linux.deb"
+          else
+            echo "::warning::No .deb was produced — dpkg-deb missing or the build failed."
+          fi
+
+          if [ ${#PKG[@]} -gt 0 ]; then
+            mv "${PKG[0]}" "build/linux/arch/${SLUG}-linux.pkg.tar.zst"
+          else
+            echo "::warning::No pacman package was produced — makepkg missing or the build failed."
+          fi
+
+          if [ ${#DEB[@]} -eq 0 ] && [ ${#PKG[@]} -eq 0 ]; then
+            echo "::error::build_linux_packages.sh produced no package at all."
+            exit 1
+          fi
+
+      - name: Upload DEB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-release-DEB
+          path: "build/linux/deb/${{ needs.metadata.outputs.tag_name }}-linux.deb"
+
+      - name: Upload Pacman artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-release-Pacman
+          path: "build/linux/arch/${{ needs.metadata.outputs.tag_name }}-linux.pkg.tar.zst"
+
   # ── github release ─────────────────────────────────────────────────────────
   release:
-    needs: [metadata, build-android, build-windows, build-ios]
+    needs: [metadata, build-android, build-windows, build-ios, build-linux]
     runs-on: ubuntu-latest
     # An unselected platform leaves its build job "skipped", which would block
     # the implicit success() gate, so the results are checked explicitly: no
@@ -472,7 +586,8 @@ jobs:
       !contains(needs.*.result, 'cancelled') &&
       (github.event.inputs.build_android == 'true' ||
        github.event.inputs.build_windows == 'true' ||
-       github.event.inputs.build_ios == 'true') }}
+       github.event.inputs.build_ios == 'true' ||
+       github.event.inputs.build_linux == 'true') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -517,7 +632,7 @@ jobs:
 
   # ── telegram notify ────────────────────────────────────────────────────────
   notify:
-    needs: [metadata, build-android, build-windows, build-ios, release]
+    needs: [metadata, build-android, build-windows, build-ios, build-linux, release]
     runs-on: ubuntu-latest
     if: >-
       ${{ !cancelled() &&

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -117,23 +117,28 @@ selector.
 
 | Workflow | File | Produces |
 |----------|------|----------|
-| *Build (Branch)* | `.github/workflows/build-branch.yml` | Dev build of any branch — APK, Windows ZIP, IPA as run artifacts |
-| *Build Release (Publish)* | `.github/workflows/build-release.yml` | The same three, plus a tagged GitHub Release carrying them as assets |
+| *Build (Branch)* | `.github/workflows/build-branch.yml` | Dev build of any branch — APK, Windows ZIP, IPA, Linux DEB + pacman package as run artifacts |
+| *Build Release (Publish)* | `.github/workflows/build-release.yml` | The same set, plus a tagged GitHub Release carrying them as assets |
 
 **Platform selection.** Each workflow has an *Android (APK)* / *Windows (ZIP)* /
-*iOS (IPA)* checkbox, all on by default. An unchecked platform does not build at
-all, so it costs no runner time and is absent from the release and the Telegram
-post. Unchecking all three leaves nothing to do and the run stops after the
-metadata job.
+*iOS (IPA)* / *Linux (DEB + pacman)* checkbox, all on by default. An unchecked
+platform does not build at all, so it costs no runner time and is absent from the
+release and the Telegram post. Unchecking every platform leaves nothing to do and
+the run stops after the metadata job.
+
+The Linux job produces two packages from `scripts/build_linux_packages.sh` — a
+`.deb` (dpkg-deb) and an Arch/CachyOS `.pkg.tar.zst` (makepkg). A format whose
+tooling is missing is skipped with a warning rather than failing the job; the run
+only fails when neither package comes out.
 
 **Telegram delivery.** `post_to_telegram` announces the build in the public
 group and replies to that announcement with each selected file;
 `dm_developers` sends the same set to the developers' private chats. Both go
 through `.github/scripts/telegram_post.sh`, which is also where the 50 MB Bot
 API upload limit is handled — a file over the limit is replaced by a reply
-linking to the workflow run instead of failing the post. Because the Windows ZIP
-is the one artifact that can realistically cross that limit, check the run log
-after a Windows build if the ZIP does not show up in the group.
+linking to the workflow run instead of failing the post. The Windows ZIP and the
+Linux packages are the artifacts that can realistically cross that limit, so
+check the run log if one of them does not show up in the group.
 
 Secrets used by the delivery step:
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -109,6 +109,52 @@ git checkout staging && git pull && git merge --no-ff nightly && git push
 git checkout stable && git pull && git merge --no-ff staging && git push
 ```
 
+## Build distribution
+
+Two manual workflows produce installable builds. Both are started from the
+Actions tab, and both take the branch from GitHub's native "Use workflow from"
+selector.
+
+| Workflow | File | Produces |
+|----------|------|----------|
+| *Build (Branch)* | `.github/workflows/build-branch.yml` | Dev build of any branch — APK, Windows ZIP, IPA as run artifacts |
+| *Build Release (Publish)* | `.github/workflows/build-release.yml` | The same three, plus a tagged GitHub Release carrying them as assets |
+
+**Platform selection.** Each workflow has an *Android (APK)* / *Windows (ZIP)* /
+*iOS (IPA)* checkbox, all on by default. An unchecked platform does not build at
+all, so it costs no runner time and is absent from the release and the Telegram
+post. Unchecking all three leaves nothing to do and the run stops after the
+metadata job.
+
+**Telegram delivery.** `post_to_telegram` announces the build in the public
+group and replies to that announcement with each selected file;
+`dm_developers` sends the same set to the developers' private chats. Both go
+through `.github/scripts/telegram_post.sh`, which is also where the 50 MB Bot
+API upload limit is handled — a file over the limit is replaced by a reply
+linking to the workflow run instead of failing the post. Because the Windows ZIP
+is the one artifact that can realistically cross that limit, check the run log
+after a Windows build if the ZIP does not show up in the group.
+
+Secrets used by the delivery step:
+
+| Secret | Meaning |
+|--------|---------|
+| `TG_BOT_TOKEN` | Bot token |
+| `TG_CHAT_ID` | Chat id of the public group builds are announced in |
+| `TG_TOPIC_ID` | Message thread id of the topic inside that group. Leave unset for a group without topics — the post then goes to the chat itself |
+| `TG_MENTIONS` | Text posted in a spoiler when `notify_people` is on |
+| `TG_DEV_CHAT_IDS` | Numeric private chat ids for `dm_developers`, comma- or whitespace-separated |
+
+The bot has to be a member of the group, and an administrator with
+*Pin messages* for the announcement pin to work — a failed pin is a warning, not
+a failed run. To read a topic's thread id, open the topic in Telegram Web: it is
+the last number in the URL (`.../#-1001234567890_25` → topic `25`).
+
+A successful group post moves the `build/last` tag to the built commit, which is
+the baseline for the "commits since last build" list in the next announcement.
+The developer DMs deliberately do not move it — an internal share is not an
+announcement.
+
 ## Trello board
 
 - **Board URL:** https://trello.com/b/jRUaax0b/glazeflutter

--- a/scripts/build_linux_packages.sh
+++ b/scripts/build_linux_packages.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+set -e
+
+# Change to the root of the project
+cd "$(dirname "$0")/.."
+
+APP_NAME="glaze-flutter"
+# Extract version from pubspec.yaml (e.g. 0.7.0)
+VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //g' | cut -d '+' -f 1 | tr -d '\r')
+ARCH=$(uname -m)
+
+if [ -z "$VERSION" ]; then
+    echo "Error: Could not determine version from pubspec.yaml"
+    exit 1
+fi
+
+echo "Building $APP_NAME version $VERSION for architecture $ARCH..."
+
+if [ "$ARCH" = "x86_64" ]; then
+    DEB_ARCH="amd64"
+elif [ "$ARCH" = "aarch64" ]; then
+    DEB_ARCH="arm64"
+else
+    DEB_ARCH="$ARCH"
+fi
+
+# Run the flutter build
+echo "Running flutter build linux --release $@"
+flutter build linux --release "$@"
+
+BUNDLE_DIR="build/linux/x64/release/bundle"
+
+if [ ! -d "$BUNDLE_DIR" ]; then
+    echo "Error: Build directory '$BUNDLE_DIR' not found. Did the build fail?"
+    exit 1
+fi
+
+# 1. Build DEB Package
+if command -v dpkg-deb &> /dev/null; then
+    echo "Building .deb package..."
+    DEB_DIR="build/linux/deb/$APP_NAME-${VERSION}_$DEB_ARCH"
+    mkdir -p "$DEB_DIR/opt/$APP_NAME"
+    mkdir -p "$DEB_DIR/usr/bin"
+    mkdir -p "$DEB_DIR/usr/share/applications"
+    mkdir -p "$DEB_DIR/usr/share/icons/hicolor/512x512/apps"
+    mkdir -p "$DEB_DIR/DEBIAN"
+
+    # Copy bundle contents
+    cp -r $BUNDLE_DIR/* "$DEB_DIR/opt/$APP_NAME/"
+    
+    # Create symlink for the executable
+    ln -sf "/opt/$APP_NAME/glaze_flutter" "$DEB_DIR/usr/bin/$APP_NAME"
+
+    # Copy icon
+    if [ -f "assets/logos/glaze.png" ]; then
+        cp assets/logos/glaze.png "$DEB_DIR/usr/share/icons/hicolor/512x512/apps/$APP_NAME.png"
+    else
+        echo "Warning: assets/logos/glaze.png not found, skipping icon."
+    fi
+
+    # Create .desktop file
+    cat <<EOF > "$DEB_DIR/usr/share/applications/$APP_NAME.desktop"
+[Desktop Entry]
+Name=Glaze
+Comment=Native LLM frontend for AI roleplay
+Exec=$APP_NAME
+Icon=$APP_NAME
+Terminal=false
+Type=Application
+Categories=Utility;Chat;Network;
+EOF
+
+    # Create DEBIAN/control
+    cat <<EOF > "$DEB_DIR/DEBIAN/control"
+Package: $APP_NAME
+Version: $VERSION
+Architecture: $DEB_ARCH
+Maintainer: Glaze Developers
+Description: AI chat client
+ Glaze is a Native LLM frontend for AI roleplay.
+EOF
+
+    # Build the package
+    dpkg-deb --build "$DEB_DIR"
+    echo "Deb package created at build/linux/deb/$APP_NAME-${VERSION}_$DEB_ARCH.deb"
+else
+    echo "dpkg-deb not found. Skipping .deb package creation."
+fi
+
+# 2. Build Pacman Package (Arch / CachyOS)
+if command -v makepkg &> /dev/null; then
+    echo "Building pacman package..."
+    ARCH_DIR="build/linux/arch"
+    mkdir -p "$ARCH_DIR"
+    
+    # Generate PKGBUILD for pre-built binaries
+    cat <<EOF > "$ARCH_DIR/PKGBUILD"
+pkgname=$APP_NAME-bin
+pkgver=$VERSION
+pkgrel=1
+pkgdesc="Native LLM frontend for AI roleplay (Flutter)"
+arch=('x86_64')
+url="https://github.com/hydall/Glaze"
+license=('AGPL3')
+depends=('gtk3' 'glib2' 'sqlite3')
+options=('!strip' '!emptydirs')
+
+package() {
+    mkdir -p "\\\$pkgdir/opt/$APP_NAME"
+    mkdir -p "\\\$pkgdir/usr/bin"
+    mkdir -p "\\\$pkgdir/usr/share/applications"
+    mkdir -p "\\\$pkgdir/usr/share/icons/hicolor/512x512/apps"
+
+    # Copy from the flutter release bundle
+    cp -r "\\\$srcdir/../../../x64/release/bundle/"* "\\\$pkgdir/opt/$APP_NAME/"
+    
+    # Symlink binary
+    ln -s "/opt/$APP_NAME/glaze_flutter" "\\\$pkgdir/usr/bin/$APP_NAME"
+    
+    # Copy icon
+    if [ -f "\\\$srcdir/../../../../assets/logos/glaze.png" ]; then
+        cp "\\\$srcdir/../../../../assets/logos/glaze.png" "\\\$pkgdir/usr/share/icons/hicolor/512x512/apps/$APP_NAME.png"
+    fi
+
+    # Create desktop file
+    cat <<DESKTOP > "\\\$pkgdir/usr/share/applications/$APP_NAME.desktop"
+[Desktop Entry]
+Name=Glaze
+Comment=Native LLM frontend for AI roleplay
+Exec=$APP_NAME
+Icon=$APP_NAME
+Terminal=false
+Type=Application
+Categories=Utility;Chat;Network;
+DESKTOP
+}
+EOF
+
+    # Build the package using makepkg (don't fail if we can't extract sources, since there are none, use -sf)
+    # We do not use sudo with makepkg
+    cd "$ARCH_DIR"
+    # Execute makepkg: 
+    # -R repacks if needed, -f force, -s sync deps, --noconfirm for no prompts
+    makepkg -sf --noconfirm
+    cd - > /dev/null
+    
+    echo "Pacman package created in $ARCH_DIR"
+else
+    echo "makepkg not found. Skipping pacman package creation."
+fi
+
+echo "Packaging complete!"

--- a/scripts/build_linux_packages.sh
+++ b/scripts/build_linux_packages.sh
@@ -106,24 +106,24 @@ depends=('gtk3' 'glib2' 'sqlite3')
 options=('!strip' '!emptydirs')
 
 package() {
-    mkdir -p "\\\$pkgdir/opt/$APP_NAME"
-    mkdir -p "\\\$pkgdir/usr/bin"
-    mkdir -p "\\\$pkgdir/usr/share/applications"
-    mkdir -p "\\\$pkgdir/usr/share/icons/hicolor/512x512/apps"
+    mkdir -p "\$pkgdir/opt/$APP_NAME"
+    mkdir -p "\$pkgdir/usr/bin"
+    mkdir -p "\$pkgdir/usr/share/applications"
+    mkdir -p "\$pkgdir/usr/share/icons/hicolor/512x512/apps"
 
     # Copy from the flutter release bundle
-    cp -r "\\\$srcdir/../../../x64/release/bundle/"* "\\\$pkgdir/opt/$APP_NAME/"
+    cp -r "\$srcdir/../../x64/release/bundle/"* "\$pkgdir/opt/$APP_NAME/"
     
     # Symlink binary
-    ln -s "/opt/$APP_NAME/glaze_flutter" "\\\$pkgdir/usr/bin/$APP_NAME"
+    ln -s "/opt/$APP_NAME/glaze_flutter" "\$pkgdir/usr/bin/$APP_NAME"
     
     # Copy icon
-    if [ -f "\\\$srcdir/../../../../assets/logos/glaze.png" ]; then
-        cp "\\\$srcdir/../../../../assets/logos/glaze.png" "\\\$pkgdir/usr/share/icons/hicolor/512x512/apps/$APP_NAME.png"
+    if [ -f "\$srcdir/../../../../assets/logos/glaze.png" ]; then
+        cp "\$srcdir/../../../../assets/logos/glaze.png" "\$pkgdir/usr/share/icons/hicolor/512x512/apps/$APP_NAME.png"
     fi
 
     # Create desktop file
-    cat <<DESKTOP > "\\\$pkgdir/usr/share/applications/$APP_NAME.desktop"
+    cat <<DESKTOP > "\$pkgdir/usr/share/applications/$APP_NAME.desktop"
 [Desktop Entry]
 Name=Glaze
 Comment=Native LLM frontend for AI roleplay


### PR DESCRIPTION
Builds are now announced in a topic of the public Telegram group, every platform
is opt-in from the workflow_dispatch form, and Windows and Linux are part of the
delivered set.

Supersedes #163 — its packaging script is included here as its own commit
(`d7baf3f`, @s1mplym4tt), with its CI wiring redone on top of the platform
toggles.

## Telegram delivery

- Post the announcement and the build files into a forum topic: every
  `sendMessage` / `sendDocument` carries `message_thread_id` from the new
  `TG_TOPIC_ID` secret. The secret is optional — left unset, the post goes to
  the chat itself, which is the pre-topic behaviour.
- Extract the four near-identical curl blocks (group post and developer DMs, in
  both workflows) into `.github/scripts/telegram_post.sh`.
- Report Telegram API errors. The old blocks piped every response to
  `/dev/null`, so a rejected upload looked like a successful run; the script
  checks `ok` and fails the step, while a lost pin stays a warning because it
  only needs `can_pin_messages`.
- Handle the 50 MB Bot API upload limit: a file over the limit is replaced by a
  reply linking to the workflow run instead of silently vanishing. The Windows
  ZIP and the Linux packages are the artifacts that can realistically hit it.

## Platform picker

- Add *Android (APK)* / *Windows (ZIP)* / *iOS (IPA)* / *Linux (DEB + pacman)*
  checkboxes to both build workflows, all on by default. Each one gates its
  build job, so an unchecked platform costs no runner time and is absent from
  the GitHub Release and the Telegram post.
- Download artifacts by `Glaze-release-*` pattern with `merge-multiple`, so the
  toggles alone decide what the release and the post carry — no per-platform
  download steps to keep in sync.
- Gate the `release` and `notify` jobs on explicit `needs.*.result` checks. A
  skipped platform is not a success, so the previous `success()` gate would
  have blocked delivery for any partial selection.

## Windows

- Zip the Windows build and post it from *Build (Branch)*, which previously
  uploaded the bare `Release` directory and never delivered it anywhere.
- Write the ZIP outside the directory it archives in *Build Release*, where
  `Compress-Archive` was run from inside `Release` with the archive as its own
  destination.

## Linux (from #163)

- Gate the `build-linux` job on the new toggle and name its outputs
  `Glaze-release-DEB` / `Glaze-release-Pacman` so the pattern download finds
  them.
- Fix the PKGBUILD escaping: the heredoc emitted `"\$pkgdir/..."`, which bash
  reads as a literal string, so `package()` installed into a directory named
  `$pkgdir` instead of the staging root and shipped an empty package.
- Fix the bundle path in `package()`: `$srcdir/../../../x64/release/bundle`
  resolves to `build/x64/...`, one level above the real `build/linux/x64/...`
  bundle, so the copy failed and aborted makepkg. The icon path in the same
  block already used the correct depth.
- Rename the packages tolerantly: `build_linux_packages.sh` skips a format whose
  tooling is missing instead of failing, so the step warns about the missing
  format and fails only when neither package was produced.

## Docs

- Document both build workflows, the platform picker, the Telegram secrets
  (including `TG_TOPIC_ID`) and the `build/last` tag behaviour in
  `docs/WORKFLOW.md` § Build distribution.

## Verification

CI-only changes; no Dart was touched, so `flutter analyze` / `flutter test`
results are unchanged and left to the CI gate.

What was actually run locally:

- `.github/scripts/telegram_post.sh` against a stubbed `curl`, covering: forum
  topic (asserted `message_thread_id` in every payload) and plain chat (asserted
  the field is absent), a `sendDocument` rejected by the API (step fails), a
  rejected announcement (hard fail before any upload), an empty artifacts
  directory, and a 57 MB file (link reply instead of upload).
- `scripts/build_linux_packages.sh` with a stubbed `flutter` and a fake bundle:
  the `.deb` builds with the real `dpkg-deb`, and the generated `package()` was
  sourced against a fake `pkgdir` — it now installs the binary, `data/`, the
  `/usr/bin` symlink, the `.desktop` file and the icon.
- The tolerant rename step for all three cases: both packages, `.deb` only, and
  neither (exit 1).
- Both workflows parsed as YAML, with job dependencies and inputs asserted.

Not run: `makepkg` itself is unavailable in the agent environment, so whether
Ubuntu's `pacman-package-manager` provides it on the runner is unverified. If it
does not, the job still succeeds with the `.deb` and warns about the missing
pacman package. No workflow was dispatched, so the Telegram posting path has not
been exercised against the real API.

Runtime setup this needs before the first run: point `TG_CHAT_ID` at the public
group and add `TG_TOPIC_ID` (the trailing number in the topic's Telegram Web
URL). The bot has to be a member of the group, and an administrator with
*Pin messages* for the pin.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVFDnwT2zoREeG3eVbmYLd)_