### PR TITLE
feat(presets): sync preset covers and outline cards that carry art

### DIFF
--- a/lib/core/services/preset_image_paths.dart
+++ b/lib/core/services/preset_image_paths.dart
@@ -1,0 +1,39 @@
+/// Pure path helpers for preset cover images.
+///
+/// Kept free of Flutter imports so the cloud-sync layer can share them with the
+/// UI (`features/presets/preset_image.dart` re-exports these).
+///
+/// A stored cover path is deliberately **relative** to the Glaze data dir
+/// (`avatars/preset_<id>_<version>.png`) rather than absolute: presets travel
+/// between devices as one JSON blob, and an absolute path from another device's
+/// data dir would differ on every machine — making the entry hash flip back and
+/// forth on each sync. The `<version>` segment changes whenever the user picks
+/// a new image, so replacing a cover changes the preset JSON (and therefore its
+/// manifest hash), which is what makes the replacement propagate at all.
+library;
+
+/// True when [path] points at a bundled asset instead of a file on disk.
+/// Featured covers live in the asset bundle and stay there when a preset is
+/// cloned, so both kinds of path can end up in `Preset.imagePath`.
+bool isPresetAssetImage(String? path) =>
+    path != null && path.startsWith('assets/');
+
+/// Storage id of a preset cover — the file name (without extension) it gets
+/// under `avatars/`, alongside the character/persona avatars.
+String presetImageStorageId(String presetId, int version) =>
+    'preset_${presetId}_$version';
+
+/// Path stored on the preset, relative to the Glaze data dir.
+String presetImageRelativePath(String storageId, String ext) =>
+    'avatars/$storageId.$ext';
+
+/// Storage id encoded in a stored cover [path], or null when there is none
+/// (no cover, or a bundled asset). Used to delete the file a replaced cover
+/// leaves behind.
+String? presetImageStorageIdOf(String? path) {
+  if (path == null || path.isEmpty || isPresetAssetImage(path)) return null;
+  final name = path.split(RegExp(r'[/\\]')).last;
+  final dot = name.lastIndexOf('.');
+  final base = dot > 0 ? name.substring(0, dot) : name;
+  return base.isEmpty ? null : base;
+}

--- a/lib/features/cloud_sync/services/sync_binary_asset_syncer.dart
+++ b/lib/features/cloud_sync/services/sync_binary_asset_syncer.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import '../../../core/models/gallery_entry.dart';
+import '../../../core/services/preset_image_paths.dart';
 import '../cloud_adapter.dart';
 import '../sync_models.dart';
 import '../sync_repo_interfaces.dart';
