### PR TITLE
fix(image-viewer): send same-origin Referer for remote image fetches

### DIFF
--- a/lib/core/utils/image_src.dart
+++ b/lib/core/utils/image_src.dart
@@ -5,11 +5,31 @@ import 'package:flutter/widgets.dart';
 
 import 'platform_paths.dart';
 
-const Map<String, String> _imageFetchHeaders = {
+const Map<String, String> _baseImageFetchHeaders = {
   'User-Agent': 'Mozilla/5.0 (compatible) AppleWebKit/537.36 (KHTML, like Gecko)'
       ' Chrome/124.0.0.0 Safari/537.36',
   'Accept': 'image/avif,image/webp,image/apng,image/*,*/*;q=0.8',
 };
+
+/// Headers for a remote image fetch, including a same-origin `Referer`.
+///
+/// The chat WebView loads messages from a real `http(s)` origin
+/// (`appassets.androidplatform.net` on Android, a `127.0.0.1` loopback
+/// server on iOS/Windows), so Chromium attaches a `Referer` when it fetches
+/// `<img>` sub-resources. The native viewer's bare `dart:io` request has no
+/// page context and sends none, and some hotlink-protected CDNs 403 a
+/// referer-less request while allowing the WebView's — sending the image's
+/// own origin as `Referer` satisfies that check without needing to know the
+/// real embedding page.
+Map<String, String> _imageFetchHeaders(String url) {
+  try {
+    final origin = Uri.parse(url).origin;
+    if (origin.isEmpty) return _baseImageFetchHeaders;
+    return {..._baseImageFetchHeaders, 'Referer': '$origin/'};
+  } catch (_) {
+    return _baseImageFetchHeaders;
+  }
+}
 
 /// Turns an image `src` as it appears inside the chat WebView into an
 /// [ImageProvider] usable by native Flutter widgets (the full-screen viewer).
@@ -54,7 +74,7 @@ ImageProvider? imageProviderForSrc(String src) {
     // The UA matters: several image CDNs answer 403 to the bare Dart client
     // (`Dart/3.x (dart:io)`) while happily serving the same URL to the WebView,
     // which is exactly the "renders in the message, blank in the viewer" case.
-    return CachedNetworkImageProvider(trimmed, headers: _imageFetchHeaders);
+    return CachedNetworkImageProvider(trimmed, headers: _imageFetchHeaders(trimmed));
   }
 
   return _fileProvider(imageSrcToFilePath(trimmed));

--- a/test/image_src_resolver_test.dart
+++ b/test/image_src_resolver_test.dart
@@ -40,6 +40,15 @@ void main() {
       expect(provider.headers?['User-Agent'], isNotNull);
     });
 
+    test('remote URLs send a same-origin Referer', () {
+      // Some CDNs 403 a referer-less request from the bare Dart client while
+      // happily serving the WebView, which always fetches as a sub-resource
+      // of a real page and so always sends one.
+      final provider = imageProviderForSrc('https://cdn.example.com/a.webp');
+      expect((provider as CachedNetworkImageProvider).headers?['Referer'],
+          'https://cdn.example.com/');
+    });
+
     test('surrounding whitespace does not turn a URL into a file path', () {
       // The WebView trims this when loading <img src>, so the picture shows in
       // the message; the viewer has to trim it too or it looks for a file.


### PR DESCRIPTION
## Summary
- The full-screen image viewer fetches remote markdown images (`[...](url)`) with a bare `dart:io` request that carries no `Referer`, while the chat WebView always loads the same URL as a sub-resource of a real `http(s)` page and so sends one automatically.
- Some hotlink-protected CDNs reject the referer-less native request while serving the WebView fine, which shows up as an image that renders correctly inline in the chat but fails to open (blank/error) in the full-screen viewer — reported for `https://files.kammii.org/tACftoO2qI.webp`.
- `lib/core/utils/image_src.dart`: build the `CachedNetworkImageProvider` headers per-request and include a `Referer` set to the image's own origin, matching what the WebView already sends.

## Test plan
- [x] Added `test/image_src_resolver_test.dart` case asserting the `Referer` header equals the image's own origin.
- [ ] `flutter analyze` / `flutter test` (not runnable in this sandbox — no Flutter/Dart SDK available; needs to be run before merge).
- [ ] Manual repro: open a chat message containing the reported markdown image and confirm the full-screen viewer now opens it.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ks6RufLDGkYBDKy6EoFHL)_