### PR TITLE
fix(variations): name the variation in the character sheet, unindent sheet titles

### DIFF
--- a/lib/features/character_list/character_detail_screen.dart
+++ b/lib/features/character_list/character_detail_screen.dart
@@ -38,6 +38,8 @@ import '../../shared/widgets/glaze_toast.dart';
 import '../../shared/widgets/image_viewer.dart';
 import '../../shared/widgets/sheet_view.dart';
 import '../../shared/widgets/colored_markdown.dart';
+import '../../shared/widgets/variation_chip.dart';
+import '../../shared/utils/variant_label.dart';
 import 'character_editor_screen.dart';
 import '../character_gallery/widgets/character_gallery_view.dart';
 import 'widgets/character_variations_sheet.dart';
@@ -448,6 +450,11 @@ class _CharacterDetailScreenState extends ConsumerState<CharacterDetailScreen> {
     }
   }
 
+  /// Label of the variation this sheet shows, or null when the character has no
+  /// variations and there is nothing to disambiguate — same rule as the card.
+  String? _variationLabelOf(Character char) =>
+      _variantCount(char) > 1 ? variantLabel(char) : null;
+
   /// Number of variations in [char]'s group (1 for a standalone character).
   int _variantCount(Character? char) {
     if (char == null) return 1;
@@ -684,6 +691,7 @@ class _CharacterDetailScreenState extends ConsumerState<CharacterDetailScreen> {
               previewAvatarUrl: widget.previewAvatarUrl,
               authorUrl: widget.previewAuthorUrl,
               onOpenAuthor: _openExternal,
+              variationLabel: _variationLabelOf(char),
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
@@ -975,11 +983,19 @@ class _HeroSection extends StatelessWidget {
   final String? previewAvatarUrl;
   final String? authorUrl;
   final void Function(String url)? onOpenAuthor;
+
+  /// Name of the variation this sheet belongs to, or null when the character
+  /// has none. Shown as a plain chip above the name, mirroring the card you
+  /// arrived from; it is a label, not a control — the sheet is already the
+  /// variation it names.
+  final String? variationLabel;
+
   const _HeroSection({
     required this.character,
     this.previewAvatarUrl,
     this.authorUrl,
     this.onOpenAuthor,
+    this.variationLabel,
   });
 
   String get _displayName {
@@ -1039,6 +1055,10 @@ class _HeroSection extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  if (variationLabel != null) ...[
+                    VariationChip(name: variationLabel!, maxWidth: 180),
+                    const SizedBox(height: 6),
+                  ],
                   Text(
                     _displayName,
                     style: const TextStyle(

--- a/lib/shared/widgets/sheet_view.dart
+++ b/lib/shared/widgets/sheet_view.dart
@@ -838,7 +838,10 @@ class _SheetViewHeader extends StatelessWidget {
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
             child: Row(
               children: [
-                if (showBack)
+                // No reserved slot when there is no back button: the title is
+                // left-aligned anyway, so an empty 40pt gap in front of it only
+                // reads as a misalignment.
+                if (showBack) ...[
                   _HeaderIconButton(
                     onPressed: onBack ?? () => Navigator.of(context).maybePop(),
                     child: Icon(
@@ -846,10 +849,9 @@ class _SheetViewHeader extends StatelessWidget {
                       size: 20,
                       color: context.cs.primary,
                     ),
-                  )
-                else
-                  const SizedBox(width: 40),
-                const SizedBox(width: 8),
+                  ),
+                  const SizedBox(width: 8),
+                ],
                 Expanded(
                   child:
                       titleWidget ??


### PR DESCRIPTION
Two small follow-ups to #185.

## Variation chip in the character sheet

The card you tap in the variations grid names its variation with a chip above the character name, but the sheet it opens did not — so the one screen where you actually read and edit a variation was the one that never said which variation it was.

- `_HeroSection` now takes a `variationLabel` and renders the same `VariationChip` above the name.
- It is a plain label with no tap target: the sheet *is* the variation it names, so drilling into the group from here would be a loop.
- Hidden for a character with no variations, matching the card's rule.

## Sheet header indent

A modal `SheetView` header reserved a 40pt slot for the back button even when there was no back button, leaving the title floating an icon's width from the edge. Since the title is left-aligned anyway, the gap only read as a misalignment.

- The slot (and its 8pt gap) is now emitted only alongside an actual back button.
- This affects every `SheetView` modal that has a title and no back button — the variations grid, the filter sheet, the block editor, add-to-folder, and so on; all of them gain a flush-left title.
- Route-mode headers are untouched: `GlazeAppBar` fills that slot with the app logo, so there is no empty space there to remove.

## Verification

`flutter analyze` clean, `flutter test` 2050 passing, run after rebasing onto current `nightly` (which needed a `dart run build_runner build` for the `Preset.imagePath` field added by #188). Flutter 3.44.8 stable.

Not verified: rendering. The chip's placement in the hero over the gradient, and the new title alignment across the other sheets it touches, need a look on device.


---
_Generated by [Claude Code](https://claude.ai/code/session_014ivRgvNSXF8WRkhUcdh9gk)_