@@ -12,14 +13,20 @@ class SyncBinaryAssetSyncer {
   final CloudAdapter _adapter;
   final SyncCharacterStore _characterRepo;
   final SyncPersonaStore _personaRepo;
+  final SyncPresetStore _presetRepo;
   final SyncImageStore _imageStorage;
 
   SyncBinaryAssetSyncer(
     this._adapter,
     this._characterRepo,
     this._personaRepo,
+    this._presetRepo,
     this._imageStorage,
   );
+
+  /// Extensions probed when pulling a binary whose stored extension is unknown
+  /// on this device.
+  static const _imageExtensions = ['png', 'jpg', 'webp', 'gif'];
 
   Future<void> pushCharacterAvatar(String charId) async {
     try {
@@ -45,7 +52,7 @@ class SyncBinaryAssetSyncer {
       final current = await _characterRepo.getById(charId);
       if (current == null) return;
 
-      for (final ext in ['png', 'jpg', 'webp', 'gif']) {
+      for (final ext in _imageExtensions) {
         try {
           final imgCloudPath = galleryCloudPath(charId, 'avatar', ext);
           final bytes = await _adapter.downloadBinary(imgCloudPath);
@@ -85,7 +92,7 @@ class SyncBinaryAssetSyncer {
       final p = await _personaRepo.getById(personaId);
       if (p == null) return;
 
-      for (final ext in ['png', 'jpg', 'webp', 'gif']) {
+      for (final ext in _imageExtensions) {
         try {
           final imgCloudPath = personaAvatarCloudPath(personaId, ext);
           final bytes = await _adapter.downloadBinary(imgCloudPath);
@@ -102,6 +109,89 @@ class SyncBinaryAssetSyncer {
         } catch (_) {}
       }
     } catch (_) {}
+  }
+
+  /// Uploads every preset cover that lives on this device.
+  ///
+  /// Presets travel as one `theme_presets` singleton, so this runs once for the
+  /// whole list instead of per entry. Covers pointing at a bundled `assets/...`
+  /// path are skipped — they ship with the app on every device.
+  Future<void> pushPresetImages() async {
+    try {
+      final presets = await _presetRepo.getAll();
+      var folderEnsured = false;
+      for (final preset in presets) {
+        final path = preset.imagePath;
+        if (path == null || path.isEmpty || _isBundledAsset(path)) continue;
+        final absPath = _imageStorage.absolutePath(path);
+        if (absPath == null) continue;
+        final file = File(absPath);
+        if (!await file.exists()) continue;
+        final bytes = await file.readAsBytes();
+        if (!folderEnsured) {
+          await _adapter.ensureFolder('$cloudBase/preset_images');
+          folderEnsured = true;
+        }
+        await _adapter.ensureFolder('$cloudBase/preset_images/${preset.id}');
+        await _adapter.uploadBinary(
+          presetImageCloudPath(preset.id, _extensionOf(path)),
+          bytes,
+        );
+      }
+    } catch (_) {}
+  }
+
+  /// Downloads the cover of every preset that references a file this device
+  /// does not have yet.
+  ///
+  /// The stored path is relative and carries its own version suffix, so it is
+  /// valid on every device and never rewritten here — the pull only has to put
+  /// the bytes where the path already points. A cover that fails to download is
+  /// left alone: the next push from the device that owns the file must not be
+  /// told the image is gone, and the UI simply shows no cover meanwhile.
+  Future<void> pullPresetImages() async {
+    try {
+      final presets = await _presetRepo.getAll();
+      for (final preset in presets) {
+        final path = preset.imagePath;
+        if (path == null || path.isEmpty || _isBundledAsset(path)) continue;
+        final storageId = presetImageStorageIdOf(path);
+        if (storageId == null) continue;
+        final absPath = _imageStorage.absolutePath(path);
+        if (absPath != null && await File(absPath).exists()) continue;
+
+        for (final ext in _extensionsToProbe(path)) {
+          try {
+            final bytes = await _adapter.downloadBinary(
+              presetImageCloudPath(preset.id, ext),
+            );
+            if (bytes.isEmpty) continue;
+            await _imageStorage.saveBytes(bytes, 'avatars', storageId, ext);
+            // The pushed and stored extensions agree in practice (covers are
+            // always written as PNG), but honour a mismatch rather than leaving
+            // the preset pointing at a file saved under another name.
+            final relative = presetImageRelativePath(storageId, ext);
+            if (relative != path) {
+              await _presetRepo.put(preset.copyWith(imagePath: relative));
+            }
+            break;
+          } catch (_) {}
+        }
+      }
+    } catch (_) {}
+  }
+
+  /// Bundled covers (a cloned featured preset) exist in every install's asset
+  /// bundle, so they are neither uploaded nor downloaded.
+  bool _isBundledAsset(String path) => isPresetAssetImage(path);
+
+  String _extensionOf(String path) => path.split('.').last;
+
+  /// The extension the path already claims, tried first, then the rest.
+  List<String> _extensionsToProbe(String path) {
+    final own = _extensionOf(path).toLowerCase();
+    if (!_imageExtensions.contains(own)) return _imageExtensions;
+    return [own, ..._imageExtensions.where((e) => e != own)];
   }
 
   Future<void> pushCharacterGallery(String charId) async {
@@ -132,7 +222,7 @@ class SyncBinaryAssetSyncer {
       final updatedGallery = <GalleryEntry>[];
       for (final entry in c.gallery) {
         var pulled = false;
-        for (final ext in ['png', 'jpg', 'webp', 'gif']) {
+        for (final ext in _imageExtensions) {
           try {
             final imgCloudPath = galleryCloudPath(charId, entry.id, ext);
             final bytes = await _adapter.downloadBinary(imgCloudPath);

--- a/lib/features/cloud_sync/services/sync_engine.dart
+++ b/lib/features/cloud_sync/services/sync_engine.dart
@@ -97,6 +97,7 @@ class SyncEngine {
       _adapter,
       _characterRepo,
       _personaRepo,
+      _presetRepo,
       _imageStorage,
     );
   }
@@ -112,6 +113,7 @@ class SyncEngine {
     await _adapter.ensureFolder('$cloudBase/chats');
     await _adapter.ensureFolder('$cloudBase/memory_books');
     await _adapter.ensureFolder('$cloudBase/persona_avatars');
+    await _adapter.ensureFolder('$cloudBase/preset_images');
     await _adapter.ensureFolder('$cloudBase/extension_presets');
     await _adapter.ensureFolder('$cloudBase/info_blocks');
     await _adapter.ensureFolder('$cloudBase/tracker_snapshots');
@@ -650,6 +652,11 @@ class SyncEngine {
     if (entry.type == 'persona') {
       await _binarySyncer.pushPersonaAvatar(entry.id);
     }
+    // Presets travel as one singleton entry, so their covers are pushed as a
+    // batch keyed by preset id rather than per manifest entry.
+    if (entry.type == 'theme_presets') {
+      await _binarySyncer.pushPresetImages();
+    }
   }
 
   Future<void> _pullEntry(SyncManifestEntry entry) async {
@@ -669,6 +676,9 @@ class SyncEngine {
     }
     if (entry.type == 'persona') {
       await _binarySyncer.pullPersonaAvatar(entry.id);
+    }
+    if (entry.type == 'theme_presets') {
+      await _binarySyncer.pullPresetImages();
     }
     if (entry.type == 'chat') {
       final charId = cloudData['characterId'] as String?;

--- a/lib/features/cloud_sync/sync_models.dart
+++ b/lib/features/cloud_sync/sync_models.dart
@@ -266,3 +266,8 @@ String galleryCloudPath(String charId, String imgId, String ext) =>
 
 String personaAvatarCloudPath(String personaId, String ext) =>
     '$cloudBase/persona_avatars/$personaId/avatar.$ext';
+
+/// Cover image of an LLM preset. Presets themselves travel as the single
+/// `theme_presets` entry, so their binaries are keyed by preset id here.
+String presetImageCloudPath(String presetId, String ext) =>
+    '$cloudBase/preset_images/$presetId/cover.$ext';

--- a/lib/features/presets/preset_editor_screen.dart
+++ b/lib/features/presets/preset_editor_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/llm/tokenizer.dart';
 import '../../core/models/preset.dart';
 import '../../core/services/featured_presets.dart';
+import '../../core/services/image_storage_service.dart';
 import '../../core/services/preset_defaults.dart';
 import '../../core/state/db_provider.dart';
 import '../../core/utils/id_generator.dart';
@@ -834,8 +835,9 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
     );
   }
 
-  /// Picks a cover image, stores it next to the character/persona avatars (so
-  /// it gets a thumbnail) and saves the new path on the preset.
+  /// Picks a cover image and stores it next to the character/persona avatars
+  /// (so it gets a thumbnail). The preset keeps a *relative*, version-suffixed
+  /// path — see `preset_image_paths.dart` for why both matter to cloud sync.
   Future<void> _pickImage() async {
     if (_isFeatured) return;
 
@@ -859,25 +861,44 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
     if (bytes == null || bytes.isEmpty) return;
 
     final storage = await ref.read(imageStorageProvider.future);
-    final savedPath = await storage.saveAvatar(
-      presetImageStorageId(_currentId),
-      bytes,
+    final storageId = presetImageStorageId(
+      _currentId,
+      currentTimestampSeconds(),
     );
-    // The file name never changes, so the previously decoded frames have to be
-    // dropped or the card keeps showing the old cover.
-    await FileImage(File(savedPath)).evict();
-    final thumbPath = storage.thumbnailPath(savedPath);
-    if (thumbPath != null) await FileImage(File(thumbPath)).evict();
+    // saveAvatar always writes `<id>.png` (plus a thumbnail).
+    await storage.saveAvatar(storageId, bytes);
+    final previous = _imagePath;
 
     if (!mounted) return;
-    setState(() => _imagePath = savedPath);
+    setState(() => _imagePath = presetImageRelativePath(storageId, 'png'));
     _scheduleSave();
+
+    await _deleteStoredCover(storage, previous);
   }
 
   void _removeImage() {
     if (_isFeatured) return;
+    final previous = _imagePath;
     setState(() => _imagePath = null);
     _scheduleSave();
+    unawaited(
+      ref
+          .read(imageStorageProvider.future)
+          .then((storage) => _deleteStoredCover(storage, previous)),
+    );
+  }
+
+  /// Drops the file a replaced/removed cover left behind. Bundled asset covers
+  /// (a cloned featured preset) have no file to delete.
+  Future<void> _deleteStoredCover(
+    ImageStorageService storage,
+    String? path,
+  ) async {
+    final storageId = presetImageStorageIdOf(path);
+    if (storageId == null) return;
+    try {
+      await storage.deleteAvatar(storageId);
+    } catch (_) {}
   }
 
   /// Builds a [Preset] from the live editor state (used for Export and Clone).

--- a/lib/features/presets/preset_image.dart
+++ b/lib/features/presets/preset_image.dart
@@ -1,14 +1,19 @@
+import 'dart:io';
+
 import 'package:flutter/widgets.dart';
 
 import '../../core/models/preset.dart';
 import '../../core/services/featured_presets.dart';
+import '../../core/services/preset_image_paths.dart';
+import '../../core/utils/platform_paths.dart';
 import '../../shared/utils/avatar_image.dart';
 
-/// True when [path] points at a bundled asset instead of a file on disk.
-/// Featured covers live in the asset bundle and stay there when a preset is
-/// cloned, so both kinds of path can end up in `Preset.imagePath`.
-bool isPresetAssetImage(String? path) =>
-    path != null && path.startsWith('assets/');
+export '../../core/services/preset_image_paths.dart'
+    show
+        isPresetAssetImage,
+        presetImageRelativePath,
+        presetImageStorageId,
+        presetImageStorageIdOf;
 
 /// Cover image of [preset], or null when it has none.
 ///
@@ -26,13 +31,18 @@ ImageProvider? resolvePresetCoverImage({
 }) {
   if (imagePath != null && imagePath.isNotEmpty) {
     if (isPresetAssetImage(imagePath)) return AssetImage(imagePath);
-    return glazeAvatarImage(imagePath);
+    // A path can outlive its file — a cover synced from another device before
+    // its binary arrived, or a data dir restored without the images. Fall
+    // through to the featured cover (or none) instead of handing back a
+    // provider that only ever fails to decode.
+    if (_coverFileExists(imagePath)) return glazeAvatarImage(imagePath);
   }
   final asset = featuredPresetImageAsset(presetId);
   return asset != null ? AssetImage(asset) : null;
 }
 
-/// Storage id used for a preset's user-picked cover, so the file lands next to
-/// the character/persona avatars (and gets a thumbnail) instead of in a
-/// preset-specific folder.
-String presetImageStorageId(String presetId) => 'preset_$presetId';
+bool _coverFileExists(String imagePath) {
+  final resolved = resolveGlazeFilePath(imagePath);
+  if (resolved == null || resolved.isEmpty) return false;
+  return File(resolved).existsSync();
+}

--- a/lib/features/presets/preset_list_provider.dart
+++ b/lib/features/presets/preset_list_provider.dart
@@ -1,9 +1,11 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/preset.dart';
 import '../../core/services/featured_presets.dart';
+import '../../core/services/preset_image_paths.dart';
 import '../../core/state/db_provider.dart';
 import '../../core/state/shared_prefs_provider.dart';
 import '../../core/utils/id_generator.dart';
@@ -40,17 +42,42 @@ class PresetListNotifier extends AsyncNotifier<List<Preset>> {
   /// suffixed name. Blocks and regexes are carried over unchanged (their ids
   /// are scoped to the owning preset). Returns the new preset.
   Future<Preset> clone(Preset preset) async {
+    final newId = generateId();
     final copy = preset.copyWith(
-      id: generateId(),
+      id: newId,
       name: '${preset.name} (copy)',
       // A featured preset resolves its cover from its fixed id, which the copy
       // no longer has — pin the bundled asset so the clone keeps the artwork.
-      imagePath: preset.imagePath ?? featuredPresetImageAsset(preset.id),
+      imagePath:
+          await _copyCoverForClone(preset.imagePath, newId) ??
+          featuredPresetImageAsset(preset.id),
       createdAt: currentTimestampSeconds(),
     );
     await ref.read(presetRepoProvider).put(copy);
     ref.invalidateSelf();
     return copy;
+  }
+
+  /// Gives the clone its own copy of a file-based cover, so that replacing or
+  /// removing the image on either preset cannot delete the other's file.
+  /// Bundled asset covers are shared as-is (there is no file to own), and a
+  /// failed copy falls back to sharing the source path rather than dropping the
+  /// artwork.
+  Future<String?> _copyCoverForClone(String? sourcePath, String newId) async {
+    if (sourcePath == null || sourcePath.isEmpty) return null;
+    if (isPresetAssetImage(sourcePath)) return sourcePath;
+    try {
+      final storage = await ref.read(imageStorageProvider.future);
+      final abs = storage.absolutePath(sourcePath);
+      if (abs == null) return sourcePath;
+      final file = File(abs);
+      if (!await file.exists()) return sourcePath;
+      final storageId = presetImageStorageId(newId, currentTimestampSeconds());
+      await storage.saveAvatar(storageId, await file.readAsBytes());
+      return presetImageRelativePath(storageId, 'png');
+    } catch (_) {
+      return sourcePath;
+    }
   }
 
   Future<void> remove(String id) async {

--- a/lib/features/presets/preset_list_screen.dart
+++ b/lib/features/presets/preset_list_screen.dart
@@ -298,6 +298,13 @@ class _PsCard extends ConsumerWidget {
   /// intrinsic (single-row) height.
   static const double _coverHeight = 132;
 
+  /// Border width of the active card, and of any card carrying artwork.
+  static const double _accentBorderWidth = 2;
+
+  /// How long the active highlight takes to cross-fade when the selection
+  /// moves between presets.
+  static const _activeFade = Duration(milliseconds: 220);
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final connections = ref.watch(presetConnectionsProvider);
@@ -305,38 +312,58 @@ class _PsCard extends ConsumerWidget {
     final hasChatBinding = connections.chat.values.contains(preset.id);
     final cover = presetCoverImage(preset);
 
-    return GlassSurface(
-      enableRipple: true,
-      tint: isActive
-          ? Color.alphaBlend(
-              context.cs.primary.withValues(alpha: 0.12),
-              context.cs.surfaceContainerHighest,
-            )
-          : null,
-      borderRadius: BorderRadius.circular(12),
-      border: Border.all(
-        color: isActive
-            ? context.cs.primary.withValues(alpha: 0.5)
-            : context.cs.outline,
-        width: isActive ? 2 : 1,
-      ),
-      onTap: onActivate,
-      child: cover == null
-          ? Padding(
-              padding: const EdgeInsets.all(10),
-              child: _buildRow(
-                context,
-                hasChatBinding: hasChatBinding,
-                hasCharBinding: hasCharBinding,
-                onCover: false,
-              ),
-            )
-          : _buildCover(
+    // A card filled with artwork needs a real frame even when idle — a hairline
+    // disappears against the cover (same treatment as the Tools hero card).
+    final idleBorder = cover != null
+        ? context.cs.outlineVariant
+        : context.cs.outline;
+    final idleWidth = cover != null ? _accentBorderWidth : 1.0;
+    final activeBorder = context.cs.primary.withValues(alpha: 0.5);
+    final baseTint = context.cs.surfaceContainerHighest;
+    final activeTint = Color.alphaBlend(
+      context.cs.primary.withValues(alpha: 0.12),
+      baseTint,
+    );
+
+    final content = cover == null
+        ? Padding(
+            padding: const EdgeInsets.all(10),
+            child: _buildRow(
               context,
-              cover,
               hasChatBinding: hasChatBinding,
               hasCharBinding: hasCharBinding,
+              onCover: false,
             ),
+          )
+        : _buildCover(
+            context,
+            cover,
+            hasChatBinding: hasChatBinding,
+            hasCharBinding: hasCharBinding,
+          );
+
+    // `begin` only applies on the first build, so a card that is already active
+    // when the list opens starts highlighted instead of animating in; later
+    // changes to `end` fade the border (and its tint) between the two states.
+    return TweenAnimationBuilder<double>(
+      tween: Tween<double>(
+        begin: isActive ? 1.0 : 0.0,
+        end: isActive ? 1.0 : 0.0,
+      ),
+      duration: _activeFade,
+      curve: Curves.easeOut,
+      child: content,
+      builder: (context, t, child) => GlassSurface(
+        enableRipple: true,
+        tint: Color.lerp(baseTint, activeTint, t),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: Color.lerp(idleBorder, activeBorder, t)!,
+          width: idleWidth + (_accentBorderWidth - idleWidth) * t,
+        ),
+        onTap: onActivate,
+        child: child!,
+      ),
     );
   }
 

--- a/lib/features/tools/tools_screen.dart
+++ b/lib/features/tools/tools_screen.dart
@@ -319,12 +319,22 @@ class _HeroCard extends StatelessWidget {
     color: Color(0xE6FFFFFF), // rgba(255,255,255,0.9)
   );
 
+  /// Cards filled with artwork — the persona avatar, a preset cover — get a
+  /// stronger accent outline: the default hairline is invisible against a
+  /// photo, and the frame is what separates the art from the page background.
+  bool get _hasArtwork => isAvatar || backgroundImage != null;
+
   @override
   Widget build(BuildContext context) {
     final card = GlassSurface(
       onTap: onTap,
       borderRadius: BorderRadius.circular(20),
-      border: Border.all(color: context.cs.outlineVariant),
+      border: Border.all(
+        color: _hasArtwork
+            ? context.cs.primary.withValues(alpha: 0.5)
+            : context.cs.outlineVariant,
+        width: _hasArtwork ? 2 : 1,
+      ),
       child: SizedBox(
         height: isAvatar ? null : 140,
         child: Stack(

--- a/test/preset_cover_image_test.dart
+++ b/test/preset_cover_image_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -6,6 +8,22 @@ import 'package:glaze_flutter/core/services/featured_presets.dart';
 import 'package:glaze_flutter/features/presets/preset_image.dart';
 
 void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('glaze_preset_cover');
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  String writeCover(String name) {
+    final file = File('${tempDir.path}${Platform.pathSeparator}$name')
+      ..writeAsBytesSync([0x89, 0x50, 0x4E, 0x47]);
+    return file.path;
+  }
+
   group('isFeaturedPreset', () {
     test('recognises every bundled featured preset', () {
       expect(featuredPresets, isNotEmpty);
@@ -43,31 +61,89 @@ void main() {
       expect((cover! as AssetImage).assetName, asset);
     });
 
-    test('a stored file path resolves to a file image', () {
+    test('a stored cover that exists on disk resolves to a file image', () {
+      final path = writeCover('preset_p1_1.png');
       final cover = presetCoverImage(
-        const Preset(
-          id: 'p1',
-          name: 'P',
-          imagePath: '/tmp/glaze/avatars/preset_p1.png',
-        ),
+        Preset(id: 'p1', name: 'P', imagePath: path),
       );
       expect(cover, isA<FileImage>());
     });
 
-    test('a user image overrides a featured preset cover', () {
+    test('a user cover overrides a featured preset cover', () {
+      final featured = featuredPresets.first;
+      final path = writeCover('preset_custom_1.png');
+      final cover = presetCoverImage(
+        Preset(id: featured.id, name: 'P', imagePath: path),
+      );
+      expect(cover, isA<FileImage>());
+    });
+
+    test('a cover whose file is missing reports no cover', () {
+      // Happens between pulling a preset from the cloud and its image binary
+      // arriving — the card must fall back instead of rendering a broken image.
+      final cover = presetCoverImage(
+        Preset(
+          id: 'p1',
+          name: 'P',
+          imagePath: '${tempDir.path}/never_written.png',
+        ),
+      );
+      expect(cover, isNull);
+    });
+
+    test('a missing user cover on a featured preset falls back to the art', () {
       final featured = featuredPresets.first;
       final cover = presetCoverImage(
         Preset(
           id: featured.id,
           name: 'P',
-          imagePath: '/tmp/glaze/avatars/preset_custom.png',
+          imagePath: '${tempDir.path}/never_written.png',
         ),
       );
-      expect(cover, isA<FileImage>());
+      expect(cover, isA<AssetImage>());
+      expect((cover! as AssetImage).assetName, featured.imageAsset);
     });
   });
 
-  test('presetImageStorageId namespaces preset covers', () {
-    expect(presetImageStorageId('abc'), 'preset_abc');
+  group('cover path helpers', () {
+    test('storage ids are namespaced and versioned', () {
+      expect(presetImageStorageId('abc', 42), 'preset_abc_42');
+      // A new pick must produce a new path, otherwise the preset JSON is
+      // unchanged and cloud sync never notices the replacement.
+      expect(
+        presetImageStorageId('abc', 42),
+        isNot(presetImageStorageId('abc', 43)),
+      );
+    });
+
+    test('stored paths are relative to the data dir', () {
+      expect(
+        presetImageRelativePath('preset_abc_42', 'png'),
+        'avatars/preset_abc_42.png',
+      );
+    });
+
+    test('the storage id round-trips out of a stored path', () {
+      expect(
+        presetImageStorageIdOf('avatars/preset_abc_42.png'),
+        'preset_abc_42',
+      );
+      expect(
+        presetImageStorageIdOf(r'C:\Glaze\avatars\preset_abc_42.png'),
+        'preset_abc_42',
+      );
+    });
+
+    test('bundled assets and empty paths own no file', () {
+      expect(presetImageStorageIdOf('assets/presets/renri.jpg'), isNull);
+      expect(presetImageStorageIdOf(null), isNull);
+      expect(presetImageStorageIdOf(''), isNull);
+    });
+
+    test('asset paths are recognised', () {
+      expect(isPresetAssetImage('assets/presets/renri.jpg'), isTrue);
+      expect(isPresetAssetImage('avatars/preset_abc_42.png'), isFalse);
+      expect(isPresetAssetImage(null), isFalse);
+    });
   });
 }

--- a/test/sync_preset_images_test.dart
+++ b/test/sync_preset_images_test.dart
@@ -1,0 +1,295 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/models/persona.dart';
+import 'package:glaze_flutter/core/models/preset.dart';
+import 'package:glaze_flutter/features/cloud_sync/cloud_adapter.dart';
+import 'package:glaze_flutter/features/cloud_sync/services/sync_binary_asset_syncer.dart';
+import 'package:glaze_flutter/features/cloud_sync/sync_models.dart';
+import 'package:glaze_flutter/features/cloud_sync/sync_repo_interfaces.dart';
+
+// ─── In-memory fakes ─────────────────────────────────────────────────────────
+
+class FakeAdapter implements CloudAdapter {
+  final Map<String, Uint8List> binaries = {};
+  final List<String> ensuredFolders = [];
+  final List<String> downloadAttempts = [];
+
+  @override
+  Future<void> ensureFolder(String path) async => ensuredFolders.add(path);
+
+  @override
+  Future<void> uploadBinary(String path, Uint8List data) async {
+    binaries[path] = data;
+  }
+
+  @override
+  Future<Uint8List> downloadBinary(String path) async {
+    downloadAttempts.add(path);
+    final bytes = binaries[path];
+    if (bytes == null) throw CloudFileNotFoundException(path);
+    return bytes;
+  }
+
+  @override
+  Future<bool> isConnected() async => true;
+
+  @override
+  Future<void> invalidateFolderCache() async {}
+
+  @override
+  Future<void> upload(String path, String data) =>
+      throw UnimplementedError('upload');
+
+  @override
+  Future<String> download(String path) => throw UnimplementedError('download');
+
+  @override
+  Future<void> deleteFile(String path) => throw UnimplementedError('deleteFile');
+
+  @override
+  Future<void> deleteFolder(String path) =>
+      throw UnimplementedError('deleteFolder');
+
+  @override
+  Future<List<CloudFileInfo>> listFolder(String path) =>
+      throw UnimplementedError('listFolder');
+
+  @override
+  Future<Map<String, dynamic>?> getAccountInfo() =>
+      throw UnimplementedError('getAccountInfo');
+}
+
+class FakePresetStore implements SyncPresetStore {
+  final Map<String, Preset> data = {};
+
+  @override
+  Future<List<Preset>> getAll() async => data.values.toList();
+
+  @override
+  Future<Preset?> getById(String id) async => data[id];
+
+  @override
+  Future<void> put(Preset p) async => data[p.id] = p;
+
+  @override
+  Future<void> delete(String id) async => data.remove(id);
+}
+
+class UnusedCharacterStore implements SyncCharacterStore {
+  @override
+  Future<List<Character>> getAll() => throw UnimplementedError();
+
+  @override
+  Future<Character?> getById(String id) => throw UnimplementedError();
+
+  @override
+  Future<void> put(Character c) => throw UnimplementedError();
+
+  @override
+  Future<void> delete(String id) => throw UnimplementedError();
+}
+
+class UnusedPersonaStore implements SyncPersonaStore {
+  @override
+  Future<List<Persona>> getAll() => throw UnimplementedError();
+
+  @override
+  Future<Persona?> getById(String id) => throw UnimplementedError();
+
+  @override
+  Future<void> put(Persona p) => throw UnimplementedError();
+
+  @override
+  Future<void> delete(String id) => throw UnimplementedError();
+}
+
+/// Mirrors ImageStorageService's path semantics: relative paths hang off the
+/// data dir, `saveBytes` writes `<base>/<subfolder>/<name>.<ext>`.
+class FakeImageStore implements SyncImageStore {
+  final String baseDir;
+  FakeImageStore(this.baseDir);
+
+  @override
+  String? absolutePath(String? relativePath) {
+    if (relativePath == null || relativePath.isEmpty) return relativePath;
+    if (p.isAbsolute(relativePath)) return relativePath;
+    return p.join(baseDir, relativePath);
+  }
+
+  @override
+  Future<String> saveBytes(
+    Uint8List bytes,
+    String subfolder,
+    String filename,
+    String ext,
+  ) async {
+    final dir = Directory(p.join(baseDir, subfolder));
+    if (!dir.existsSync()) dir.createSync(recursive: true);
+    final path = p.join(dir.path, '$filename.$ext');
+    await File(path).writeAsBytes(bytes);
+    return path;
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+void main() {
+  late Directory tempDir;
+  late FakeAdapter adapter;
+  late FakePresetStore presets;
+  late FakeImageStore images;
+  late SyncBinaryAssetSyncer syncer;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('glaze_preset_sync');
+    adapter = FakeAdapter();
+    presets = FakePresetStore();
+    images = FakeImageStore(tempDir.path);
+    syncer = SyncBinaryAssetSyncer(
+      adapter,
+      UnusedCharacterStore(),
+      UnusedPersonaStore(),
+      presets,
+      images,
+    );
+  });
+
+  tearDown(() {
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  /// Writes a cover file at the relative path a preset would store.
+  void writeCover(String relativePath, List<int> bytes) {
+    final file = File(p.join(tempDir.path, relativePath));
+    file.parent.createSync(recursive: true);
+    file.writeAsBytesSync(bytes);
+  }
+
+  group('pushPresetImages', () {
+    test('uploads the cover of a preset that has one on disk', () async {
+      writeCover('avatars/preset_p1_10.png', [1, 2, 3]);
+      presets.data['p1'] = const Preset(
+        id: 'p1',
+        name: 'P1',
+        imagePath: 'avatars/preset_p1_10.png',
+      );
+
+      await syncer.pushPresetImages();
+
+      expect(
+        adapter.binaries[presetImageCloudPath('p1', 'png')],
+        Uint8List.fromList([1, 2, 3]),
+      );
+      expect(adapter.ensuredFolders, contains('$cloudBase/preset_images/p1'));
+    });
+
+    test('skips bundled asset covers and presets without one', () async {
+      presets.data['featured_clone'] = const Preset(
+        id: 'featured_clone',
+        name: 'Clone',
+        imagePath: 'assets/presets/renri.jpg',
+      );
+      presets.data['plain'] = const Preset(id: 'plain', name: 'Plain');
+
+      await syncer.pushPresetImages();
+
+      expect(adapter.binaries, isEmpty);
+    });
+
+    test('skips a cover whose file is missing locally', () async {
+      presets.data['p1'] = const Preset(
+        id: 'p1',
+        name: 'P1',
+        imagePath: 'avatars/preset_p1_10.png',
+      );
+
+      await syncer.pushPresetImages();
+
+      expect(adapter.binaries, isEmpty);
+    });
+  });
+
+  group('pullPresetImages', () {
+    test('downloads a cover this device does not have yet', () async {
+      adapter.binaries[presetImageCloudPath('p1', 'png')] = Uint8List.fromList(
+        [4, 5, 6],
+      );
+      presets.data['p1'] = const Preset(
+        id: 'p1',
+        name: 'P1',
+        imagePath: 'avatars/preset_p1_10.png',
+      );
+
+      await syncer.pullPresetImages();
+
+      final saved = File(p.join(tempDir.path, 'avatars/preset_p1_10.png'));
+      expect(saved.existsSync(), isTrue);
+      expect(saved.readAsBytesSync(), [4, 5, 6]);
+      // The stored path is device-independent, so it must survive the pull.
+      expect(presets.data['p1']!.imagePath, 'avatars/preset_p1_10.png');
+    });
+
+    test('does not re-download a cover that is already on disk', () async {
+      writeCover('avatars/preset_p1_10.png', [1, 2, 3]);
+      presets.data['p1'] = const Preset(
+        id: 'p1',
+        name: 'P1',
+        imagePath: 'avatars/preset_p1_10.png',
+      );
+
+      await syncer.pullPresetImages();
+
+      expect(adapter.downloadAttempts, isEmpty);
+    });
+
+    test('a new version of a cover is fetched on its own path', () async {
+      // Another device replaced the image: the version suffix changed, so the
+      // old local file no longer satisfies the preset.
+      writeCover('avatars/preset_p1_10.png', [1, 2, 3]);
+      adapter.binaries[presetImageCloudPath('p1', 'png')] = Uint8List.fromList(
+        [9, 9, 9],
+      );
+      presets.data['p1'] = const Preset(
+        id: 'p1',
+        name: 'P1',
+        imagePath: 'avatars/preset_p1_20.png',
+      );
+
+      await syncer.pullPresetImages();
+
+      final saved = File(p.join(tempDir.path, 'avatars/preset_p1_20.png'));
+      expect(saved.readAsBytesSync(), [9, 9, 9]);
+    });
+
+    test('keeps the stored path when the cloud has no cover', () async {
+      presets.data['p1'] = const Preset(
+        id: 'p1',
+        name: 'P1',
+        imagePath: 'avatars/preset_p1_10.png',
+      );
+
+      await syncer.pullPresetImages();
+
+      // Nulling it here would tell the device that owns the file to drop it.
+      expect(presets.data['p1']!.imagePath, 'avatars/preset_p1_10.png');
+    });
+
+    test('ignores bundled asset covers', () async {
+      presets.data['clone'] = const Preset(
+        id: 'clone',
+        name: 'Clone',
+        imagePath: 'assets/presets/renri.jpg',
+      );
+
+      await syncer.pullPresetImages();
+
+      expect(adapter.downloadAttempts, isEmpty);
+      expect(presets.data['clone']!.imagePath, 'assets/presets/renri.jpg');
+    });
+  });
+}


### PR DESCRIPTION
Follow-up to #188, which added `Preset.imagePath` and the cover cards. This branch was rebased onto `nightly` after that PR was squash-merged, so it now carries only the new work.

## Cloud sync

- `SyncBinaryAssetSyncer` gains `pushPresetImages` / `pullPresetImages`, wired into `SyncEngine._pushEntry` / `_pullEntry` for the `theme_presets` entry. Presets travel as one singleton entry, so covers are pushed and pulled as a batch keyed by preset id, under `preset_images/PRESET_ID/cover.EXT`.
- Bundled asset covers (an `assets/...` path on a cloned featured preset) are neither uploaded nor downloaded — they ship with the app on every device.
- The pull only writes bytes to the path already stored, and skips a cover whose file is already on disk. A cover that fails to download leaves the stored path untouched, so the device that owns the file is never told the image is gone.
- Deduplicate the four copies of the image-extension probe list in the syncer into `_imageExtensions`.

## Cover paths, so that sync can work at all

New `core/services/preset_image_paths.dart` (Flutter-free, shared by the UI and the sync layer) changes what `Preset.imagePath` holds:

- **Relative to the Glaze data dir** instead of absolute. An absolute path from another device's data dir differs on every machine, which would make the sync manifest hash for `theme_presets` flip back and forth on every run. Relative keeps the preset JSON byte-identical across devices, and lets the pull write bytes without rewriting the row.
- **Version-suffixed** — `avatars/preset_PRESETID_TIMESTAMP.png`. Writing every cover to the same file name left the preset JSON unchanged when the user replaced an image, so the manifest hash never moved and the replacement reached no other device.
- Replacing or removing a cover now deletes the file the old one left behind.
- Cloning a preset copies its cover file so the copy owns it — replacing or removing the image on either preset can no longer delete the other's. A bundled asset cover is still shared as-is.

## UI

- A preset card carrying a cover gets a real 2px frame even when idle — a hairline is invisible against the artwork. The same treatment is applied to the Tools hero cards for the persona and for a preset with a cover.
- Activating a preset cross-fades the border colour/width and the highlight tint over 220ms instead of snapping (`TweenAnimationBuilder` in `_PsCard`). A card that is already active when the list opens renders highlighted without animating in.
- A cover whose file is missing — pulled from the cloud before its binary arrived, or a restored data dir — now resolves to "no cover" instead of an image provider that only fails to decode; featured presets fall back to their bundled art.

## Verification

- Added `test/sync_preset_images_test.dart` with in-memory fakes for the cloud adapter, preset store and image store: push skips bundled assets and missing files, pull does not re-download a cover that is already present, fetches a new version on its own path, and keeps the stored path when the cloud has nothing.
- Extended `test/preset_cover_image_test.dart` with the missing-file fallback and the new path helpers.
- `flutter analyze` and `flutter test` were **not** run for this branch — the environment it was written in has no Flutter SDK. CI is the only execution of the analyzer and the test suite here.