### PR TITLE
fix(ci): initialize alpm db for pacman package build, don't lose the .deb on makepkg failure

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -524,6 +524,14 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev pacman-package-manager libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 
+          # pacman-package-manager on Ubuntu ships no alpm database at its
+          # dbpath (/var/lib/pacman/), so makepkg's dependency check fails with
+          # "could not create database" on a fresh runner. makepkg refuses to
+          # run as root, so the directory has to be created and owned by the
+          # runner user here, ahead of time.
+          sudo mkdir -p /var/lib/pacman
+          sudo chown -R "$(id -u):$(id -g)" /var/lib/pacman
+
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -508,6 +508,14 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y clang cmake git ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev pacman-package-manager libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 
+          # pacman-package-manager on Ubuntu ships no alpm database at its
+          # dbpath (/var/lib/pacman/), so makepkg's dependency check fails with
+          # "could not create database" on a fresh runner. makepkg refuses to
+          # run as root, so the directory has to be created and owned by the
+          # runner user here, ahead of time.
+          sudo mkdir -p /var/lib/pacman
+          sudo chown -R "$(id -u):$(id -g)" /var/lib/pacman
+
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:

--- a/scripts/build_linux_packages.sh
+++ b/scripts/build_linux_packages.sh
@@ -80,9 +80,15 @@ Description: AI chat client
  Glaze is a Native LLM frontend for AI roleplay.
 EOF
 
-    # Build the package
-    dpkg-deb --build "$DEB_DIR"
-    echo "Deb package created at build/linux/deb/$APP_NAME-${VERSION}_$DEB_ARCH.deb"
+    # Build the package. Guarded by an if so a dpkg-deb failure doesn't trip
+    # `set -e` and abort the whole script before the pacman package below gets
+    # a chance to build — each format's failure is independent and reported as
+    # a warning, not a fatal script error.
+    if dpkg-deb --build "$DEB_DIR"; then
+        echo "Deb package created at build/linux/deb/$APP_NAME-${VERSION}_$DEB_ARCH.deb"
+    else
+        echo "::warning::dpkg-deb failed — no .deb package was produced."
+    fi
 else
     echo "dpkg-deb not found. Skipping .deb package creation."
 fi
@@ -136,15 +142,24 @@ DESKTOP
 }
 EOF
 
-    # Build the package using makepkg (don't fail if we can't extract sources, since there are none, use -sf)
-    # We do not use sudo with makepkg
+    # Build the package using makepkg. --nodeps skips the depends=() check: the
+    # CI runner has no configured pacman repositories, so -s (syncdeps) cannot
+    # resolve anything, and even the local-only check can fail outright on a
+    # bare Ubuntu runner ("failed to initialize alpm library ... could not
+    # create database") before /var/lib/pacman exists. A real `pacman -U`
+    # install still enforces depends=() using the target machine's own
+    # database, so skipping the check here only affects this build step.
+    # We do not use sudo with makepkg. Guarded the same way as the .deb build
+    # above, so a makepkg failure doesn't abort the script and lose a .deb that
+    # already built successfully.
     cd "$ARCH_DIR"
-    # Execute makepkg: 
-    # -R repacks if needed, -f force, -s sync deps, --noconfirm for no prompts
-    makepkg -sf --noconfirm
-    cd - > /dev/null
-    
-    echo "Pacman package created in $ARCH_DIR"
+    if makepkg -f --nodeps --noconfirm; then
+        cd - > /dev/null
+        echo "Pacman package created in $ARCH_DIR"
+    else
+        cd - > /dev/null
+        echo "::warning::makepkg failed — no pacman package was produced. See the log above for the pacman/alpm error."
+    fi
 else
     echo "makepkg not found. Skipping pacman package creation."
 fi


### PR DESCRIPTION
Follow-up to #175. GStreamer fixed the CMake configure failure, but the next
*Build (Branch)* run
([30531395413](https://github.com/hydall/Glaze/actions/runs/30531395413/job/90834373184))
still failed: Flutter and the `.deb` built successfully, then `makepkg` died
with:

```
==> Checking runtime dependencies...
error: failed to initialize alpm library:
(root: /, dbpath: /var/lib/pacman/)
could not create database
==> ERROR: 'pacman' returned a fatal error (255):
```

`pacman-package-manager` on Ubuntu ships no alpm database at its dbpath
(`/var/lib/pacman/`), and `set -e` in `build_linux_packages.sh` aborted the
whole script on that failure — discarding the `.deb` that had already built
successfully just before it.

- Create and `chown` `/var/lib/pacman` to the runner user in both workflows'
  *Install Linux dependencies* step, ahead of the `makepkg` call — `makepkg`
  refuses to run as root and can't create the directory itself mid-build.
- Change the `makepkg` invocation to `-f --nodeps` instead of `-sf`: the runner
  has no configured pacman repositories, so `-s` (syncdeps) can't resolve
  `depends=('gtk3' 'glib2' 'sqlite3')` regardless of the db fix, and would fail
  at that step instead. A real `pacman -U` install still enforces `depends=()`
  against the target machine's own database.
- Guard both the `dpkg-deb` and `makepkg` calls in `build_linux_packages.sh`
  with an `if` instead of letting `set -e` propagate — a failure in either
  format is now reported as a warning and the script continues, instead of
  losing a package that already built. This matches what the workflow's
  *Rename Linux packages* step was already written to tolerate (from #173),
  but the script itself never gave it the chance to run.

## Verification

Exercised the new `dpkg-deb`/`makepkg` guarding locally with stubbed binaries:

- "makepkg fails after deb succeeds" (this run's exact scenario) — script now
  exits 0, the `.deb` survives in `build/linux/deb/`, only `PKGBUILD` is left
  in `build/linux/arch/`.
- "both fail" — script exits 0, no package files produced; the existing
  file-tolerant *Rename Linux packages* logic (verified in #173) is what turns
  that into a hard job failure.

The alpm/`--nodeps` fix itself is **not verified locally** — no Arch tooling
available in the agent sandbox. Relying on the next *Build (Branch)* rerun on
`nightly` to confirm `makepkg` actually succeeds end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVFDnwT2zoREeG3eVbmYLd)_