### PR TITLE
fix(presets): render idle preset cards as the app's plain glass

### DIFF
--- a/lib/features/presets/preset_list_screen.dart
+++ b/lib/features/presets/preset_list_screen.dart
@@ -319,7 +319,14 @@ class _PsCard extends ConsumerWidget {
         : context.cs.outline;
     final idleWidth = cover != null ? _accentBorderWidth : 1.0;
     final activeBorder = context.cs.primary.withValues(alpha: 0.5);
-    final baseTint = context.cs.surfaceContainerHighest;
+    // GlassSurface multiplies a tint's own alpha into the theme's element
+    // opacity, and only falls back to `surface × elementOpacity` when no tint
+    // is given. A theme whose UI colour is translucent (8-digit hex) therefore
+    // renders a card handed `surfaceContainerHighest` verbatim thinner than
+    // every other glass surface in the app. Pinning both tints to full alpha
+    // makes the multiplication a no-op, so an idle card is exactly the app's
+    // plain glass and the active one is that same glass plus the highlight.
+    final baseTint = context.cs.surfaceContainerHighest.withValues(alpha: 1.0);
     final activeTint = Color.alphaBlend(
       context.cs.primary.withValues(alpha: 0.12),
       baseTint,


### PR DESCRIPTION
Follow-up to #189. Preset cards without a cover stopped matching the rest of the app's glass surfaces on themes with a translucent UI colour.

## The cause

`GlassSurface` treats a supplied tint differently from no tint at all:

- `tint == null` → `surfaceContainerHighest.withValues(alpha: elementOpacity)` — the alpha is **replaced**.
- `tint != null` → `tint.withValues(alpha: tint.a * elementOpacity)` — the alpha is **multiplied**.

The active-preset cross-fade added in #189 needs a colour on both ends of the lerp, so the idle card began passing `surfaceContainerHighest` where it previously passed `null`. Those are equivalent only while that colour is opaque — and it is not always: `surfaceContainerHighest` is the theme preset's UI colour, which `_parseHex` reads as `AARRGGBB` when the user supplies an 8-digit hex. On such a theme the card's fill got multiplied instead of replaced and rendered thinner than every other glass surface.

## The fix

- Pin both the base and the active tint to full alpha in `_PsCard`, which makes the multiplication a no-op. An idle card now produces exactly `defaultBase.withValues(alpha: elementOpacity)` — byte-identical to the fill `GlassSurface` derives on its own — and the active card is that same glass plus the highlight blend. The border/tint cross-fade is unchanged.
- This also corrects the active card, which had the same multiplication applied to its highlight tint before #189 too.

## Verification

- Reasoned against `GlassSurface._build`'s fill formula rather than measured: `surfaceContainerHighest.withValues(alpha: 1.0)` has `a == 1`, so `tint.a * elementOpacity == elementOpacity` and the RGB channels are untouched.
- No behaviour is under test here; the change is a colour computation in a widget build.
- `flutter analyze` and `flutter test` were **not** run for this branch — the environment it was written in has no Flutter SDK. CI is the only execution of the analyzer and the test suite here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpyYuo7cUxiRri3txBDcSi)_