### PR TITLE
fix(ci): install GStreamer dev packages for the Linux build

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -514,11 +514,15 @@ jobs:
 
       - name: Install Linux dependencies
         # pacman-package-manager brings makepkg, which the packaging script uses
-        # for the Arch/CachyOS package; the rest is the standard Flutter Linux
+        # for the Arch/CachyOS package. libgstreamer1.0-dev and
+        # libgstreamer-plugins-base1.0-dev provide the gstreamer-1.0 /
+        # gstreamer-audio-1.0 pkg-config modules that audioplayers_linux's
+        # CMakeLists requires — without them CMake configure fails before
+        # Flutter even starts compiling. The rest is the standard Flutter Linux
         # desktop toolchain.
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev pacman-package-manager
+          sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev pacman-package-manager libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -498,11 +498,15 @@ jobs:
 
       - name: Install Linux dependencies
         # pacman-package-manager brings makepkg, which the packaging script uses
-        # for the Arch/CachyOS package; the rest is the standard Flutter Linux
+        # for the Arch/CachyOS package. libgstreamer1.0-dev and
+        # libgstreamer-plugins-base1.0-dev provide the gstreamer-1.0 /
+        # gstreamer-audio-1.0 pkg-config modules that audioplayers_linux's
+        # CMakeLists requires — without them CMake configure fails before
+        # Flutter even starts compiling. The rest is the standard Flutter Linux
         # desktop toolchain.
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev pacman-package-manager
+          sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev pacman-package-manager libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
The `build-linux` job failed on the first real run after #173/#174 merged
([run 30529800322](https://github.com/hydall/Glaze/actions/runs/30529800322/job/90829215658)):

```
CMake Error at /usr/local/share/cmake-3.31/Modules/FindPkgConfig.cmake:645 (message):
  The following required packages were not found:

   - gstreamer-1.0

  flutter/ephemeral/.plugin_symlinks/audioplayers_linux/linux/CMakeLists.txt:24 (pkg_check_modules)
```

- Add `libgstreamer1.0-dev` and `libgstreamer-plugins-base1.0-dev` to the apt
  install list in both workflows' *Install Linux dependencies* step. They
  provide the `gstreamer-1.0` / `gstreamer-audio-1.0` pkg-config modules that
  `audioplayers_linux`'s CMakeLists requires — CMake configure failed before
  Flutter started compiling, so this wasn't a Dart problem.

## Verification

Not run locally — no Linux/apt environment available in the agent sandbox to
reproduce `cmake`'s configure step. The error names exactly the pkg-config
module `libgstreamer1.0-dev` provides, and `libgstreamer-plugins-base1.0-dev`
is the companion package for `gstreamer-audio-1.0`, which the same CMakeLists
checks next. Confirming via a *Build (Branch)* rerun on `nightly` once this
merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVFDnwT2zoREeG3eVbmYLd)_