### PR TITLE
fix(stats): show character names in the statistics pickers

### DIFF
--- a/lib/features/chat/widgets/chat_stats_sheet.dart
+++ b/lib/features/chat/widgets/chat_stats_sheet.dart
@@ -5,7 +5,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../core/state/character_provider.dart';
 import '../../../core/utils/platform_paths.dart';
 import '../../../core/state/db_provider.dart';
 import '../../../core/services/model_usage_service.dart';
@@ -106,7 +105,13 @@ class _ChatStatsSheetState extends ConsumerState<ChatStatsSheet> {
   }
 
   Future<void> _initData() async {
-    _allCharacters = ref.read(charactersProvider).value ?? [];
+    // Read characters straight from the DB for the same reason as the sessions
+    // below: `charactersProvider` is an AsyncNotifier, so a plain `read` on a
+    // sheet opened before it was warmed returns `AsyncLoading` (no value) and
+    // the list would stay empty for the sheet's whole lifetime — the character
+    // picker then shows "—" and the chat picker falls back to raw character ids.
+    _allCharacters = await ref.read(characterRepoProvider).getAll();
+    if (!mounted) return;
     // Read sessions straight from the DB rather than the cached provider: the
     // cache is not invalidated on message edits/deletions (counts would lag),
     // and a plain repo future reliably completes so the initial compute — and
@@ -124,9 +129,14 @@ class _ChatStatsSheetState extends ConsumerState<ChatStatsSheet> {
     // seed defaults from the last-interacted chat so every tab shows data
     // immediately instead of waiting for the user to pick a character/chat.
     if (_selectedCharId == null || _selectedCharId!.isEmpty) {
-      _selectedCharId = _allSessions.isNotEmpty
-          ? _allSessions.first.characterId
-          : (_allCharacters.isNotEmpty ? _allCharacters.first.id : null);
+      // Skip sessions whose character no longer exists — seeding the picker with
+      // an orphaned id would leave the Character tab without a name or avatar.
+      final knownIds = _allCharacters.map((c) => c.id).toSet();
+      _selectedCharId = _allSessions
+              .where((s) => knownIds.contains(s.characterId))
+              .firstOrNull
+              ?.characterId ??
+          (_allCharacters.isNotEmpty ? _allCharacters.first.id : null);
     }
     String? currentSessionId;
     if (widget.initialCharId.isNotEmpty) {
@@ -609,7 +619,11 @@ class _ChatStatsSheetState extends ConsumerState<ChatStatsSheet> {
   /// Human label for a chat/session in the chat picker: `<character> · <chat>`.
   String _sessionLabel(ChatSession s) {
     final char = _allCharacters.where((c) => c.id == s.characterId).firstOrNull;
-    final charName = char?.name ?? s.characterId;
+    // Never fall back to the raw character id — an orphaned session shows a
+    // readable placeholder instead of a bare timestamp-looking number.
+    final charName = (char?.name.trim().isNotEmpty ?? false)
+        ? char!.name
+        : 'Unknown character';
     final name = s.sessionVars['sessionName']?.trim();
     final chatName = (name != null && name.isNotEmpty)
         ? name
@@ -885,84 +899,100 @@ class _ChatStatsSheetState extends ConsumerState<ChatStatsSheet> {
             ),
             child: ClipRRect(
               borderRadius: BorderRadius.circular(14),
-              child: ListView.separated(
-                shrinkWrap: true,
-                padding: EdgeInsets.zero,
-                itemCount: _allCharacters.length,
-                separatorBuilder: (context, index) => Container(
-                  height: 0.5,
-                  color: Colors.white.withValues(alpha: 0.06),
-                ),
-                itemBuilder: (context, index) {
-                  final char = _allCharacters[index];
-                  final active = char.id == _selectedCharId;
-                  final cColor = Color(
-                    int.parse(
-                      (char.color ?? '#66ccff').replaceFirst('#', '0xFF'),
-                    ),
-                  );
-                  return InkWell(
-                    onTap: () {
-                      setState(() {
-                        _selectedCharId = char.id;
-                        _showCharDropdown = false;
-                      });
-                      unawaited(_calculateStats());
-                    },
-                    child: Container(
-                      color: active
-                          ? context.cs.primary.withValues(alpha: 0.08)
-                          : Colors.transparent,
+              child: _allCharacters.isEmpty
+                  ? Padding(
                       padding: const EdgeInsets.symmetric(
                         horizontal: 14,
-                        vertical: 10,
+                        vertical: 14,
                       ),
-                      child: Row(
-                        children: [
-                          Container(
-                            width: 32,
-                            height: 32,
-                            decoration: BoxDecoration(
-                              color: cColor,
-                              shape: BoxShape.circle,
+                      child: Text(
+                        _loading ? '...' : 'No characters yet',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: context.cs.onSurfaceVariant,
+                        ),
+                      ),
+                    )
+                  : ListView.separated(
+                      shrinkWrap: true,
+                      padding: EdgeInsets.zero,
+                      itemCount: _allCharacters.length,
+                      separatorBuilder: (context, index) => Container(
+                        height: 0.5,
+                        color: Colors.white.withValues(alpha: 0.06),
+                      ),
+                      itemBuilder: (context, index) {
+                        final char = _allCharacters[index];
+                        final active = char.id == _selectedCharId;
+                        final cColor = Color(
+                          int.parse(
+                            (char.color ?? '#66ccff').replaceFirst('#', '0xFF'),
+                          ),
+                        );
+                        return InkWell(
+                          onTap: () {
+                            setState(() {
+                              _selectedCharId = char.id;
+                              _showCharDropdown = false;
+                            });
+                            unawaited(_calculateStats());
+                          },
+                          child: Container(
+                            color: active
+                                ? context.cs.primary.withValues(alpha: 0.08)
+                                : Colors.transparent,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 14,
+                              vertical: 10,
                             ),
-                            clipBehavior: Clip.antiAlias,
-                            child: char.avatarPath != null
-                                ? Image.file(
-                                    File(
-                                      resolveGlazeFilePath(char.avatarPath!)!,
+                            child: Row(
+                              children: [
+                                Container(
+                                  width: 32,
+                                  height: 32,
+                                  decoration: BoxDecoration(
+                                    color: cColor,
+                                    shape: BoxShape.circle,
+                                  ),
+                                  clipBehavior: Clip.antiAlias,
+                                  child: char.avatarPath != null
+                                      ? Image.file(
+                                          File(
+                                            resolveGlazeFilePath(
+                                              char.avatarPath!,
+                                            )!,
+                                          ),
+                                          fit: BoxFit.cover,
+                                          errorBuilder:
+                                              (context, error, stackTrace) =>
+                                                  _buildInitials(char.name),
+                                        )
+                                      : _buildInitials(char.name),
+                                ),
+                                const SizedBox(width: 10),
+                                Expanded(
+                                  child: Text(
+                                    char.name,
+                                    style: TextStyle(
+                                      fontSize: 15,
+                                      fontWeight: FontWeight.w500,
+                                      color: context.cs.onSurface,
                                     ),
-                                    fit: BoxFit.cover,
-                                    errorBuilder:
-                                        (context, error, stackTrace) =>
-                                            _buildInitials(char.name),
-                                  )
-                                : _buildInitials(char.name),
-                          ),
-                          const SizedBox(width: 10),
-                          Expanded(
-                            child: Text(
-                              char.name,
-                              style: TextStyle(
-                                fontSize: 15,
-                                fontWeight: FontWeight.w500,
-                                color: context.cs.onSurface,
-                              ),
-                              overflow: TextOverflow.ellipsis,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                                if (active)
+                                  Icon(
+                                    Icons.check,
+                                    color: context.cs.primary,
+                                    size: 20,
+                                  ),
+                              ],
                             ),
                           ),
-                          if (active)
-                            Icon(
-                              Icons.check,
-                              color: context.cs.primary,
-                              size: 20,
-                            ),
-                        ],
-                      ),
+                        );
+                      },
                     ),
-                  );
-                },
-              ),
             ),
           ),
           crossFadeState: _showCharDropdown

--- a/test/characterization/chat_stats_character_names_test.dart
+++ b/test/characterization/chat_stats_character_names_test.dart
@@ -1,0 +1,49 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression guard for the two statistics bugs where the sheet had no
+/// character data to render:
+///
+///  * the Chat picker printed raw character ids instead of names, and
+///  * the Character picker showed "—" with an empty dropdown.
+///
+/// Both came from seeding `_allCharacters` with
+/// `ref.read(charactersProvider).value ?? []`: `charactersProvider` is an
+/// `AsyncNotifier`, so a sheet opened before it was warmed reads `AsyncLoading`
+/// (no value) and keeps an empty list for its whole lifetime. Characters are now
+/// read from the repository, awaited like the sessions next to them.
+void main() {
+  final source =
+      File('lib/features/chat/widgets/chat_stats_sheet.dart').readAsStringSync();
+
+  group('ChatStatsSheet character data', () {
+    test('characters are awaited from the repo, not a maybe-loading provider',
+        () {
+      expect(
+        source.contains('await ref.read(characterRepoProvider).getAll()'),
+        isTrue,
+        reason: 'the sheet must load characters from the repository',
+      );
+      expect(
+        source.contains('ref.read(charactersProvider)'),
+        isFalse,
+        reason:
+            'reading charactersProvider without awaiting it yields an empty '
+            'list when the provider has not been built yet',
+      );
+    });
+
+    test('session labels never fall back to the raw character id', () {
+      expect(
+        source.contains('char?.name ?? s.characterId'),
+        isFalse,
+        reason: 'an orphaned session must show a placeholder, not an id',
+      );
+    });
+
+    test('character dropdown renders an empty state', () {
+      expect(source.contains('No characters yet'), isTrue);
+    });
+  });
+}

--- a/test/characterization/ui_db_violations_test.dart
+++ b/test/characterization/ui_db_violations_test.dart
@@ -33,12 +33,14 @@ void main() {
       }
     });
 
-    // Documented exception. chat_stats_sheet.dart reads sessions straight from
-    // chatRepoProvider on purpose — see the comment at its _initData(): the
-    // cached provider is not invalidated on message edits/deletions, so the
-    // stats counts would lag, and a plain repo future is guaranteed to complete
-    // where the provider may stay unresolved. Deliberate, so the rule below
-    // skips it rather than the rule being deleted for everyone else.
+    // Documented exception. chat_stats_sheet.dart reads sessions and characters
+    // straight from chatRepoProvider/characterRepoProvider on purpose — see the
+    // comments at its _initData(): the cached session provider is not
+    // invalidated on message edits/deletions, so the stats counts would lag,
+    // and a plain repo future is guaranteed to complete where the (async)
+    // providers may stay unresolved and hand the sheet an empty list.
+    // Deliberate, so the rule below skips it rather than the rule being deleted
+    // for everyone else.
     final directRepoExceptions = <String>{
       'lib/features/chat/widgets/chat_stats_sheet.dart',
     };


### PR DESCRIPTION
Fixes two reported statistics bugs that share one root cause: the sheet seeded `_allCharacters` from `ref.read(charactersProvider).value ?? []`. `charactersProvider` is an `AsyncNotifier`, so a sheet opened before it was warmed (e.g. from Tools) read `AsyncLoading` — no value — and kept an empty character list for its whole lifetime.

- The Chat tab then fell back to the raw character id, rendering entries like `1785272937664 · Chat #2`
- The Character tab showed `—` with no avatar over an empty dropdown, even though the stats themselves computed correctly

## Changes

- Load characters with `characterRepoProvider.getAll()`, awaited right next to the existing sessions read, so both pickers always have names and avatars regardless of provider warm-up
- Seed the default character from the newest session whose character still exists, so an orphaned session can't leave the Character tab blank
- Label sessions whose character is gone as `Unknown character` instead of printing the raw id
- Show a `No characters yet` empty state in the character dropdown, matching the chat dropdown
- Drop the now-unused `character_provider.dart` import
- Extend the documented UI→DB exception note for this sheet to cover the character repo read (the file was already on the exception list, so the rule is unchanged for everyone else)

## Verification

- Added `test/characterization/chat_stats_character_names_test.dart`, which asserts the sheet awaits the repo instead of reading the maybe-loading provider, that session labels no longer fall back to `s.characterId`, and that the character dropdown has an empty state
- `flutter analyze` / `flutter test` were not run locally — no Flutter SDK in this environment — so CI is the check; the diff touches one widget file plus tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEZkuHaLv7h4jzeZBABUqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEZkuHaLv7h4jzeZBABUqC)_