### PR TITLE
Refactor follow-up baselines and extension runtime contracts

### DIFF
--- a/assets/chat_webview/bridge.legacy.js
+++ b/assets/chat_webview/bridge.legacy.js
@@ -950,7 +950,7 @@ class Bridge {
           type: 'glaze:response',
           id: data.id,
           ok: false,
-          error: { message: String(error && error.message ? error.message : error) },
+          error: { code: error && error.code, message: String(error && error.message ? error.message : error) },
         }, '*');
       }
     });
@@ -963,7 +963,9 @@ class Bridge {
     const response = await window.flutter_inappwebview.callHandler('glazeBridge', request);
     if (response && response.ok === false) {
       const error = response.error || {};
-      throw new Error(error.message || 'Glaze bridge error');
+      const bridgeError = new Error(error.message || 'Glaze bridge error');
+      bridgeError.code = error.code;
+      throw bridgeError;
     }
     return response && Object.prototype.hasOwnProperty.call(response, 'result')
       ? response.result
@@ -2054,7 +2056,7 @@ class PanelHost {
         id: data.id,
         method: data.method,
         params: data.params || {},
-        context: data.context || {},
+        context: { ...(data.context || {}), panelId: panel.panelId, messageId: panel.messageId },
       });
       panel.iframe.contentWindow.postMessage(
         { type: 'glaze:response', id: data.id, ok: true, result },
@@ -2067,6 +2069,7 @@ class PanelHost {
           id: data.id,
           ok: false,
           error: {
+            code: error && error.code,
             message: String(error && error.message ? error.message : error),
           },
         },
@@ -2105,7 +2108,7 @@ class PanelHost {
     iframe.style.width = '100%';
     iframe.style.height = placeholderHeight + 'px';
     iframe.style.background = 'transparent';
-    iframe.srcdoc = this._buildSrcdoc(html, options);
+    iframe.srcdoc = this._buildSrcdoc(html, options, panelId, messageId);
 
     host.appendChild(iframe);
 
@@ -2139,12 +2142,12 @@ class PanelHost {
     return panelId;
   }
 
-  _buildSrcdoc(html, options) {
+  _buildSrcdoc(html, options, panelId, messageId) {
     const sdk = JSON.stringify(window.__glazeSdkSource || '');
     const userHtml = String(html == null ? '' : html);
     const context = JSON.stringify({
-      messageId: options.messageId || '',
-      panelId: options.panelId || '',
+      messageId,
+      panelId,
       title: options.title || '',
     });
     const bootstrap = `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>

--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -189,7 +189,7 @@ export class Bridge {
           type: 'glaze:response',
           id: data.id,
           ok: false,
-          error: { message: String(error && error.message ? error.message : error) },
+          error: { code: error && error.code, message: String(error && error.message ? error.message : error) },
         }, '*');
       }
     });
@@ -202,7 +202,9 @@ export class Bridge {
     const response = await window.flutter_inappwebview.callHandler('glazeBridge', request);
     if (response && response.ok === false) {
       const error = response.error || {};
-      throw new Error(error.message || 'Glaze bridge error');
+      const bridgeError = new Error(error.message || 'Glaze bridge error');
+      bridgeError.code = error.code;
+      throw bridgeError;
     }
     return response && Object.prototype.hasOwnProperty.call(response, 'result')
       ? response.result

--- a/assets/chat_webview/bridge/panel_host.js
+++ b/assets/chat_webview/bridge/panel_host.js
@@ -58,7 +58,9 @@ export class PanelHost {
         id: data.id,
         method: data.method,
         params: data.params || {},
-        context: data.context || {},
+        // Panel identity belongs to the host, never to caller supplied options
+        // or panel-controlled context.
+        context: { ...(data.context || {}), panelId: panel.panelId, messageId: panel.messageId },
       });
       panel.iframe.contentWindow.postMessage(
         { type: 'glaze:response', id: data.id, ok: true, result },
@@ -71,6 +73,7 @@ export class PanelHost {
           id: data.id,
           ok: false,
           error: {
+            code: error && error.code,
             message: String(error && error.message ? error.message : error),
           },
         },
@@ -109,7 +112,7 @@ export class PanelHost {
     iframe.style.width = '100%';
     iframe.style.height = placeholderHeight + 'px';
     iframe.style.background = 'transparent';
-    iframe.srcdoc = this._buildSrcdoc(html, options);
+    iframe.srcdoc = this._buildSrcdoc(html, options, panelId, messageId);
 
     host.appendChild(iframe);
 
@@ -143,12 +146,12 @@ export class PanelHost {
     return panelId;
   }
 
-  _buildSrcdoc(html, options) {
+  _buildSrcdoc(html, options, panelId, messageId) {
     const sdk = JSON.stringify(window.__glazeSdkSource || '');
     const userHtml = String(html == null ? '' : html);
     const context = JSON.stringify({
-      messageId: options.messageId || '',
-      panelId: options.panelId || '',
+      messageId,
+      panelId,
       title: options.title || '',
     });
     const bootstrap = `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1072,17 +1072,14 @@ feature-local adapters to `SyncService`.
 
 ## 9. Extensions (Info Blocks + JS Bridge SDK)
 
-The extensions feature ships two surfaces with the same registry-defined bridge
-contract. Each visual chat owns its fully wired `JsBridgeService`; headless
-authority is bound explicitly per run rather than selected globally:
+The extensions feature supports the Chat WebView bridge and sandboxed panels
+that relay through it. Each visual chat owns its fully wired `JsBridgeService`:
 
 1. **Post-generation block chain** — preset-driven infoblock / imageGen /
    jsRunner / interactive blocks that run after the assistant message
    is saved on the normal/regen path.
 2. **JS Bridge SDK** (`window.glaze`) — extension authors can call
-   `glaze.*` from sandboxed iframes (interactive panels) or from a
-   headless `InAppWebView` that runs in the background even when no
-   chat is open.
+   `glaze.*` from the Chat WebView or sandboxed interactive panels.
 
 Formal invariants: `docs/INVARIANTS.md` INV-EG1–INV-EG8 and
 INV-JS1–INV-JS6.
@@ -1110,7 +1107,7 @@ per block via `InfoBlocksRepository.updateStatus()`.
 |---|---|---|
 | `infoblock` | `blocks/infoblock_handler.dart` | Calls `InfoBlockService`; injects last N results into prompt context |
 | `imageGen` | `blocks/image_gen_block_handler.dart` | Reads `[img gen:…]` tag, calls `ImageGenService`, saves via `ImageStorageService`; result stored as `[IMG:RESULT:<path>]` |
-| `jsRunner` | `blocks/js_runner_block_handler.dart` | Runs JS via `JsBlockExecutor`: headless `JsEngineService` preferred, visual bridge fallback. Periodic ticks only ever run here. |
+| `jsRunner` | `blocks/js_runner_block_handler.dart` | Runs JS through the Chat WebView via `JsBlockExecutor`; absent bridges produce a bounded unavailable error. |
 | `interactive` | `blocks/interactive_block_handler.dart` | LLM → strip code-fence → sandboxed iframe island under the assistant message. JS inside the panel has access to `window.glaze.*` |
 
 ### Block triggers
@@ -1119,7 +1116,7 @@ per block via `InfoBlocksRepository.updateStatus()`.
 |---|---|---|
 | `afterAssistant` | `PostGenCoordinator`: background when Studio is off; `CleanerStage` after canonical swipe selection when Studio is on | all block types |
 | `afterUser` | `ChatNotifier.sendMessage` (fire-and-forget `unawaited(_dispatchAfterUserBlocks(...))`) | all block types |
-| `periodic` | `PeriodicTriggerScheduler` (`Timer.periodic(block.periodicIntervalSeconds)`) | `jsRunner` only — headless engine preferred, visual bridge fallback |
+| `periodic` | `PeriodicTriggerScheduler` (`Timer.periodic(block.periodicIntervalSeconds)`) | `jsRunner` only — no supported bridge runtime is available without the Chat WebView |
 
 The chain filter is enforced by `BlockProcessor` and `SingleBlockRunner`, with
 `ExtensionPostGenService` kept as the public entrypoint. The same chain is reused
@@ -1166,11 +1163,10 @@ independent of the chat text-generation token (INV-EG5).
 Each extension preset carries a `PresetPermissions` freezed model with
 19 capability toggles (default-deny except `showToast`). The immutable
 `JsBridgeMethodRegistry` is the canonical public method set and records each
-method's capability resolver plus visual/headless host availability.
+method's capability resolver plus Chat WebView host availability.
 `JsBridgeService.dispatch` rejects unregistered methods, enforces the registered
 capability through the injected `PermissionCheck`, and then selects the
-registered operation. Visual/headless declarations and parity tests consume the
-registry's host sets. Production
+registered operation. Supported-profile tests consume the registry's host sets. Production
 wiring in `ChatWebViewWidget` reads `activePresetPermissionsProvider`.
 
 | Capability | Bridge method |
@@ -1239,25 +1235,15 @@ returns the `Source` subclass (or `null` for built-in cues).
 
 User-authored JS runs in a `<iframe sandbox="allow-scripts">` (without
 `allow-same-origin`) — null origin, no access to `window.parent`,
-`window.flutter_inappwebview`, or any API keys. Two execution paths:
+`window.flutter_inappwebview`, or any API keys. The supported execution path is:
 
 * **Visual WebView** — `ChatBridgeController.runJsBlock()` is used
   when the chat is open; the script is forwarded into the chat
   WebView's `assets/chat_webview/bridge/chat_bridge_controller.js`
   `runSandboxedScript()` path.
-* **Headless engine** — `JsEngineService` is a process-wide
-  `HeadlessInAppWebView` that loads `assets/chat_webview/headless.html`. Each
-  `runScript` allocates an opaque `runId` and may bind it to a
-  `JsEngineBridgeHost` wrapping the relevant visual bridge. Missing, hostless,
-  completed, or expired run IDs receive `bridge_unavailable`; bindings are
-  removed in `finally`. Concurrent runs therefore cannot borrow another chat's
-  authority. Callers may fall back to the visual execution path when the engine
-  itself is unavailable.
-
-The headless path calls
-`window.headlessBridge.runSandboxedScript(script, contextJson, runId)`. Both
-paths ultimately use the same registry and `JsBridgeService.dispatch` contract
-for `glaze.*` calls, but they do not share mutable process-wide chat authority.
+The retained headless engine assets are not a supported bridge profile or
+fallback runtime. JS block runners never retry a script in another runtime;
+when the Chat WebView is absent they return an explicit unavailable outcome.
 
 ### Dart files
 
@@ -1267,18 +1253,18 @@ for `glaze.*` calls, but they do not share mutable process-wide chat authority.
 * `blocks/block_status_tracker.dart` — placeholder/status/error/dedupe lifecycle
 * `blocks/block_panel_updater.dart` — shared panel update/throttling plumbing
 * `blocks/image_pixel_renderer.dart` — image bytes → persisted file/result token
-* `blocks/js_block_executor.dart` — message-bound `jsRunner` execution + headless/visual fallback persistence
-* `blocks/periodic_js_block_runner.dart` — periodic headless/visual fallback execution
+* `blocks/js_block_executor.dart` — message-bound `jsRunner` execution through the Chat WebView
+* `blocks/periodic_js_block_runner.dart` — periodic JS-runner integration (not a supported bridge profile)
 * `blocks/image_only_rerunner.dart` — manual image-only rerun validation/status update flow
 * `blocks/*_block_handler.dart` — concrete `infoblock`, `imageGen`, `jsRunner`, `interactive` handlers
 * `info_block_service.dart` — LLM call + prompt assembly for `infoblock` type
 * `info_block_injector.dart` — inserts stored `InfoBlock` outputs into the prompt context
 * `js_bridge_service.dart` — compatibility export for `js_bridge/js_bridge_service.dart`
 * `js_bridge/js_bridge_service.dart` — pure dispatcher: `{ method, params, context }` → `{ ok, result/error }`; no Riverpod
-* `js_bridge/js_bridge_method_registry.dart` — immutable canonical method set with operation, capability resolver, and host availability metadata
+* `js_bridge/js_bridge_method_registry.dart` — immutable canonical method set with operation, capability resolver, and supported-host metadata
 * `js_bridge/handlers/*_handler.dart` — variables, generation, prompt injection, audio, commands, toast
 * `js_bridge/capability_resolver.dart` + `permission_gate.dart` — method/scope capability mapping and default-deny enforcement
-* `js_engine_service.dart` — singleton headless engine + `JsEngineBridgeHost` (optional `currentCharIdProvider` for `triggerGeneration` in headless mode)
+* `js_engine_service.dart` — retained unused headless-engine compatibility implementation
 * `panel_host_service.dart` — singleton panel registry + resize/event broadcast streams
 * `audio_bridge_service.dart` — `SystemSound` + `audioplayers` routing
 * `command_registry.dart` — `/trigger` / `/getvar` / `/setvar` / `/inject` / `/toast` registry; `buildWiredCommandRegistry(WiredCommandDeps)` is the production default
@@ -1306,7 +1292,7 @@ Active chat WebView JS is loaded as ES modules from `assets/chat_webview/index.h
 * `assets/chat_webview/bridge/index.js` — imports `Formatter` and `Renderer`, creates `window.bridge`, registers scaled wheel handling and `onWebViewReady`
 * `assets/chat_webview/bridge/chat_bridge_controller.js` — main JS bridge facade, Flutter transport, message list API, ext-block panel, sandbox runner
 * `assets/chat_webview/bridge/panel_host.js` — sandboxed interactive iframe lifecycle and `glaze:*` relay
-* `assets/chat_webview/headless.html` — headless engine host
+* `assets/chat_webview/headless.html` — retained unused headless-engine asset
 
 Legacy single-file paths (`bridge.js`, `renderer.js`, `formatter.js`) are
 compatibility markers only; `bridge.legacy.js` is the retained pre-module bridge
@@ -1362,7 +1348,7 @@ Resolved (kept for history; details in git / PR notes):
 - **Session vars on abort/error** — only a successful guarded commit applies the
   isolate variable delta (INV-C5).
 - **Memory injection token budget** — `memory_budget.dart` + INV-PS4.
-- **JS extensions MVP** — `window.glaze` SDK, headless `JsEngineService`, capability permissions, periodic/afterUser triggers, interactive panels, audioplayers-backed audio, big/medium/small connection profiles, wired `CommandRegistry`, lifecycle-paused periodic scheduler. Current module boundaries are documented in § 9.
+- **JS extensions MVP** — `window.glaze` SDK, Chat WebView bridge, capability permissions, periodic/afterUser triggers, interactive panels, audioplayers-backed audio, big/medium/small connection profiles, wired `CommandRegistry`, lifecycle-paused periodic scheduler. Current module boundaries are documented in § 9.
 - **`sync_engine.dart` decomposition** — `SyncBinaryAssetSyncer` (avatar/gallery push/pull) + `sync_image_stripper.dart` extracted; `saveLorebookActivations` injected as callback (removed provider-layer import from service).
 - **`prompt_builder.dart` decomposition** — regex application extracted to `prompt_regex_applicator.dart`; deferred-memory finalization extracted to `_finalizeDeferredMemory()`.
 - **`image_gen_service.dart` decomposition** — `[IMG:*]` tag-markup text transforms extracted to `image_tag_markup.dart` (`ImageTagMarkup`).

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -844,14 +844,11 @@ share the same contract, not mutable process-wide chat authority:
 
 * `ChatBridgeController.runJsBlock()` — visual WebView, used while a
   chat is open.
-* `JsEngineService.runScript()` — headless `HeadlessInAppWebView`, with an
-  optional bridge host bound to an opaque per-run ID. Hostless or expired IDs
-  cannot call `window.glaze`. Falls back to visual execution when the engine is
-  unavailable.
+* Sandboxed panels relay through that same Chat WebView and receive the host's
+  authoritative panel and message identifiers.
 
 `runSandboxedScript` is implemented in
-`assets/chat_webview/bridge/chat_bridge_controller.js` (visual) and
-`headless.html` (headless). Both wire the iframe's
+`assets/chat_webview/bridge/chat_bridge_controller.js`. It wires the iframe's
 `postMessage` channel to a Dart `glazeBridge` handler with a
 matching source-check (`e.source !== iframe.contentWindow` /
 `!== contentWindow`).
@@ -866,7 +863,8 @@ Every public bridge method is defined in the immutable
 `JsBridgeMethodRegistry`, including its capability resolver and host
 availability. `JsBridgeService.dispatch` rejects methods absent from that
 registry and enforces the resolved capability before invoking a handler.
-The default policy is **deny** when no `PermissionCheck` is registered (test seam).
+The production constructor requires a `PermissionCheck`; test compositions use
+an explicit harmless fake.
 Production wires `_bridgePermissionCheck` in `ChatWebViewWidget`, which reads
 `activePresetPermissionsProvider`. The `PresetPermissions` model has 19
 toggles; only `showToast` defaults to allow.
@@ -884,10 +882,10 @@ toggles; only `showToast` defaults to allow.
 | `glaze.executeCommand` | `execute_command` |
 | `glaze.showToast` (default ALLOW) | `show_toast` |
 
-The visual and headless hosts currently expose the same registry-defined
-contract. Scope-sensitive variable methods resolve their capability from
-`params.scope`; fixed-capability methods carry a fixed resolver. Handler code
-does not maintain a second capability table.
+The Chat WebView is the sole registry-defined bridge host. Scope-sensitive
+variable methods resolve their capability from `params.scope`; fixed-capability
+methods carry a fixed resolver. Handler code does not maintain a second
+capability table.
 
 ### INV-JS2: Variable writes are atomic; payload is JSON-validated and ≤ 64 KiB ✅ ENFORCED
 
@@ -946,11 +944,9 @@ variable access, `inject_prompt`, or `show_toast`). The command context is
 forwarded unchanged so session, character, message, and global routing match
 the dedicated method.
 
-Headless execution binds that bridge authority to an opaque per-run id.
-Sandbox requests without an active id are denied, so the process-wide engine
-lifecycle cannot select one chat's authority for another chat's script.
-Runs without a visual chat bridge may execute pure JS, but receive no bridge
-authority and therefore cannot call `window.glaze` methods.
+Sandboxed panel requests relay only through their containing Chat WebView.
+Absent Chat WebView bridges produce the explicit unavailable outcome; they do
+not execute or retry in a headless runtime.
 
 `buildDefaultCommandRegistry` is retained for tests/CMS — its
 handlers echo arguments. The `CommandRegistry.run` contract catches

--- a/docs/decisions/001-memory-graph-disabled-is-inactive.md
+++ b/docs/decisions/001-memory-graph-disabled-is-inactive.md
@@ -1,0 +1,20 @@
+# Memory Graph disabled is inactive
+
+## Context
+
+Memory Graph has persisted data and separate build and retrieval paths. A
+disabled setting must not leave graph-derived context in generation through an
+older index or an experimental read path.
+
+## Decision
+
+When Memory Graph is disabled, Glaze does not build graph data and does not
+read graph data during generation. Existing stored graph data is ignored while
+the feature remains disabled.
+
+## Consequences
+
+- Disabling the feature prevents graph work and graph-derived prompt context.
+- Re-enabling may use data according to its own lifecycle rules; this decision
+  does not require deleting stored graph data.
+- SQLite runtime replacement and relational message storage are separate work.

--- a/docs/decisions/002-periodic-extensions-use-active-chat.md
+++ b/docs/decisions/002-periodic-extensions-use-active-chat.md
@@ -1,0 +1,20 @@
+# Periodic extensions use the active chat
+
+## Context
+
+Periodic extensions need an authority boundary before a scheduler can run.
+Executing against a background, previously selected, or global chat could make
+user-visible state change unexpectedly.
+
+## Decision
+
+Periodic extensions are authorized only for the chat currently visible to the
+user. They must not run for inactive chats.
+
+## Consequences
+
+- The scheduler must resolve and verify the active user-visible chat before
+  extension execution.
+- Switching away from a chat removes periodic-extension authority for that
+  chat.
+- SQLite runtime replacement and relational message storage are separate work.

--- a/docs/decisions/003-js-bridge-supported-profiles.md
+++ b/docs/decisions/003-js-bridge-supported-profiles.md
@@ -1,0 +1,20 @@
+# JS bridge supports Chat WebView and sandboxed panel profiles
+
+## Context
+
+The JS bridge has different execution profiles with different host services.
+Making every optional service dependency required before deciding which profiles
+are supported would port dependencies for runtimes Glaze does not support.
+
+## Decision
+
+The supported JS bridge profiles are Chat WebView and sandboxed panel. The
+headless engine is not a supported profile. Required dependency ports are
+guided by the services needed by the two supported profiles.
+
+## Consequences
+
+- Bridge dependency ports must support Chat WebView and sandboxed-panel calls.
+- The headless engine does not define required bridge dependencies or
+compatibility behavior.
+- SQLite runtime replacement and relational message storage are separate work.

--- a/lib/core/debug/perf_debug.dart
+++ b/lib/core/debug/perf_debug.dart
@@ -9,6 +9,7 @@ import 'package:flutter/widgets.dart';
 /// ```
 /// flutter run --profile --dart-define=PERF_LOG_FRAMES=true
 /// flutter run --profile --dart-define=NO_GLASS_BLUR=true
+/// flutter run --profile --dart-define=PERF_LOG_CHAT_WEBVIEW=true
 /// ```
 abstract final class PerfDebug {
   /// Print every frame that misses the 60fps budget, split by thread
@@ -23,6 +24,116 @@ abstract final class PerfDebug {
 
   /// Disable the film-grain NoiseOverlay on glass surfaces and backgrounds.
   static const bool noNoise = bool.fromEnvironment('NO_NOISE');
+
+  /// Collect process-local Chat WebView lifecycle totals. This does not write
+  /// to storage or send data anywhere. With this define off, each recorder is
+  /// a single no-op branch.
+  static const bool logChatWebView = bool.fromEnvironment(
+    'PERF_LOG_CHAT_WEBVIEW',
+  );
+
+  static int _chatScreenBuilds = 0;
+  static int _chatWebViewWidgetInits = 0;
+  static int _chatWebViewWidgetDisposes = 0;
+  static int _chatWebViewInitAttempts = 0;
+  static int _chatWebViewInitCompletions = 0;
+  static int _chatWebViewBridgeReadies = 0;
+  static int _chatWebViewJsBridgeReadies = 0;
+  static int _chatWebViewSyncUpdates = 0;
+  static int _chatWebViewMessageSyncs = 0;
+  static int _chatWebViewSessionSwitches = 0;
+  static int _chatWebViewSurfaceCreated = 0;
+  static int _chatWebViewLoadStops = 0;
+
+  static void chatScreenBuilt() {
+    if (!logChatWebView) return;
+    _chatScreenBuilds++;
+  }
+
+  static void chatWebViewWidgetInitialized() {
+    if (!logChatWebView) return;
+    _chatWebViewWidgetInits++;
+  }
+
+  /// Records Dart widget-state disposal only; it does not assert native WebView
+  /// disposal, because the platform view can be kept alive independently.
+  static void chatWebViewWidgetDisposed() {
+    if (!logChatWebView) return;
+    _chatWebViewWidgetDisposes++;
+  }
+
+  static void chatWebViewInitAttempted() {
+    if (!logChatWebView) return;
+    _chatWebViewInitAttempts++;
+  }
+
+  static void chatWebViewInitCompleted() {
+    if (!logChatWebView) return;
+    _chatWebViewInitCompletions++;
+  }
+
+  static void chatWebViewBridgeReady() {
+    if (!logChatWebView) return;
+    _chatWebViewBridgeReadies++;
+  }
+
+  static void chatWebViewJsBridgeReady() {
+    if (!logChatWebView) return;
+    _chatWebViewJsBridgeReadies++;
+  }
+
+  static void chatWebViewSyncResult({
+    required bool runMessageSync,
+    required bool sessionSwitched,
+  }) {
+    if (!logChatWebView) return;
+    _chatWebViewSyncUpdates++;
+    if (runMessageSync) _chatWebViewMessageSyncs++;
+    if (sessionSwitched) _chatWebViewSessionSwitches++;
+  }
+
+  static void chatWebViewSurfaceCreated() {
+    if (!logChatWebView) return;
+    _chatWebViewSurfaceCreated++;
+  }
+
+  static void chatWebViewLoadStopped() {
+    if (!logChatWebView) return;
+    _chatWebViewLoadStops++;
+  }
+
+  /// Returns concise process-local totals for an enabled profiling run.
+  static PerfDebugSnapshot chatWebViewSnapshot() => PerfDebugSnapshot(
+    chatScreenBuilds: _chatScreenBuilds,
+    widgetInits: _chatWebViewWidgetInits,
+    widgetDisposes: _chatWebViewWidgetDisposes,
+    initAttempts: _chatWebViewInitAttempts,
+    initCompletions: _chatWebViewInitCompletions,
+    bridgeReadies: _chatWebViewBridgeReadies,
+    jsBridgeReadies: _chatWebViewJsBridgeReadies,
+    syncUpdates: _chatWebViewSyncUpdates,
+    messageSyncs: _chatWebViewMessageSyncs,
+    sessionSwitches: _chatWebViewSessionSwitches,
+    surfaceCreated: _chatWebViewSurfaceCreated,
+    loadStops: _chatWebViewLoadStops,
+  );
+
+  /// Clears Chat WebView profiling totals for the current process.
+  static void resetChatWebViewSnapshot() {
+    if (!logChatWebView) return;
+    _chatScreenBuilds = 0;
+    _chatWebViewWidgetInits = 0;
+    _chatWebViewWidgetDisposes = 0;
+    _chatWebViewInitAttempts = 0;
+    _chatWebViewInitCompletions = 0;
+    _chatWebViewBridgeReadies = 0;
+    _chatWebViewJsBridgeReadies = 0;
+    _chatWebViewSyncUpdates = 0;
+    _chatWebViewMessageSyncs = 0;
+    _chatWebViewSessionSwitches = 0;
+    _chatWebViewSurfaceCreated = 0;
+    _chatWebViewLoadStops = 0;
+  }
 
   /// Installs the slow-frame logger; no-op unless [logSlowFrames] is set.
   static void installFrameLoggerIfEnabled() {
@@ -42,4 +153,44 @@ abstract final class PerfDebug {
       }
     });
   }
+}
+
+/// Immutable aggregate returned by [PerfDebug.chatWebViewSnapshot].
+class PerfDebugSnapshot {
+  const PerfDebugSnapshot({
+    required this.chatScreenBuilds,
+    required this.widgetInits,
+    required this.widgetDisposes,
+    required this.initAttempts,
+    required this.initCompletions,
+    required this.bridgeReadies,
+    required this.jsBridgeReadies,
+    required this.syncUpdates,
+    required this.messageSyncs,
+    required this.sessionSwitches,
+    required this.surfaceCreated,
+    required this.loadStops,
+  });
+
+  final int chatScreenBuilds;
+  final int widgetInits;
+  final int widgetDisposes;
+  final int initAttempts;
+  final int initCompletions;
+  final int bridgeReadies;
+  final int jsBridgeReadies;
+  final int syncUpdates;
+  final int messageSyncs;
+  final int sessionSwitches;
+  final int surfaceCreated;
+  final int loadStops;
+
+  @override
+  String toString() =>
+      'ChatWebViewPerf('
+      'screen=$chatScreenBuilds, widget=$widgetInits/$widgetDisposes, '
+      'init=$initAttempts/$initCompletions, '
+      'bridge=$bridgeReadies/$jsBridgeReadies, '
+      'sync=$syncUpdates/$messageSyncs/$sessionSwitches, '
+      'surface=$surfaceCreated/$loadStops)';
 }

--- a/lib/core/llm/prompt_payload_builder.dart
+++ b/lib/core/llm/prompt_payload_builder.dart
@@ -169,7 +169,17 @@ class PromptPayloadBuilder {
     String? recalledMessagesContent;
     List<RecalledMessageChunk> recalledMessageChunks = const [];
     final g = _ref.read(memoryGlobalSettingsProvider);
+    MemoryBook? memoryBook;
+    var memoryGraphEnabled = g.enabled;
+    if (memoryGraphEnabled && sessionId != null) {
+      memoryBook = await _ref
+          .read(memoryBookRepoProvider)
+          .getBySessionId(sessionId);
+      throwIfAborted();
+      memoryGraphEnabled = memoryBook?.settings.enabled ?? true;
+    }
     var memorySettings = MemoryBookSettings(
+      enabled: g.enabled,
       memoryExcerptingEnabled: g.memoryExcerptingEnabled,
       memoryPackingMode: g.memoryPackingMode,
       memoryExcerptTokensPerChunk: g.memoryExcerptTokensPerChunk,
@@ -210,15 +220,23 @@ class PromptPayloadBuilder {
                 .timeout(const Duration(seconds: 30), onTimeout: () => const [])
           : Future<List<LorebookEntry>>.value(const []);
 
-      final memoryFuture = memoryService.buildCandidatesWithDiagnostics(
-        sessionId: session.id,
-        history: session.messages,
-        currentText: currentText,
-        embeddingConfig: embeddingConfig,
-        shouldAbort: shouldAbort,
-        cancelToken: cancelToken,
-        contextBudgetTokens: chatApi.contextSize,
-      );
+      final memoryFuture = memoryGraphEnabled && memoryBook != null
+          ? memoryService.buildCandidatesWithDiagnostics(
+              sessionId: session.id,
+              history: session.messages,
+              currentText: currentText,
+              embeddingConfig: embeddingConfig,
+              shouldAbort: shouldAbort,
+              cancelToken: cancelToken,
+              contextBudgetTokens: chatApi.contextSize,
+            )
+          : Future.value(
+              MemoryCandidateBuildResult(
+                selection: const MemorySelection(),
+                diagnostics: null,
+                settings: memoryBook?.settings,
+              ),
+            );
 
       // NEW (patch #3): raw-message recall — cosine search over
       // `sourceType='chat_message'` chunks embedded by
@@ -345,7 +363,7 @@ class PromptPayloadBuilder {
     String? studioSessionStateContent;
     String? characterKnowledgeContent;
     List<Tracker>? ledgerTrackers;
-    if (sessionId != null) {
+    if (memoryGraphEnabled && sessionId != null) {
       try {
         final facts = await _ref
             .read(characterKnowledgeFactRepoProvider)
@@ -359,7 +377,7 @@ class PromptPayloadBuilder {
         debugPrint('[PromptBuilder] character knowledge load failed: $e');
       }
     }
-    if (sessionId != null) {
+    if (memoryGraphEnabled && sessionId != null) {
       try {
         ledgerTrackers = List.unmodifiable(
           await _loadEffectiveLedgerTrackers(sessionId),
@@ -393,7 +411,9 @@ class PromptPayloadBuilder {
     // unrelated completed arcs unless needed to prevent card-baseline regression.
     String? arcContent;
     String? entitiesContent;
-    if (memorySettings.memoryMode != 'fast' && sessionId != null) {
+    if (memoryGraphEnabled &&
+        memorySettings.memoryMode != 'fast' &&
+        sessionId != null) {
       try {
         if (ledgerTrackers != null) {
           arcContent = buildArcContent(
@@ -500,9 +520,17 @@ class PromptPayloadBuilder {
     }
 
     final memSettings = _ref.read(memoryGlobalSettingsProvider);
+    MemoryBook? memoryBook;
+    var memoryGraphEnabled = memSettings.enabled;
+    if (memoryGraphEnabled && session != null) {
+      memoryBook = await _ref
+          .read(memoryBookRepoProvider)
+          .getBySessionId(session.id);
+      memoryGraphEnabled = memoryBook?.settings.enabled ?? true;
+    }
     String? studioSessionStateContent;
     List<Tracker>? ledgerTrackers;
-    if (session != null) {
+    if (memoryGraphEnabled && session != null) {
       try {
         ledgerTrackers = List.unmodifiable(
           await _loadEffectiveLedgerTrackers(session.id),
@@ -526,7 +554,9 @@ class PromptPayloadBuilder {
     }
     String? arcContent;
     String? entitiesContent;
-    if (memSettings.memoryMode != 'fast' && session != null) {
+    if (memoryGraphEnabled &&
+        (memoryBook?.settings.memoryMode ?? memSettings.memoryMode) != 'fast' &&
+        session != null) {
       try {
         if (ledgerTrackers != null) {
           arcContent = buildArcContent(

--- a/lib/core/services/generation_notification_service.dart
+++ b/lib/core/services/generation_notification_service.dart
@@ -25,6 +25,20 @@ class NotificationNavigationData {
   });
 }
 
+/// Immutable authority for work that may only target the chat currently
+/// visible to the user. [revision] invalidates snapshots on context changes.
+class ActiveChatContext {
+  const ActiveChatContext({
+    required this.charId,
+    required this.sessionId,
+    required this.revision,
+  });
+
+  final String charId;
+  final String sessionId;
+  final int revision;
+}
+
 class GenerationNotificationService {
   GenerationNotificationService._();
   static final GenerationNotificationService instance =
@@ -42,6 +56,8 @@ class GenerationNotificationService {
       FlutterLocalNotificationsPlugin();
   final StreamController<NotificationNavigationData> _navigationController =
       StreamController<NotificationNavigationData>.broadcast();
+  final StreamController<void> _activeContextChanges =
+      StreamController<void>.broadcast();
 
   bool _isGenerating = false;
   bool _initialized = false;
@@ -50,9 +66,13 @@ class GenerationNotificationService {
   NotificationNavigationData? _pendingNotificationData;
   String? _activeCharId;
   String? _activeSessionId;
+  int _activeContextRevision = 0;
 
   Stream<NotificationNavigationData> get navigationStream =>
       _navigationController.stream;
+
+  /// Emits whenever an active-chat authority snapshot becomes stale.
+  Stream<void> get activeChatContextChanges => _activeContextChanges.stream;
 
   bool get _isMobile => !kIsWeb && (Platform.isAndroid || Platform.isIOS);
 
@@ -197,7 +217,33 @@ class GenerationNotificationService {
   }
 
   void updateLifecycleState(AppLifecycleState state) {
+    if (_lifecycleState == state) return;
     _lifecycleState = state;
+    _activeContextRevision++;
+    _activeContextChanges.add(null);
+  }
+
+  /// Read-only authority snapshot for user-visible chat work.
+  ActiveChatContext? get activeChatContext {
+    final charId = _activeCharId;
+    final sessionId = _activeSessionId;
+    if (_lifecycleState != AppLifecycleState.resumed ||
+        charId == null || charId.isEmpty ||
+        sessionId == null || sessionId.isEmpty) {
+      return null;
+    }
+    return ActiveChatContext(
+      charId: charId,
+      sessionId: sessionId,
+      revision: _activeContextRevision,
+    );
+  }
+
+  bool isCurrentActiveChatContext(ActiveChatContext context) {
+    final current = activeChatContext;
+    return current != null && current.charId == context.charId &&
+        current.sessionId == context.sessionId &&
+        current.revision == context.revision;
   }
 
   /// True when the given character+session is the one the user currently has
@@ -213,8 +259,11 @@ class GenerationNotificationService {
   /// Call when the user opens / focuses a chat screen to suppress redundant
   /// notifications for that character+session. Pass nulls when leaving.
   void setActiveContext(String? charId, String? sessionId) {
+    if (_activeCharId == charId && _activeSessionId == sessionId) return;
     _activeCharId = charId;
     _activeSessionId = sessionId;
+    _activeContextRevision++;
+    _activeContextChanges.add(null);
   }
 
   Future<void> onGenerationStarted(String charName) async {
@@ -487,6 +536,7 @@ class GenerationNotificationService {
 
   void dispose() {
     _navigationController.close();
+    _activeContextChanges.close();
   }
 }
 

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -74,8 +74,7 @@ class ChatBridgeController {
   late final LayoutBridgeCommands layout = LayoutBridgeCommands(this);
   late final MemoryBridgeCommands memory = MemoryBridgeCommands(this);
 
-  ChatBridgeController(this._controller, {JsBridgeService? jsBridgeService})
-    : _jsBridgeService = jsBridgeService ?? JsBridgeService() {
+  ChatBridgeController(this._controller, this._jsBridgeService) {
     setupHandlers();
   }
 

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -15,6 +15,7 @@ import 'package:path/path.dart' as p;
 // ignore: depend_on_referenced_packages
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
+import '../../core/debug/perf_debug.dart';
 import '../../core/utils/image_src.dart';
 import '../../core/utils/platform_paths.dart';
 import 'editing_message_provider.dart';
@@ -244,6 +245,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
 
   @override
   Widget build(BuildContext context) {
+    PerfDebug.chatScreenBuilt();
     final charId = widget.charId;
     final chatStateAsync = ref.watch(chatProvider(charId));
     final chatState = chatStateAsync.value;
@@ -1315,8 +1317,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                       index == widget.state.messages.length - 1,
                                   isError: false,
                                   isLast:
-                                      index ==
-                                      widget.state.messages.length - 1,
+                                      index == widget.state.messages.length - 1,
                                   isGenerating: widget.state.isGenerating,
                                   isHidden:
                                       widget.state.messages[index].isHidden,

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/debug/perf_debug.dart';
 import '../bridge/chat_bridge_controller.dart';
 import '../bridge/chat_bridge_registry.dart';
 import '../bridge/chat_webview_bridge_host.dart';
@@ -187,6 +188,7 @@ class ChatWebViewSurface extends ConsumerWidget {
               initialUrlRequest: chatWebViewInitialUrlRequest(),
               initialSettings: chatWebViewInAppSettings(),
               onWebViewCreated: (controller) async {
+                PerfDebug.chatWebViewSurfaceCreated();
                 final jsBridgeService = await bridgeHost.buildJsBridgeService();
                 if (!isMounted()) return;
                 final bridge = ChatBridgeController(
@@ -204,6 +206,7 @@ class ChatWebViewSurface extends ConsumerWidget {
                 ref.read(chatBridgeRegistryProvider(charId).notifier).state =
                     bridge;
                 onBridgeReady(bridge);
+                PerfDebug.chatWebViewBridgeReady();
 
                 // Kick off the singleton headless engine. Failure is
                 // non-fatal — the visual bridge above remains the fallback
@@ -276,6 +279,7 @@ class ChatWebViewSurface extends ConsumerWidget {
                 }
               },
               onLoadStop: (controller, url) async {
+                PerfDebug.chatWebViewLoadStopped();
                 // The init path is also wired through onWebViewCreated. When
                 // load stop wins the race, run init here.
                 await ref

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -14,7 +14,6 @@ import '../bridge/chat_webview_bridge_host.dart';
 import '../bridge/chat_webview_environment.dart';
 import '../bridge/chat_webview_keep_alive.dart';
 import '../bridge/chat_webview_settings.dart';
-import '../../extensions/services/js_engine_service.dart';
 import '../../settings/app_settings_provider.dart';
 import 'chat_webview_callbacks.dart';
 import 'chat_webview_ext_block_callbacks.dart';
@@ -193,7 +192,7 @@ class ChatWebViewSurface extends ConsumerWidget {
                 if (!isMounted()) return;
                 final bridge = ChatBridgeController(
                   controller,
-                  jsBridgeService: jsBridgeService,
+                  jsBridgeService,
                 );
                 final allowMessageScripts =
                     ref.read(appSettingsProvider).value?.allowMessageScripts ??
@@ -208,10 +207,6 @@ class ChatWebViewSurface extends ConsumerWidget {
                 onBridgeReady(bridge);
                 PerfDebug.chatWebViewBridgeReady();
 
-                // Kick off the singleton headless engine. Failure is
-                // non-fatal — the visual bridge above remains the fallback
-                // for jsRunner blocks and for background scripts.
-                unawaited(JsEngineService.instance.init());
                 // Do not call clearAll() here — it races with _initWebViewOnce
                 // (shows #loading-screen via JS) and broke UseVirtualScroll on
                 // keep-alive re-attach. Initializer.setMessages resets the DOM.

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/debug/perf_debug.dart';
 import '../../../core/state/active_regex_provider.dart';
 import '../../../core/state/character_provider.dart';
 import '../../../core/state/persona_resolution.dart';
@@ -212,6 +213,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
   @override
   void initState() {
     super.initState();
+    PerfDebug.chatWebViewWidgetInitialized();
     _bindBridgeRegistry(widget.charId);
     // Keep-alive re-attach safety net: when the chat body is rebuilt (e.g. a
     // full-screen spinner during an import-driven session switch destroys and
@@ -281,6 +283,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
 
   @override
   void dispose() {
+    PerfDebug.chatWebViewWidgetDisposed();
     // Unregister bridge so the service doesn't hold a stale reference.
     _clearBridgeRegistry?.call();
     // Drop interactive panel state for this character so the singleton
@@ -306,7 +309,10 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     final alreadyReady = await bridge.evalJsWithResult(
       'typeof window.bridge !== "undefined" && window.bridge != null',
     );
-    if (alreadyReady == true) return;
+    if (alreadyReady == true) {
+      PerfDebug.chatWebViewJsBridgeReady();
+      return;
+    }
 
     // Slow path: race between the JS-side onWebViewReady signal (event-driven)
     // and a polling fallback. The event wins on normal loads; the poll catches
@@ -344,6 +350,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
           );
         },
       );
+      PerfDebug.chatWebViewJsBridgeReady();
     } finally {
       // Restore the previous callback if we were disposed before the signal.
       if (!completer.isCompleted) bridge.onReady = prevOnReady;
@@ -354,6 +361,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     final bridge = _bridge;
     if (bridge == null) return;
     final initSessionId = widget.sessionId;
+    PerfDebug.chatWebViewInitAttempted();
     try {
       await _waitForJsBridgeReady();
       // The WebView is kept alive across chats, so the JS header tracker still
@@ -408,6 +416,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
         onSyncExtBlockPanels: _syncExtBlockPanels,
         applyTheme: _applyThemeToBridge,
       ).run().timeout(_kWebViewInitTimeout);
+      PerfDebug.chatWebViewInitCompleted();
     } on TimeoutException catch (e, st) {
       _handleWebViewFailure(e, st, phase: 'init');
       return;
@@ -801,6 +810,11 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       isImpersonating: ref
           .read(impersonationStateProvider(widget.charId))
           .active,
+    );
+    // Aggregate only: streaming chunks can make this method very hot.
+    PerfDebug.chatWebViewSyncResult(
+      runMessageSync: result.runMessageSync,
+      sessionSwitched: result.sessionSwitched,
     );
     if (result.sessionSwitched) {
       // Raise the cover synchronously (build runs right after didUpdateWidget)

--- a/lib/features/chat/widgets/session_lifecycle_tracker.dart
+++ b/lib/features/chat/widgets/session_lifecycle_tracker.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/services/generation_notification_service.dart';
 import '../../../core/state/shared_prefs_provider.dart';
+import '../../extensions/services/periodic_trigger_scheduler.dart';
 import '../chat_provider.dart';
 import '../unread_sessions_provider.dart';
 
@@ -41,6 +42,7 @@ class _SessionLifecycleTrackerState extends ConsumerState<SessionLifecycleTracke
       widget.charId,
       session?.id,
     );
+    ref.read(periodicTriggerSchedulerProvider);
     // Opening / focusing a session clears its unread dot in the chat list.
     final sessionId = session?.id;
     if (sessionId != null) {

--- a/lib/features/extensions/services/blocks/js_block_executor.dart
+++ b/lib/features/extensions/services/blocks/js_block_executor.dart
@@ -11,7 +11,6 @@ import '../../models/block_run_status.dart';
 import '../../models/info_block.dart';
 import '../../providers/info_blocks_provider.dart';
 import '../block_context_builder.dart';
-import '../js_engine_service.dart';
 import 'block_context.dart';
 import 'infoblock_handler.dart';
 
@@ -35,15 +34,13 @@ class JsBlockExecutor {
   }) async {
     final blockConfig = context.blockConfig;
     final bridge = ref.read(chatBridgeRegistryProvider(context.charId));
-    final engine = JsEngineService.instance;
-    if (!engine.isReady && bridge == null) {
+    if (bridge == null) {
       debugPrint(
-        '[ExtPostGen] jsRunner "${blockConfig.name}" - no JS engine or bridge',
+        '[ExtPostGen] jsRunner "${blockConfig.name}" - Chat WebView bridge unavailable',
       );
       return markBlockError(
         context: context,
-        errorMessage:
-            'JS engine not ready and WebView bridge not available (jsRunner needs at least one of them)',
+        errorMessage: 'Chat WebView JS bridge is unavailable',
       );
     }
 
@@ -54,7 +51,6 @@ class JsBlockExecutor {
         count: blockConfig.contextMessageCount,
       );
       final result = await runWithFallback(
-        engine: engine,
         bridge: bridge,
         script: script,
         contextMessages: contextMessages,
@@ -136,7 +132,6 @@ class JsBlockExecutor {
   }
 
   static Future<String> runWithFallback({
-    required JsEngineService engine,
     required ChatBridgeController? bridge,
     required String script,
     required List<ChatMessage> contextMessages,
@@ -145,39 +140,9 @@ class JsBlockExecutor {
     required String? previousOutput,
     required CancelToken cancelToken,
   }) async {
-    if (engine.isReady) {
-      try {
-        final contextMap = jsContextMap(
-          messages: contextMessages
-              .map((m) => {'role': m.role, 'text': m.content})
-              .toList(),
-          character: character,
-          sessionId: sessionId,
-          previousOutput: previousOutput,
-        );
-        return await engine.runScript(
-          script: script,
-          context: contextMap,
-          host: bridge == null
-              ? null
-              : JsEngineBridgeHost(bridge: bridge.extensionBridgeService),
-          cancelToken: cancelToken,
-        );
-      } on HeadlessUnavailableError catch (e) {
-        debugPrint(
-          '[ExtPostGen] headless engine unavailable, falling back: $e',
-        );
-      } catch (e) {
-        // Non-fatal: fall through to visual bridge. Bridge will record the
-        // error in its own logs.
-        debugPrint('[ExtPostGen] headless engine run failed: $e');
-      }
-    }
     final visualBridge = bridge;
     if (visualBridge == null) {
-      throw StateError(
-        'JS engine is not ready and visual WebView bridge is not available',
-      );
+      throw StateError('Chat WebView JS bridge is unavailable');
     }
     return visualBridge.runJsBlock(
       script: script,

--- a/lib/features/extensions/services/blocks/periodic_js_block_runner.dart
+++ b/lib/features/extensions/services/blocks/periodic_js_block_runner.dart
@@ -8,8 +8,6 @@ import '../../../../core/models/chat_message.dart';
 import '../../../../core/services/generation_notification_service.dart';
 import '../../../chat/bridge/chat_bridge_registry.dart';
 import '../../models/block_config.dart';
-import '../js_engine_service.dart';
-import 'js_block_executor.dart';
 
 class PeriodicJsBlockRunner {
   const PeriodicJsBlockRunner({required this.ref});
@@ -33,16 +31,16 @@ class PeriodicJsBlockRunner {
     if (script.isEmpty) {
       return null;
     }
-    final engine = JsEngineService.instance;
     final bridge = ref.read(chatBridgeRegistryProvider(charId));
-    if (!engine.isReady && bridge == null) {
+    if (bridge == null) {
       debugPrint(
-        '[ExtPostGen] runJsBlock: no engine or bridge (block "${block.name}")',
+        '[ExtPostGen] runJsBlock: no active chat bridge (block "${block.name}")',
       );
       return null;
     }
     final cancelToken = CancelToken();
-    final authoritySub = GenerationNotificationService.instance
+    final authoritySub = GenerationNotificationService
+        .instance
         .activeChatContextChanges
         .listen((_) {
           if (!(isAuthorized?.call() ?? true) && !cancelToken.isCancelled) {
@@ -53,43 +51,7 @@ class PeriodicJsBlockRunner {
       if (cancelToken.isCancelled || !(isAuthorized?.call() ?? true)) {
         return null;
       }
-      if (engine.isReady) {
-        try {
-          final contextMap = JsBlockExecutor.jsContextMap(
-            messages: contextMessages
-                .map((m) => {'role': m.role, 'text': m.content})
-                .toList(),
-            character: null, // no character payload for periodic
-            sessionId: sessionId,
-            previousOutput: null,
-          );
-          final patchedContext = Map<String, dynamic>.from(contextMap)
-            ..['characterId'] = charId
-            ..['sessionId'] = sessionId;
-          final result = await engine.runScript(
-            script: script,
-            context: patchedContext,
-            host: bridge == null
-                ? null
-                : JsEngineBridgeHost(
-                    bridge: bridge.extensionBridgeService,
-                    currentCharIdProvider: () => charId,
-                  ),
-            cancelToken: cancelToken,
-          );
-          return !cancelToken.isCancelled && (isAuthorized?.call() ?? true)
-              ? result
-              : null;
-        } on HeadlessUnavailableError catch (_) {
-          // Fall through to visual bridge.
-        }
-      }
-      final visualBridge = bridge;
-      if (visualBridge == null) {
-        return null;
-      }
-      if (cancelToken.isCancelled || !(isAuthorized?.call() ?? true)) return null;
-      final result = await visualBridge.runJsBlock(
+      final result = await bridge.runJsBlock(
         script: script,
         messages: contextMessages,
         character: null,

--- a/lib/features/extensions/services/blocks/periodic_js_block_runner.dart
+++ b/lib/features/extensions/services/blocks/periodic_js_block_runner.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/models/chat_message.dart';
+import '../../../../core/services/generation_notification_service.dart';
 import '../../../chat/bridge/chat_bridge_registry.dart';
 import '../../models/block_config.dart';
 import '../js_engine_service.dart';
@@ -15,9 +18,12 @@ class PeriodicJsBlockRunner {
 
   Future<String?> run({
     required String charId,
+    required String sessionId,
     required BlockConfig block,
     required List<ChatMessage> contextMessages,
+    bool Function()? isAuthorized,
   }) async {
+    if (!(isAuthorized?.call() ?? true)) return null;
     if (block.type != BlockType.jsRunner) {
       throw ArgumentError(
         'runJsBlock only supports BlockType.jsRunner (got ${block.type.name})',
@@ -36,7 +42,17 @@ class PeriodicJsBlockRunner {
       return null;
     }
     final cancelToken = CancelToken();
+    final authoritySub = GenerationNotificationService.instance
+        .activeChatContextChanges
+        .listen((_) {
+          if (!(isAuthorized?.call() ?? true) && !cancelToken.isCancelled) {
+            cancelToken.cancel('Periodic chat authority changed');
+          }
+        });
     try {
+      if (cancelToken.isCancelled || !(isAuthorized?.call() ?? true)) {
+        return null;
+      }
       if (engine.isReady) {
         try {
           final contextMap = JsBlockExecutor.jsContextMap(
@@ -44,15 +60,13 @@ class PeriodicJsBlockRunner {
                 .map((m) => {'role': m.role, 'text': m.content})
                 .toList(),
             character: null, // no character payload for periodic
-            sessionId: '',
+            sessionId: sessionId,
             previousOutput: null,
           );
-          // Periodic ticks have no character/session payload; the script
-          // can still read `messages` from the context (empty list by default).
           final patchedContext = Map<String, dynamic>.from(contextMap)
             ..['characterId'] = charId
-            ..['sessionId'] = '';
-          return await engine.runScript(
+            ..['sessionId'] = sessionId;
+          final result = await engine.runScript(
             script: script,
             context: patchedContext,
             host: bridge == null
@@ -63,6 +77,9 @@ class PeriodicJsBlockRunner {
                   ),
             cancelToken: cancelToken,
           );
+          return !cancelToken.isCancelled && (isAuthorized?.call() ?? true)
+              ? result
+              : null;
         } on HeadlessUnavailableError catch (_) {
           // Fall through to visual bridge.
         }
@@ -71,18 +88,24 @@ class PeriodicJsBlockRunner {
       if (visualBridge == null) {
         return null;
       }
-      return await visualBridge.runJsBlock(
+      if (cancelToken.isCancelled || !(isAuthorized?.call() ?? true)) return null;
+      final result = await visualBridge.runJsBlock(
         script: script,
         messages: contextMessages,
         character: null,
-        sessionId: '',
+        sessionId: sessionId,
         previousOutput: null,
         contextMessageCount: -1,
         cancelToken: cancelToken,
       );
+      return !cancelToken.isCancelled && (isAuthorized?.call() ?? true)
+          ? result
+          : null;
     } catch (e) {
       debugPrint('[ExtPostGen] runJsBlock failed: $e');
       return null;
+    } finally {
+      unawaited(authoritySub.cancel());
     }
   }
 }

--- a/lib/features/extensions/services/extension_post_gen_service.dart
+++ b/lib/features/extensions/services/extension_post_gen_service.dart
@@ -626,9 +626,15 @@ class ExtensionPostGenService {
   /// does not need the chat history, it just runs on a timer.
   Future<String?> runJsBlock({
     required String charId,
+    required String sessionId,
     required BlockConfig block,
     required List<ChatMessage> contextMessages,
-  }) => PeriodicJsBlockRunner(
-    ref: _ref,
-  ).run(charId: charId, block: block, contextMessages: contextMessages);
+    bool Function()? isAuthorized,
+  }) => PeriodicJsBlockRunner(ref: _ref).run(
+    charId: charId,
+    sessionId: sessionId,
+    block: block,
+    contextMessages: contextMessages,
+    isAuthorized: isAuthorized,
+  );
 }

--- a/lib/features/extensions/services/js_bridge/handlers/audio_handler.dart
+++ b/lib/features/extensions/services/js_bridge/handlers/audio_handler.dart
@@ -10,11 +10,7 @@ class AudioHandler {
     if (source != null && source is! String) {
       throw ArgumentError('playAudio source must be a string');
     }
-    final handler =
-        bridge.playAudio ??
-        (throw UnsupportedError(
-          'glaze.playAudio is not available in this context',
-        ));
+    final handler = bridge.playAudio;
     return handler(source as String?, asBridgeMap(bridge.params['options']));
   }
 }

--- a/lib/features/extensions/services/js_bridge/handlers/command_handler.dart
+++ b/lib/features/extensions/services/js_bridge/handlers/command_handler.dart
@@ -10,11 +10,7 @@ class CommandHandler {
     if (command is! String || command.isEmpty) {
       throw ArgumentError('executeCommand requires a non-empty string command');
     }
-    final handler =
-        bridge.executeCommand ??
-        (throw UnsupportedError(
-          'glaze.executeCommand is not available in this context',
-        ));
+    final handler = bridge.executeCommand;
     return handler(command, asBridgeMap(bridge.params['args']), bridge.context);
   }
 }

--- a/lib/features/extensions/services/js_bridge/handlers/generation_handler.dart
+++ b/lib/features/extensions/services/js_bridge/handlers/generation_handler.dart
@@ -6,11 +6,7 @@ class GenerationHandler {
   const GenerationHandler();
 
   FutureOr<Map<String, dynamic>> triggerGeneration(JsBridgeContext bridge) {
-    final handler =
-        bridge.triggerGeneration ??
-        (throw UnsupportedError(
-          'glaze.triggerGeneration is not available in this context',
-        ));
+    final handler = bridge.triggerGeneration;
     return handler(bridge.characterIdOrNull(), bridge.params);
   }
 
@@ -31,11 +27,7 @@ class GenerationHandler {
         preset != 'small') {
       throw ArgumentError('Unsupported generateText preset "$preset"');
     }
-    final handler =
-        bridge.generateText ??
-        (throw UnsupportedError(
-          'glaze.generateText is not available in this context',
-        ));
+    final handler = bridge.generateText;
     return handler(prompt, options, bridge.context);
   }
 }

--- a/lib/features/extensions/services/js_bridge/handlers/prompt_injection_handler.dart
+++ b/lib/features/extensions/services/js_bridge/handlers/prompt_injection_handler.dart
@@ -14,11 +14,7 @@ class PromptInjectionHandler {
     if (content is! String || content.trim().isEmpty) {
       throw ArgumentError('injectPrompt content is required');
     }
-    final handler =
-        bridge.injectPrompt ??
-        (throw UnsupportedError(
-          'glaze.injectPrompt is not available in this context',
-        ));
+    final handler = bridge.injectPrompt;
     return handler(
       id,
       content,
@@ -32,11 +28,7 @@ class PromptInjectionHandler {
     if (id is! String || id.trim().isEmpty) {
       throw ArgumentError('uninjectPrompt id is required');
     }
-    final handler =
-        bridge.uninjectPrompt ??
-        (throw UnsupportedError(
-          'glaze.uninjectPrompt is not available in this context',
-        ));
+    final handler = bridge.uninjectPrompt;
     return handler(id, bridge.context);
   }
 }

--- a/lib/features/extensions/services/js_bridge/handlers/toast_handler.dart
+++ b/lib/features/extensions/services/js_bridge/handlers/toast_handler.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/foundation.dart';
-
 import '../js_bridge_context.dart';
 
 class ToastHandler {
@@ -11,9 +9,7 @@ class ToastHandler {
       throw ArgumentError('showToast message must be a string');
     }
     final options = asBridgeMap(bridge.params['options']);
-    final handler =
-        bridge.showToast ??
-        (msg, _) => debugPrint('[JsBridge] toast: ${msg ?? ''}');
+    final handler = bridge.showToast;
     handler(message as String?, {...options, '_context': bridge.context});
     return true;
   }

--- a/lib/features/extensions/services/js_bridge/handlers/variables_handler.dart
+++ b/lib/features/extensions/services/js_bridge/handlers/variables_handler.dart
@@ -73,8 +73,7 @@ class VariablesHandler {
   ) async {
     switch (scope) {
       case 'chat':
-        final repo =
-            bridge.chatRepo ?? (throw StateError('Chat repo is not available'));
+        final repo = bridge.chatRepo;
         final session = await repo.getById(bridge.sessionId());
         if (session == null) {
           throw StateError(
@@ -83,18 +82,14 @@ class VariablesHandler {
         }
         return _decodeChatVars(session.sessionVars);
       case 'character':
-        final repo =
-            bridge.characterRepo ??
-            (throw StateError('Character repo is not available'));
+        final repo = bridge.characterRepo;
         final character = await repo.getById(bridge.characterId());
         if (character == null) {
           throw StateError('Character "${bridge.characterId()}" was not found');
         }
         return _decodeCharacterVars(character.extensions);
       case 'global':
-        final repo =
-            bridge.globalVariablesRepo ??
-            (throw StateError('Global variables repo is not available'));
+        final repo = bridge.globalVariablesRepo;
         return await repo.read();
       case 'message':
         return _readMessageScope(bridge);
@@ -110,8 +105,7 @@ class VariablesHandler {
   ) async {
     switch (scope) {
       case 'chat':
-        final repo =
-            bridge.chatRepo ?? (throw StateError('Chat repo is not available'));
+        final repo = bridge.chatRepo;
         Map<String, dynamic> nextRoot = const {};
         await repo.updateSessionVarsJson(bridge.sessionId(), (vars) {
           nextRoot = update(_decodeChatVars(vars));
@@ -124,9 +118,7 @@ class VariablesHandler {
         });
         return Map<String, dynamic>.from(nextRoot);
       case 'character':
-        final repo =
-            bridge.characterRepo ??
-            (throw StateError('Character repo is not available'));
+        final repo = bridge.characterRepo;
         Map<String, dynamic> nextRoot = const {};
         await repo.updateExtensionsJson(bridge.characterId(), (extensions) {
           nextRoot = update(_decodeCharacterVars(extensions));
@@ -139,9 +131,7 @@ class VariablesHandler {
         });
         return Map<String, dynamic>.from(nextRoot);
       case 'global':
-        final repo =
-            bridge.globalVariablesRepo ??
-            (throw StateError('Global variables repo is not available'));
+        final repo = bridge.globalVariablesRepo;
         return await repo.update(update);
       case 'message':
         return _updateMessageScope(bridge, update);
@@ -151,9 +141,7 @@ class VariablesHandler {
   }
 
   Map<String, dynamic> _readMessageScope(JsBridgeContext bridge) {
-    final accessor =
-        bridge.messageVariables ??
-        (throw StateError('Message variables accessor is not available'));
+    final accessor = bridge.messageVariables;
     return accessor().read(bridge.sessionId(), bridge.messageId());
   }
 
@@ -161,9 +149,7 @@ class VariablesHandler {
     JsBridgeContext bridge,
     Map<String, dynamic> Function(Map<String, dynamic> root) update,
   ) {
-    final accessor =
-        bridge.messageVariables ??
-        (throw StateError('Message variables accessor is not available'));
+    final accessor = bridge.messageVariables;
     return accessor().update(bridge.sessionId(), bridge.messageId(), update);
   }
 

--- a/lib/features/extensions/services/js_bridge/js_bridge_context.dart
+++ b/lib/features/extensions/services/js_bridge/js_bridge_context.dart
@@ -68,38 +68,38 @@ typedef ShowToastHandler =
 class JsBridgeContext {
   final Map<String, dynamic> params;
   final Map<String, dynamic> context;
-  final ChatRepo? chatRepo;
-  final CharacterRepo? characterRepo;
-  final GlobalVariablesRepo? globalVariablesRepo;
-  final MessageVariablesAccessor? messageVariables;
-  final String? Function()? currentSessionId;
-  final String? Function()? currentCharacterId;
-  final GenerateTextHandler? generateText;
-  final InjectPromptHandler? injectPrompt;
-  final UninjectPromptHandler? uninjectPrompt;
-  final TriggerGenerationHandlerFn? triggerGeneration;
-  final PermissionCheck? permissionCheck;
-  final PlayAudioHandler? playAudio;
-  final ExecuteCommandHandler? executeCommand;
-  final ShowToastHandler? showToast;
+  final ChatRepo chatRepo;
+  final CharacterRepo characterRepo;
+  final GlobalVariablesRepo globalVariablesRepo;
+  final MessageVariablesAccessor messageVariables;
+  final String? Function() currentSessionId;
+  final String? Function() currentCharacterId;
+  final GenerateTextHandler generateText;
+  final InjectPromptHandler injectPrompt;
+  final UninjectPromptHandler uninjectPrompt;
+  final TriggerGenerationHandlerFn triggerGeneration;
+  final PermissionCheck permissionCheck;
+  final PlayAudioHandler playAudio;
+  final ExecuteCommandHandler executeCommand;
+  final ShowToastHandler showToast;
 
   const JsBridgeContext({
     required this.params,
     required this.context,
-    this.chatRepo,
-    this.characterRepo,
-    this.globalVariablesRepo,
-    this.messageVariables,
-    this.currentSessionId,
-    this.currentCharacterId,
-    this.generateText,
-    this.injectPrompt,
-    this.uninjectPrompt,
-    this.triggerGeneration,
-    this.permissionCheck,
-    this.playAudio,
-    this.executeCommand,
-    this.showToast,
+    required this.chatRepo,
+    required this.characterRepo,
+    required this.globalVariablesRepo,
+    required this.messageVariables,
+    required this.currentSessionId,
+    required this.currentCharacterId,
+    required this.generateText,
+    required this.injectPrompt,
+    required this.uninjectPrompt,
+    required this.triggerGeneration,
+    required this.permissionCheck,
+    required this.playAudio,
+    required this.executeCommand,
+    required this.showToast,
   });
 
   void requireCapability(String capabilityId) {
@@ -107,7 +107,7 @@ class JsBridgeContext {
   }
 
   String sessionId() {
-    final value = (context['sessionId'] as String?) ?? currentSessionId?.call();
+    final value = (context['sessionId'] as String?) ?? currentSessionId();
     if (value == null || value.isEmpty) {
       throw StateError('Chat session context is not available');
     }
@@ -115,8 +115,7 @@ class JsBridgeContext {
   }
 
   String characterId() {
-    final value =
-        (context['characterId'] as String?) ?? currentCharacterId?.call();
+    final value = (context['characterId'] as String?) ?? currentCharacterId();
     if (value == null || value.isEmpty) {
       throw StateError('Character context is not available');
     }
@@ -126,7 +125,7 @@ class JsBridgeContext {
   String? characterIdOrNull() {
     final raw = context['characterId'];
     if (raw is String && raw.isNotEmpty) return raw;
-    final fallback = currentCharacterId?.call();
+    final fallback = currentCharacterId();
     if (fallback == null || fallback.isEmpty) return null;
     return fallback;
   }

--- a/lib/features/extensions/services/js_bridge/js_bridge_method_registry.dart
+++ b/lib/features/extensions/services/js_bridge/js_bridge_method_registry.dart
@@ -5,7 +5,9 @@ import 'capability_resolver.dart';
 typedef JsBridgeCapabilityResolver =
     String Function(Map<String, dynamic> params);
 
-enum JsBridgeHostProfile { visual, headless }
+/// The Chat WebView is the only bridge host. Sandboxed panels relay through it.
+/// `visual` is retained as the public name to avoid a needless API migration.
+enum JsBridgeHostProfile { visual }
 
 enum JsBridgeOperation {
   showToast,
@@ -43,10 +45,7 @@ class JsBridgeMethodDefinition {
 /// A method cannot be registered without a capability resolver or an explicit
 /// host set.
 abstract final class JsBridgeMethodRegistry {
-  static const _allHosts = {
-    JsBridgeHostProfile.visual,
-    JsBridgeHostProfile.headless,
-  };
+  static const _allHosts = {JsBridgeHostProfile.visual};
 
   static final List<JsBridgeMethodDefinition> methods = List.unmodifiable([
     JsBridgeMethodDefinition(

--- a/lib/features/extensions/services/js_bridge/js_bridge_service.dart
+++ b/lib/features/extensions/services/js_bridge/js_bridge_service.dart
@@ -33,20 +33,20 @@ export 'js_bridge_method_registry.dart'
         JsBridgeOperation;
 
 class JsBridgeService {
-  final ChatRepo? _chatRepo;
-  final CharacterRepo? _characterRepo;
-  final GlobalVariablesRepo? _globalVariablesRepo;
-  final MessageVariablesAccessor? _messageVariables;
-  final String? Function()? _currentSessionId;
-  final String? Function()? _currentCharacterId;
-  final GenerateTextHandler? _generateText;
-  final InjectPromptHandler? _injectPrompt;
-  final UninjectPromptHandler? _uninjectPrompt;
-  final TriggerGenerationHandlerFn? _triggerGeneration;
-  final PermissionCheck? _permissionCheck;
-  final PlayAudioHandler? _playAudio;
-  final ExecuteCommandHandler? _executeCommand;
-  final ShowToastHandler? _showToast;
+  final ChatRepo _chatRepo;
+  final CharacterRepo _characterRepo;
+  final GlobalVariablesRepo _globalVariablesRepo;
+  final MessageVariablesAccessor _messageVariables;
+  final String? Function() _currentSessionId;
+  final String? Function() _currentCharacterId;
+  final GenerateTextHandler _generateText;
+  final InjectPromptHandler _injectPrompt;
+  final UninjectPromptHandler _uninjectPrompt;
+  final TriggerGenerationHandlerFn _triggerGeneration;
+  final PermissionCheck _permissionCheck;
+  final PlayAudioHandler _playAudio;
+  final ExecuteCommandHandler _executeCommand;
+  final ShowToastHandler _showToast;
 
   final VariablesHandler _variablesHandler;
   final GenerationHandler _generationHandler;
@@ -56,20 +56,20 @@ class JsBridgeService {
   final ToastHandler _toastHandler;
 
   JsBridgeService({
-    ChatRepo? chatRepo,
-    CharacterRepo? characterRepo,
-    GlobalVariablesRepo? globalVariablesRepo,
-    MessageVariablesAccessor? messageVariables,
-    String? Function()? currentSessionId,
-    String? Function()? currentCharacterId,
-    GenerateTextHandler? generateText,
-    InjectPromptHandler? injectPrompt,
-    UninjectPromptHandler? uninjectPrompt,
-    TriggerGenerationHandlerFn? triggerGeneration,
-    PermissionCheck? permissionCheck,
-    PlayAudioHandler? playAudio,
-    ExecuteCommandHandler? executeCommand,
-    ShowToastHandler? showToast,
+    required ChatRepo chatRepo,
+    required CharacterRepo characterRepo,
+    required GlobalVariablesRepo globalVariablesRepo,
+    required MessageVariablesAccessor messageVariables,
+    required String? Function() currentSessionId,
+    required String? Function() currentCharacterId,
+    required GenerateTextHandler generateText,
+    required InjectPromptHandler injectPrompt,
+    required UninjectPromptHandler uninjectPrompt,
+    required TriggerGenerationHandlerFn triggerGeneration,
+    required PermissionCheck permissionCheck,
+    required PlayAudioHandler playAudio,
+    required ExecuteCommandHandler executeCommand,
+    required ShowToastHandler showToast,
   }) : this._(
          chatRepo,
          characterRepo,

--- a/lib/features/extensions/services/js_bridge/permission_gate.dart
+++ b/lib/features/extensions/services/js_bridge/permission_gate.dart
@@ -1,14 +1,9 @@
 import 'js_bridge_context.dart';
 
 void requireBridgeCapability(
-  PermissionCheck? permissionCheck,
+  PermissionCheck permissionCheck,
   String capabilityId,
 ) {
-  if (permissionCheck == null) {
-    // No permission check registered: default-deny. Production always
-    // registers one from ChatWebViewWidget.
-    throw StateError('Permission denied: $capabilityId (no check)');
-  }
   if (!permissionCheck(capabilityId)) {
     throw StateError('Permission denied: $capabilityId');
   }

--- a/lib/features/extensions/services/js_engine_service.dart
+++ b/lib/features/extensions/services/js_engine_service.dart
@@ -75,9 +75,6 @@ class JsEngineBridgeHost {
   final JsBridgeService bridge;
   final String? Function()? currentCharIdProvider;
 
-  static Set<String> get supportedMethods =>
-      JsBridgeMethodRegistry.methodsFor(JsBridgeHostProfile.headless);
-
   Future<Map<String, dynamic>> handle(List<dynamic> args) async {
     if (args.isEmpty) {
       return {

--- a/lib/features/extensions/services/periodic_trigger_scheduler.dart
+++ b/lib/features/extensions/services/periodic_trigger_scheduler.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/services/generation_notification_service.dart';
 import '../models/block_config.dart';
 import '../models/extension_preset.dart';
 import '../providers/extension_presets_provider.dart';
@@ -150,6 +151,8 @@ class PeriodicTriggerScheduler with WidgetsBindingObserver {
 
   Future<void> _tick(BlockConfig block) async {
     try {
+      final authority = GenerationNotificationService.instance.activeChatContext;
+      if (authority == null) return;
       final post = _ref.read(extensionPostGenServiceProvider);
       // `runJsBlock` is the existing entry point — it handles headless /
       // visual fallback and the cancel token. We don't need a
@@ -157,9 +160,12 @@ class PeriodicTriggerScheduler with WidgetsBindingObserver {
       // fire-and-forget.
       unawaited(
         post.runJsBlock(
-          charId: _ref.read(extensionsSettingsProvider).activePresetId ?? '',
+          charId: authority.charId,
+          sessionId: authority.sessionId,
           block: block,
           contextMessages: const [],
+          isAuthorized: () => GenerationNotificationService.instance
+              .isCurrentActiveChatContext(authority),
         ),
       );
     } catch (e) {
@@ -178,6 +184,9 @@ class PeriodicTriggerScheduler with WidgetsBindingObserver {
 
   /// Visible for tests.
   int get activeTimerCount => _timers.length;
+
+  @visibleForTesting
+  Future<void> debugTick(BlockConfig block) => _tick(block);
 
   void dispose() {
     if (_isLifecycleListener) {

--- a/test/chat_message_embedding_baseline_test.dart
+++ b/test/chat_message_embedding_baseline_test.dart
@@ -1,0 +1,258 @@
+// Run headlessly: flutter test test/chat_message_embedding_baseline_test.dart
+//
+// This is a deterministic reconciliation baseline: timings are logged for
+// comparison, while operation counts and stored-row state are asserted.
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/embedding_repo.dart';
+import 'package:glaze_flutter/core/llm/chat_message_embedding_service.dart';
+import 'package:glaze_flutter/core/llm/embedding_service.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+
+class _FakeEmbeddingService extends EmbeddingService {
+  int requests = 0;
+  int texts = 0;
+
+  @override
+  Future<List<EmbeddingChunk>> getEmbeddingsWithChunks(
+    List<String> input,
+    EmbeddingConfig config, {
+    cancelToken,
+  }) async {
+    requests++;
+    texts += input.length;
+    return [
+      for (final text in input)
+        EmbeddingChunk(text: text, vector: const [1, 0]),
+    ];
+  }
+
+  void reset() {
+    requests = 0;
+    texts = 0;
+  }
+}
+
+class _CountingEmbeddingRepo extends EmbeddingRepo {
+  _CountingEmbeddingRepo(super.db);
+
+  int sourceLoads = 0;
+  int vectorWrites = 0;
+  int bulkDeleteCalls = 0;
+  int bulkDeletedEntryIds = 0;
+
+  @override
+  Future<List<EmbeddingRow>> getBySource(String sourceType, String sourceId) {
+    sourceLoads++;
+    return super.getBySource(sourceType, sourceId);
+  }
+
+  @override
+  Future<void> putEmbeddingVector({
+    required String entryId,
+    required String sourceType,
+    String? sourceId,
+    required List<List<double>> vectors,
+    required String textHash,
+    List<String>? retrievalHints,
+    Map<String, dynamic>? retrievalMetadata,
+  }) {
+    vectorWrites++;
+    return super.putEmbeddingVector(
+      entryId: entryId,
+      sourceType: sourceType,
+      sourceId: sourceId,
+      vectors: vectors,
+      textHash: textHash,
+      retrievalHints: retrievalHints,
+      retrievalMetadata: retrievalMetadata,
+    );
+  }
+
+  @override
+  Future<void> deleteBySourceAndEntryIds(
+    String sourceType,
+    String sourceId,
+    Iterable<String> entryIds,
+  ) {
+    final ids = entryIds.toSet();
+    bulkDeleteCalls++;
+    bulkDeletedEntryIds += ids.length;
+    return super.deleteBySourceAndEntryIds(sourceType, sourceId, ids);
+  }
+
+  void reset() {
+    sourceLoads = 0;
+    vectorWrites = 0;
+    bulkDeleteCalls = 0;
+    bulkDeletedEntryIds = 0;
+  }
+}
+
+class _OperationCounts {
+  const _OperationCounts({
+    required this.sourceLoads,
+    required this.vectorWrites,
+    required this.embeddingRequests,
+    required this.embeddedTexts,
+    required this.bulkDeleteCalls,
+    required this.bulkDeletedEntryIds,
+  });
+
+  final int sourceLoads;
+  final int vectorWrites;
+  final int embeddingRequests;
+  final int embeddedTexts;
+  final int bulkDeleteCalls;
+  final int bulkDeletedEntryIds;
+
+  @override
+  String toString() =>
+      'loads=$sourceLoads writes=$vectorWrites requests=$embeddingRequests '
+      'texts=$embeddedTexts deleteCalls=$bulkDeleteCalls '
+      'deletedIds=$bulkDeletedEntryIds';
+}
+
+void main() {
+  const config = EmbeddingConfig(endpoint: 'test');
+  late AppDatabase db;
+  late _CountingEmbeddingRepo repo;
+  late _FakeEmbeddingService embeddingService;
+  late ChatMessageEmbeddingService service;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = _CountingEmbeddingRepo(db);
+    embeddingService = _FakeEmbeddingService();
+    service = ChatMessageEmbeddingService(repo, embeddingService);
+  });
+
+  tearDown(() => db.close());
+
+  List<ChatMessage> messages(int count) => [
+    for (var index = 0; index < count; index++)
+      ChatMessage(
+        id: 'message-$index',
+        role: index.isEven ? 'user' : 'assistant',
+        content: 'baseline message $index',
+      ),
+  ];
+
+  _OperationCounts counts() => _OperationCounts(
+    sourceLoads: repo.sourceLoads,
+    vectorWrites: repo.vectorWrites,
+    embeddingRequests: embeddingService.requests,
+    embeddedTexts: embeddingService.texts,
+    bulkDeleteCalls: repo.bulkDeleteCalls,
+    bulkDeletedEntryIds: repo.bulkDeletedEntryIds,
+  );
+
+  Future<void> reconcile({
+    required String label,
+    required String sessionId,
+    required List<ChatMessage> input,
+  }) async {
+    repo.reset();
+    embeddingService.reset();
+    final stopwatch = Stopwatch()..start();
+    await service.indexSessionMessages(
+      sessionId: sessionId,
+      messages: input,
+      config: config,
+    );
+    stopwatch.stop();
+    // Informational only: operation counters below are the test oracle.
+    print(
+      'embedding baseline [$label]: ${stopwatch.elapsedMilliseconds}ms; '
+      '${counts()}',
+    );
+  }
+
+  test('reconciles representative chat sizes with stable operation counts', () async {
+    for (final messageCount in [25, 100]) {
+      final sessionId = 'baseline-$messageCount';
+      final original = messages(messageCount);
+      final chunkCount = messageCount ~/ ChatMessageEmbeddingService.defaultChunkSize;
+
+      await reconcile(
+        label: '$messageCount initial',
+        sessionId: sessionId,
+        input: original,
+      );
+      expect(
+        counts(),
+        isA<_OperationCounts>()
+            .having((value) => value.sourceLoads, 'source loads', 1)
+            .having((value) => value.vectorWrites, 'vector writes', chunkCount)
+            .having(
+              (value) => value.embeddingRequests,
+              'embedding requests',
+              chunkCount,
+            )
+            .having((value) => value.embeddedTexts, 'embedded texts', chunkCount)
+            .having((value) => value.bulkDeleteCalls, 'bulk delete calls', 0),
+      );
+
+      await reconcile(
+        label: '$messageCount warm',
+        sessionId: sessionId,
+        input: original,
+      );
+      expect(counts().sourceLoads, 1);
+      expect(counts().vectorWrites, 0);
+      expect(counts().embeddingRequests, 0);
+      expect(counts().bulkDeleteCalls, 0);
+
+      for (final index in [0, messageCount ~/ 2, messageCount - 1]) {
+        final modified = List<ChatMessage>.of(original);
+        modified[index] = modified[index].copyWith(
+          content: '${modified[index].content} (changed)',
+        );
+
+        await reconcile(
+          label: '$messageCount modified-$index',
+          sessionId: sessionId,
+          input: modified,
+        );
+        expect(counts().sourceLoads, 1);
+        expect(counts().vectorWrites, 1);
+        expect(counts().embeddingRequests, 1);
+        expect(counts().embeddedTexts, 1);
+        expect(counts().bulkDeleteCalls, 0);
+
+        // Restore the same baseline before measuring the next position.
+        await reconcile(
+          label: '$messageCount restore-$index',
+          sessionId: sessionId,
+          input: original,
+        );
+        expect(counts().vectorWrites, 1);
+        expect(counts().embeddingRequests, 1);
+      }
+
+      final truncatedCount = messageCount - 5;
+      await reconcile(
+        label: '$messageCount truncated-$truncatedCount',
+        sessionId: sessionId,
+        input: original.take(truncatedCount).toList(),
+      );
+      final remainingChunks = truncatedCount ~/ ChatMessageEmbeddingService.defaultChunkSize;
+      expect(counts().sourceLoads, 1);
+      expect(counts().vectorWrites, 0);
+      expect(counts().embeddingRequests, 0);
+      expect(counts().bulkDeleteCalls, 1);
+      expect(counts().bulkDeletedEntryIds, chunkCount - remainingChunks);
+      expect(
+        (await repo.getBySource('chat_message', sessionId))
+            .map((row) => row.entryId)
+            .toSet(),
+        {
+          for (var index = 0; index < remainingChunks; index++)
+            '${sessionId}_$index',
+        },
+      );
+    }
+  });
+}

--- a/test/chat_message_embedding_baseline_test.dart
+++ b/test/chat_message_embedding_baseline_test.dart
@@ -164,6 +164,7 @@ void main() {
     );
     stopwatch.stop();
     // Informational only: operation counters below are the test oracle.
+    // ignore: avoid_print
     print(
       'embedding baseline [$label]: ${stopwatch.elapsedMilliseconds}ms; '
       '${counts()}',

--- a/test/command_registry_test.dart
+++ b/test/command_registry_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/features/extensions/services/command_registry.dart';
 import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
+import 'helpers/js_bridge_test_support.dart';
 
 void main() {
   group('CommandRegistry', () {
@@ -9,7 +10,11 @@ void main() {
       final r = CommandRegistry();
       expect(
         () => r.register(
-          GlazeCommand(name: 'trigger', summary: '', handler: (_, _) async => const CommandResult.ok()),
+          GlazeCommand(
+            name: 'trigger',
+            summary: '',
+            handler: (_, _) async => const CommandResult.ok(),
+          ),
         ),
         throwsA(isA<ArgumentError>()),
       );
@@ -26,11 +31,9 @@ void main() {
           ),
         ),
       );
-      final result = await r.run(
-        '/echo',
-        {'text': 'hi'},
-        context: const CommandContext(charId: 'c1'),
-      );
+      final result = await r.run('/echo', {
+        'text': 'hi',
+      }, context: const CommandContext(charId: 'c1'));
       expect(result.ok, isTrue);
       expect(result.message, 'echoed hi');
       expect(result.data, {'charId': 'c1'});
@@ -59,40 +62,39 @@ void main() {
     test('list() exposes every registered command', () {
       final r = buildDefaultCommandRegistry();
       final names = r.list().map((c) => c.name).toSet();
-      expect(names, {
-        '/trigger',
-        '/getvar',
-        '/setvar',
-        '/inject',
-        '/toast',
-      });
+      expect(names, {'/trigger', '/getvar', '/setvar', '/inject', '/toast'});
     });
   });
 
   group('JsBridgeService executeCommand', () {
-    test('delegates command + args + context to the injected handler',
-        () async {
-      String? seenCommand;
-      Map<String, dynamic>? seenArgs;
-      final bridge = JsBridgeService(
-        permissionCheck: (_) => true,
-        executeCommand: (command, args, context) async {
-          seenCommand = command;
-          seenArgs = args;
-          return {'ok': true, 'message': 'done'};
-        },
-      );
-      final result = await bridge.dispatch({
-        'method': 'executeCommand',
-        'params': {'command': '/toast', 'args': {'message': 'hi'}},
-      });
-      expect(result['ok'], isTrue);
-      expect(seenCommand, '/toast');
-      expect(seenArgs, {'message': 'hi'});
-    });
+    test(
+      'delegates command + args + context to the injected handler',
+      () async {
+        String? seenCommand;
+        Map<String, dynamic>? seenArgs;
+        final bridge = TestJsBridge.create(
+          permissionCheck: (_) => true,
+          executeCommand: (command, args, context) async {
+            seenCommand = command;
+            seenArgs = args;
+            return {'ok': true, 'message': 'done'};
+          },
+        );
+        final result = await bridge.dispatch({
+          'method': 'executeCommand',
+          'params': {
+            'command': '/toast',
+            'args': {'message': 'hi'},
+          },
+        });
+        expect(result['ok'], isTrue);
+        expect(seenCommand, '/toast');
+        expect(seenArgs, {'message': 'hi'});
+      },
+    );
 
     test('rejects empty command with invalid_request', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         permissionCheck: (_) => true,
         executeCommand: (_, _, _) async => const {'ok': true},
       );
@@ -105,7 +107,7 @@ void main() {
     });
 
     test('denies when execute_command capability is not granted', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         permissionCheck: (_) => false,
         executeCommand: (_, _, _) async => const {'ok': true},
       );
@@ -114,12 +116,14 @@ void main() {
         'params': {'command': '/toast'},
       });
       expect(result['ok'], isFalse);
-      expect((result['error']['message'] as String),
-          contains('execute_command'));
+      expect(
+        (result['error']['message'] as String),
+        contains('execute_command'),
+      );
     });
 
     test('returns unsupported_method when no handler is registered', () async {
-      final bridge = JsBridgeService(permissionCheck: (_) => true);
+      final bridge = TestJsBridge.create(permissionCheck: (_) => true);
       final result = await bridge.dispatch({
         'method': 'executeCommand',
         'params': {'command': '/toast'},

--- a/test/command_registry_test.dart
+++ b/test/command_registry_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/features/extensions/services/command_registry.dart';
-import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
 import 'helpers/js_bridge_test_support.dart';
 
 void main() {

--- a/test/helpers/js_bridge_test_support.dart
+++ b/test/helpers/js_bridge_test_support.dart
@@ -1,0 +1,104 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/character_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/chat_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/global_variables_repo.dart';
+import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
+import 'package:glaze_flutter/features/extensions/services/js_bridge/js_bridge_context.dart';
+import 'package:glaze_flutter/features/extensions/state/message_variables_notifier.dart';
+
+/// Fully wired inert ports for JS bridge unit tests.
+class TestJsBridge {
+  static JsBridgeContext context({
+    required Map<String, dynamic> params,
+    required Map<String, dynamic> context,
+    String? Function()? currentSessionId,
+    String? Function()? currentCharacterId,
+    GenerateTextHandler? generateText,
+    InjectPromptHandler? injectPrompt,
+    UninjectPromptHandler? uninjectPrompt,
+    TriggerGenerationHandlerFn? triggerGeneration,
+    PermissionCheck? permissionCheck,
+    PlayAudioHandler? playAudio,
+    ExecuteCommandHandler? executeCommand,
+    ShowToastHandler? showToast,
+  }) {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    return JsBridgeContext(
+      params: params,
+      context: context,
+      chatRepo: ChatRepo(db),
+      characterRepo: CharacterRepo(db),
+      globalVariablesRepo: GlobalVariablesRepo.withPrefsLoader(
+        SharedPreferences.getInstance,
+      ),
+      messageVariables: MessageVariablesNotifier.new,
+      currentSessionId: currentSessionId ?? () => null,
+      currentCharacterId: currentCharacterId ?? () => null,
+      generateText:
+          generateText ?? (_, _, _) => throw UnsupportedError('unwired'),
+      injectPrompt:
+          injectPrompt ?? (_, _, _, _) => throw UnsupportedError('unwired'),
+      uninjectPrompt:
+          uninjectPrompt ?? (_, _) => throw UnsupportedError('unwired'),
+      triggerGeneration:
+          triggerGeneration ?? (_, _) => throw UnsupportedError('unwired'),
+      permissionCheck: permissionCheck ?? (_) => false,
+      playAudio: playAudio ?? (_, _) => throw UnsupportedError('unwired'),
+      executeCommand:
+          executeCommand ?? (_, _, _) => throw UnsupportedError('unwired'),
+      showToast: showToast ?? (_, _) {},
+    );
+  }
+
+  static JsBridgeService create({
+    ChatRepo? chatRepo,
+    CharacterRepo? characterRepo,
+    GlobalVariablesRepo? globalVariablesRepo,
+    MessageVariablesAccessor? messageVariables,
+    String? Function()? currentSessionId,
+    String? Function()? currentCharacterId,
+    GenerateTextHandler? generateText,
+    InjectPromptHandler? injectPrompt,
+    UninjectPromptHandler? uninjectPrompt,
+    TriggerGenerationHandlerFn? triggerGeneration,
+    PermissionCheck? permissionCheck,
+    PlayAudioHandler? playAudio,
+    ExecuteCommandHandler? executeCommand,
+    ShowToastHandler? showToast,
+  }) {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    TestWidgetsFlutterBinding.ensureInitialized();
+    if (globalVariablesRepo == null) {
+      SharedPreferences.setMockInitialValues({});
+    }
+    return JsBridgeService(
+      chatRepo: chatRepo ?? ChatRepo(db),
+      characterRepo: characterRepo ?? CharacterRepo(db),
+      globalVariablesRepo:
+          globalVariablesRepo ??
+          GlobalVariablesRepo.withPrefsLoader(SharedPreferences.getInstance),
+      messageVariables: messageVariables ?? MessageVariablesNotifier.new,
+      currentSessionId: currentSessionId ?? () => null,
+      currentCharacterId: currentCharacterId ?? () => null,
+      generateText:
+          generateText ?? (_, _, _) => throw UnsupportedError('unwired'),
+      injectPrompt:
+          injectPrompt ?? (_, _, _, _) => throw UnsupportedError('unwired'),
+      uninjectPrompt:
+          uninjectPrompt ?? (_, _) => throw UnsupportedError('unwired'),
+      triggerGeneration:
+          triggerGeneration ?? (_, _) => throw UnsupportedError('unwired'),
+      permissionCheck: permissionCheck ?? (_) => false,
+      playAudio: playAudio ?? (_, _) => throw UnsupportedError('unwired'),
+      executeCommand:
+          executeCommand ?? (_, _, _) => throw UnsupportedError('unwired'),
+      showToast: showToast ?? (_, _) {},
+    );
+  }
+}

--- a/test/js_bridge/generation_handler_test.dart
+++ b/test/js_bridge/generation_handler_test.dart
@@ -1,14 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/features/extensions/services/js_bridge/handlers/generation_handler.dart';
-import 'package:glaze_flutter/features/extensions/services/js_bridge/js_bridge_context.dart';
-import 'package:glaze_flutter/features/extensions/services/js_bridge/js_bridge_service.dart';
+import '../helpers/js_bridge_test_support.dart';
 
 void main() {
   group('GenerationHandler', () {
     test('generateText validates preset before delegating', () async {
       final handler = GenerationHandler();
-      final bridge = JsBridgeContext(
+      final bridge = TestJsBridge.context(
         params: {
           'prompt': 'Hello',
           'options': {'preset': 'tiny'},
@@ -23,7 +22,7 @@ void main() {
 
     test('generateText delegates prompt, options, and context', () async {
       final handler = GenerationHandler();
-      final bridge = JsBridgeContext(
+      final bridge = TestJsBridge.context(
         params: {
           'prompt': 'Write one line',
           'options': {'preset': 'small'},
@@ -45,7 +44,7 @@ void main() {
       'triggerGeneration resolves character id from context first',
       () async {
         final handler = GenerationHandler();
-        final bridge = JsBridgeContext(
+        final bridge = TestJsBridge.context(
           params: {'mode': 'auto'},
           context: {'characterId': 'explicit'},
           currentCharacterId: () => 'fallback',
@@ -62,26 +61,29 @@ void main() {
       },
     );
 
-    test('canonical dispatch default-denies without a permission check', () async {
-      final bridge = JsBridgeService(
-        generateText: (_, _, _) async => 'must not run',
-      );
+    test(
+      'canonical dispatch default-denies without a permission check',
+      () async {
+        final bridge = TestJsBridge.create(
+          generateText: (_, _, _) async => 'must not run',
+        );
 
-      final response = await bridge.dispatch({
-        'method': 'generateText',
-        'params': {'prompt': 'Hello'},
-      });
+        final response = await bridge.dispatch({
+          'method': 'generateText',
+          'params': {'prompt': 'Hello'},
+        });
 
-      expect(response['ok'], isFalse);
-      expect(response['error'], isA<Map<String, dynamic>>());
-      expect(
-        (response['error'] as Map<String, dynamic>)['code'],
-        'bridge_error',
-      );
-      expect(
-        (response['error'] as Map<String, dynamic>)['message'],
-        contains('Permission denied: generate_text'),
-      );
-    });
+        expect(response['ok'], isFalse);
+        expect(response['error'], isA<Map<String, dynamic>>());
+        expect(
+          (response['error'] as Map<String, dynamic>)['code'],
+          'bridge_error',
+        );
+        expect(
+          (response['error'] as Map<String, dynamic>)['message'],
+          contains('Permission denied: generate_text'),
+        );
+      },
+    );
   });
 }

--- a/test/js_bridge_method_registry_test.dart
+++ b/test/js_bridge_method_registry_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:glaze_flutter/features/chat/bridge/chat_bridge_controller.dart';
 import 'package:glaze_flutter/features/extensions/models/preset_permissions.dart';
 import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
-import 'package:glaze_flutter/features/extensions/services/js_engine_service.dart';
+import 'helpers/js_bridge_test_support.dart';
 
 void main() {
   group('JsBridgeMethodRegistry', () {
@@ -62,20 +62,20 @@ void main() {
       }
     });
 
-    test('visual and headless hosts expose the same intended contract', () {
+    test('only the Chat WebView profile exposes the bridge contract', () {
       final canonical = JsBridgeMethodRegistry.methods
           .map((e) => e.name)
           .toSet();
 
       expect(ChatBridgeController.supportedExtensionMethods, canonical);
-      expect(JsEngineBridgeHost.supportedMethods, canonical);
+      expect(JsBridgeHostProfile.values, [JsBridgeHostProfile.visual]);
     });
 
     test(
       'unknown methods remain unsupported without a permission lookup',
       () async {
         var permissionChecks = 0;
-        final response = await JsBridgeService(
+        final response = await TestJsBridge.create(
           permissionCheck: (_) {
             permissionChecks++;
             return true;

--- a/test/js_bridge_service_test.dart
+++ b/test/js_bridge_service_test.dart
@@ -7,6 +7,7 @@ import 'package:glaze_flutter/core/db/repositories/chat_repo.dart';
 import 'package:glaze_flutter/core/models/character.dart';
 import 'package:glaze_flutter/core/models/chat_message.dart';
 import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
+import 'helpers/js_bridge_test_support.dart';
 
 AppDatabase _testDb() => AppDatabase.forTesting(NativeDatabase.memory());
 
@@ -20,7 +21,7 @@ void main() {
     db = _testDb();
     characterRepo = CharacterRepo(db);
     chatRepo = ChatRepo(db);
-    bridge = JsBridgeService(
+    bridge = TestJsBridge.create(
       chatRepo: chatRepo,
       characterRepo: characterRepo,
       currentSessionId: () => 's1',
@@ -118,7 +119,7 @@ void main() {
 
   group('JsBridgeService generateText', () {
     test('delegates prompt and options to injected handler', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         chatRepo: chatRepo,
         characterRepo: characterRepo,
         currentSessionId: () => 's1',
@@ -161,7 +162,7 @@ void main() {
 
   group('JsBridgeService prompt injection', () {
     test('delegates injectPrompt to injected handler', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         currentSessionId: () => 's1',
         permissionCheck: (_) => true,
         injectPrompt: (id, content, options, context) {
@@ -188,7 +189,7 @@ void main() {
     });
 
     test('delegates uninjectPrompt to injected handler', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         currentSessionId: () => 's1',
         permissionCheck: (_) => true,
         uninjectPrompt: (id, context) {
@@ -221,7 +222,7 @@ void main() {
 
   group('JsBridgeService triggerGeneration', () {
     test('delegates to injected handler with resolved charId', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         currentSessionId: () => 's1',
         currentCharacterId: () => 'c1',
         permissionCheck: (_) => true,
@@ -229,11 +230,7 @@ void main() {
           expect(charId, 'c1');
           expect(params['mode'], 'continue');
           expect(params['reason'], 'tick');
-          return {
-            'accepted': true,
-            'mode': 'continue',
-            'reason': 'tick',
-          };
+          return {'accepted': true, 'mode': 'continue', 'reason': 'tick'};
         },
       );
 
@@ -251,7 +248,7 @@ void main() {
     });
 
     test('prefers context.characterId over currentCharacterId', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         currentCharacterId: () => 'fallback',
         permissionCheck: (_) => true,
         triggerGeneration: (charId, params) async {
@@ -269,41 +266,43 @@ void main() {
       expect(result['result'], {'accepted': true, 'charId': 'explicit'});
     });
 
-    test('rejects non-string params when the typed handler validates them',
-        () async {
-      // The validation contract lives in `TriggerGenerationHandler`; the
-      // bridge service itself is a thin dispatcher that propagates
-      // exceptions. We simulate the typed handler throwing an
-      // ArgumentError (mirroring real behavior) and check the bridge
-      // converts it into `invalid_request`.
-      final bridge = JsBridgeService(
-        currentCharacterId: () => 'c1',
-        permissionCheck: (_) => true,
-        triggerGeneration: (charId, params) async {
-          if (params['mode'] is! String && params['mode'] != null) {
-            throw ArgumentError('triggerGeneration mode must be a string');
-          }
-          if (params['reason'] is! String && params['reason'] != null) {
-            throw ArgumentError('triggerGeneration reason must be a string');
-          }
-          return {'accepted': true};
-        },
-      );
+    test(
+      'rejects non-string params when the typed handler validates them',
+      () async {
+        // The validation contract lives in `TriggerGenerationHandler`; the
+        // bridge service itself is a thin dispatcher that propagates
+        // exceptions. We simulate the typed handler throwing an
+        // ArgumentError (mirroring real behavior) and check the bridge
+        // converts it into `invalid_request`.
+        final bridge = TestJsBridge.create(
+          currentCharacterId: () => 'c1',
+          permissionCheck: (_) => true,
+          triggerGeneration: (charId, params) async {
+            if (params['mode'] is! String && params['mode'] != null) {
+              throw ArgumentError('triggerGeneration mode must be a string');
+            }
+            if (params['reason'] is! String && params['reason'] != null) {
+              throw ArgumentError('triggerGeneration reason must be a string');
+            }
+            return {'accepted': true};
+          },
+        );
 
-      final badMode = await bridge.dispatch({
-        'method': 'triggerGeneration',
-        'params': {'mode': 42},
-      });
-      expect(badMode['ok'], isFalse);
-      expect(badMode['error']['code'], 'invalid_request');
+        final badMode = await bridge.dispatch({
+          'method': 'triggerGeneration',
+          'params': {'mode': 42},
+        });
+        expect(badMode['ok'], isFalse);
+        expect(badMode['error']['code'], 'invalid_request');
 
-      final badReason = await bridge.dispatch({
-        'method': 'triggerGeneration',
-        'params': {'mode': 'auto', 'reason': 7},
-      });
-      expect(badReason['ok'], isFalse);
-      expect(badReason['error']['code'], 'invalid_request');
-    });
+        final badReason = await bridge.dispatch({
+          'method': 'triggerGeneration',
+          'params': {'mode': 'auto', 'reason': 7},
+        });
+        expect(badReason['ok'], isFalse);
+        expect(badReason['error']['code'], 'invalid_request');
+      },
+    );
 
     test('returns bridge_error when no handler is registered', () async {
       final result = await bridge.dispatch({

--- a/test/js_bridge_toast_test.dart
+++ b/test/js_bridge_toast_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
 import 'package:glaze_flutter/features/extensions/services/js_bridge_toast_controller.dart';
+import 'helpers/js_bridge_test_support.dart';
 
 void main() {
   group('GlazeToastSeverity.parse', () {
@@ -14,12 +15,9 @@ void main() {
     test('maps known severities', () {
       expect(GlazeToastSeverity.parse('info'), GlazeToastSeverity.info);
       expect(GlazeToastSeverity.parse('INFO'), GlazeToastSeverity.info);
-      expect(GlazeToastSeverity.parse('success'),
-          GlazeToastSeverity.success);
-      expect(GlazeToastSeverity.parse('warning'),
-          GlazeToastSeverity.warning);
-      expect(GlazeToastSeverity.parse('warn'),
-          GlazeToastSeverity.warning);
+      expect(GlazeToastSeverity.parse('success'), GlazeToastSeverity.success);
+      expect(GlazeToastSeverity.parse('warning'), GlazeToastSeverity.warning);
+      expect(GlazeToastSeverity.parse('warn'), GlazeToastSeverity.warning);
       expect(GlazeToastSeverity.parse('error'), GlazeToastSeverity.error);
     });
   });
@@ -34,16 +32,17 @@ void main() {
     test('passes severity through to the user-supplied resolver', () {
       String? captured;
       GlazeToastSeverity? capturedSeverity;
-      final controller = JsBridgeToastController(
-        overlayResolver: () => null,
-      );
+      final controller = JsBridgeToastController(overlayResolver: () => null);
       // Re-point the debug hook by replacing the resolver. We test the
       // controller's pure-data path: the controller never inspects the
       // BuildContext directly, so a null overlay is enough to trigger
       // the log branch.
       controller.show('hi', severity: GlazeToastSeverity.error);
-      expect(captured, isNull,
-          reason: 'this test only exercises the no-overlay path');
+      expect(
+        captured,
+        isNull,
+        reason: 'this test only exercises the no-overlay path',
+      );
       expect(capturedSeverity, isNull);
     });
   });
@@ -52,7 +51,7 @@ void main() {
     test('delegates message + options to the injected handler', () async {
       String? seenMessage;
       Map<String, dynamic>? seenOptions;
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         permissionCheck: (_) => true,
         showToast: (message, options) {
           seenMessage = message;
@@ -72,7 +71,7 @@ void main() {
     });
 
     test('rejects non-string message with invalid_request', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         permissionCheck: (_) => true,
         showToast: (_, _) {},
       );
@@ -85,7 +84,7 @@ void main() {
     });
 
     test('denies when show_toast capability is not granted', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         permissionCheck: (_) => false,
         showToast: (_, _) {},
       );

--- a/test/js_bridge_toast_test.dart
+++ b/test/js_bridge_toast_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
 import 'package:glaze_flutter/features/extensions/services/js_bridge_toast_controller.dart';
 import 'helpers/js_bridge_test_support.dart';
 

--- a/test/js_engine_service_test.dart
+++ b/test/js_engine_service_test.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
 import 'package:glaze_flutter/features/extensions/services/js_engine_service.dart';
 import 'helpers/js_bridge_test_support.dart';
 

--- a/test/js_engine_service_test.dart
+++ b/test/js_engine_service_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
 import 'package:glaze_flutter/features/extensions/services/js_engine_service.dart';
+import 'helpers/js_bridge_test_support.dart';
 
 class _FakeEngineController implements JsEngineController {
   _FakeEngineController();
@@ -72,7 +73,7 @@ void main() {
     test('runScript returns the controller value as a string', () async {
       final fake = _FakeEngineController()
         ..scriptResult = 'hello from headless';
-      final host = JsEngineBridgeHost(bridge: JsBridgeService());
+      final host = JsEngineBridgeHost(bridge: TestJsBridge.create());
       final service = JsEngineService.instance;
       await service.debugInitWithController(controller: fake);
 
@@ -94,13 +95,13 @@ void main() {
       var firstCalls = 0;
       var secondCalls = 0;
       final firstHost = JsEngineBridgeHost(
-        bridge: JsBridgeService(
+        bridge: TestJsBridge.create(
           permissionCheck: (_) => true,
           showToast: (_, _) => firstCalls++,
         ),
       );
       final secondHost = JsEngineBridgeHost(
-        bridge: JsBridgeService(
+        bridge: TestJsBridge.create(
           permissionCheck: (_) => true,
           showToast: (_, _) => secondCalls++,
         ),
@@ -159,7 +160,7 @@ void main() {
         script: 'return 1;',
         context: const {},
         host: JsEngineBridgeHost(
-          bridge: JsBridgeService(
+          bridge: TestJsBridge.create(
             permissionCheck: (_) => true,
             showToast: (_, _) => firstCalls++,
           ),
@@ -176,7 +177,7 @@ void main() {
       ]);
 
       final secondHost = JsEngineBridgeHost(
-        bridge: JsBridgeService(
+        bridge: TestJsBridge.create(
           permissionCheck: (_) => true,
           showToast: (_, _) => secondCalls++,
         ),
@@ -214,7 +215,7 @@ void main() {
         () => service.runScript(
           script: 'return 1;',
           context: const {},
-          host: JsEngineBridgeHost(bridge: JsBridgeService()),
+          host: JsEngineBridgeHost(bridge: TestJsBridge.create()),
         ),
         throwsA(isA<HeadlessUnavailableError>()),
       );
@@ -222,7 +223,7 @@ void main() {
 
     test('cancel rejects an in-flight run', () async {
       final fake = _FakeEngineController()..pendingResult = Completer<Object>();
-      final host = JsEngineBridgeHost(bridge: JsBridgeService());
+      final host = JsEngineBridgeHost(bridge: TestJsBridge.create());
       final service = JsEngineService.instance;
       await service.debugInitWithController(controller: fake);
 

--- a/test/perf_debug_test.dart
+++ b/test/perf_debug_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/debug/perf_debug.dart';
+
+void main() {
+  test('Chat WebView profiling is inert without its compile-time define', () {
+    PerfDebug.resetChatWebViewSnapshot();
+    PerfDebug.chatScreenBuilt();
+    PerfDebug.chatWebViewWidgetInitialized();
+    PerfDebug.chatWebViewInitAttempted();
+    PerfDebug.chatWebViewSyncResult(
+      runMessageSync: true,
+      sessionSwitched: true,
+    );
+
+    final snapshot = PerfDebug.chatWebViewSnapshot();
+    if (!PerfDebug.logChatWebView) {
+      expect(snapshot.chatScreenBuilds, 0);
+      expect(snapshot.widgetInits, 0);
+      expect(snapshot.initAttempts, 0);
+      expect(snapshot.syncUpdates, 0);
+    }
+  });
+}

--- a/test/periodic_js_block_runner_test.dart
+++ b/test/periodic_js_block_runner_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/features/extensions/models/block_config.dart';
+import 'package:glaze_flutter/features/extensions/services/blocks/periodic_js_block_runner.dart';
+import 'package:glaze_flutter/features/extensions/services/js_engine_service.dart';
+
+class _FakeJsEngineController implements JsEngineController {
+  int runCalls = 0;
+
+  @override
+  Future<void> addJavaScriptHandler({
+    required String handlerName,
+    required Future<dynamic> Function(List<dynamic> args) callback,
+  }) async {}
+
+  @override
+  Future<JsAsyncJsResult?> callAsyncJavaScript({
+    required String functionBody,
+    required Map<String, dynamic> arguments,
+  }) async {
+    runCalls++;
+    return JsAsyncJsResult('headless result');
+  }
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> evaluateJavascript({required String source}) async {}
+}
+
+void main() {
+  test('periodic block skips when no active chat bridge is mounted', () async {
+    JsEngineService.debugSetInstance(null);
+    final engine = JsEngineService.instance;
+    final controller = _FakeJsEngineController();
+    await engine.debugInitWithController(controller: controller);
+    addTearDown(() => JsEngineService.debugSetInstance(null));
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final runner = container.read(
+      Provider((ref) => PeriodicJsBlockRunner(ref: ref)),
+    );
+
+    final result = await runner.run(
+      charId: 'character-1',
+      sessionId: 'session-1',
+      block: BlockConfig(
+        id: 'periodic-1',
+        name: 'Periodic',
+        type: BlockType.jsRunner,
+        prompt: 'return "result";',
+      ),
+      contextMessages: const <ChatMessage>[],
+    );
+
+    expect(result, isNull);
+    expect(
+      controller.runCalls,
+      0,
+      reason: 'periodic blocks must not execute through the headless engine',
+    );
+  });
+}

--- a/test/periodic_lifecycle_test.dart
+++ b/test/periodic_lifecycle_test.dart
@@ -48,8 +48,10 @@ class _FakePostGen extends ExtensionPostGenService {
   @override
   Future<String?> runJsBlock({
     required String charId,
+    required String sessionId,
     required BlockConfig block,
     required List<ChatMessage> contextMessages,
+    bool Function()? isAuthorized,
   }) async {
     tickBlockIds.add(block.id);
     if (!_signalled) {

--- a/test/periodic_trigger_scheduler_test.dart
+++ b/test/periodic_trigger_scheduler_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:drift/native.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -9,6 +10,7 @@ import 'package:glaze_flutter/core/db/app_db.dart';
 import 'package:glaze_flutter/core/db/repositories/character_repo.dart';
 import 'package:glaze_flutter/core/models/character.dart';
 import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/services/generation_notification_service.dart';
 import 'package:glaze_flutter/core/state/db_provider.dart';
 import 'package:glaze_flutter/features/extensions/models/extensions_settings.dart';
 import 'package:glaze_flutter/features/extensions/models/block_config.dart';
@@ -24,16 +26,20 @@ class _FakePostGen extends ExtensionPostGenService {
   _FakePostGen(super.ref);
 
   final List<String> tickBlockIds = [];
+  final List<(String charId, String sessionId)> tickContexts = [];
   final Completer<void> _firstTick = Completer<void>();
   bool _signalled = false;
 
   @override
   Future<String?> runJsBlock({
     required String charId,
+    required String sessionId,
     required BlockConfig block,
     required List<ChatMessage> contextMessages,
+    bool Function()? isAuthorized,
   }) async {
     tickBlockIds.add(block.id);
+    tickContexts.add((charId, sessionId));
     if (!_signalled) {
       _signalled = true;
       _firstTick.complete();
@@ -54,6 +60,9 @@ void main() {
     characterRepo = CharacterRepo(db);
     await characterRepo.put(Character(id: 'c1', name: 'Alice'));
     SharedPreferences.setMockInitialValues({});
+    GenerationNotificationService.instance
+      ..updateLifecycleState(AppLifecycleState.resumed)
+      ..setActiveContext(null, null);
   });
 
   tearDown(() async {
@@ -113,6 +122,7 @@ void main() {
       ],
     );
     await container.read(extensionPresetsProvider.notifier).add(preset);
+    GenerationNotificationService.instance.setActiveContext('c1', 's1');
 
     // Touch the scheduler — reading the provider forces `start()`.
     final scheduler = container.read(periodicTriggerSchedulerProvider);
@@ -124,6 +134,8 @@ void main() {
     await fake.waitForFirstTick().timeout(const Duration(seconds: 5));
     expect(fake.tickBlockIds, contains('b1'),
         reason: 'periodic jsRunner should be dispatched at least once');
+    expect(fake.tickContexts, contains(('c1', 's1')),
+        reason: 'periodic execution uses the active chat character and session');
   });
 
   test('scheduler drops timers when extensions are disabled', () async {
@@ -159,5 +171,33 @@ void main() {
     final scheduler = container.read(periodicTriggerSchedulerProvider);
     expect(scheduler.activeTimerCount, 0,
         reason: 'scheduler must not start timers when extensions are off');
+  });
+
+  test('scheduler executes only for active chat authority', () async {
+    final container = ProviderContainer(
+      overrides: [
+        appDbProvider.overrideWith((ref) => db),
+        extensionPostGenServiceProvider.overrideWith((ref) => _FakePostGen(ref)),
+      ],
+    );
+    addTearDown(container.dispose);
+    final scheduler = container.read(periodicTriggerSchedulerProvider);
+    final block = BlockConfig(
+      id: 'b1',
+      name: 'Tick',
+      type: BlockType.jsRunner,
+      enabled: true,
+      trigger: BlockTrigger.periodic,
+      prompt: '// js',
+    );
+    final fake = container.read(extensionPostGenServiceProvider) as _FakePostGen;
+
+    await scheduler.debugTick(block);
+    expect(fake.tickBlockIds, isEmpty);
+
+    GenerationNotificationService.instance.setActiveContext('c1', 's1');
+    await scheduler.debugTick(block);
+    expect(fake.tickBlockIds, ['b1']);
+    expect(fake.tickContexts, [('c1', 's1')]);
   });
 }

--- a/test/play_audio_bridge_test.dart
+++ b/test/play_audio_bridge_test.dart
@@ -1,13 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
+import 'helpers/js_bridge_test_support.dart';
 
 void main() {
   group('JsBridgeService playAudio', () {
     test('delegates source + options to the injected handler', () async {
       String? seenSource;
       Map<String, dynamic>? seenOptions;
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         permissionCheck: (_) => true,
         playAudio: (source, options) async {
           seenSource = source;
@@ -27,7 +28,7 @@ void main() {
     });
 
     test('rejects non-string source with invalid_request', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         permissionCheck: (_) => true,
         playAudio: (_, _) async {},
       );
@@ -40,7 +41,7 @@ void main() {
     });
 
     test('denies when play_audio capability is not granted', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         permissionCheck: (_) => false,
         playAudio: (_, _) async {},
       );
@@ -53,9 +54,7 @@ void main() {
     });
 
     test('returns unsupported_method when no handler is registered', () async {
-      final bridge = JsBridgeService(
-        permissionCheck: (_) => true,
-      );
+      final bridge = TestJsBridge.create(permissionCheck: (_) => true);
       final result = await bridge.dispatch({
         'method': 'playAudio',
         'params': {'source': 'click'},

--- a/test/play_audio_bridge_test.dart
+++ b/test/play_audio_bridge_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
 import 'helpers/js_bridge_test_support.dart';
 
 void main() {

--- a/test/preset_permissions_test.dart
+++ b/test/preset_permissions_test.dart
@@ -8,6 +8,7 @@ import 'package:glaze_flutter/core/models/character.dart';
 import 'package:glaze_flutter/core/models/chat_message.dart';
 import 'package:glaze_flutter/features/extensions/models/preset_permissions.dart';
 import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
+import 'helpers/js_bridge_test_support.dart';
 
 AppDatabase _testDb() => AppDatabase.forTesting(NativeDatabase.memory());
 
@@ -57,34 +58,40 @@ void main() {
       const base = PresetPermissions();
       for (final cap in GlazeCapability.values) {
         final flipped = base.copyWithField(cap, true);
-        expect(flipped.isGranted(cap), isTrue,
-            reason: 'capability ${cap.id} should be true after flip');
+        expect(
+          flipped.isGranted(cap),
+          isTrue,
+          reason: 'capability ${cap.id} should be true after flip',
+        );
       }
     });
   });
 
   group('JsBridgeService permission gating', () {
-    test('denies setVariables when no permission check is registered',
-        () async {
-      final bridge = JsBridgeService(
-        chatRepo: chatRepo,
-        characterRepo: characterRepo,
-        currentSessionId: () => 's1',
-        currentCharacterId: () => 'c1',
-      );
-      final result = await bridge.dispatch({
-        'method': 'setVariables',
-        'params': {'scope': 'chat', 'path': 'hp', 'value': 1},
-      });
-      expect(result['ok'], isFalse);
-      expect(result['error']['code'], 'bridge_error');
-      expect((result['error']['message'] as String).toLowerCase(),
-          contains('permission denied'));
-    });
+    test(
+      'denies setVariables when no permission check is registered',
+      () async {
+        final bridge = TestJsBridge.create(
+          chatRepo: chatRepo,
+          characterRepo: characterRepo,
+          currentSessionId: () => 's1',
+          currentCharacterId: () => 'c1',
+        );
+        final result = await bridge.dispatch({
+          'method': 'setVariables',
+          'params': {'scope': 'chat', 'path': 'hp', 'value': 1},
+        });
+        expect(result['ok'], isFalse);
+        expect(result['error']['code'], 'bridge_error');
+        expect(
+          (result['error']['message'] as String).toLowerCase(),
+          contains('permission denied'),
+        );
+      },
+    );
 
-    test('denies setVariables when permission check returns false',
-        () async {
-      final bridge = JsBridgeService(
+    test('denies setVariables when permission check returns false', () async {
+      final bridge = TestJsBridge.create(
         chatRepo: chatRepo,
         characterRepo: characterRepo,
         currentSessionId: () => 's1',
@@ -96,11 +103,14 @@ void main() {
         'params': {'scope': 'chat', 'path': 'hp', 'value': 1},
       });
       expect(result['ok'], isFalse);
-      expect((result['error']['message'] as String), contains('write_chat_vars'));
+      expect(
+        (result['error']['message'] as String),
+        contains('write_chat_vars'),
+      );
     });
 
     test('allows setVariables when permission is granted', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         chatRepo: chatRepo,
         characterRepo: characterRepo,
         currentSessionId: () => 's1',
@@ -121,32 +131,40 @@ void main() {
       expect(read['result'], 7);
     });
 
-    test('read requires read capability, write requires write capability',
-        () async {
-      final bridge = JsBridgeService(
-        chatRepo: chatRepo,
-        characterRepo: characterRepo,
-        currentSessionId: () => 's1',
-        currentCharacterId: () => 'c1',
-        permissionCheck: (cap) => cap == 'write_chat_vars',
-      );
+    test(
+      'read requires read capability, write requires write capability',
+      () async {
+        final bridge = TestJsBridge.create(
+          chatRepo: chatRepo,
+          characterRepo: characterRepo,
+          currentSessionId: () => 's1',
+          currentCharacterId: () => 'c1',
+          permissionCheck: (cap) => cap == 'write_chat_vars',
+        );
 
-      final readDenied = await bridge.dispatch({
-        'method': 'getVariables',
-        'params': {'scope': 'chat'},
-      });
-      expect(readDenied['ok'], isFalse);
-      expect((readDenied['error']['message'] as String), contains('read_chat_vars'));
+        final readDenied = await bridge.dispatch({
+          'method': 'getVariables',
+          'params': {'scope': 'chat'},
+        });
+        expect(readDenied['ok'], isFalse);
+        expect(
+          (readDenied['error']['message'] as String),
+          contains('read_chat_vars'),
+        );
 
-      final writeOk = await bridge.dispatch({
-        'method': 'setVariables',
-        'params': {'scope': 'chat', 'values': {'hp': 9}},
-      });
-      expect(writeOk['ok'], isTrue);
-    });
+        final writeOk = await bridge.dispatch({
+          'method': 'setVariables',
+          'params': {
+            'scope': 'chat',
+            'values': {'hp': 9},
+          },
+        });
+        expect(writeOk['ok'], isTrue);
+      },
+    );
 
     test('character scope is gated by its own capability id', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         chatRepo: chatRepo,
         characterRepo: characterRepo,
         currentSessionId: () => 's1',
@@ -161,7 +179,7 @@ void main() {
     });
 
     test('generateText is gated by generate_text capability', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         currentCharacterId: () => 'c1',
         permissionCheck: (cap) => cap == 'generate_text',
         generateText: (p, o, c) async => 'ok',
@@ -172,7 +190,7 @@ void main() {
       });
       expect(allowed['ok'], isTrue);
 
-      final deniedBridge = JsBridgeService(
+      final deniedBridge = TestJsBridge.create(
         currentCharacterId: () => 'c1',
         permissionCheck: (cap) => false,
         generateText: (p, o, c) async => 'ok',
@@ -185,7 +203,7 @@ void main() {
     });
 
     test('showToast is allowed by default', () async {
-      final bridge = JsBridgeService(
+      final bridge = TestJsBridge.create(
         permissionCheck: (cap) => cap == 'show_toast',
       );
       final result = await bridge.dispatch({

--- a/test/preset_permissions_test.dart
+++ b/test/preset_permissions_test.dart
@@ -7,7 +7,6 @@ import 'package:glaze_flutter/core/db/repositories/chat_repo.dart';
 import 'package:glaze_flutter/core/models/character.dart';
 import 'package:glaze_flutter/core/models/chat_message.dart';
 import 'package:glaze_flutter/features/extensions/models/preset_permissions.dart';
-import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
 import 'helpers/js_bridge_test_support.dart';
 
 AppDatabase _testDb() => AppDatabase.forTesting(NativeDatabase.memory());

--- a/test/prompt_lorebook_baseline_test.dart
+++ b/test/prompt_lorebook_baseline_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/prompt_builder.dart';
+import 'package:glaze_flutter/core/llm/prompt_inputs.dart';
+import 'package:glaze_flutter/core/llm/prompt_isolate.dart';
+import 'package:glaze_flutter/core/llm/prompt_worker.dart';
+import 'package:glaze_flutter/core/models/api_config.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/models/lorebook.dart';
+import 'package:glaze_flutter/core/models/preset.dart';
+
+// Baseline command: flutter test test/prompt_lorebook_baseline_test.dart
+void main() {
+  test('baseline: isolate prompt build handles long history and large lorebook',
+      () async {
+    const historyCount = 160;
+    const lorebookEntryCount = 240;
+    const injectedLorebookEntries = 6;
+    final inputs = _baselineInputs();
+
+    // The first request includes worker/isolate initialization; the second
+    // measures the persistent worker path. Timings are diagnostic only.
+    final coldWatch = Stopwatch()..start();
+    final cold = await buildFromInputsInIsolate(inputs);
+    coldWatch.stop();
+
+    final warmWatch = Stopwatch()..start();
+    final warm = await buildFromInputsInIsolate(inputs);
+    warmWatch.stop();
+
+    addTearDown(() async {
+      final worker = await PromptWorker.ensureInitialized();
+      worker.dispose();
+    });
+
+    final outputChars = cold.messages.fold<int>(
+      0,
+      (total, message) => total + message.content.length,
+    );
+    print(
+      'prompt/lorebook baseline: history=$historyCount '
+      'lorebookEntries=$lorebookEntryCount cold=${coldWatch.elapsedMilliseconds}ms '
+      'warm=${warmWatch.elapsedMilliseconds}ms outputChars=$outputChars '
+      'tokens=${cold.breakdown.totalTokens}',
+    );
+
+    final expectedLoreIds = [
+      for (var index = 0; index < injectedLorebookEntries; index++)
+        'lore-$index',
+    ];
+    expect(cold.triggeredLorebooks.map((entry) => entry.id), expectedLoreIds);
+    expect(
+      cold.messages.where((message) => message.isHistory).length,
+      historyCount,
+    );
+    expect(
+      cold.messages.map((message) => message.content).join('\n'),
+      allOf(contains('LOREBOOK_BASELINE_0'), contains('history-marker-159')),
+    );
+
+    // Assert output semantics, never a machine-dependent timing threshold.
+    expect(_signature(warm), _signature(cold));
+    expect(warm.breakdown.totalTokens, cold.breakdown.totalTokens);
+  });
+}
+
+PromptInputs _baselineInputs() {
+  const filler = 'synthetic history payload for deterministic prompt benchmarking ';
+  return PromptInputs(
+    character: const Character(
+      id: 'baseline-character',
+      name: 'Baseline Character',
+      description: 'A deterministic benchmark character.',
+    ),
+    apiConfig: const ApiConfig(
+      id: 'baseline-api',
+      contextSize: 128000,
+      maxTokens: 2048,
+    ),
+    preset: const Preset(
+      id: 'baseline-preset',
+      name: 'Baseline preset',
+      blocks: [
+        PresetBlock(
+          id: 'char_card',
+          name: 'Character',
+          role: 'system',
+          content: '{{description}}',
+        ),
+        PresetBlock(
+          id: 'chat_history',
+          name: 'History',
+          role: 'system',
+          content: '',
+        ),
+      ],
+    ),
+    history: [
+      for (var index = 0; index < 160; index++)
+        ChatMessage(
+          id: 'history-$index',
+          role: index.isEven ? 'user' : 'assistant',
+          content:
+              'history-marker-$index ${List.filled(4, filler).join()}${index == 159 ? 'benchmark-anchor' : ''}',
+        ),
+    ],
+    lorebooks: [
+      Lorebook(
+        id: 'baseline-lorebook',
+        name: 'Baseline lorebook',
+        entries: [
+          for (var index = 0; index < 240; index++)
+            LorebookEntry(
+              id: 'lore-$index',
+              comment: 'Benchmark lore $index',
+              keys: const ['benchmark-anchor'],
+              content:
+                  'LOREBOOK_BASELINE_$index ${List.filled(12, 'lore fact ').join()}',
+              position: 'worldInfoBefore',
+              order: index,
+            ),
+        ],
+      ),
+    ],
+    lorebookSettings: const LorebookGlobalSettings(
+      scanDepth: 160,
+      maxInjectedEntries: 6,
+      recursiveScan: false,
+    ),
+    memoryEnabled: false,
+  );
+}
+
+String _signature(PromptResult result) => [
+  for (final message in result.messages)
+    '${message.role}|${message.blockId}|${message.sourceMessageId}|${message.content}',
+  for (final entry in result.triggeredLorebooks)
+    'lore|${entry.id}|${entry.source}|${entry.lorebookId}',
+].join('\n');

--- a/test/prompt_lorebook_baseline_test.dart
+++ b/test/prompt_lorebook_baseline_test.dart
@@ -37,6 +37,7 @@ void main() {
       0,
       (total, message) => total + message.content.length,
     );
+    // ignore: avoid_print
     print(
       'prompt/lorebook baseline: history=$historyCount '
       'lorebookEntries=$lorebookEntryCount cold=${coldWatch.elapsedMilliseconds}ms '

--- a/test/prompt_payload_builder_test.dart
+++ b/test/prompt_payload_builder_test.dart
@@ -10,6 +10,7 @@ import 'package:glaze_flutter/core/llm/prompt_builder.dart';
 import 'package:glaze_flutter/core/models/api_config.dart';
 import 'package:glaze_flutter/core/models/character.dart';
 import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/models/memory_book.dart';
 import 'package:glaze_flutter/core/models/tracker.dart';
 import 'package:glaze_flutter/core/state/db_provider.dart';
 import 'package:glaze_flutter/core/state/memory_settings_provider.dart';
@@ -18,7 +19,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test(
-    'buildFromPreFetched loads ledger once and preserves fast-mode fields',
+    'buildFromPreFetched only loads graph prompt content when memory is enabled',
     () async {
       SharedPreferences.setMockInitialValues({});
       final db = AppDatabase.forTesting(NativeDatabase.memory());
@@ -108,6 +109,59 @@ void main() {
           expect(payload.arcContent, contains('- Escape'));
         }
       }
+
+      await container
+          .read(memoryGlobalSettingsProvider.notifier)
+          .save(const MemoryGlobalSettings(enabled: false));
+      final callsBeforeGlobalDisable = loadCount;
+      final globallyDisabledPayload = await builder.buildFromPreFetched(
+        charId: 'c1',
+        session: const ChatSession(
+          id: 's1',
+          characterId: 'c1',
+          sessionIndex: 0,
+        ),
+        character: const Character(id: 'c1', name: 'Character'),
+        chatApi: const ApiConfig(id: 'api'),
+        preset: null,
+        persona: null,
+        lorebooks: const [],
+      );
+
+      expect(loadCount, callsBeforeGlobalDisable);
+      expect(globallyDisabledPayload.studioSessionStateContent, isNull);
+      expect(globallyDisabledPayload.arcContent, isNull);
+      expect(globallyDisabledPayload.entitiesContent, isNull);
+
+      await container
+          .read(memoryGlobalSettingsProvider.notifier)
+          .save(const MemoryGlobalSettings());
+      await container.read(memoryBookRepoProvider).put(
+        const MemoryBook(
+          id: 'memorybook_s1',
+          sessionId: 's1',
+          settings: MemoryBookSettings(enabled: false),
+        ),
+      );
+      final callsBeforeBookDisable = loadCount;
+      final bookDisabledPayload = await builder.buildFromPreFetched(
+        charId: 'c1',
+        session: const ChatSession(
+          id: 's1',
+          characterId: 'c1',
+          sessionIndex: 0,
+        ),
+        character: const Character(id: 'c1', name: 'Character'),
+        chatApi: const ApiConfig(id: 'api'),
+        preset: null,
+        persona: null,
+        lorebooks: const [],
+      );
+
+      expect(loadCount, callsBeforeBookDisable);
+      expect(bookDisabledPayload.studioSessionStateContent, isNull);
+      expect(bookDisabledPayload.arcContent, isNull);
+      expect(bookDisabledPayload.entitiesContent, isNull);
     },
   );
 }

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -115,13 +115,20 @@ void main() {
       },
     );
 
-    test('headless sandbox relays requests with per-run authority', () {
-      expect(headlessHtml, contains("event.data.type === 'glaze:request'"));
-      expect(headlessHtml, contains("'glazeBridge'"));
-      expect(headlessHtml, contains('runId'));
-      expect(headlessHtml, contains("type: 'glaze:response'"));
-      expect(headlessHtml, contains('event.source !== frame.contentWindow'));
-    });
+    test(
+      'panel relay preserves authoritative context and bridge error codes',
+      () {
+        expect(panelHostJs, contains('panelId: panel.panelId'));
+        expect(panelHostJs, contains('messageId: panel.messageId'));
+        expect(panelHostJs, contains('code: error && error.code'));
+        expect(
+          panelHostJs,
+          contains('_buildSrcdoc(html, options, panelId, messageId)'),
+        );
+        expect(panelHostJs, contains("sandbox = 'allow-scripts'"));
+        expect(panelHostJs, isNot(contains('allow-same-origin')));
+      },
+    );
   });
 
   group('message script execution policy', () {

--- a/test/wired_command_registry_test.dart
+++ b/test/wired_command_registry_test.dart
@@ -24,6 +24,7 @@ import 'package:glaze_flutter/features/extensions/services/generation_dispatcher
 import 'package:glaze_flutter/features/extensions/services/js_bridge_service.dart';
 import 'package:glaze_flutter/features/extensions/services/runtime_prompt_injection_service.dart';
 import 'package:glaze_flutter/features/extensions/services/trigger_generation_handler.dart';
+import 'helpers/js_bridge_test_support.dart';
 
 AppDatabase _testDb() => AppDatabase.forTesting(NativeDatabase.memory());
 
@@ -70,8 +71,7 @@ void main() {
     final triggerHandler = TriggerGenerationHandler(
       dispatcher: _NoopDispatcher(),
     );
-    bridge = JsBridgeService(
-      chatRepo: null,
+    bridge = TestJsBridge.create(
       characterRepo: characterRepo,
       currentSessionId: () => 's1',
       currentCharacterId: () => 'c1',
@@ -286,7 +286,7 @@ void main() {
       final registry = buildWiredCommandRegistry(
         WiredCommandDeps(bridgeDispatch: (request) => bridge.dispatch(request)),
       );
-      bridge = JsBridgeService(
+      bridge = TestJsBridge.create(
         permissionCheck: granted.contains,
         showToast: (_, _) => toastCalls++,
         executeCommand: (command, args, context) async {
@@ -361,7 +361,7 @@ void main() {
       final registry = buildWiredCommandRegistry(
         WiredCommandDeps(bridgeDispatch: (request) => bridge.dispatch(request)),
       );
-      bridge = JsBridgeService(
+      bridge = TestJsBridge.create(
         globalVariablesRepo: globalRepo,
         currentSessionId: () => 's1',
         currentCharacterId: () => 'c1',
@@ -438,7 +438,7 @@ void main() {
       final registry = buildWiredCommandRegistry(
         WiredCommandDeps(bridgeDispatch: (request) => bridge.dispatch(request)),
       );
-      bridge = JsBridgeService(
+      bridge = TestJsBridge.create(
         globalVariablesRepo: globalRepo,
         permissionCheck: (_) => true,
         executeCommand: (command, args, context) async {


### PR DESCRIPTION
## Summary
- document the agreed Memory Graph, periodic-extension, and JS bridge decisions
- add deterministic embedding and prompt/lorebook baseline coverage
- add opt-in Chat WebView profiling counters
- gate Memory Graph prompt reads when disabled and scope periodic extensions to the active chat
- require the mounted Chat WebView bridge for extension execution and panel relays

## Validation
- lutter analyze`n- focused embedding, prompt, WebView diagnostics, periodic lifecycle/runner, and JS bridge tests

## Follow-ups
- manual Windows/mobile WebView profile runs remain pending
- independent SQLite runtime, relational-message storage, and 100k streaming benchmark work remain deliberately deferred