### PR TITLE
fix(ci): send build files with --form-string so an @username chat id works

### DIFF
--- a/.github/scripts/telegram_post.sh
+++ b/.github/scripts/telegram_post.sh
@@ -113,8 +113,13 @@ for FILE in "${FILES[@]}"; do
     continue
   fi
 
-  ARGS=(-F "chat_id=$CHAT_ID" -F "reply_to_message_id=$MSG_ID" -F "document=@$FILE")
-  [ -n "$TOPIC_ID" ] && ARGS+=(-F "message_thread_id=$TOPIC_ID")
+  # --form-string for the scalar fields, because -F treats a leading "@" as
+  # "read this local file" — which silently breaks a public-group chat id given
+  # as @username. Only the document itself is meant to be a file reference.
+  ARGS=(--form-string "chat_id=$CHAT_ID"
+        --form-string "reply_to_message_id=$MSG_ID"
+        -F "document=@$FILE")
+  [ -n "$TOPIC_ID" ] && ARGS+=(--form-string "message_thread_id=$TOPIC_ID")
 
   RESPONSE=$(curl -sS -X POST "$API/sendDocument" "${ARGS[@]}")
   if [ "$(jq -r '.ok' <<<"$RESPONSE")" != "true" ]; then

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -145,7 +145,7 @@ Secrets used by the delivery step:
 | Secret | Meaning |
 |--------|---------|
 | `TG_BOT_TOKEN` | Bot token |
-| `TG_CHAT_ID` | Chat id of the public group builds are announced in |
+| `TG_CHAT_ID` | Chat id of the public group builds are announced in. A numeric `-100…` id, or `@username` for a group that has one |
 | `TG_TOPIC_ID` | Message thread id of the topic inside that group. Leave unset for a group without topics — the post then goes to the chat itself |
 | `TG_MENTIONS` | Text posted in a spoiler when `notify_people` is on |
 | `TG_DEV_CHAT_IDS` | Numeric private chat ids for `dm_developers`, comma- or whitespace-separated |


### PR DESCRIPTION
Follow-up to #173, found while resolving the real chat id for the public group.

- Build the `sendDocument` fields in `.github/scripts/telegram_post.sh` with
  `--form-string` instead of `-F`. curl reads a leading `@` in an `-F` value as
  "upload this local file", so a `TG_CHAT_ID` set to `@groupname` made every
  build upload fail with `Failed to open/read local data from file` — while the
  announcement itself, built as JSON with `jq --arg`, went out fine. The result
  would have been an announcement in the topic with no builds under it. Only the
  document stays an `-F` file reference.
- Note in `docs/WORKFLOW.md` that `TG_CHAT_ID` accepts either the numeric
  `-100…` id or `@username`.

## Verification

- Ran `telegram_post.sh` against a stubbed curl with `chat_id=@glazeappcommunity`
  and topic `12`, and asserted the emitted argument list.
- Replayed that exact argument list through the real curl against a dead local
  port: with `-F` it fails at argument parsing (`curl: (26) Failed to open/read
  local data from file`, before any connection), with `--form-string` it reaches
  the connection attempt (`curl: (7)`), which is the expected outcome offline.
- No Dart touched; `flutter analyze` / `flutter test` left to the CI gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVFDnwT2zoREeG3eVbmYLd)_