### PR TITLE
Remove blue tap-highlight on message edit confirm/cancel buttons

### DIFF
--- a/assets/chat_webview/styles.css
+++ b/assets/chat_webview/styles.css
@@ -944,6 +944,9 @@
   -webkit-backdrop-filter: blur(var(--element-blur, 12px));
   border: 1px solid rgba(255, 255, 255, 0.1);
   transition: all 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+  tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
 }
 .edit-btn:active {
   transform: scale(0.9);


### PR DESCRIPTION
## Summary
- `.edit-btn` (the save/cancel buttons shown under a message while editing) was missing the `-webkit-tap-highlight-color` reset that other message-control buttons already have, causing a blue rectangle to flash over the round button on tap
- Added `-webkit-tap-highlight-color: transparent`, `tap-highlight-color: transparent`, and `-webkit-touch-callout: none` to `.edit-btn` in `assets/chat_webview/styles.css`

## Test plan
- [ ] Hot restart the app (JS asset change) and confirm tapping the edit confirm/cancel buttons no longer shows a blue highlight rectangle

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHYHpxgDDE53yBjLmUKvn3)_