### PR TITLE
chore: bump version to 0.7.0-a

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: glaze_flutter
 description: "Glaze — AI chat client (Flutter)"
 publish_to: 'none'
-version: 0.7.0
+version: 0.7.0-a
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Changes

- Bump `pubspec.yaml` version from `0.7.0` to `0.7.0-a` (pub/semver pre-release suffix, valid pub versioning syntax)

## Verification

- Confirmed `0.7.0-a` is valid Pub package versioning syntax (semver pre-release identifier after `-`); a bare `0.7.0a` is not accepted by the pub version parser


---
_Generated by [Claude Code](https://claude.ai/code/session_011QQLjfn3cpwd16L7ZDprhn)_