### PR TITLE
Catalog: show sort-mode icons in the picker sheet

### DIFF
--- a/lib/features/catalog/widgets/catalog_controls.dart
+++ b/lib/features/catalog/widgets/catalog_controls.dart
@@ -168,6 +168,7 @@ class CatalogControls extends ConsumerWidget {
                     label: e.value,
                     isActive: e.key == state.filters.sort,
                     value: e.key,
+                    icon: sortIconForKey(e.key),
                   ),
                 )
                 .toList(),
@@ -192,9 +193,25 @@ class CatalogControls extends ConsumerWidget {
       items: items
           .map(
             (item) => BottomSheetItem(
-              icon: item.isActive ? Icons.check_rounded : null,
-              iconColor: context.cs.primary,
+              icon: item.icon ?? (item.isActive ? Icons.check_rounded : null),
+              iconColor: item.icon != null
+                  ? (item.isActive
+                        ? context.cs.primary
+                        : context.cs.onSurfaceVariant)
+                  : context.cs.primary,
               label: item.label,
+              actions: item.icon != null && item.isActive
+                  ? [
+                      BottomSheetAction(
+                        icon: Icons.check_rounded,
+                        color: context.cs.primary,
+                        onTap: () {
+                          Navigator.of(context, rootNavigator: true).pop();
+                          onSelect(item.value);
+                        },
+                      ),
+                    ]
+                  : const [],
               onTap: () {
                 Navigator.of(context, rootNavigator: true).pop();
                 onSelect(item.value);
@@ -210,10 +227,12 @@ class _PickerItem {
   final String label;
   final bool isActive;
   final dynamic value;
+  final IconData? icon;
   const _PickerItem({
     required this.label,
     required this.isActive,
     required this.value,
+    this.icon,
   });
 }
 


### PR DESCRIPTION
## Summary
- Each row in the sort-mode picker sheet now shows the same icon as the chip, instead of just a plain checkmark on the active row
- The active row keeps a trailing checkmark so the current selection is still clear

## Test plan
- [ ] `flutter analyze`
- [ ] `flutter test`
- [ ] Manual check: open the sort picker sheet in Catalog, confirm every option has its icon and the active option shows the checkmark

---
_Generated by [Claude Code](https://claude.ai/code/session_016r6S12BQLDRZTnk9zfou1W)_