### PR TITLE
feat(presets): cover images on preset cards, locked for featured presets

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -297,6 +297,7 @@
   "preset_options": "Preset Options",
   "change_author": "Change Author",
   "change_image": "Change Image",
+  "action_remove_image": "Remove Image",
   "action_edit_name": "Change Name",
   "label_active_preset": "Active Preset",
   "level_chat": "Chat",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -299,6 +299,7 @@
   "preset_options": "Опции пресета",
   "change_author": "Изменить автора",
   "change_image": "Изменить картинку",
+  "action_remove_image": "Удалить картинку",
   "action_edit_name": "Изменить название",
   "label_active_preset": "Активный пресет",
   "level_chat": "Чат",

--- a/lib/core/models/preset.dart
+++ b/lib/core/models/preset.dart
@@ -58,6 +58,12 @@ abstract class Preset with _$Preset {
     required String id,
     required String name,
     String? author,
+
+    /// Cover image shown on the preset cards. Either a path to a user-picked
+    /// file under the Glaze data dir, or a bundled `assets/...` path carried
+    /// over from a featured preset (e.g. when one is cloned). Null = no cover;
+    /// featured presets resolve theirs from their fixed id instead.
+    String? imagePath,
     @Default([]) List<PresetBlock> blocks,
     @Default([]) List<PresetRegex> regexes,
     @Default(false) bool reasoningEnabled,

--- a/lib/core/services/featured_presets.dart
+++ b/lib/core/services/featured_presets.dart
@@ -85,6 +85,12 @@ String? featuredPresetImageAsset(String? presetId) {
   return null;
 }
 
+/// Whether [presetId] is one of the bundled featured presets. Their author and
+/// cover image are part of the shipped preset, so the editor must not let the
+/// user change either (a clone gets a fresh id and is fully editable).
+bool isFeaturedPreset(String? presetId) =>
+    presetId != null && featuredPresets.any((f) => f.id == presetId);
+
 /// Loads and parses a featured preset's bundled ST JSON into a [Preset],
 /// stamping the fixed id/name/author/metadata so re-seeding is idempotent.
 Future<Preset> loadFeaturedPreset(FeaturedPreset f) async {

--- a/lib/features/presets/preset_editor_screen.dart
+++ b/lib/features/presets/preset_editor_screen.dart
@@ -1,12 +1,17 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:easy_localization/easy_localization.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/llm/tokenizer.dart';
 import '../../core/models/preset.dart';
+import '../../core/services/featured_presets.dart';
 import '../../core/services/preset_defaults.dart';
+import '../../core/state/db_provider.dart';
 import '../../core/utils/id_generator.dart';
 import '../../core/utils/time_helpers.dart';
 import '../../shared/theme/app_colors.dart';
@@ -16,6 +21,7 @@ import '../../shared/widgets/glaze_scaffold.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import '../../shared/widgets/generic_editor.dart';
 import '../../shared/widgets/help_tip.dart';
+import 'preset_image.dart';
 import 'preset_list_provider.dart';
 import 'preset_export.dart';
 import 'widgets/preset_block_row.dart';
@@ -99,6 +105,7 @@ class PresetEditorBody extends ConsumerStatefulWidget {
 class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
   late final _nameCtrl = TextEditingController(text: widget.preset?.name ?? '');
   late String _author = widget.preset?.author ?? '';
+  late String? _imagePath = widget.preset?.imagePath;
   late List<PresetBlock> _blocks;
   late List<PresetRegex> _regexes;
   late bool _parseInlineReasoning = widget.preset?.reasoningEnabled ?? false;
@@ -122,6 +129,10 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
   late final String _currentId = widget.preset?.id ?? generateId();
   late final int _createdAt =
       widget.preset?.createdAt ?? currentTimestampSeconds();
+
+  /// Bundled featured presets ship with a fixed author and cover image — both
+  /// are read-only here. Cloning one produces a normal, fully editable preset.
+  bool get _isFeatured => isFeaturedPreset(widget.preset?.id);
 
   @override
   void initState() {
@@ -178,6 +189,7 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
       id: _currentId,
       name: name,
       author: _author.trim().isEmpty ? null : _author.trim(),
+      imagePath: _imagePath,
       blocks: _blocks,
       regexes: _regexes,
       reasoningEnabled: _parseInlineReasoning,
@@ -308,6 +320,10 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
         : _nameCtrl.text.trim();
     final addBlockAtTop =
         ref.watch(appSettingsProvider).value?.addBlockAtTop ?? false;
+    final cover = resolvePresetCoverImage(
+      presetId: _currentId,
+      imagePath: _imagePath,
+    );
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
@@ -323,6 +339,22 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  if (cover != null) ...[
+                    GestureDetector(
+                      onTap: _isFeatured ? null : _pickImage,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(10),
+                        child: Image(
+                          image: cover,
+                          width: 52,
+                          height: 52,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                  ],
                   Expanded(
                     child: GestureDetector(
                       onTap: _showRenameDialog,
@@ -802,6 +834,52 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
     );
   }
 
+  /// Picks a cover image, stores it next to the character/persona avatars (so
+  /// it gets a thumbnail) and saves the new path on the preset.
+  Future<void> _pickImage() async {
+    if (_isFeatured) return;
+
+    FilePickerResult? result;
+    try {
+      result = await FilePicker.pickFiles(
+        type: FileType.image,
+        allowMultiple: false,
+        withData: true,
+      );
+    } catch (_) {}
+    if (result == null || result.files.isEmpty) return;
+
+    final picked = result.files.first;
+    Uint8List? bytes = picked.bytes;
+    if ((bytes == null || bytes.isEmpty) &&
+        picked.path != null &&
+        picked.path!.isNotEmpty) {
+      bytes = await File(picked.path!).readAsBytes();
+    }
+    if (bytes == null || bytes.isEmpty) return;
+
+    final storage = await ref.read(imageStorageProvider.future);
+    final savedPath = await storage.saveAvatar(
+      presetImageStorageId(_currentId),
+      bytes,
+    );
+    // The file name never changes, so the previously decoded frames have to be
+    // dropped or the card keeps showing the old cover.
+    await FileImage(File(savedPath)).evict();
+    final thumbPath = storage.thumbnailPath(savedPath);
+    if (thumbPath != null) await FileImage(File(thumbPath)).evict();
+
+    if (!mounted) return;
+    setState(() => _imagePath = savedPath);
+    _scheduleSave();
+  }
+
+  void _removeImage() {
+    if (_isFeatured) return;
+    setState(() => _imagePath = null);
+    _scheduleSave();
+  }
+
   /// Builds a [Preset] from the live editor state (used for Export and Clone).
   Preset _currentSnapshot() {
     final name = _nameCtrl.text.trim().isEmpty
@@ -811,6 +889,7 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
       id: _currentId,
       name: name,
       author: _author.trim().isEmpty ? null : _author.trim(),
+      imagePath: _imagePath,
       blocks: _blocks,
       regexes: _regexes,
       reasoningEnabled: _parseInlineReasoning,
@@ -841,14 +920,35 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
             _showRenameDialog();
           },
         ),
-        BottomSheetItem(
-          icon: Icons.person_outline,
-          label: 'action_set_author'.tr(),
-          onTap: () {
-            Navigator.of(context, rootNavigator: true).pop();
-            _showAuthorDialog();
-          },
-        ),
+        // Author and cover image are part of a bundled featured preset — the
+        // user edits them on a clone, not on the original.
+        if (!_isFeatured)
+          BottomSheetItem(
+            icon: Icons.person_outline,
+            label: 'action_set_author'.tr(),
+            onTap: () {
+              Navigator.of(context, rootNavigator: true).pop();
+              _showAuthorDialog();
+            },
+          ),
+        if (!_isFeatured)
+          BottomSheetItem(
+            icon: Icons.image_outlined,
+            label: 'change_image'.tr(),
+            onTap: () {
+              Navigator.of(context, rootNavigator: true).pop();
+              _pickImage();
+            },
+          ),
+        if (!_isFeatured && _imagePath != null && _imagePath!.isNotEmpty)
+          BottomSheetItem(
+            icon: Icons.hide_image_outlined,
+            label: 'action_remove_image'.tr(),
+            onTap: () {
+              Navigator.of(context, rootNavigator: true).pop();
+              _removeImage();
+            },
+          ),
         BottomSheetItem(
           icon: Icons.copy_outlined,
           label: 'action_clone_block'.tr(),

--- a/lib/features/presets/preset_image.dart
+++ b/lib/features/presets/preset_image.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/widgets.dart';
+
+import '../../core/models/preset.dart';
+import '../../core/services/featured_presets.dart';
+import '../../shared/utils/avatar_image.dart';
+
+/// True when [path] points at a bundled asset instead of a file on disk.
+/// Featured covers live in the asset bundle and stay there when a preset is
+/// cloned, so both kinds of path can end up in `Preset.imagePath`.
+bool isPresetAssetImage(String? path) =>
+    path != null && path.startsWith('assets/');
+
+/// Cover image of [preset], or null when it has none.
+///
+/// Resolution order:
+///   1. a user-picked image stored on disk (thumbnail preferred),
+///   2. an `assets/...` cover carried in `imagePath` (a cloned featured preset),
+///   3. the bundled cover of a featured preset, keyed by its fixed id.
+ImageProvider? presetCoverImage(Preset preset) =>
+    resolvePresetCoverImage(presetId: preset.id, imagePath: preset.imagePath);
+
+/// [presetCoverImage] for editor state that has no persisted [Preset] yet.
+ImageProvider? resolvePresetCoverImage({
+  required String presetId,
+  String? imagePath,
+}) {
+  if (imagePath != null && imagePath.isNotEmpty) {
+    if (isPresetAssetImage(imagePath)) return AssetImage(imagePath);
+    return glazeAvatarImage(imagePath);
+  }
+  final asset = featuredPresetImageAsset(presetId);
+  return asset != null ? AssetImage(asset) : null;
+}
+
+/// Storage id used for a preset's user-picked cover, so the file lands next to
+/// the character/persona avatars (and gets a thumbnail) instead of in a
+/// preset-specific folder.
+String presetImageStorageId(String presetId) => 'preset_$presetId';

--- a/lib/features/presets/preset_list_provider.dart
+++ b/lib/features/presets/preset_list_provider.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/preset.dart';
+import '../../core/services/featured_presets.dart';
 import '../../core/state/db_provider.dart';
 import '../../core/state/shared_prefs_provider.dart';
 import '../../core/utils/id_generator.dart';
@@ -42,6 +43,9 @@ class PresetListNotifier extends AsyncNotifier<List<Preset>> {
     final copy = preset.copyWith(
       id: generateId(),
       name: '${preset.name} (copy)',
+      // A featured preset resolves its cover from its fixed id, which the copy
+      // no longer has — pin the bundled asset so the clone keeps the artwork.
+      imagePath: preset.imagePath ?? featuredPresetImageAsset(preset.id),
       createdAt: currentTimestampSeconds(),
     );
     await ref.read(presetRepoProvider).put(copy);

--- a/lib/features/presets/preset_list_screen.dart
+++ b/lib/features/presets/preset_list_screen.dart
@@ -19,6 +19,7 @@ import '../../shared/widgets/glaze_error_dialog.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import 'preset_connections_sheet.dart';
 import 'preset_editor_screen.dart';
+import 'preset_image.dart';
 import 'preset_list_provider.dart';
 
 class PresetListScreen extends ConsumerStatefulWidget {
@@ -293,11 +294,16 @@ class _PsCard extends ConsumerWidget {
     required this.onEdit,
   });
 
+  /// Height of a card that shows a cover image. Plain cards keep their
+  /// intrinsic (single-row) height.
+  static const double _coverHeight = 132;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final connections = ref.watch(presetConnectionsProvider);
     final hasCharBinding = connections.character.values.contains(preset.id);
     final hasChatBinding = connections.chat.values.contains(preset.id);
+    final cover = presetCoverImage(preset);
 
     return GlassSurface(
       enableRipple: true,
@@ -315,95 +321,172 @@ class _PsCard extends ConsumerWidget {
         width: isActive ? 2 : 1,
       ),
       onTap: onActivate,
-      child: Padding(
-        padding: const EdgeInsets.all(10),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            // Circular icon
-            Container(
-              width: 40,
-              height: 40,
-              decoration: BoxDecoration(
-                color: context.cs.primary.withValues(alpha: 0.1),
-                shape: BoxShape.circle,
+      child: cover == null
+          ? Padding(
+              padding: const EdgeInsets.all(10),
+              child: _buildRow(
+                context,
+                hasChatBinding: hasChatBinding,
+                hasCharBinding: hasCharBinding,
+                onCover: false,
               ),
-              child: Icon(
-                Icons.description_outlined,
-                size: 20,
-                color: context.cs.primary,
-              ),
-            ),
-            const SizedBox(width: 12),
-            // Info
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    preset.name,
-                    style: TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.w600,
-                      color: context.cs.onSurface,
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Row(
-                    children: [
-                      _SmallBadge(
-                        icon: Icons.description,
-                        label: '${_presetTokenCount(preset)}',
-                      ),
-                      if (preset.author != null &&
-                          preset.author!.isNotEmpty) ...[
-                        const SizedBox(width: 8),
-                        Flexible(
-                          child: Text(
-                            'by ${preset.author}',
-                             style: TextStyle(
-                               fontSize: 12,
-                               color: context.cs.onSurfaceVariant,
-                             ),
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(width: 8),
-            // Connection badge — tappable, colour shows binding type
-            _ConnBadge(
-              isActive: isActive,
+            )
+          : _buildCover(
+              context,
+              cover,
               hasChatBinding: hasChatBinding,
               hasCharBinding: hasCharBinding,
-              onTap: onConnections,
             ),
-            const SizedBox(width: 8),
-            // Edit button
-            SizedBox(
-              width: 34,
-              height: 34,
-              child: Material(
-                color: Colors.transparent,
-                borderRadius: BorderRadius.circular(8),
-                child: InkWell(
-                  onTap: onEdit,
-                  borderRadius: BorderRadius.circular(8),
-                   child: Icon(
-                     Icons.edit_outlined,
-                     size: 18,
-                     color: context.cs.onSurfaceVariant,
-                   ),
-                ),
+    );
+  }
+
+  /// Taller card: the cover fills it, a scrim keeps the text legible and the
+  /// usual info row sits at the bottom.
+  Widget _buildCover(
+    BuildContext context,
+    ImageProvider cover, {
+    required bool hasChatBinding,
+    required bool hasCharBinding,
+  }) {
+    return SizedBox(
+      height: _coverHeight,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Image(
+            image: cover,
+            fit: BoxFit.cover,
+            // A missing/corrupt file falls back to the plain glass surface
+            // rather than Flutter's error box.
+            errorBuilder: (_, _, _) => const SizedBox.shrink(),
+          ),
+          const DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [Color(0x33000000), Color(0xD9000000)],
               ),
             ),
-          ],
-        ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _buildRow(
+                  context,
+                  hasChatBinding: hasChatBinding,
+                  hasCharBinding: hasCharBinding,
+                  onCover: true,
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
+    );
+  }
+
+  /// Shared info row. Over a cover the leading icon is dropped (the art already
+  /// identifies the preset) and the text switches to light-on-dark.
+  Widget _buildRow(
+    BuildContext context, {
+    required bool hasChatBinding,
+    required bool hasCharBinding,
+    required bool onCover,
+  }) {
+    final primaryText = onCover ? Colors.white : context.cs.onSurface;
+    final secondaryText = onCover
+        ? Colors.white.withValues(alpha: 0.75)
+        : context.cs.onSurfaceVariant;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        if (!onCover) ...[
+          // Circular icon
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: context.cs.primary.withValues(alpha: 0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              Icons.description_outlined,
+              size: 20,
+              color: context.cs.primary,
+            ),
+          ),
+          const SizedBox(width: 12),
+        ],
+        // Info
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                preset.name,
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  color: primaryText,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  _SmallBadge(
+                    icon: Icons.description,
+                    label: '${_presetTokenCount(preset)}',
+                    foreground: secondaryText,
+                    onCover: onCover,
+                  ),
+                  if (preset.author != null && preset.author!.isNotEmpty) ...[
+                    const SizedBox(width: 8),
+                    Flexible(
+                      child: Text(
+                        'by ${preset.author}',
+                        style: TextStyle(fontSize: 12, color: secondaryText),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 8),
+        // Connection badge — tappable, colour shows binding type
+        _ConnBadge(
+          isActive: isActive,
+          hasChatBinding: hasChatBinding,
+          hasCharBinding: hasCharBinding,
+          onTap: onConnections,
+        ),
+        const SizedBox(width: 8),
+        // Edit button
+        SizedBox(
+          width: 34,
+          height: 34,
+          child: Material(
+            color: Colors.transparent,
+            borderRadius: BorderRadius.circular(8),
+            child: InkWell(
+              onTap: onEdit,
+              borderRadius: BorderRadius.circular(8),
+              child: Icon(
+                Icons.edit_outlined,
+                size: 18,
+                color: secondaryText,
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }
@@ -413,27 +496,42 @@ class _PsCard extends ConsumerWidget {
 class _SmallBadge extends StatelessWidget {
   final IconData icon;
   final String label;
-  const _SmallBadge({required this.icon, required this.label});
+
+  /// Overrides the icon/label colour (set when the badge sits on a cover).
+  final Color? foreground;
+
+  /// Over a cover the near-transparent black pill disappears, so a light
+  /// scrim is used instead.
+  final bool onCover;
+  const _SmallBadge({
+    required this.icon,
+    required this.label,
+    this.foreground,
+    this.onCover = false,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final color = foreground ?? context.cs.onSurfaceVariant;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(
-        color: Colors.black.withValues(alpha: 0.05),
+        color: onCover
+            ? Colors.black.withValues(alpha: 0.35)
+            : Colors.black.withValues(alpha: 0.05),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(icon, size: 12, color: context.cs.onSurfaceVariant),
+          Icon(icon, size: 12, color: color),
           const SizedBox(width: 4),
           Text(
             label,
             style: TextStyle(
               fontSize: 10,
               fontWeight: FontWeight.w700,
-              color: context.cs.onSurfaceVariant,
+              color: color,
             ),
           ),
         ],

--- a/lib/features/tools/tools_screen.dart
+++ b/lib/features/tools/tools_screen.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../core/services/featured_presets.dart';
+import '../../core/models/preset.dart';
 import '../../core/state/active_selection_provider.dart';
 import '../../core/state/active_studio_preset_provider.dart';
 import '../../core/utils/platform_paths.dart';
@@ -14,6 +14,7 @@ import '../../core/state/db_provider.dart';
 import '../../shared/shell/nav_height_provider.dart';
 import '../../shared/shell/nav_retap_provider.dart';
 import '../personas/persona_list_provider.dart';
+import '../presets/preset_image.dart';
 import '../presets/preset_list_provider.dart';
 import '../../shared/shell/shell_header_provider.dart';
 import '../../shared/theme/app_colors.dart';
@@ -54,18 +55,20 @@ final _resolvedPersonaAvatarPathProvider = FutureProvider<String?>((ref) async {
   return null;
 });
 
-final _activePresetNameProvider = FutureProvider<String>((ref) async {
+/// The globally active preset. Watches the list (not just the id) so a rename
+/// or a new cover image is reflected on the card without leaving the screen.
+final _activePresetProvider = Provider<Preset?>((ref) {
   final activeId = ref.watch(activePresetIdProvider);
-  if (activeId == null) return 'label_default'.tr();
-  final preset = await ref
-      .read(presetListProvider.notifier)
-      .getPresetById(activeId);
-  return preset?.name ?? 'label_default'.tr();
+  if (activeId == null) return null;
+  final presets = ref.watch(presetListProvider).value ?? const <Preset>[];
+  return presets.where((p) => p.id == activeId).firstOrNull;
 });
 
-/// Cover image asset for the active preset, when it's a bundled featured preset.
-final _activePresetImageProvider = Provider<String?>((ref) {
-  return featuredPresetImageAsset(ref.watch(activePresetIdProvider));
+/// Cover image of the active preset — a user-picked one, or the bundled art of
+/// a featured preset.
+final _activePresetImageProvider = Provider<ImageProvider?>((ref) {
+  final preset = ref.watch(_activePresetProvider);
+  return preset != null ? presetCoverImage(preset) : null;
 });
 
 // SVG paths matching ToolsView.vue
@@ -149,7 +152,7 @@ class _ToolsScreenState extends ConsumerState<ToolsScreen>
     final personaInfo = ref.watch(_activePersonaInfoProvider);
     final resolvedAvatar = ref.watch(_resolvedPersonaAvatarPathProvider).value;
     final presetName =
-        ref.watch(_activePresetNameProvider).value ?? 'label_default'.tr();
+        ref.watch(_activePresetProvider)?.name ?? 'label_default'.tr();
     final presetImage = ref.watch(_activePresetImageProvider);
     final studioEnabled = ref.watch(studioFeatureEnabledProvider);
     final topPad = MediaQuery.of(context).padding.top + 66.0;
@@ -181,7 +184,7 @@ class _ToolsScreenState extends ConsumerState<ToolsScreen>
                 iconPath: _kIconPresets,
                 title: 'tab_presets'.tr(),
                 subtitle: presetName,
-                backgroundAsset: presetImage,
+                backgroundImage: presetImage,
                 onTap: () => context.push('/tools/presets'),
               ),
               const SizedBox(height: 10),
@@ -293,9 +296,10 @@ class _HeroCard extends StatelessWidget {
   final bool isAvatar;
   final String? avatarPath;
 
-  /// Bundled asset shown as the card background (e.g. a featured preset's cover).
+  /// Image shown as the card background (e.g. a preset's cover — a bundled
+  /// asset for a featured preset, a stored file for a user-picked one).
   /// Applies only to the non-avatar layout and does not change the card size.
-  final String? backgroundAsset;
+  final ImageProvider? backgroundImage;
   final VoidCallback onTap;
 
   const _HeroCard({
@@ -304,7 +308,7 @@ class _HeroCard extends StatelessWidget {
     required this.subtitle,
     this.isAvatar = false,
     this.avatarPath,
-    this.backgroundAsset,
+    this.backgroundImage,
     required this.onTap,
   });
 
@@ -351,12 +355,13 @@ class _HeroCard extends StatelessWidget {
                   ),
                 ),
               ),
-            ] else if (backgroundAsset != null) ...[
+            ] else if (backgroundImage != null) ...[
               Positioned.fill(
-                child: Image.asset(
-                  backgroundAsset!,
-                  key: ValueKey(backgroundAsset),
+                child: Image(
+                  image: backgroundImage!,
+                  key: ValueKey(backgroundImage),
                   fit: BoxFit.cover,
+                  errorBuilder: (_, _, _) => const SizedBox.shrink(),
                 ),
               ),
               // Dark scrim so the white label/subtitle stay legible over art.

--- a/test/preset_cover_image_test.dart
+++ b/test/preset_cover_image_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/models/preset.dart';
+import 'package:glaze_flutter/core/services/featured_presets.dart';
+import 'package:glaze_flutter/features/presets/preset_image.dart';
+
+void main() {
+  group('isFeaturedPreset', () {
+    test('recognises every bundled featured preset', () {
+      expect(featuredPresets, isNotEmpty);
+      for (final f in featuredPresets) {
+        expect(isFeaturedPreset(f.id), isTrue, reason: f.id);
+      }
+    });
+
+    test('is false for user presets and for null', () {
+      expect(isFeaturedPreset('some_generated_id'), isFalse);
+      // A clone of a featured preset gets a fresh id, so it stays editable.
+      expect(isFeaturedPreset('${featuredPresets.first.id}_copy'), isFalse);
+      expect(isFeaturedPreset(null), isFalse);
+    });
+  });
+
+  group('presetCoverImage', () {
+    test('a plain preset without an image has no cover', () {
+      expect(presetCoverImage(const Preset(id: 'p1', name: 'P')), isNull);
+    });
+
+    test('a featured preset resolves its bundled cover from its id', () {
+      final featured = featuredPresets.first;
+      final cover = presetCoverImage(Preset(id: featured.id, name: 'P'));
+      expect(cover, isA<AssetImage>());
+      expect((cover! as AssetImage).assetName, featured.imageAsset);
+    });
+
+    test('an asset path stored on the preset wins over the id lookup', () {
+      const asset = 'assets/presets/renri.jpg';
+      final cover = presetCoverImage(
+        const Preset(id: 'clone', name: 'P', imagePath: asset),
+      );
+      expect(cover, isA<AssetImage>());
+      expect((cover! as AssetImage).assetName, asset);
+    });
+
+    test('a stored file path resolves to a file image', () {
+      final cover = presetCoverImage(
+        const Preset(
+          id: 'p1',
+          name: 'P',
+          imagePath: '/tmp/glaze/avatars/preset_p1.png',
+        ),
+      );
+      expect(cover, isA<FileImage>());
+    });
+
+    test('a user image overrides a featured preset cover', () {
+      final featured = featuredPresets.first;
+      final cover = presetCoverImage(
+        Preset(
+          id: featured.id,
+          name: 'P',
+          imagePath: '/tmp/glaze/avatars/preset_custom.png',
+        ),
+      );
+      expect(cover, isA<FileImage>());
+    });
+  });
+
+  test('presetImageStorageId namespaces preset covers', () {
+    expect(presetImageStorageId('abc'), 'preset_abc');
+  });
+}


### PR DESCRIPTION
- Add `Preset.imagePath` (stored in the preset's JSON blob, no migration).
- Add "Change Image" / "Remove Image" to the preset editor's three-dot menu; the picked file is stored via ImageStorageService (thumbnail included) and previewed in the editor header.
- Preset list cards render the cover when there is one and grow to a taller layout (art + scrim + the usual info row), keeping the plain row otherwise.
- The Tools hero card now shows a user-picked cover too, not just the bundled art of a featured preset, and reacts to renames/cover changes live.
- Bundled featured presets keep their shipped author and cover: both menu entries are hidden for them, and the guards also cover the picker itself. Cloning one pins the bundled asset onto the copy so the artwork survives.
- Add en/ru string for removing the image.

Verified: added test/preset_cover_image_test.dart covering isFeaturedPreset and the cover resolution order (stored file > asset path > featured id). Note the flutter SDK is unavailable in this environment, so analyze/test were not run locally — CI runs build_runner + analyze + test.