### PR TITLE
feat(presets): folders, filters, multi-select and a per-row menu

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2073,5 +2073,20 @@
   "studio_slot_model_auto": "Automatic",
   "studio_slot_model_hint": "Model id, e.g. gpt-4o-mini",
   "studio_agent_always_on": "Always on",
-  "studio_blocks_title": "Prompt Blocks"
+  "studio_blocks_title": "Prompt Blocks",
+  "preset_filter_type": "Preset type",
+  "preset_type_normal": "Regular",
+  "preset_type_agentic": "Agentic",
+  "label_no_presets": "No presets",
+  "preset_folder_empty": "No presets in this folder",
+  "preset_folder_delete_confirm": "Delete this folder? The presets in it won't be deleted.",
+  "preset_delete_none_toast": "Nothing to delete",
+  "preset_exported_toast": {
+    "one": "{} preset exported",
+    "other": "{} presets exported"
+  },
+  "preset_delete_many_confirm": {
+    "one": "Delete {} preset? This cannot be undone.",
+    "other": "Delete {} presets? This cannot be undone."
+  }
 }

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -2096,5 +2096,24 @@
   "studio_slot_model_auto": "Автоматически",
   "studio_slot_model_hint": "Идентификатор модели, напр. gpt-4o-mini",
   "studio_agent_always_on": "Всегда включён",
-  "studio_blocks_title": "Промпт-блоки"
+  "studio_blocks_title": "Промпт-блоки",
+  "preset_filter_type": "Тип пресета",
+  "preset_type_normal": "Обычный",
+  "preset_type_agentic": "Агентский",
+  "label_no_presets": "Пресетов нет",
+  "preset_folder_empty": "В этой папке нет пресетов",
+  "preset_folder_delete_confirm": "Удалить эту папку? Пресеты в ней удалены не будут.",
+  "preset_delete_none_toast": "Удалять нечего",
+  "preset_exported_toast": {
+    "one": "Экспортирован {} пресет",
+    "few": "Экспортировано {} пресета",
+    "many": "Экспортировано {} пресетов",
+    "other": "Экспортировано {} пресета"
+  },
+  "preset_delete_many_confirm": {
+    "one": "Удалить {} пресет? Это действие необратимо.",
+    "few": "Удалить {} пресета? Это действие необратимо.",
+    "many": "Удалить {} пресетов? Это действие необратимо.",
+    "other": "Удалить {} пресета? Это действие необратимо."
+  }
 }

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -79,7 +79,7 @@ All schema changes go in `AppDatabase.migration` in `app_db.dart`.
 Bump the schema version and add a `from → to` migration step.
 Never modify existing column types without a migration.
 
-Current version: **101**
+Current version: **103**
 
 Migration history:
 - v18: added `characters.picksHash`
@@ -163,6 +163,12 @@ Migration history:
   `session_id` exists in `chat_sessions` are retained; canonical profile-only
   rows are dropped (their runtime payloads were already preserved as migrated
   presets in v99).
+- v103: added `preset_folders` + `preset_folder_members` tables (folders for the
+  Presets list, mirroring the character folders). Membership PK is
+  `{folderId, presetId, kind}` — `kind` is `normal` for rows in `presets` and
+  `agentic` for rows in `studio_preset_rows`, whose id spaces are independent,
+  so it must be part of the key. Deleting a preset must also drop its member
+  rows (`PresetFolderRepo.deleteMembersForPreset`).
 
 ---
 

--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -24,6 +24,8 @@ part 'app_db.g.dart';
     CharacterFolderMembers,
     ChatSessions,
     Presets,
+    PresetFolders,
+    PresetFolderMembers,
     ApiConfigs,
     Personas,
     Lorebooks,
@@ -70,7 +72,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 102;
+  int get schemaVersion => 103;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1972,6 +1974,17 @@ class AppDatabase extends _$AppDatabase {
             studioPresetRows,
             studioPresetRows.ledgerApiConfigId,
           );
+        }
+      }
+      if (from < 103) {
+        final tableNames = (await customSelect(
+          "SELECT name FROM sqlite_master WHERE type = 'table'",
+        ).get()).map((row) => row.read<String>('name')).toSet();
+        if (!tableNames.contains('preset_folders')) {
+          await m.createTable(presetFolders);
+        }
+        if (!tableNames.contains('preset_folder_members')) {
+          await m.createTable(presetFolderMembers);
         }
       }
     },

--- a/lib/core/db/repositories/preset_folder_repo.dart
+++ b/lib/core/db/repositories/preset_folder_repo.dart
@@ -1,0 +1,141 @@
+import 'package:drift/drift.dart';
+
+import '../app_db.dart';
+import '../../models/preset_folder.dart';
+import '../../utils/id_generator.dart';
+import '../../utils/time_helpers.dart';
+
+/// Folders for the Presets list. Mirrors [CharacterFolderRepo]; membership rows
+/// carry a `kind` so chat presets and Studio (agentic) presets can share a
+/// folder without their independent id spaces colliding.
+class PresetFolderRepo {
+  final AppDatabase _db;
+  PresetFolderRepo(this._db);
+
+  // ── Folders ────────────────────────────────────────────────────────────
+
+  Stream<List<PresetFolder>> watchFolders() {
+    return (_db.select(_db.presetFolders)
+          ..orderBy([
+            (t) => OrderingTerm.asc(t.sortOrder),
+            (t) => OrderingTerm.asc(t.createdAt),
+          ]))
+        .watch()
+        .map((rows) => rows.map(_toModel).toList());
+  }
+
+  Future<List<PresetFolder>> getFolders() async {
+    final rows = await (_db.select(_db.presetFolders)
+          ..orderBy([
+            (t) => OrderingTerm.asc(t.sortOrder),
+            (t) => OrderingTerm.asc(t.createdAt),
+          ]))
+        .get();
+    return rows.map(_toModel).toList();
+  }
+
+  Future<PresetFolder> create({required String name, String? color}) async {
+    final now = currentTimestampSeconds();
+    final folder = PresetFolder(
+      id: generateId(),
+      name: name,
+      color: color,
+      sortOrder: now,
+      createdAt: now,
+      updatedAt: now,
+    );
+    await _db
+        .into(_db.presetFolders)
+        .insert(
+          PresetFoldersCompanion(
+            folderId: Value(folder.id),
+            name: Value(folder.name),
+            color: Value(folder.color),
+            sortOrder: Value(folder.sortOrder),
+            createdAt: Value(folder.createdAt),
+            updatedAt: Value(folder.updatedAt),
+          ),
+        );
+    return folder;
+  }
+
+  Future<void> rename(String folderId, String name) async {
+    await (_db.update(_db.presetFolders)
+          ..where((t) => t.folderId.equals(folderId)))
+        .write(
+          PresetFoldersCompanion(
+            name: Value(name),
+            updatedAt: Value(currentTimestampSeconds()),
+          ),
+        );
+  }
+
+  /// Deletes the folder and its membership rows (presets are untouched).
+  Future<void> delete(String folderId) async {
+    await _db.transaction(() async {
+      await (_db.delete(_db.presetFolderMembers)
+            ..where((t) => t.folderId.equals(folderId)))
+          .go();
+      await (_db.delete(_db.presetFolders)
+            ..where((t) => t.folderId.equals(folderId)))
+          .go();
+    });
+  }
+
+  // ── Membership ─────────────────────────────────────────────────────────
+
+  Stream<List<PresetFolderMemberRow>> watchMembers() {
+    return _db.select(_db.presetFolderMembers).watch();
+  }
+
+  /// Idempotent: re-adding a preset already in the folder is a no-op, which
+  /// enforces the "no duplicates within a folder" rule (composite PK).
+  Future<void> addMember(
+    String folderId,
+    String presetId,
+    PresetKind kind,
+  ) async {
+    await _db
+        .into(_db.presetFolderMembers)
+        .insertOnConflictUpdate(
+          PresetFolderMembersCompanion(
+            folderId: Value(folderId),
+            presetId: Value(presetId),
+            kind: Value(kind.wireName),
+            addedAt: Value(currentTimestampSeconds()),
+          ),
+        );
+  }
+
+  Future<void> removeMember(
+    String folderId,
+    String presetId,
+    PresetKind kind,
+  ) async {
+    await (_db.delete(_db.presetFolderMembers)..where(
+          (t) =>
+              t.folderId.equals(folderId) &
+              t.presetId.equals(presetId) &
+              t.kind.equals(kind.wireName),
+        ))
+        .go();
+  }
+
+  /// Drops every membership row for a preset — called when the preset itself is
+  /// deleted so folders don't keep dangling members.
+  Future<void> deleteMembersForPreset(String presetId, PresetKind kind) async {
+    await (_db.delete(_db.presetFolderMembers)..where(
+          (t) => t.presetId.equals(presetId) & t.kind.equals(kind.wireName),
+        ))
+        .go();
+  }
+
+  PresetFolder _toModel(PresetFolderRow r) => PresetFolder(
+    id: r.folderId,
+    name: r.name,
+    color: r.color,
+    sortOrder: r.sortOrder,
+    createdAt: r.createdAt,
+    updatedAt: r.updatedAt,
+  );
+}

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -717,6 +717,45 @@ class Presets extends Table {
   Set<Column> get primaryKey => {presetId};
 }
 
+@DataClassName('PresetFolderRow')
+class PresetFolders extends Table {
+  @override
+  String get tableName => 'preset_folders';
+
+  TextColumn get folderId => text()();
+  TextColumn get name => text()();
+  TextColumn get color => text().nullable()();
+  IntColumn get sortOrder => integer().withDefault(const Constant(0))();
+  IntColumn get createdAt => integer().withDefault(const Constant(0))();
+  IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+
+  @override
+  Set<Column> get primaryKey => {folderId};
+}
+
+@DataClassName('PresetFolderMemberRow')
+@TableIndex(name: 'idx_pfm_folder', columns: {#folderId})
+@TableIndex(name: 'idx_pfm_preset', columns: {#presetId})
+class PresetFolderMembers extends Table {
+  @override
+  String get tableName => 'preset_folder_members';
+
+  TextColumn get folderId => text()();
+  TextColumn get presetId => text()();
+
+  /// `normal` for rows in `presets`, `agentic` for rows in
+  /// `studio_preset_rows`. The two id spaces are independent, so the kind is
+  /// part of the key — without it an agentic preset could shadow a plain one
+  /// that happens to share its id.
+  TextColumn get kind => text().withDefault(const Constant('normal'))();
+  IntColumn get addedAt => integer().withDefault(const Constant(0))();
+
+  // Composite PK: a preset can live in many folders, but cannot be duplicated
+  // within one folder.
+  @override
+  Set<Column> get primaryKey => {folderId, presetId, kind};
+}
+
 @DataClassName('ApiConfigRow')
 class ApiConfigs extends Table {
   @override

--- a/lib/core/models/preset_folder.dart
+++ b/lib/core/models/preset_folder.dart
@@ -1,0 +1,59 @@
+/// Which list a preset entry comes from.
+///
+/// `normal` — a chat preset (`presets` table, [Preset] model).
+/// `agentic` — a Studio agent preset (`studio_preset_rows`, [StudioPreset]).
+enum PresetKind {
+  normal,
+  agentic;
+
+  /// Stable wire name used as the `kind` column in `preset_folder_members`.
+  String get wireName => name;
+
+  static PresetKind fromWireName(String? value) =>
+      value == agentic.wireName ? agentic : normal;
+}
+
+/// A user-created folder for organizing presets.
+///
+/// Membership is stored separately (`preset_folder_members`); a preset may
+/// belong to many folders, but never twice to the same folder. Mirrors
+/// [CharacterFolder] — the only difference is that members are keyed by
+/// (id, kind) because chat and Studio presets have independent id spaces.
+class PresetFolder {
+  final String id;
+  final String name;
+  final String? color;
+  final int sortOrder;
+  final int createdAt;
+  final int updatedAt;
+
+  const PresetFolder({
+    required this.id,
+    required this.name,
+    this.color,
+    this.sortOrder = 0,
+    this.createdAt = 0,
+    this.updatedAt = 0,
+  });
+
+  PresetFolder copyWith({
+    String? id,
+    String? name,
+    String? color,
+    int? sortOrder,
+    int? createdAt,
+    int? updatedAt,
+  }) => PresetFolder(
+    id: id ?? this.id,
+    name: name ?? this.name,
+    color: color ?? this.color,
+    sortOrder: sortOrder ?? this.sortOrder,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+}
+
+/// Stable key identifying a preset inside folder membership maps. Chat and
+/// Studio presets are stored side by side, so the kind is part of the key.
+String presetMemberKey(String presetId, PresetKind kind) =>
+    '${kind.wireName}:$presetId';

--- a/lib/core/state/preset_folder_provider.dart
+++ b/lib/core/state/preset_folder_provider.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../db/repositories/preset_folder_repo.dart';
+import '../models/preset_folder.dart';
+import 'db_provider.dart';
+
+final presetFolderRepoProvider = Provider<PresetFolderRepo>((ref) {
+  return PresetFolderRepo(ref.watch(appDbProvider));
+});
+
+/// Reactive list of preset folders, ordered by sortOrder then createdAt.
+final presetFoldersProvider = StreamProvider<List<PresetFolder>>((ref) {
+  return ref.watch(presetFolderRepoProvider).watchFolders();
+});
+
+/// Two-way view of preset-folder membership, derived from the (small) member
+/// table. Entries are keyed by [presetMemberKey] so chat and Studio presets
+/// never collide.
+class PresetFolderMemberships {
+  /// folderId → set of member keys.
+  final Map<String, Set<String>> byFolder;
+
+  /// member key → set of folder ids.
+  final Map<String, Set<String>> byPreset;
+
+  const PresetFolderMemberships({
+    required this.byFolder,
+    required this.byPreset,
+  });
+
+  static const empty = PresetFolderMemberships(byFolder: {}, byPreset: {});
+
+  Set<String> presetsIn(String folderId) => byFolder[folderId] ?? const {};
+
+  Set<String> foldersOf(String presetId, PresetKind kind) =>
+      byPreset[presetMemberKey(presetId, kind)] ?? const {};
+
+  int countFor(String folderId) => byFolder[folderId]?.length ?? 0;
+}
+
+final presetFolderMembershipsProvider =
+    StreamProvider<PresetFolderMemberships>((ref) {
+      return ref.watch(presetFolderRepoProvider).watchMembers().map((rows) {
+        final byFolder = <String, Set<String>>{};
+        final byPreset = <String, Set<String>>{};
+        for (final r in rows) {
+          final key = presetMemberKey(
+            r.presetId,
+            PresetKind.fromWireName(r.kind),
+          );
+          (byFolder[r.folderId] ??= <String>{}).add(key);
+          (byPreset[key] ??= <String>{}).add(r.folderId);
+        }
+        return PresetFolderMemberships(byFolder: byFolder, byPreset: byPreset);
+      });
+    });

--- a/lib/features/character_list/widgets/character_folders_section.dart
+++ b/lib/features/character_list/widgets/character_folders_section.dart
@@ -11,7 +11,7 @@ import '../../../core/state/character_provider.dart';
 import '../../../core/utils/platform_paths.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
-import 'folder_name_dialog.dart';
+import '../../../shared/widgets/folder_name_dialog.dart';
 
 /// Folders strip for the My Characters root view: a horizontal row of circular
 /// folder covers. Tapping opens a folder; long-pressing exposes rename/delete.

--- a/lib/features/character_list/widgets/widgets.dart
+++ b/lib/features/character_list/widgets/widgets.dart
@@ -6,4 +6,4 @@ export 'character_folders_section.dart';
 export 'character_grid.dart';
 export 'character_hiding_onboarding_sheet.dart';
 export 'empty_state.dart';
-export 'folder_name_dialog.dart';
+export '../../../shared/widgets/folder_name_dialog.dart';

--- a/lib/features/presets/preset_cover_service.dart
+++ b/lib/features/presets/preset_cover_service.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/services/image_storage_service.dart';
+import '../../core/state/db_provider.dart';
+import '../../core/utils/time_helpers.dart';
+import 'preset_image.dart';
+
+/// Picking and clearing a preset's cover image, shared by the preset editor
+/// (which holds the path in unsaved state) and the preset list's "⋯" menu
+/// (which writes straight through to the repository).
+
+/// Prompts for an image, stores it under [presetId] and returns the new
+/// relative path — or null when the user cancelled or the file was unreadable.
+///
+/// The caller owns persistence: it decides when the returned path reaches the
+/// [Preset]. Dropping the replaced file is left to [deleteStoredPresetCover],
+/// so a caller whose save can still fail keeps the old file until it commits.
+Future<String?> pickPresetCover(WidgetRef ref, String presetId) async {
+  FilePickerResult? result;
+  try {
+    result = await FilePicker.pickFiles(
+      type: FileType.image,
+      allowMultiple: false,
+      withData: true,
+    );
+  } catch (_) {}
+  if (result == null || result.files.isEmpty) return null;
+
+  final picked = result.files.first;
+  Uint8List? bytes = picked.bytes;
+  if ((bytes == null || bytes.isEmpty) &&
+      picked.path != null &&
+      picked.path!.isNotEmpty) {
+    bytes = await File(picked.path!).readAsBytes();
+  }
+  if (bytes == null || bytes.isEmpty) return null;
+
+  final storage = await ref.read(imageStorageProvider.future);
+  final storageId = presetImageStorageId(presetId, currentTimestampSeconds());
+  // saveAvatar always writes `<id>.png` (plus a thumbnail).
+  await storage.saveAvatar(storageId, bytes);
+  return presetImageRelativePath(storageId, 'png');
+}
+
+/// Drops the file a replaced/removed cover left behind. Bundled asset covers
+/// (a cloned featured preset) have no file to delete.
+Future<void> deleteStoredPresetCover(
+  ImageStorageService storage,
+  String? path,
+) async {
+  final storageId = presetImageStorageIdOf(path);
+  if (storageId == null) return;
+  try {
+    await storage.deleteAvatar(storageId);
+  } catch (_) {}
+}

--- a/lib/features/presets/preset_deletion.dart
+++ b/lib/features/presets/preset_deletion.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/preset_folder.dart';
+import '../../core/state/db_provider.dart';
+import '../../core/state/preset_folder_provider.dart';
+import '../studio/studio_preset_workflow_provider.dart';
+import 'preset_list_provider.dart';
+
+/// Deletes a preset of either kind and drops its folder membership rows, so no
+/// folder is left holding a member that no longer exists. Every delete path
+/// (editor menu, list row menu, bulk delete) goes through here.
+Future<void> deletePresetAndFolderMemberships(
+  WidgetRef ref,
+  String presetId,
+  PresetKind kind,
+) async {
+  if (kind == PresetKind.normal) {
+    await ref.read(presetListProvider.notifier).remove(presetId);
+  } else {
+    // The workflow service also records the sync deletion and moves the active
+    // selection off the deleted preset.
+    await ref.read(studioPresetWorkflowServiceProvider).deletePreset(presetId);
+    ref.invalidate(studioPresetListProvider);
+  }
+  await ref
+      .read(presetFolderRepoProvider)
+      .deleteMembersForPreset(presetId, kind);
+}

--- a/lib/features/presets/preset_editor_screen.dart
+++ b/lib/features/presets/preset_editor_screen.dart
@@ -1,16 +1,13 @@
 import 'dart:async';
-import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:easy_localization/easy_localization.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/llm/tokenizer.dart';
 import '../../core/models/preset.dart';
+import '../../core/models/preset_folder.dart';
 import '../../core/services/featured_presets.dart';
-import '../../core/services/image_storage_service.dart';
 import '../../core/services/preset_defaults.dart';
 import '../../core/state/db_provider.dart';
 import '../../core/utils/id_generator.dart';
@@ -22,11 +19,14 @@ import '../../shared/widgets/glaze_scaffold.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import '../../shared/widgets/generic_editor.dart';
 import '../../shared/widgets/help_tip.dart';
+import 'preset_cover_service.dart';
+import 'preset_deletion.dart';
 import 'preset_image.dart';
 import 'preset_list_provider.dart';
 import 'preset_export.dart';
 import 'widgets/preset_block_row.dart';
 import 'widgets/preset_dashboard_card.dart';
+import 'widgets/preset_options_sheet.dart';
 import '../../core/state/summary_providers.dart';
 import '../chat/chat_provider.dart';
 import '../settings/app_settings_provider.dart';
@@ -737,36 +737,24 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
   }
 
   void _showRenameDialog() {
-    GlazeBottomSheet.show<void>(
+    showPresetRename(
       context,
-      title: 'action_rename_preset'.tr(),
-      input: BottomSheetInput(
-        placeholder: 'Preset name',
-        value: _nameCtrl.text,
-        confirmLabel: 'Rename',
-        onConfirm: (val) {
-          Navigator.of(context, rootNavigator: true).pop();
-          setState(() => _nameCtrl.text = val);
-          _scheduleSave();
-        },
-      ),
+      currentName: _nameCtrl.text,
+      onRename: (val) {
+        setState(() => _nameCtrl.text = val);
+        _scheduleSave();
+      },
     );
   }
 
   void _showAuthorDialog() {
-    GlazeBottomSheet.show<void>(
+    showPresetAuthorDialog(
       context,
-      title: 'action_set_author'.tr(),
-      input: BottomSheetInput(
-        placeholder: 'Author (optional)',
-        value: _author,
-        confirmLabel: 'Save',
-        onConfirm: (val) {
-          Navigator.of(context, rootNavigator: true).pop();
-          setState(() => _author = val.trim());
-          _scheduleSave();
-        },
-      ),
+      currentAuthor: _author,
+      onSubmit: (val) {
+        setState(() => _author = val);
+        _scheduleSave();
+      },
     );
   }
 
@@ -776,39 +764,15 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
   Future<void> _pickImage() async {
     if (_isFeatured) return;
 
-    FilePickerResult? result;
-    try {
-      result = await FilePicker.pickFiles(
-        type: FileType.image,
-        allowMultiple: false,
-        withData: true,
-      );
-    } catch (_) {}
-    if (result == null || result.files.isEmpty) return;
+    final path = await pickPresetCover(ref, _currentId);
+    if (path == null || !mounted) return;
 
-    final picked = result.files.first;
-    Uint8List? bytes = picked.bytes;
-    if ((bytes == null || bytes.isEmpty) &&
-        picked.path != null &&
-        picked.path!.isNotEmpty) {
-      bytes = await File(picked.path!).readAsBytes();
-    }
-    if (bytes == null || bytes.isEmpty) return;
-
-    final storage = await ref.read(imageStorageProvider.future);
-    final storageId = presetImageStorageId(
-      _currentId,
-      currentTimestampSeconds(),
-    );
-    // saveAvatar always writes `<id>.png` (plus a thumbnail).
-    await storage.saveAvatar(storageId, bytes);
     final previous = _imagePath;
-
-    if (!mounted) return;
-    setState(() => _imagePath = presetImageRelativePath(storageId, 'png'));
+    setState(() => _imagePath = path);
     _scheduleSave();
 
-    await _deleteStoredCover(storage, previous);
+    final storage = await ref.read(imageStorageProvider.future);
+    await deleteStoredPresetCover(storage, previous);
   }
 
   void _removeImage() {
@@ -819,21 +783,8 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
     unawaited(
       ref
           .read(imageStorageProvider.future)
-          .then((storage) => _deleteStoredCover(storage, previous)),
+          .then((storage) => deleteStoredPresetCover(storage, previous)),
     );
-  }
-
-  /// Drops the file a replaced/removed cover left behind. Bundled asset covers
-  /// (a cloned featured preset) have no file to delete.
-  Future<void> _deleteStoredCover(
-    ImageStorageService storage,
-    String? path,
-  ) async {
-    final storageId = presetImageStorageIdOf(path);
-    if (storageId == null) return;
-    try {
-      await storage.deleteAvatar(storageId);
-    } catch (_) {}
   }
 
   /// Builds a [Preset] from the live editor state (used for Export and Clone).
@@ -864,85 +815,34 @@ class PresetEditorBodyState extends ConsumerState<PresetEditorBody> {
   }
 
   void _showOptionsMenu() {
-    GlazeBottomSheet.show<void>(
+    showPresetOptions(
       context,
-      title: 'preset_options'.tr(),
-      items: [
-        BottomSheetItem(
-          icon: Icons.drive_file_rename_outline,
-          label: 'action_rename'.tr(),
-          onTap: () {
-            Navigator.of(context, rootNavigator: true).pop();
-            _showRenameDialog();
-          },
-        ),
-        // Author and cover image are part of a bundled featured preset — the
-        // user edits them on a clone, not on the original.
-        if (!_isFeatured)
-          BottomSheetItem(
-            icon: Icons.person_outline,
-            label: 'action_set_author'.tr(),
-            onTap: () {
-              Navigator.of(context, rootNavigator: true).pop();
-              _showAuthorDialog();
-            },
-          ),
-        if (!_isFeatured)
-          BottomSheetItem(
-            icon: Icons.image_outlined,
-            label: 'change_image'.tr(),
-            onTap: () {
-              Navigator.of(context, rootNavigator: true).pop();
-              _pickImage();
-            },
-          ),
-        if (!_isFeatured && _imagePath != null && _imagePath!.isNotEmpty)
-          BottomSheetItem(
-            icon: Icons.hide_image_outlined,
-            label: 'action_remove_image'.tr(),
-            onTap: () {
-              Navigator.of(context, rootNavigator: true).pop();
-              _removeImage();
-            },
-          ),
-        BottomSheetItem(
-          icon: Icons.copy_outlined,
-          label: 'action_clone_block'.tr(),
-          onTap: () async {
-            Navigator.of(context, rootNavigator: true).pop();
-            // Clone the live editor state (including unsaved edits) rather than
-            // the persisted preset. `clone` assigns a fresh id and a "(copy)"
-            // suffixed name.
-            await ref
-                .read(presetListProvider.notifier)
-                .clone(_currentSnapshot());
-            if (mounted) GlazeToast.show(context, 'Preset cloned');
-          },
-        ),
-        BottomSheetItem(
-          icon: Icons.upload_file_outlined,
-          label: 'action_export_st'.tr(),
-          onTap: () {
-            Navigator.of(context, rootNavigator: true).pop();
-            exportPreset(context, _currentSnapshot());
-          },
-        ),
-        if (widget.preset != null)
-          BottomSheetItem(
-            icon: Icons.delete_outlined,
-            iconColor: const Color(0xFFFF4444),
-            label: 'action_delete_msg'.tr(),
-            isDestructive: true,
-            onTap: () async {
-              Navigator.of(context, rootNavigator: true).pop();
-              await ref
-                  .read(presetListProvider.notifier)
-                  .remove(widget.preset!.id);
-              widget.onDeleted?.call();
-            },
-          ),
-      ],
+      isFeatured: _isFeatured,
+      hasImage: _imagePath != null && _imagePath!.isNotEmpty,
+      canDelete: widget.preset != null,
+      onRename: _showRenameDialog,
+      onSetAuthor: _showAuthorDialog,
+      onPickImage: () => unawaited(_pickImage()),
+      onRemoveImage: _removeImage,
+      // Clone/Export act on the live editor state (including unsaved edits),
+      // not on the persisted preset.
+      onClone: () => unawaited(_clonePreset()),
+      onExport: () => unawaited(exportPreset(context, _currentSnapshot())),
+      onDelete: () => unawaited(_deletePreset()),
     );
+  }
+
+  Future<void> _clonePreset() async {
+    // `clone` assigns a fresh id and a "(copy)" suffixed name.
+    await ref.read(presetListProvider.notifier).clone(_currentSnapshot());
+    if (mounted) GlazeToast.show(context, 'Preset cloned');
+  }
+
+  Future<void> _deletePreset() async {
+    final preset = widget.preset;
+    if (preset == null) return;
+    await deletePresetAndFolderMemberships(ref, preset.id, PresetKind.normal);
+    widget.onDeleted?.call();
   }
 
   Future<void> _showRegexSheet() async {

--- a/lib/features/presets/preset_entry.dart
+++ b/lib/features/presets/preset_entry.dart
@@ -1,0 +1,36 @@
+import '../../core/llm/preset_macro_attribution.dart';
+import '../../core/models/preset.dart';
+import '../../core/models/preset_folder.dart';
+import '../../core/models/studio_config.dart';
+import '../studio/studio_preset_stats.dart';
+
+/// One row of the Presets list, regardless of which store it came from: a plain
+/// chat preset ([PresetKind.normal]) or an agentic Studio preset
+/// ([PresetKind.agentic]).
+///
+/// The two kinds keep their own models — the card still branches on
+/// [isAgentic] to render them — but folders, filters and multi-select only ever
+/// need the shared projection below.
+class PresetItem {
+  final Preset? preset;
+  final StudioPreset? studioPreset;
+
+  PresetItem({this.preset, this.studioPreset});
+
+  bool get isAgentic => studioPreset != null;
+
+  PresetKind get kind => isAgentic ? PresetKind.agentic : PresetKind.normal;
+
+  String get id => isAgentic ? studioPreset!.id : preset!.id;
+
+  /// Key this row is stored under in `preset_folder_members`.
+  String get memberKey => presetMemberKey(id, kind);
+
+  /// Counting a plain preset's tokens resolves every block's macros, so it
+  /// stays lazy: the list rebuilds on every preset save (the editor autosaves
+  /// while typing) and only rendered rows — plus a token filter, when one is
+  /// set — need the number.
+  late final int tokens = isAgentic
+      ? studioPresetTokenEstimate(studioPreset!)
+      : presetOnlyTokenCount(preset!);
+}

--- a/lib/features/presets/preset_export.dart
+++ b/lib/features/presets/preset_export.dart
@@ -10,56 +10,7 @@ import '../../shared/widgets/glaze_toast.dart';
 /// Exports [preset] to a JSON file and shows a toast with the result.
 Future<void> exportPreset(BuildContext context, Preset preset) async {
   try {
-    final exportJson = <String, dynamic>{
-      'name': preset.name,
-      if (preset.author != null && preset.author!.isNotEmpty)
-        'author': preset.author,
-      'prompts': preset.blocks
-          .map((b) => <String, dynamic>{
-                'name': b.name,
-                'role': b.role,
-                'content': b.content,
-                'enabled': b.enabled,
-                'insertion_mode': b.insertionMode,
-                if (b.depth != null) 'depth': b.depth,
-                if (b.appendToLastMessage) 'appendToLastMessage': true,
-              })
-          .toList(),
-      'regexes': preset.regexes
-          .map((r) => <String, dynamic>{
-                'scriptName': r.name,
-                'findRegex': r.regex,
-                'replaceString': r.replacement,
-                'trimStrings': r.trimOut.isEmpty
-                    ? <String>[]
-                    : r.trimOut
-                        .split('\n')
-                        .where((t) => t.isNotEmpty)
-                        .toList(),
-                'placement': r.placement,
-                'isEnabled': !r.disabled,
-                'markdownOnly': r.markdownOnly,
-                'promptOnly': r.promptOnly,
-                'runOnEdit': r.runOnEdit,
-                'substituteRegex': r.substituteRegex,
-                if (r.minDepth != null) 'minDepth': r.minDepth,
-                if (r.maxDepth != null) 'maxDepth': r.maxDepth,
-              })
-          .toList(),
-      'reasoning': preset.reasoningEnabled,
-      if (preset.mergePrompts) 'mergePrompts': true,
-      if (preset.mergeRole != 'system') 'mergeRole': preset.mergeRole,
-    };
-
-    final encoded = const JsonEncoder.withIndent('  ').convert(exportJson);
-    final safeName =
-        preset.name.replaceAll(RegExp(r'[^\w\s-]'), '').trim();
-    final savedPath = await FileExportService.export(
-      data: encoded,
-      filename: '${safeName.isNotEmpty ? safeName : 'preset'}.json',
-      subfolder: 'presets',
-    );
-
+    final savedPath = await savePresetJson(preset);
     if (context.mounted) {
       GlazeToast.show(context, 'Exported to $savedPath');
     }
@@ -68,4 +19,58 @@ Future<void> exportPreset(BuildContext context, Preset preset) async {
       GlazeErrorDialog.show(context, e, prefix: 'Export failed: ');
     }
   }
+}
+
+/// Writes [preset] to a JSON file and returns the saved path. Split out of
+/// [exportPreset] so bulk export can report one summary instead of a toast per
+/// file.
+Future<String> savePresetJson(Preset preset) async {
+  final exportJson = <String, dynamic>{
+    'name': preset.name,
+    if (preset.author != null && preset.author!.isNotEmpty)
+      'author': preset.author,
+    'prompts': preset.blocks
+        .map((b) => <String, dynamic>{
+              'name': b.name,
+              'role': b.role,
+              'content': b.content,
+              'enabled': b.enabled,
+              'insertion_mode': b.insertionMode,
+              if (b.depth != null) 'depth': b.depth,
+              if (b.appendToLastMessage) 'appendToLastMessage': true,
+            })
+        .toList(),
+    'regexes': preset.regexes
+        .map((r) => <String, dynamic>{
+              'scriptName': r.name,
+              'findRegex': r.regex,
+              'replaceString': r.replacement,
+              'trimStrings': r.trimOut.isEmpty
+                  ? <String>[]
+                  : r.trimOut
+                      .split('\n')
+                      .where((t) => t.isNotEmpty)
+                      .toList(),
+              'placement': r.placement,
+              'isEnabled': !r.disabled,
+              'markdownOnly': r.markdownOnly,
+              'promptOnly': r.promptOnly,
+              'runOnEdit': r.runOnEdit,
+              'substituteRegex': r.substituteRegex,
+              if (r.minDepth != null) 'minDepth': r.minDepth,
+              if (r.maxDepth != null) 'maxDepth': r.maxDepth,
+            })
+        .toList(),
+    'reasoning': preset.reasoningEnabled,
+    if (preset.mergePrompts) 'mergePrompts': true,
+    if (preset.mergeRole != 'system') 'mergeRole': preset.mergeRole,
+  };
+
+  final encoded = const JsonEncoder.withIndent('  ').convert(exportJson);
+  final safeName = preset.name.replaceAll(RegExp(r'[^\w\s-]'), '').trim();
+  return FileExportService.export(
+    data: encoded,
+    filename: '${safeName.isNotEmpty ? safeName : 'preset'}.json',
+    subfolder: 'presets',
+  );
 }

--- a/lib/features/presets/preset_list_screen.dart
+++ b/lib/features/presets/preset_list_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -8,25 +9,46 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/import/silly_tavern_preset_parser.dart';
-import '../../core/llm/preset_macro_attribution.dart';
 import '../../core/models/preset.dart';
+import '../../core/models/preset_folder.dart';
 import '../../core/models/studio_config.dart';
+import '../../core/services/featured_presets.dart';
 import '../../core/state/active_selection_provider.dart';
 import '../../core/state/db_provider.dart';
 import '../../core/state/active_studio_preset_provider.dart';
+import '../../core/state/preset_folder_provider.dart';
+import '../../core/utils/time_helpers.dart';
 import '../studio/studio_preset_stats.dart';
 import '../studio/studio_preset_workflow_provider.dart';
+import '../studio/widgets/studio_preset_options_sheet.dart';
 import 'studio_preset_editor_screen.dart';
+import 'studio_preset_export.dart';
+import '../../shared/shell/nav_height_provider.dart';
 import '../../shared/theme/app_colors.dart';
+import '../../shared/widgets/folder_name_dialog.dart';
 import '../../shared/widgets/glass_surface.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../shared/widgets/sheet_view.dart';
 import '../../shared/widgets/glaze_error_dialog.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import 'preset_connections_sheet.dart';
+import 'preset_cover_service.dart';
+import 'preset_deletion.dart';
 import 'preset_editor_screen.dart';
+import 'preset_entry.dart';
+import 'preset_export.dart';
 import 'preset_image.dart';
 import 'preset_list_provider.dart';
+import 'preset_selection_provider.dart';
+import 'widgets/add_presets_to_folder_sheet.dart';
+import 'widgets/preset_filter_sheet.dart';
+import 'widgets/preset_folders_section.dart';
+import 'widgets/preset_options_sheet.dart';
+
+/// Nominal height of one preset row (card + the gap below it). Only used to
+/// estimate the scroll offset of the active preset before its row is laid out;
+/// [Scrollable.ensureVisible] corrects the estimate on the following frame.
+const double _kRowExtent = 72;
 
 class PresetListScreen extends ConsumerStatefulWidget {
   final bool startExpanded;
@@ -48,12 +70,48 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
   Preset? _editingPreset;
   bool _isCreating = false;
   String? _editingStudioId;
-  GlobalKey<PresetEditorBodyState> _editorKey = GlobalKey<PresetEditorBodyState>();
+  GlobalKey<PresetEditorBodyState> _editorKey =
+      GlobalKey<PresetEditorBodyState>();
   GlobalKey<StudioPresetEditorBodyState> _studioEditorKey =
       GlobalKey<StudioPresetEditorBodyState>();
 
+  /// Folder currently being browsed, or null at the top level.
+  String? _currentFolderId;
+  PresetListFilters _filters = const PresetListFilters();
+
+  final ScrollController _scrollController = ScrollController();
+
+  /// Key on the header sliver, used to measure what sits above the rows when
+  /// estimating the active preset's scroll offset.
+  final GlobalKey _headerKey = GlobalKey();
+
+  /// Key on the active preset's row, used to fine-tune that scroll.
+  final GlobalKey _activeRowKey = GlobalKey();
+
+  /// The list scrolls to the active preset once per screen open, not on every
+  /// rebuild — otherwise the user could never scroll away from it.
+  bool _didAutoScroll = false;
+
   bool get _inEditor => _isCreating || _editingPreset != null;
   bool get _inStudioEditor => _editingStudioId != null;
+  bool get _inAnyEditor => _inEditor || _inStudioEditor;
+
+  @override
+  void initState() {
+    super.initState();
+    // The selection provider outlives this screen, so a selection left behind
+    // when the sheet was dismissed would reopen with a stale bar. Reset after
+    // the first frame (writing to a provider during initState is not allowed).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) ref.read(presetSelectionProvider.notifier).clear();
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   void _openEditor(Preset? preset) {
     setState(() {
@@ -85,18 +143,33 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
     if (_inStudioEditor) {
       final handled = _studioEditorKey.currentState?.handleBack() ?? false;
       if (!handled) _closeEditor();
-    } else if (_inEditor) {
-      final handled = _editorKey.currentState?.handleBack() ?? false;
-      if (!handled) {
-        _closeEditor();
-      }
-    } else {
-      if (widget.startExpanded) {
-        context.go('/tools');
-      } else {
-        Navigator.of(context).maybePop();
-      }
+      return;
     }
+    if (_inEditor) {
+      final handled = _editorKey.currentState?.handleBack() ?? false;
+      if (!handled) _closeEditor();
+      return;
+    }
+    // Selection mode and the folder view are both "inner" states: back leaves
+    // them before it leaves the screen.
+    if (ref.read(presetSelectionProvider).active) {
+      ref.read(presetSelectionProvider.notifier).clear();
+      return;
+    }
+    if (_currentFolderId != null) {
+      setState(() => _currentFolderId = null);
+      return;
+    }
+    if (widget.startExpanded) {
+      context.go('/tools');
+    } else {
+      Navigator.of(context).maybePop();
+    }
+  }
+
+  String? _folderName(String id) {
+    final folders = ref.watch(presetFoldersProvider).value;
+    return folders?.where((f) => f.id == id).firstOrNull?.name;
   }
 
   @override
@@ -104,23 +177,62 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
     final presets = ref.watch(presetListProvider);
     final activeId = ref.watch(activePresetIdProvider);
     final studioPresets = ref.watch(studioPresetListProvider);
-    final activeStudioId = ref.watch(activeStudioPresetProvider).value ?? 'default';
+    final activeStudioId =
+        ref.watch(activeStudioPresetProvider).value ?? 'default';
     // The Studio master switch is the single "which kind is in effect" flag:
     // ON → an agentic preset is active, OFF → a plain preset is active. Using
     // it as the discriminator keeps the two lists mutually exclusive so exactly
     // one card is ever highlighted.
     final studioEnabled = ref.watch(studioFeatureEnabledProvider);
+    final selection = ref.watch(presetSelectionProvider);
+    final folderId = _currentFolderId;
+
+    final String title;
+    if (_inStudioEditor) {
+      title = 'Edit Agentic Preset';
+    } else if (_inEditor) {
+      title = _editingPreset != null ? 'Edit Preset' : 'New Preset';
+    } else if (folderId != null) {
+      title = _folderName(folderId) ?? 'Presets';
+    } else {
+      title = 'Presets';
+    }
 
     return SheetView(
       startExpanded: widget.startExpanded,
       showRouteBackground: false,
-      title: _inStudioEditor
-          ? 'Edit Agentic Preset'
-          : _inEditor
-          ? (_editingPreset != null ? 'Edit Preset' : 'New Preset')
-          : 'Presets',
+      title: title,
       showBack: true,
       onBack: _handleBack,
+      actions: _inAnyEditor
+          ? const []
+          : [
+              SheetViewAction(
+                icon: Icon(
+                  Icons.tune_rounded,
+                  size: 20,
+                  color: _filters.isActive
+                      ? context.cs.primary
+                      : context.cs.onSurfaceVariant,
+                ),
+                tooltip: 'catalog_filters'.tr(),
+                onPressed: () => _showFilterSheet(context),
+              ),
+            ],
+      floating: _inAnyEditor || !selection.active
+          ? null
+          : Align(
+              alignment: Alignment.bottomCenter,
+              child: Padding(
+                padding: EdgeInsets.fromLTRB(16, 0, 16, _floatingBottom()),
+                child: _SelectionBar(
+                  count: selection.count,
+                  onCancel: () =>
+                      ref.read(presetSelectionProvider.notifier).clear(),
+                  onMore: () => _showSelectionActions(context, selection),
+                ),
+              ),
+            ),
       body: _inStudioEditor
           ? StudioPresetEditorBody(
               key: _studioEditorKey,
@@ -135,116 +247,389 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
               onDeleted: _closeEditor,
             )
           : presets.when(
+              // A save from the editor invalidates the list; keep the rows on
+              // screen instead of flashing a spinner while it reloads.
+              skipLoadingOnReload: true,
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (e, _) => Center(child: Text('${'title_error'.tr()}: $e')),
-              data: (list) => _buildBody(
-                context, ref, list, activeId,
-                studioPresets.value ?? [], activeStudioId, studioEnabled,
+              // The inner Builder reads the MediaQuery padding SheetView
+              // overrides for its body (header inset + nav bar), which the
+              // outer context doesn't carry.
+              data: (list) => Builder(
+                builder: (context) => _buildBody(
+                  context,
+                  list,
+                  activeId,
+                  studioPresets.value ?? const [],
+                  activeStudioId,
+                  studioEnabled,
+                ),
               ),
             ),
     );
   }
 
+  /// The selection bar floats above whichever chrome sits at the bottom: the
+  /// shell nav bar when the screen is opened as a route, the safe-area inset
+  /// when it is opened as a modal sheet.
+  double _floatingBottom() {
+    final navHeight = ref.watch(navHeightProvider);
+    final inset = MediaQuery.paddingOf(context).bottom;
+    return (navHeight > inset ? navHeight : inset) + 16;
+  }
+
+  // ─── list ──────────────────────────────────────────────────────────────
+
   Widget _buildBody(
     BuildContext context,
-    WidgetRef ref,
-    List<Preset> list,
+    List<Preset> presets,
     String? activeId,
     List<StudioPreset> studioList,
     String activeStudioId,
     bool studioEnabled,
   ) {
-    final items = <_PresetItem>[
-      for (final p in list) _PresetItem(preset: p),
-      for (final sp in studioList) _PresetItem(studioPreset: sp),
+    final folderId = _currentFolderId;
+    final memberships =
+        ref.watch(presetFolderMembershipsProvider).value ??
+        PresetFolderMemberships.empty;
+    final selection = ref.watch(presetSelectionProvider);
+
+    var items = <PresetItem>[
+      for (final p in presets) PresetItem(preset: p),
+      for (final sp in studioList) PresetItem(studioPreset: sp),
     ];
-    return Builder(
-      builder: (context) => ListView.builder(
-        padding: const EdgeInsets.fromLTRB(
-          16,
-          12,
-          16,
-          16,
-        ).add(EdgeInsets.only(
-          top: MediaQuery.paddingOf(context).top,
-          bottom: MediaQuery.paddingOf(context).bottom,
-        )),
-        itemCount: items.length + 1,
-        itemBuilder: (_, i) {
-          if (i == items.length) return _buildAddButton(context, ref);
-          final item = items[i];
-          // Studio ON ⇒ only an agentic preset can be active; Studio OFF ⇒ only
-          // a plain preset can be active. So the two lists never both highlight.
-          final isActive = item.isAgentic
-              ? (studioEnabled && item.studioPreset!.id == activeStudioId)
-              : (!studioEnabled && activeId == item.preset!.id);
-          return Padding(
-            padding: const EdgeInsets.only(bottom: 10),
-            child: _PsCard(
-              item: item,
-              isActive: isActive,
-              onActivate: () {
-                if (!isActive) {
-                  if (item.isAgentic) {
-                    ref.read(activeStudioPresetProvider.notifier)
-                        .set(item.studioPreset!.id);
-                    ref.read(studioFeatureEnabledProvider.notifier).enable();
-                  } else {
-                    setActivePreset(ref, item.preset!.id);
-                    // Switching to a plain preset turns Studio off so the
-                    // agentic pipeline stops overriding it.
-                    ref.read(studioFeatureEnabledProvider.notifier)
-                        .setEnabled(false);
-                  }
-                }
-              },
-              onConnections: item.isAgentic
-                  ? null
-                  : () => showPresetConnections(context, item.preset!.id),
-              onEdit: item.isAgentic
-                  ? () => _openStudioEditor(item.studioPreset!.id)
-                  : () => _openEditor(item.preset),
+    if (folderId != null) {
+      final keys = memberships.presetsIn(folderId);
+      items = items.where((e) => keys.contains(e.memberKey)).toList();
+    }
+    items = items.where(_filters.matches).toList();
+
+    // Studio ON ⇒ only an agentic preset can be active; Studio OFF ⇒ only a
+    // plain preset can be active. So the two kinds never both highlight.
+    bool isActive(PresetItem item) => item.isAgentic
+        ? (studioEnabled && item.studioPreset!.id == activeStudioId)
+        : (!studioEnabled && activeId == item.preset!.id);
+
+    final activeIndex = items.indexWhere(isActive);
+
+    // Auto-reveal the active preset the first time the plain (unfiltered,
+    // top-level) list is shown.
+    if (folderId == null && !_filters.isActive) {
+      _scheduleAutoScroll(activeIndex);
+    }
+
+    final topInset = MediaQuery.paddingOf(context).top;
+    final bottomInset = MediaQuery.paddingOf(context).bottom;
+
+    return CustomScrollView(
+      controller: _scrollController,
+      slivers: [
+        SliverPadding(
+          padding: EdgeInsets.fromLTRB(16, 12 + topInset, 16, 0),
+          sliver: SliverToBoxAdapter(
+            child: KeyedSubtree(
+              key: _headerKey,
+              child: folderId == null
+                  ? PresetFoldersSection(
+                      onOpenFolder: (id) {
+                        ref.read(presetSelectionProvider.notifier).clear();
+                        setState(() => _currentFolderId = id);
+                      },
+                    )
+                  : const SizedBox.shrink(),
             ),
-          );
-        },
-      ),
+          ),
+        ),
+        if (items.isEmpty)
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 40),
+            sliver: SliverToBoxAdapter(
+              child: Center(
+                child: Text(
+                  folderId != null
+                      ? 'preset_folder_empty'.tr()
+                      : 'label_no_presets'.tr(),
+                  style: TextStyle(color: context.cs.onSurfaceVariant),
+                ),
+              ),
+            ),
+          )
+        else
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            sliver: SliverList.builder(
+              itemCount: items.length,
+              itemBuilder: (_, i) {
+                final item = items[i];
+                final active = isActive(item);
+                return Padding(
+                  key: i == activeIndex ? _activeRowKey : null,
+                  padding: const EdgeInsets.only(bottom: 10),
+                  child: _PsCard(
+                    item: item,
+                    isActive: active,
+                    selectionMode: selection.active,
+                    isSelected: selection.contains(item.id, item.kind),
+                    onTap: () => _onCardTap(item, active),
+                    onLongPress: () => ref
+                        .read(presetSelectionProvider.notifier)
+                        .start(item.id, item.kind),
+                    onConnections: item.isAgentic
+                        ? null
+                        : () => showPresetConnections(context, item.preset!.id),
+                    onEdit: item.isAgentic
+                        ? () => _openStudioEditor(item.studioPreset!.id)
+                        : () => _openEditor(item.preset),
+                    onMenu: () => _showItemMenu(item),
+                  ),
+                );
+              },
+            ),
+          ),
+        SliverPadding(
+          padding: EdgeInsets.fromLTRB(16, 4, 16, 16 + bottomInset),
+          sliver: SliverToBoxAdapter(child: _buildAddButton(context)),
+        ),
+      ],
     );
   }
 
-  Widget _buildAddButton(BuildContext context, WidgetRef ref) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 4),
-      child: Material(
-        color: context.cs.primary,
+  void _onCardTap(PresetItem item, bool isActive) {
+    if (ref.read(presetSelectionProvider).active) {
+      ref.read(presetSelectionProvider.notifier).toggle(item.id, item.kind);
+      return;
+    }
+    if (isActive) return;
+    if (item.isAgentic) {
+      ref.read(activeStudioPresetProvider.notifier).set(item.studioPreset!.id);
+      ref.read(studioFeatureEnabledProvider.notifier).enable();
+    } else {
+      setActivePreset(ref, item.preset!.id);
+      // Switching to a plain preset turns Studio off so the agentic pipeline
+      // stops overriding it.
+      ref.read(studioFeatureEnabledProvider.notifier).setEnabled(false);
+    }
+  }
+
+  /// Jumps the list so the active preset is visible on open. Runs at most once.
+  void _scheduleAutoScroll(int index) {
+    if (_didAutoScroll || index < 0) return;
+    _didAutoScroll = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) => _revealIndex(index));
+  }
+
+  void _revealIndex(int index) {
+    if (!mounted || !_scrollController.hasClients) return;
+
+    final headerBox =
+        _headerKey.currentContext?.findRenderObject() as RenderBox?;
+    final double headerExtent = headerBox?.size.height ?? 0.0;
+    final viewport = _scrollController.position.viewportDimension;
+    // Land the row a quarter of the way down the viewport rather than flush
+    // against the top edge, so the presets around it stay in context. Cards
+    // carrying a cover are taller than [_kRowExtent], so this is only a first
+    // approximation.
+    final double estimate =
+        headerExtent + index * _kRowExtent - viewport * 0.25;
+    _scrollController.jumpTo(
+      estimate.clamp(0.0, _scrollController.position.maxScrollExtent),
+    );
+
+    // Correct the estimate now that the row itself is built (it is, after that
+    // jump — the error stays inside the viewport's cache extent).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = _activeRowKey.currentContext;
+      if (!mounted || ctx == null) return;
+      Scrollable.ensureVisible(
+        ctx,
+        alignment: 0.25,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+
+  Widget _buildAddButton(BuildContext context) {
+    return Material(
+      color: context.cs.primary,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        onTap: () => _showAddSheet(context),
         borderRadius: BorderRadius.circular(14),
-        child: InkWell(
-          onTap: () => _showAddSheet(context, ref),
-          borderRadius: BorderRadius.circular(14),
-          splashColor: Colors.white.withValues(alpha: 0.1),
-          child: const Padding(
-            padding: EdgeInsets.symmetric(vertical: 14),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(Icons.add, color: Colors.white, size: 20),
-                SizedBox(width: 8),
-                Text(
-                  'Add / Import',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 15,
-                    fontWeight: FontWeight.w600,
-                  ),
+        splashColor: Colors.white.withValues(alpha: 0.1),
+        child: const Padding(
+          padding: EdgeInsets.symmetric(vertical: 14),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.add, color: Colors.white, size: 20),
+              SizedBox(width: 8),
+              Text(
+                'Add / Import',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),
     );
   }
 
-  void _showAddSheet(BuildContext context, WidgetRef ref) {
+  // ─── filters ───────────────────────────────────────────────────────────
+
+  void _showFilterSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: true,
+      useSafeArea: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => PresetFilterSheet(
+        filters: _filters,
+        showTypeFilter:
+            (ref.read(studioPresetListProvider).value ?? const []).isNotEmpty,
+        onApply: (f) {
+          if (mounted) setState(() => _filters = f);
+        },
+      ),
+    );
+  }
+
+  // ─── per-row overflow menu ─────────────────────────────────────────────
+
+  void _showItemMenu(PresetItem item) {
+    if (item.isAgentic) {
+      _showAgenticMenu(item.studioPreset!);
+    } else {
+      _showPlainMenu(item.preset!);
+    }
+  }
+
+  void _showPlainMenu(Preset preset) {
+    final notifier = ref.read(presetListProvider.notifier);
+    showPresetOptions(
+      context,
+      isFeatured: isFeaturedPreset(preset.id),
+      hasImage: preset.imagePath != null && preset.imagePath!.isNotEmpty,
+      canDelete: true,
+      onRename: () => showPresetRename(
+        context,
+        currentName: preset.name,
+        onRename: (val) {
+          final name = val.trim();
+          if (name.isEmpty) return;
+          unawaited(notifier.updatePreset(preset.copyWith(name: name)));
+        },
+      ),
+      onSetAuthor: () => showPresetAuthorDialog(
+        context,
+        currentAuthor: preset.author ?? '',
+        onSubmit: (val) => unawaited(
+          notifier.updatePreset(
+            preset.copyWith(author: val.isEmpty ? null : val),
+          ),
+        ),
+      ),
+      onPickImage: () => unawaited(_changeCover(preset)),
+      onRemoveImage: () => unawaited(_removeCover(preset)),
+      onAddToFolder: () => _showAddToFolder([
+        PresetFolderTarget(preset.id, PresetKind.normal),
+      ]),
+      onClone: () => unawaited(_clonePreset(preset)),
+      onExport: () => unawaited(exportPreset(context, preset)),
+      onDelete: () => unawaited(
+        deletePresetAndFolderMemberships(ref, preset.id, PresetKind.normal),
+      ),
+    );
+  }
+
+  Future<void> _clonePreset(Preset preset) async {
+    await ref.read(presetListProvider.notifier).clone(preset);
+    if (mounted) GlazeToast.show(context, 'Preset cloned');
+  }
+
+  Future<void> _changeCover(Preset preset) async {
+    final path = await pickPresetCover(ref, preset.id);
+    if (path == null || !mounted) return;
+    await ref
+        .read(presetListProvider.notifier)
+        .updatePreset(preset.copyWith(imagePath: path));
+    if (!mounted) return;
+    final storage = await ref.read(imageStorageProvider.future);
+    await deleteStoredPresetCover(storage, preset.imagePath);
+  }
+
+  Future<void> _removeCover(Preset preset) async {
+    await ref
+        .read(presetListProvider.notifier)
+        .updatePreset(preset.copyWith(imagePath: null));
+    if (!mounted) return;
+    final storage = await ref.read(imageStorageProvider.future);
+    await deleteStoredPresetCover(storage, preset.imagePath);
+  }
+
+  void _showAgenticMenu(StudioPreset preset) {
+    showStudioPresetOptions(
+      context,
+      preset: preset,
+      onRename: () => showStudioPresetRename(
+        context,
+        preset: preset,
+        onRename: (name) => unawaited(_renameAgentic(preset, name)),
+      ),
+      onClone: () => unawaited(_cloneAgentic(preset)),
+      onAddToFolder: () => _showAddToFolder([
+        PresetFolderTarget(preset.id, PresetKind.agentic),
+      ]),
+      onExport: () => unawaited(exportStudioPreset(context, preset)),
+      onDelete: () => unawaited(_deleteAgentic(preset)),
+    );
+  }
+
+  Future<void> _renameAgentic(StudioPreset preset, String name) async {
+    await ref
+        .read(studioPresetRepoProvider)
+        .upsert(
+          preset.copyWith(name: name, updatedAt: currentTimestampSeconds()),
+        );
+    if (mounted) ref.invalidate(studioPresetListProvider);
+  }
+
+  Future<void> _cloneAgentic(StudioPreset preset) async {
+    final now = currentTimestampSeconds();
+    await ref
+        .read(studioPresetRepoProvider)
+        .upsert(
+          preset.copyWith(
+            id: 'studio_$now',
+            name: '${preset.name} (copy)',
+            blocks: [...preset.blocks],
+            agentEnabled: {...preset.agentEnabled},
+            updatedAt: now,
+          ),
+        );
+    if (!mounted) return;
+    ref.invalidate(studioPresetListProvider);
+    GlazeToast.show(context, 'studio_preset_cloned'.tr());
+  }
+
+  Future<void> _deleteAgentic(StudioPreset preset) async {
+    final ok = await confirmStudioDelete(
+      context,
+      title: 'studio_delete_preset'.tr(),
+      description: 'studio_confirm_delete_preset'.tr(args: [preset.name]),
+    );
+    if (!ok || !mounted) return;
+    await deletePresetAndFolderMemberships(ref, preset.id, PresetKind.agentic);
+  }
+
+  // ─── add / import ──────────────────────────────────────────────────────
+
+  void _showAddSheet(BuildContext context) {
     GlazeBottomSheet.show<void>(
       context,
       title: 'Add Preset',
@@ -262,7 +647,7 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
           label: 'Add Agentic Preset',
           onTap: () {
             Navigator.of(context, rootNavigator: true).pop();
-            _createAgenticPreset(ref);
+            _createAgenticPreset();
           },
         ),
         BottomSheetItem(
@@ -270,14 +655,34 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
           label: 'Import from File',
           onTap: () {
             Navigator.of(context, rootNavigator: true).pop();
-            _importPreset(ref);
+            _importPreset();
+          },
+        ),
+        BottomSheetItem(
+          icon: Icons.create_new_folder_rounded,
+          label: 'folder_new'.tr(),
+          onTap: () {
+            Navigator.of(context, rootNavigator: true).pop();
+            _createFolder(context);
           },
         ),
       ],
     );
   }
 
-  Future<void> _createAgenticPreset(WidgetRef ref) async {
+  void _createFolder(BuildContext context) {
+    GlazeBottomSheet.show<void>(
+      context,
+      title: 'folder_create_title'.tr(),
+      child: FolderNameDialog(
+        confirmLabel: 'btn_create'.tr(),
+        onSubmit: (name) =>
+            ref.read(presetFolderRepoProvider).create(name: name),
+      ),
+    );
+  }
+
+  Future<void> _createAgenticPreset() async {
     final ctx = context;
     try {
       final repo = ref.read(studioPresetRepoProvider);
@@ -305,7 +710,7 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
     }
   }
 
-  Future<void> _importPreset(WidgetRef ref) async {
+  Future<void> _importPreset() async {
     final ctx = context;
     FilePickerResult? result;
     try {
@@ -375,34 +780,201 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
           : 'Imported ${imported.length} presets',
     );
   }
-}
 
-int _presetTokenCount(Preset preset) => presetOnlyTokenCount(preset);
+  // ─── multi-select bulk actions ─────────────────────────────────────────
 
+  /// Resolves the current selection back to items, skipping keys whose preset
+  /// disappeared while the sheet was open.
+  List<PresetItem> _selectedItems(PresetSelectionState selection) {
+    final presets = ref.read(presetListProvider).value ?? const <Preset>[];
+    final studio =
+        ref.read(studioPresetListProvider).value ?? const <StudioPreset>[];
+    return <PresetItem>[
+      for (final p in presets) PresetItem(preset: p),
+      for (final sp in studio) PresetItem(studioPreset: sp),
+    ].where((e) => selection.keys.contains(e.memberKey)).toList();
+  }
 
+  void _showSelectionActions(
+    BuildContext context,
+    PresetSelectionState selection,
+  ) {
+    final folderId = _currentFolderId;
+    GlazeBottomSheet.show<void>(
+      context,
+      title: '${selection.count} ${'selected_count'.tr()}',
+      items: [
+        BottomSheetItem(
+          icon: Icons.share_rounded,
+          label: 'action_export'.tr(),
+          onTap: () {
+            Navigator.of(context, rootNavigator: true).pop();
+            unawaited(_massExport(context, selection));
+          },
+        ),
+        BottomSheetItem(
+          icon: Icons.create_new_folder_outlined,
+          label: 'action_add_to_folder'.tr(),
+          onTap: () {
+            Navigator.of(context, rootNavigator: true).pop();
+            _showAddToFolder([
+              for (final e in _selectedItems(selection))
+                PresetFolderTarget(e.id, e.kind),
+            ], clearSelectionWhenDone: true);
+          },
+        ),
+        if (folderId != null)
+          BottomSheetItem(
+            icon: Icons.folder_off_outlined,
+            label: 'action_remove_from_folder'.tr(),
+            onTap: () {
+              Navigator.of(context, rootNavigator: true).pop();
+              unawaited(_removeSelectedFromFolder(folderId, selection));
+            },
+          ),
+        BottomSheetItem(
+          icon: Icons.delete_rounded,
+          label: 'action_delete'.tr(),
+          isDestructive: true,
+          onTap: () {
+            Navigator.of(context, rootNavigator: true).pop();
+            _confirmDeleteSelected(context, selection);
+          },
+        ),
+      ],
+    );
+  }
 
-// ─── preset item wrapper ──────────────────────────────────────────────────────
+  void _showAddToFolder(
+    List<PresetFolderTarget> targets, {
+    bool clearSelectionWhenDone = false,
+  }) {
+    if (targets.isEmpty) return;
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: true,
+      useSafeArea: true,
+      backgroundColor: Colors.transparent,
+      builder: (_) => AddPresetsToFolderSheet(
+        targets: targets,
+        onDone: clearSelectionWhenDone
+            ? () => ref.read(presetSelectionProvider.notifier).clear()
+            : null,
+      ),
+    );
+  }
 
-class _PresetItem {
-  final Preset? preset;
-  final StudioPreset? studioPreset;
-  _PresetItem({this.preset, this.studioPreset});
-  bool get isAgentic => studioPreset != null;
+  Future<void> _massExport(
+    BuildContext context,
+    PresetSelectionState selection,
+  ) async {
+    var exported = 0;
+    String? lastError;
+    for (final item in _selectedItems(selection)) {
+      try {
+        if (item.isAgentic) {
+          await saveStudioPresetJson(item.studioPreset!);
+        } else {
+          await savePresetJson(item.preset!);
+        }
+        exported++;
+      } catch (e) {
+        lastError = '$e';
+      }
+    }
+    if (!context.mounted) return;
+    ref.read(presetSelectionProvider.notifier).clear();
+    if (exported > 0) {
+      GlazeToast.show(context, 'preset_exported_toast'.plural(exported));
+    } else if (lastError != null) {
+      GlazeToast.show(context, lastError);
+    }
+  }
+
+  Future<void> _removeSelectedFromFolder(
+    String folderId,
+    PresetSelectionState selection,
+  ) async {
+    final repo = ref.read(presetFolderRepoProvider);
+    for (final item in _selectedItems(selection)) {
+      await repo.removeMember(folderId, item.id, item.kind);
+    }
+    if (!mounted) return;
+    ref.read(presetSelectionProvider.notifier).clear();
+  }
+
+  void _confirmDeleteSelected(
+    BuildContext context,
+    PresetSelectionState selection,
+  ) {
+    // The built-in `default` agentic preset is re-seeded on demand, so deleting
+    // it would only look like it worked.
+    final deletable = _selectedItems(selection)
+        .where((e) => !(e.isAgentic && e.id == 'default'))
+        .toList();
+    if (deletable.isEmpty) {
+      GlazeToast.show(context, 'preset_delete_none_toast'.tr());
+      return;
+    }
+
+    GlazeBottomSheet.show<void>(
+      context,
+      title: 'action_delete'.tr(),
+      bigInfo: BottomSheetBigInfo(
+        icon: Icons.delete_outline,
+        description: 'preset_delete_many_confirm'.plural(deletable.length),
+      ),
+      items: [
+        BottomSheetItem(
+          label: 'btn_delete'.tr(),
+          isDestructive: true,
+          centered: true,
+          onTap: () async {
+            Navigator.of(context, rootNavigator: true).pop();
+            ref.read(presetSelectionProvider.notifier).clear();
+            for (final item in deletable) {
+              // Each delete awaits a DB round-trip; bail out if the screen went
+              // away in the meantime rather than reading a disposed ref.
+              if (!mounted) return;
+              await deletePresetAndFolderMemberships(ref, item.id, item.kind);
+            }
+          },
+        ),
+        BottomSheetItem(
+          label: 'btn_cancel'.tr(),
+          centered: true,
+          onTap: () => Navigator.of(context, rootNavigator: true).pop(),
+        ),
+      ],
+    );
+  }
 }
 
 // ─── ps-card ─────────────────────────────────────────────────────────────────
 
 class _PsCard extends ConsumerWidget {
-  final _PresetItem item;
+  final PresetItem item;
   final bool isActive;
-  final VoidCallback onActivate;
+
+  /// While the list is multi-selecting, the row's action buttons give way to a
+  /// check mark and a tap anywhere on the card toggles it.
+  final bool selectionMode;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+  final VoidCallback onMenu;
   final VoidCallback? onConnections;
   final VoidCallback? onEdit;
 
   const _PsCard({
     required this.item,
     required this.isActive,
-    required this.onActivate,
+    required this.selectionMode,
+    required this.isSelected,
+    required this.onTap,
+    required this.onLongPress,
+    required this.onMenu,
     this.onConnections,
     this.onEdit,
   });
@@ -453,6 +1025,10 @@ class _PsCard extends ConsumerWidget {
       baseTint,
     );
 
+    // While selecting, the highlight tracks the checkbox rather than which
+    // preset is in effect.
+    final highlighted = selectionMode ? isSelected : isActive;
+
     final Widget content;
     if (item.isAgentic) {
       content = Padding(
@@ -483,8 +1059,8 @@ class _PsCard extends ConsumerWidget {
     // changes to `end` fade the border (and its tint) between the two states.
     return TweenAnimationBuilder<double>(
       tween: Tween<double>(
-        begin: isActive ? 1.0 : 0.0,
-        end: isActive ? 1.0 : 0.0,
+        begin: highlighted ? 1.0 : 0.0,
+        end: highlighted ? 1.0 : 0.0,
       ),
       duration: _activeFade,
       curve: Curves.easeOut,
@@ -497,7 +1073,8 @@ class _PsCard extends ConsumerWidget {
           color: Color.lerp(idleBorder, activeBorder, t)!,
           width: idleWidth + (_accentBorderWidth - idleWidth) * t,
         ),
-        onTap: onActivate,
+        onTap: onTap,
+        onLongPress: onLongPress,
         child: child!,
       ),
     );
@@ -593,6 +1170,8 @@ class _PsCard extends ConsumerWidget {
             children: [
               Text(
                 preset.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
                 style: TextStyle(
                   fontSize: 15,
                   fontWeight: FontWeight.w600,
@@ -604,7 +1183,7 @@ class _PsCard extends ConsumerWidget {
                 children: [
                   _SmallBadge(
                     icon: Icons.description,
-                    label: '${_presetTokenCount(preset)}',
+                    label: '${item.tokens}',
                     foreground: secondaryText,
                     onCover: onCover,
                   ),
@@ -624,32 +1203,28 @@ class _PsCard extends ConsumerWidget {
           ),
         ),
         const SizedBox(width: 8),
-        // Connection badge — tappable, colour shows binding type
-        _ConnBadge(
-          isActive: isActive,
-          hasChatBinding: hasChatBinding,
-          hasCharBinding: hasCharBinding,
-          onTap: onConnections ?? () {},
-        ),
-        const SizedBox(width: 8),
-        // Edit button
-        SizedBox(
-          width: 34,
-          height: 34,
-          child: Material(
-            color: Colors.transparent,
-            borderRadius: BorderRadius.circular(8),
-            child: InkWell(
-              onTap: onEdit,
-              borderRadius: BorderRadius.circular(8),
-              child: Icon(
-                Icons.edit_outlined,
-                size: 18,
-                color: secondaryText,
-              ),
-            ),
+        if (selectionMode)
+          _SelectionCheck(selected: isSelected, onCover: onCover)
+        else ...[
+          // Connection badge — tappable, colour shows binding type
+          _ConnBadge(
+            isActive: isActive,
+            hasChatBinding: hasChatBinding,
+            hasCharBinding: hasCharBinding,
+            onTap: onConnections ?? () {},
           ),
-        ),
+          const SizedBox(width: 4),
+          _RowIconButton(
+            icon: Icons.edit_outlined,
+            color: secondaryText,
+            onTap: onEdit,
+          ),
+          _RowIconButton(
+            icon: Icons.more_vert,
+            color: secondaryText,
+            onTap: onMenu,
+          ),
+        ],
       ],
     );
   }
@@ -657,7 +1232,7 @@ class _PsCard extends ConsumerWidget {
   /// Agentic counterpart of [_buildRow]: same circular icon + name + badge-row
   /// layout as a plain preset, so both kinds render identically. Differs only
   /// in the leading glyph and the badges (token estimate + requests-per-turn),
-  /// and has no connection badge or inline editor.
+  /// and has no connection badge.
   Widget _buildAgenticRow(BuildContext context) {
     final sp = item.studioPreset!;
     return Row(
@@ -695,7 +1270,7 @@ class _PsCard extends ConsumerWidget {
                 children: [
                   _SmallBadge(
                     icon: Icons.memory,
-                    label: '${studioPresetTokenEstimate(sp)}',
+                    label: '${item.tokens}',
                     foreground: context.cs.onSurfaceVariant,
                   ),
                   const SizedBox(width: 8),
@@ -712,33 +1287,82 @@ class _PsCard extends ConsumerWidget {
           ),
         ),
         const SizedBox(width: 8),
-        // Edit button — opens the Studio agents sheet for this preset. Agentic
-        // presets are global, so there is no per-chat/character connection
-        // badge like a plain preset has.
-        SizedBox(
-          width: 34,
-          height: 34,
-          child: Material(
-            color: Colors.transparent,
-            borderRadius: BorderRadius.circular(8),
-            child: InkWell(
-              onTap: onEdit,
-              borderRadius: BorderRadius.circular(8),
-              child: Icon(
-                Icons.edit_outlined,
-                size: 18,
-                color: context.cs.onSurfaceVariant,
-              ),
-            ),
+        if (selectionMode)
+          _SelectionCheck(selected: isSelected, onCover: false)
+        else ...[
+          // Agentic presets are global, so there is no per-chat/character
+          // connection badge like a plain preset has.
+          _RowIconButton(
+            icon: Icons.edit_outlined,
+            color: context.cs.onSurfaceVariant,
+            onTap: onEdit,
           ),
-        ),
+          _RowIconButton(
+            icon: Icons.more_vert,
+            color: context.cs.onSurfaceVariant,
+            onTap: onMenu,
+          ),
+        ],
       ],
     );
   }
-
 }
 
 // ─── shared small widgets ─────────────────────────────────────────────────────
+
+class _RowIconButton extends StatelessWidget {
+  final IconData icon;
+  final Color color;
+  final VoidCallback? onTap;
+
+  const _RowIconButton({
+    required this.icon,
+    required this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 32,
+      height: 34,
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(8),
+          child: Icon(icon, size: 18, color: color),
+        ),
+      ),
+    );
+  }
+}
+
+/// Check mark that replaces a row's action buttons while multi-selecting.
+class _SelectionCheck extends StatelessWidget {
+  final bool selected;
+  final bool onCover;
+
+  const _SelectionCheck({required this.selected, required this.onCover});
+
+  @override
+  Widget build(BuildContext context) {
+    final idle = onCover
+        ? Colors.white.withValues(alpha: 0.7)
+        : context.cs.onSurfaceVariant.withValues(alpha: 0.5);
+    return Padding(
+      padding: const EdgeInsets.only(right: 4),
+      child: Icon(
+        selected
+            ? Icons.check_circle_rounded
+            : Icons.radio_button_unchecked_rounded,
+        size: 22,
+        color: selected ? context.cs.primary : idle,
+      ),
+    );
+  }
+}
 
 class _SmallBadge extends StatelessWidget {
   final IconData icon;
@@ -827,6 +1451,96 @@ class _ConnBadge extends StatelessWidget {
           borderRadius: BorderRadius.circular(8),
         ),
         child: Icon(Icons.link, size: 16, color: color),
+      ),
+    );
+  }
+}
+
+/// Bottom selection bar shown while multi-selecting presets. Mirrors the chat's
+/// message-selection bar: a glass pill with a cancel button, the selected
+/// count, and a "more" button that opens the bulk-actions sheet.
+class _SelectionBar extends StatelessWidget {
+  final int count;
+  final VoidCallback onCancel;
+  final VoidCallback onMore;
+
+  const _SelectionBar({
+    required this.count,
+    required this.onCancel,
+    required this.onMore,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      elevation: 0,
+      borderRadius: BorderRadius.circular(28),
+      child: GlassSurface(
+        borderRadius: BorderRadius.circular(28),
+        tint: context.cs.surface,
+        border: Border.all(color: context.cs.primary.withValues(alpha: 0.18)),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 56),
+          child: Row(
+            children: [
+              const SizedBox(width: 8),
+              _CircleIconBtn(icon: Icons.close_rounded, onTap: onCancel),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  '$count ${'selected_count'.tr()}',
+                  style: TextStyle(
+                    color: context.cs.onSurface,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              _CircleIconBtn(
+                icon: Icons.more_horiz_rounded,
+                onTap: count > 0 ? onMore : null,
+              ),
+              const SizedBox(width: 8),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CircleIconBtn extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback? onTap;
+
+  const _CircleIconBtn({required this.icon, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: SizedBox(
+        width: 40,
+        height: 40,
+        child: GlassSurface(
+          borderRadius: BorderRadius.circular(20),
+          tint: context.cs.surface,
+          border: Border.all(
+            color: context.cs.primary.withValues(alpha: 0.18),
+          ),
+          child: Center(
+            child: Icon(
+              icon,
+              size: 20,
+              color: onTap != null
+                  ? context.cs.primary
+                  : context.cs.onSurfaceVariant.withValues(alpha: 0.5),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/presets/preset_selection_provider.dart
+++ b/lib/features/presets/preset_selection_provider.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/preset_folder.dart';
+
+/// Multi-select state for the Presets list. While [active], tapping a card
+/// toggles its membership instead of activating the preset; the selection bar
+/// at the bottom of the screen exposes the bulk actions (export, folder,
+/// delete). Mirrors the chat's message-selection mode.
+///
+/// Ids are stored as [presetMemberKey]s so chat and Studio presets can be
+/// selected together without their id spaces colliding.
+class PresetSelectionState {
+  final bool active;
+  final Set<String> keys;
+
+  const PresetSelectionState({this.active = false, this.keys = const {}});
+
+  int get count => keys.length;
+
+  bool contains(String presetId, PresetKind kind) =>
+      keys.contains(presetMemberKey(presetId, kind));
+}
+
+class PresetSelectionNotifier extends Notifier<PresetSelectionState> {
+  @override
+  PresetSelectionState build() => const PresetSelectionState();
+
+  /// Enters selection mode with one entry selected.
+  void start(String presetId, PresetKind kind) {
+    state = PresetSelectionState(
+      active: true,
+      keys: {presetMemberKey(presetId, kind)},
+    );
+  }
+
+  /// Toggles an entry; exits selection mode when the last one is removed.
+  void toggle(String presetId, PresetKind kind) {
+    final key = presetMemberKey(presetId, kind);
+    final next = {...state.keys};
+    if (!next.remove(key)) next.add(key);
+    state = next.isEmpty
+        ? const PresetSelectionState()
+        : PresetSelectionState(active: true, keys: next);
+  }
+
+  void clear() => state = const PresetSelectionState();
+}
+
+final presetSelectionProvider =
+    NotifierProvider<PresetSelectionNotifier, PresetSelectionState>(
+      PresetSelectionNotifier.new,
+    );

--- a/lib/features/presets/studio_preset_editor_screen.dart
+++ b/lib/features/presets/studio_preset_editor_screen.dart
@@ -4,6 +4,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/models/preset_folder.dart';
 import '../../core/models/studio_config.dart';
 import '../../core/models/studio_preset_block_groups.dart';
 import '../../core/models/studio_preset_block_reorder.dart';
@@ -19,6 +20,7 @@ import '../studio/studio_preset_stats.dart';
 import '../studio/widgets/studio_block_editor_inline.dart';
 import '../studio/widgets/studio_block_section_list.dart';
 import '../studio/widgets/studio_preset_options_sheet.dart';
+import 'preset_deletion.dart';
 import 'studio_preset_export.dart';
 import 'widgets/preset_dashboard_card.dart';
 
@@ -350,9 +352,8 @@ class StudioPresetEditorBodyState
     );
     if (!ok) return;
     _saveTimer?.cancel();
-    await ref.read(studioPresetRepoProvider).deleteById(preset.id);
+    await deletePresetAndFolderMemberships(ref, preset.id, PresetKind.agentic);
     if (!mounted) return;
-    ref.invalidate(studioPresetListProvider);
     widget.onClose();
   }
 

--- a/lib/features/presets/studio_preset_export.dart
+++ b/lib/features/presets/studio_preset_export.dart
@@ -9,24 +9,13 @@ import '../../shared/widgets/glaze_error_dialog.dart';
 import '../../shared/widgets/glaze_toast.dart';
 
 /// Exports an agentic (Studio) preset to JSON and shows a toast with the
-/// result. The payload is the model's own `toJson()` — it keeps the
-/// `agentEnabled` map, which is what the importer in `PresetListScreen` sniffs
-/// to tell an agentic file apart from a SillyTavern preset.
+/// result.
 Future<void> exportStudioPreset(
   BuildContext context,
   StudioPreset preset,
 ) async {
   try {
-    final encoded = const JsonEncoder.withIndent(
-      '  ',
-    ).convert(preset.toJson());
-    final safeName = preset.name.replaceAll(RegExp(r'[^\w\s-]'), '').trim();
-    final savedPath = await FileExportService.export(
-      data: encoded,
-      filename:
-          '${safeName.isNotEmpty ? safeName : 'agentic_preset'}.json',
-      subfolder: 'presets',
-    );
+    final savedPath = await saveStudioPresetJson(preset);
     if (context.mounted) {
       GlazeToast.show(context, 'export_saved_to'.tr(args: [savedPath]));
     }
@@ -39,4 +28,19 @@ Future<void> exportStudioPreset(
       );
     }
   }
+}
+
+/// Writes [preset] to a JSON file and returns the saved path. The payload is
+/// the model's own `toJson()` — it keeps the `agentEnabled` map, which is what
+/// the importer in `PresetListScreen` sniffs to tell an agentic file apart from
+/// a SillyTavern preset. Split out of [exportStudioPreset] so bulk export can
+/// report one summary instead of a toast per file.
+Future<String> saveStudioPresetJson(StudioPreset preset) {
+  final encoded = const JsonEncoder.withIndent('  ').convert(preset.toJson());
+  final safeName = preset.name.replaceAll(RegExp(r'[^\w\s-]'), '').trim();
+  return FileExportService.export(
+    data: encoded,
+    filename: '${safeName.isNotEmpty ? safeName : 'agentic_preset'}.json',
+    subfolder: 'presets',
+  );
 }

--- a/lib/features/presets/widgets/add_presets_to_folder_sheet.dart
+++ b/lib/features/presets/widgets/add_presets_to_folder_sheet.dart
@@ -2,99 +2,46 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../core/state/character_folder_provider.dart';
+import '../../../core/models/preset_folder.dart';
+import '../../../core/state/preset_folder_provider.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/folder_name_dialog.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../../shared/widgets/sheet_view.dart';
-import '../../../shared/widgets/folder_name_dialog.dart';
 
-/// Multi-select sheet to toggle a character's folder memberships. A character
-/// may be in many folders; tapping a row toggles that membership immediately
-/// (the sheet stays open). Adding to a folder it's already in is a no-op.
-class AddToFolderSheet extends ConsumerWidget {
-  final String characterId;
+/// A preset the folder sheet can act on, identified the way membership rows
+/// store it.
+class PresetFolderTarget {
+  final String id;
+  final PresetKind kind;
 
-  const AddToFolderSheet({super.key, required this.characterId});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final folders = ref.watch(characterFoldersProvider).value ?? const [];
-    final memberships =
-        ref.watch(folderMembershipsProvider).value ?? FolderMemberships.empty;
-    final selected = memberships.foldersOf(characterId);
-    final repo = ref.read(characterFolderRepoProvider);
-
-    return SheetView(
-      title: 'action_add_to_folder'.tr(),
-      showHandle: true,
-      bodyPadding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-      body: ListView(
-        children: [
-          const SizedBox(height: 8),
-          _NewFolderTile(
-            onTap: () => GlazeBottomSheet.show<void>(
-              context,
-              title: 'folder_create_title'.tr(),
-              child: FolderNameDialog(
-                confirmLabel: 'btn_create'.tr(),
-                onSubmit: (name) async {
-                  final folder = await repo.create(name: name);
-                  await repo.addMember(folder.id, characterId);
-                },
-              ),
-            ),
-          ),
-          if (folders.isEmpty)
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 24),
-              child: Center(
-                child: Text(
-                  'folder_empty'.tr(),
-                  style: TextStyle(color: context.cs.onSurfaceVariant),
-                ),
-              ),
-            ),
-          for (final folder in folders)
-            _FolderToggleTile(
-              name: folder.name,
-              count: memberships.countFor(folder.id),
-              selected: selected.contains(folder.id),
-              onTap: () {
-                if (selected.contains(folder.id)) {
-                  repo.removeMember(folder.id, characterId);
-                } else {
-                  repo.addMember(folder.id, characterId);
-                }
-              },
-            ),
-        ],
-      ),
-    );
-  }
+  const PresetFolderTarget(this.id, this.kind);
 }
 
-/// Bulk variant of [AddToFolderSheet]: tapping a folder adds every character in
-/// [characterIds] to it at once, then closes the sheet and runs [onDone].
-class AddCharactersToFolderSheet extends ConsumerWidget {
-  final Set<String> characterIds;
+/// Bulk "add to folder" sheet for the Presets list: tapping a folder adds every
+/// preset in [targets] to it at once, then closes and runs [onDone]. Mirrors
+/// `AddCharactersToFolderSheet`.
+class AddPresetsToFolderSheet extends ConsumerWidget {
+  final List<PresetFolderTarget> targets;
   final VoidCallback? onDone;
 
-  const AddCharactersToFolderSheet({
+  const AddPresetsToFolderSheet({
     super.key,
-    required this.characterIds,
+    required this.targets,
     this.onDone,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final folders = ref.watch(characterFoldersProvider).value ?? const [];
+    final folders = ref.watch(presetFoldersProvider).value ?? const [];
     final memberships =
-        ref.watch(folderMembershipsProvider).value ?? FolderMemberships.empty;
-    final repo = ref.read(characterFolderRepoProvider);
+        ref.watch(presetFolderMembershipsProvider).value ??
+        PresetFolderMemberships.empty;
+    final repo = ref.read(presetFolderRepoProvider);
 
     Future<void> addAllTo(String folderId) async {
-      for (final id in characterIds) {
-        await repo.addMember(folderId, id);
+      for (final t in targets) {
+        await repo.addMember(folderId, t.id, t.kind);
       }
     }
 
@@ -124,16 +71,15 @@ class AddCharactersToFolderSheet extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(vertical: 24),
               child: Center(
                 child: Text(
-                  'folder_empty'.tr(),
+                  'preset_folder_empty'.tr(),
                   style: TextStyle(color: context.cs.onSurfaceVariant),
                 ),
               ),
             ),
           for (final folder in folders)
-            _FolderToggleTile(
+            _FolderTile(
               name: folder.name,
               count: memberships.countFor(folder.id),
-              selected: false,
               onTap: () async {
                 await addAllTo(folder.id);
                 if (context.mounted) {
@@ -166,8 +112,11 @@ class _NewFolderTile extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
             child: Row(
               children: [
-                Icon(Icons.create_new_folder_rounded,
-                    size: 20, color: context.cs.primary),
+                Icon(
+                  Icons.create_new_folder_rounded,
+                  size: 20,
+                  color: context.cs.primary,
+                ),
                 const SizedBox(width: 12),
                 Text(
                   'folder_new'.tr(),
@@ -186,16 +135,14 @@ class _NewFolderTile extends StatelessWidget {
   }
 }
 
-class _FolderToggleTile extends StatelessWidget {
+class _FolderTile extends StatelessWidget {
   final String name;
   final int count;
-  final bool selected;
   final VoidCallback onTap;
 
-  const _FolderToggleTile({
+  const _FolderTile({
     required this.name,
     required this.count,
-    required this.selected,
     required this.onTap,
   });
 
@@ -216,9 +163,7 @@ class _FolderToggleTile extends StatelessWidget {
                 Icon(
                   Icons.folder_rounded,
                   size: 20,
-                  color: selected
-                      ? context.cs.primary
-                      : context.cs.onSurfaceVariant,
+                  color: context.cs.onSurfaceVariant,
                 ),
                 const SizedBox(width: 12),
                 Expanded(
@@ -226,10 +171,7 @@ class _FolderToggleTile extends StatelessWidget {
                     name,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 15,
-                      color: context.cs.onSurface,
-                    ),
+                    style: TextStyle(fontSize: 15, color: context.cs.onSurface),
                   ),
                 ),
                 Text(
@@ -238,16 +180,6 @@ class _FolderToggleTile extends StatelessWidget {
                     fontSize: 13,
                     color: context.cs.onSurfaceVariant,
                   ),
-                ),
-                const SizedBox(width: 12),
-                Icon(
-                  selected
-                      ? Icons.check_circle_rounded
-                      : Icons.radio_button_unchecked_rounded,
-                  size: 22,
-                  color: selected
-                      ? context.cs.primary
-                      : context.cs.onSurfaceVariant.withValues(alpha: 0.5),
                 ),
               ],
             ),

--- a/lib/features/presets/widgets/preset_filter_sheet.dart
+++ b/lib/features/presets/widgets/preset_filter_sheet.dart
@@ -1,0 +1,231 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import '../../../core/models/preset_folder.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/filter_sheet.dart';
+import '../preset_entry.dart';
+
+/// Filter state for the Presets list: preset type (chat / Studio agent) and an
+/// estimated-token range.
+class PresetListFilters {
+  static const int defaultMinTokens = 0;
+  static const int defaultMaxTokens = 100000;
+
+  /// Empty means "every type" — the same convention the tag filters use.
+  final Set<PresetKind> kinds;
+  final int minTokens;
+  final int maxTokens;
+
+  const PresetListFilters({
+    this.kinds = const {},
+    this.minTokens = defaultMinTokens,
+    this.maxTokens = defaultMaxTokens,
+  });
+
+  bool get hasTokenFilter =>
+      minTokens != defaultMinTokens || maxTokens != defaultMaxTokens;
+
+  bool get isActive => kinds.isNotEmpty || hasTokenFilter;
+
+  int get activeCount =>
+      kinds.length +
+      (minTokens != defaultMinTokens ? 1 : 0) +
+      (maxTokens != defaultMaxTokens ? 1 : 0);
+
+  bool matches(PresetItem entry) {
+    if (kinds.isNotEmpty && !kinds.contains(entry.kind)) return false;
+    // Reading `tokens` triggers the (lazy) count, so only touch it when a range
+    // is actually set.
+    if (hasTokenFilter &&
+        (entry.tokens < minTokens || entry.tokens > maxTokens)) {
+      return false;
+    }
+    return true;
+  }
+
+  PresetListFilters copyWith({
+    Set<PresetKind>? kinds,
+    int? minTokens,
+    int? maxTokens,
+  }) => PresetListFilters(
+    kinds: kinds ?? this.kinds,
+    minTokens: minTokens ?? this.minTokens,
+    maxTokens: maxTokens ?? this.maxTokens,
+  );
+}
+
+/// Reuses the shared [FilterSheet] to filter the Presets list. Mirrors
+/// [CharacterFilterSheet]'s apply-on-dispose pattern.
+class PresetFilterSheet extends StatefulWidget {
+  final PresetListFilters filters;
+
+  /// False when the Studio master switch is off — the list then only holds chat
+  /// presets, so the type section is pointless.
+  final bool showTypeFilter;
+  final ValueChanged<PresetListFilters> onApply;
+
+  const PresetFilterSheet({
+    super.key,
+    required this.filters,
+    required this.onApply,
+    this.showTypeFilter = true,
+  });
+
+  @override
+  State<PresetFilterSheet> createState() => _PresetFilterSheetState();
+}
+
+class _PresetFilterSheetState extends State<PresetFilterSheet> {
+  late Set<PresetKind> _kinds;
+  late int _minTokens;
+  late int _maxTokens;
+
+  @override
+  void initState() {
+    super.initState();
+    _kinds = Set.from(widget.filters.kinds);
+    _minTokens = widget.filters.minTokens;
+    _maxTokens = widget.filters.maxTokens;
+  }
+
+  @override
+  void dispose() {
+    final changed =
+        _minTokens != widget.filters.minTokens ||
+        _maxTokens != widget.filters.maxTokens ||
+        _kinds.length != widget.filters.kinds.length ||
+        !_kinds.containsAll(widget.filters.kinds);
+
+    if (changed) {
+      final apply = widget.onApply;
+      final result = PresetListFilters(
+        kinds: Set.from(_kinds),
+        minTokens: _minTokens,
+        maxTokens: _maxTokens,
+      );
+      Future.microtask(() => apply(result));
+    }
+    super.dispose();
+  }
+
+  void _toggleKind(PresetKind kind) {
+    setState(() {
+      if (!_kinds.remove(kind)) _kinds.add(kind);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FilterSheet(
+      title: 'catalog_filters'.tr(),
+      sections: [
+        if (widget.showTypeFilter)
+          FilterCustomSection(
+            child: _TypeSection(selected: _kinds, onToggle: _toggleKind),
+          ),
+        FilterRangeSection(
+          title: 'catalog_token_range'.tr(),
+          minLabel: 'catalog_min'.tr(),
+          maxLabel: 'catalog_max'.tr(),
+          min: _minTokens,
+          max: _maxTokens,
+          onMinChanged: (v) => setState(() => _minTokens = v),
+          onMaxChanged: (v) => setState(() => _maxTokens = v),
+        ),
+      ],
+    );
+  }
+}
+
+class _TypeSection extends StatelessWidget {
+  final Set<PresetKind> selected;
+  final ValueChanged<PresetKind> onToggle;
+
+  const _TypeSection({required this.selected, required this.onToggle});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'preset_filter_type'.tr().toUpperCase(),
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: context.cs.onSurfaceVariant,
+            letterSpacing: 0.6,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            _chip(
+              context,
+              label: 'preset_type_normal'.tr(),
+              icon: Icons.description_outlined,
+              kind: PresetKind.normal,
+            ),
+            _chip(
+              context,
+              label: 'preset_type_agentic'.tr(),
+              icon: Icons.smart_toy_outlined,
+              kind: PresetKind.agentic,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _chip(
+    BuildContext context, {
+    required String label,
+    required IconData icon,
+    required PresetKind kind,
+  }) {
+    final active = selected.contains(kind);
+    return GestureDetector(
+      onTap: () => onToggle(kind),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: active
+                ? context.cs.primary
+                : Colors.white.withValues(alpha: 0.12),
+          ),
+          color: active
+              ? context.cs.primary.withValues(alpha: 0.2)
+              : Colors.white.withValues(alpha: 0.05),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              icon,
+              size: 14,
+              color: active
+                  ? Colors.white
+                  : Colors.white.withValues(alpha: 0.65),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 13,
+                color: active
+                    ? Colors.white
+                    : Colors.white.withValues(alpha: 0.65),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/presets/widgets/preset_folders_section.dart
+++ b/lib/features/presets/widgets/preset_folders_section.dart
@@ -1,0 +1,209 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/models/preset_folder.dart';
+import '../../../core/state/preset_folder_provider.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/folder_name_dialog.dart';
+import '../../../shared/widgets/glaze_bottom_sheet.dart';
+
+/// Folders strip for the Presets list: a horizontal row of circular folder
+/// covers. Tapping opens a folder; long-pressing exposes rename/delete. New
+/// folders are created from the screen's Add sheet, not here.
+///
+/// Mirrors `CharacterFoldersSection`, minus the character-specific virtual
+/// folders (Favorites / Our Picks) and avatar covers — presets have no images,
+/// so each circle shows the folder glyph with its member count.
+class PresetFoldersSection extends ConsumerWidget {
+  final ValueChanged<String> onOpenFolder;
+
+  const PresetFoldersSection({super.key, required this.onOpenFolder});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final folders = ref.watch(presetFoldersProvider).value ?? const [];
+    if (folders.isEmpty) return const SizedBox.shrink();
+
+    final memberships =
+        ref.watch(presetFolderMembershipsProvider).value ??
+        PresetFolderMemberships.empty;
+
+    return SizedBox(
+      height: 104,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.fromLTRB(0, 12, 0, 4),
+        itemCount: folders.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 16),
+        itemBuilder: (_, i) {
+          final folder = folders[i];
+          return _FolderCircle(
+            folder: folder,
+            count: memberships.countFor(folder.id),
+            onTap: () => onOpenFolder(folder.id),
+            onLongPress: () => showPresetFolderActions(context, ref, folder),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Rename / delete actions for [folder]. Shared with the folder view's header
+/// menu so both entry points offer the same operations.
+void showPresetFolderActions(
+  BuildContext context,
+  WidgetRef ref,
+  PresetFolder folder, {
+  VoidCallback? onDeleted,
+}) {
+  GlazeBottomSheet.show<void>(
+    context,
+    title: folder.name,
+    items: [
+      BottomSheetItem(
+        icon: Icons.edit_rounded,
+        label: 'folder_rename_title'.tr(),
+        onTap: () {
+          Navigator.of(context, rootNavigator: true).pop();
+          GlazeBottomSheet.show<void>(
+            context,
+            title: 'folder_rename_title'.tr(),
+            child: FolderNameDialog(
+              initialName: folder.name,
+              confirmLabel: 'btn_save'.tr(),
+              onSubmit: (name) =>
+                  ref.read(presetFolderRepoProvider).rename(folder.id, name),
+            ),
+          );
+        },
+      ),
+      BottomSheetItem(
+        icon: Icons.delete_rounded,
+        label: 'folder_delete_title'.tr(),
+        isDestructive: true,
+        onTap: () {
+          Navigator.of(context, rootNavigator: true).pop();
+          _confirmDelete(context, ref, folder, onDeleted);
+        },
+      ),
+    ],
+  );
+}
+
+void _confirmDelete(
+  BuildContext context,
+  WidgetRef ref,
+  PresetFolder folder,
+  VoidCallback? onDeleted,
+) {
+  GlazeBottomSheet.show<void>(
+    context,
+    title: 'folder_delete_title'.tr(),
+    bigInfo: BottomSheetBigInfo(
+      icon: Icons.delete_outline,
+      description: 'preset_folder_delete_confirm'.tr(),
+    ),
+    items: [
+      BottomSheetItem(
+        label: 'btn_delete'.tr(),
+        isDestructive: true,
+        centered: true,
+        onTap: () {
+          Navigator.of(context, rootNavigator: true).pop();
+          // Fire-and-forget: the folders stream repaints the strip when the
+          // rows land.
+          ref.read(presetFolderRepoProvider).delete(folder.id);
+          onDeleted?.call();
+        },
+      ),
+      BottomSheetItem(
+        label: 'btn_cancel'.tr(),
+        centered: true,
+        onTap: () => Navigator.of(context, rootNavigator: true).pop(),
+      ),
+    ],
+  );
+}
+
+class _FolderCircle extends StatelessWidget {
+  static const double _diameter = 64;
+
+  final PresetFolder folder;
+  final int count;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+
+  const _FolderCircle({
+    required this.folder,
+    required this.count,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: SizedBox(
+        width: 72,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: _diameter,
+              height: _diameter,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [
+                    context.cs.primary.withValues(alpha: 0.35),
+                    context.cs.surfaceContainerHighest,
+                  ],
+                ),
+                border: Border.all(
+                  color: context.cs.primary.withValues(alpha: 0.25),
+                  width: 2,
+                ),
+              ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.folder_rounded,
+                    size: 24,
+                    color: Colors.white.withValues(alpha: 0.85),
+                  ),
+                  Text(
+                    '$count',
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: Colors.white.withValues(alpha: 0.75),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              folder.name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                color: context.cs.onSurface,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/presets/widgets/preset_options_sheet.dart
+++ b/lib/features/presets/widgets/preset_options_sheet.dart
@@ -1,0 +1,133 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/widgets/glaze_bottom_sheet.dart';
+
+/// The plain preset's "⋯" menu. Shared by the preset editor's dashboard card
+/// and the same button on each row of the preset list, so both entry points
+/// offer exactly the same actions. Mirrors [showStudioPresetOptions] for the
+/// agentic kind.
+///
+/// Every action is a callback: the editor applies them to its live (unsaved)
+/// state, the list writes straight through to the repository.
+void showPresetOptions(
+  BuildContext context, {
+  /// Bundled featured presets ship with a fixed author and cover image — both
+  /// are read-only. Cloning one produces a normal, fully editable preset.
+  required bool isFeatured,
+  required bool hasImage,
+  required bool canDelete,
+  required VoidCallback onRename,
+  required VoidCallback onSetAuthor,
+  required VoidCallback onPickImage,
+  required VoidCallback onRemoveImage,
+  required VoidCallback onClone,
+  required VoidCallback onExport,
+  required VoidCallback onDelete,
+  VoidCallback? onAddToFolder,
+}) {
+  void run(VoidCallback action) {
+    Navigator.of(context, rootNavigator: true).pop();
+    action();
+  }
+
+  GlazeBottomSheet.show<void>(
+    context,
+    title: 'preset_options'.tr(),
+    items: [
+      BottomSheetItem(
+        icon: Icons.drive_file_rename_outline,
+        label: 'action_rename'.tr(),
+        onTap: () => run(onRename),
+      ),
+      // Author and cover image are part of a bundled featured preset — the
+      // user edits them on a clone, not on the original.
+      if (!isFeatured)
+        BottomSheetItem(
+          icon: Icons.person_outline,
+          label: 'action_set_author'.tr(),
+          onTap: () => run(onSetAuthor),
+        ),
+      if (!isFeatured)
+        BottomSheetItem(
+          icon: Icons.image_outlined,
+          label: 'change_image'.tr(),
+          onTap: () => run(onPickImage),
+        ),
+      if (!isFeatured && hasImage)
+        BottomSheetItem(
+          icon: Icons.hide_image_outlined,
+          label: 'action_remove_image'.tr(),
+          onTap: () => run(onRemoveImage),
+        ),
+      BottomSheetItem(
+        icon: Icons.copy_outlined,
+        label: 'action_clone_block'.tr(),
+        onTap: () => run(onClone),
+      ),
+      if (onAddToFolder != null)
+        BottomSheetItem(
+          icon: Icons.create_new_folder_outlined,
+          label: 'action_add_to_folder'.tr(),
+          onTap: () => run(onAddToFolder),
+        ),
+      BottomSheetItem(
+        icon: Icons.upload_file_outlined,
+        label: 'action_export_st'.tr(),
+        onTap: () => run(onExport),
+      ),
+      if (canDelete)
+        BottomSheetItem(
+          icon: Icons.delete_outlined,
+          iconColor: const Color(0xFFFF4444),
+          label: 'action_delete_msg'.tr(),
+          isDestructive: true,
+          onTap: () => run(onDelete),
+        ),
+    ],
+  );
+}
+
+/// Rename prompt for a plain preset. [onRename] receives the raw value the
+/// user confirmed (the editor keeps empty names, falling back to "New Preset").
+void showPresetRename(
+  BuildContext context, {
+  required String currentName,
+  required ValueChanged<String> onRename,
+}) {
+  GlazeBottomSheet.show<void>(
+    context,
+    title: 'action_rename_preset'.tr(),
+    input: BottomSheetInput(
+      placeholder: 'Preset name',
+      value: currentName,
+      confirmLabel: 'Rename',
+      onConfirm: (value) {
+        Navigator.of(context, rootNavigator: true).pop();
+        onRename(value);
+      },
+    ),
+  );
+}
+
+/// Author prompt for a plain preset. [onSubmit] receives the trimmed value
+/// (empty means "no author").
+void showPresetAuthorDialog(
+  BuildContext context, {
+  required String currentAuthor,
+  required ValueChanged<String> onSubmit,
+}) {
+  GlazeBottomSheet.show<void>(
+    context,
+    title: 'action_set_author'.tr(),
+    input: BottomSheetInput(
+      placeholder: 'Author (optional)',
+      value: currentAuthor,
+      confirmLabel: 'Save',
+      onConfirm: (value) {
+        Navigator.of(context, rootNavigator: true).pop();
+        onSubmit(value.trim());
+      },
+    ),
+  );
+}

--- a/lib/features/studio/widgets/studio_preset_options_sheet.dart
+++ b/lib/features/studio/widgets/studio_preset_options_sheet.dart
@@ -13,6 +13,10 @@ void showStudioPresetOptions(
   required VoidCallback onClone,
   required VoidCallback onExport,
   required VoidCallback onDelete,
+
+  /// Omitted where folders don't apply (e.g. the editor opened outside the
+  /// preset list).
+  VoidCallback? onAddToFolder,
 }) {
   GlazeBottomSheet.show<void>(
     context,
@@ -34,6 +38,15 @@ void showStudioPresetOptions(
           onClone();
         },
       ),
+      if (onAddToFolder != null)
+        BottomSheetItem(
+          icon: Icons.create_new_folder_outlined,
+          label: 'action_add_to_folder'.tr(),
+          onTap: () {
+            Navigator.of(context, rootNavigator: true).pop();
+            onAddToFolder();
+          },
+        ),
       BottomSheetItem(
         icon: Icons.upload_file_outlined,
         label: 'action_export_st'.tr(),

--- a/lib/shared/widgets/folder_name_dialog.dart
+++ b/lib/shared/widgets/folder_name_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
-import '../../../shared/theme/app_colors.dart';
+import '../theme/app_colors.dart';
 
 /// Single-field name input for creating or renaming a folder. Shown via
 /// `GlazeBottomSheet.show(title:…, child: FolderNameDialog(...))`.

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -78,7 +78,7 @@ void main() {
 
       // user_version matches the Drift schema version (app_db.dart schemaVersion).
       // Update this constant whenever a new migration step is added.
-      expect(version, 102);
+      expect(version, 103);
     });
 
     test(

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -232,7 +232,7 @@ void main() {
         final version = await upgraded
             .customSelect('PRAGMA user_version')
             .get();
-        expect(version.first.read<int>('user_version'), 102);
+        expect(version.first.read<int>('user_version'), 103);
         expect(names, contains('variant_group_id'));
         expect(names, contains('hidden'));
       },
@@ -262,7 +262,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
     });
 
     test(
@@ -602,7 +602,7 @@ void main() {
 
     test('current schema includes atomic character fact tables', () async {
       final version = await db.customSelect('PRAGMA user_version').getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
 
       final factColumns = await db
           .customSelect("PRAGMA table_info('character_knowledge_fact_rows')")
@@ -714,7 +714,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
     });
 
     test(
@@ -824,7 +824,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
     });
 
     test('v80 adds Responses API toggle defaulting to off', () async {
@@ -864,7 +864,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
     });
 
     test('v81 adds composite embedding source index', () async {
@@ -898,7 +898,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
     });
 
     test('v82 creates rewrite persistence schema and provenance columns', () async {
@@ -972,7 +972,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
     });
 
     test('v83 rebuilds interim text revision columns without losing rows', () async {
@@ -1409,7 +1409,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
 
       // Rows and payloads survive; legacy statuses pass through or are
       // normalized fail-closed, and new columns carry neutral defaults.
@@ -1614,7 +1614,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
       final row = await upgraded
           .customSelect(
             'SELECT blocks_json FROM studio_preset_rows WHERE preset_id = ?',
@@ -1730,7 +1730,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
       final check = await upgraded.customSelect('PRAGMA integrity_check').get();
       expect(check.single.read<String>('integrity_check'), 'ok');
     });
@@ -2229,7 +2229,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 102);
+      expect(version.read<int>('user_version'), 103);
     });
 
     test(


### PR DESCRIPTION
Reworks the Presets list (`PresetListScreen`) with the four things it was missing next to the character list: folders, filtering, per-row overflow menu and multi-select.

## Folders

- Add `PresetFolders` + `PresetFolderMembers` Drift tables (schema **v103**), plus `PresetFolderRepo` and `preset_folder_provider.dart`, mirroring the character folders.
- Membership PK is `{folderId, presetId, kind}` — `PresetKind.normal` for rows in `presets`, `PresetKind.agentic` for rows in `studio_preset_rows`. The two id spaces are independent, so the kind has to be part of the key.
- `PresetFoldersSection` renders a folders strip above the list: tap to open a folder, long-press to rename/delete. Back leaves the folder before it leaves the screen.
- "New folder" in the Add sheet; "Add to folder" in both the plain and the agentic overflow menu, and as a bulk action.
- New `deletePresetAndFolderMemberships` is now the single delete path (editor, list row, Studio editor, bulk delete) so a removed preset never leaves a dangling member row. For agentic presets it routes through `StudioPresetWorkflowService.deletePreset`, which also records the sync deletion and moves the active selection — the Studio editor previously called `deleteById` directly and did neither.

## Filters

- A filter button in the sheet header opens `PresetFilterSheet` (built on the shared `FilterSheet`) with preset type (regular / agentic) and an estimated-token range.
- `PresetItem.tokens` is lazy: `presetOnlyTokenCount` resolves every block's macros, and the list rebuilds on each autosave while the editor is typing, so the count only runs for rendered rows — and for `PresetListFilters.matches` only when a token range is actually set.

## Active preset

- The list scrolls to the active preset on open (once per screen open, top level and unfiltered only): an index-based estimate, corrected by `Scrollable.ensureVisible` on the next frame since cover cards are taller than a plain row.

## Per-row overflow menu

- Add a "⋯" button next to each row's edit button, opening the same menu the preset itself has.
- The plain editor's menu is extracted into `showPresetOptions` / `showPresetRename` / `showPresetAuthorDialog` (`widgets/preset_options_sheet.dart`), so `PresetEditorBody` and the list row share one definition; agentic rows reuse the existing `showStudioPresetOptions`, which gains an optional `onAddToFolder`.
- Cover pick/remove moves out of `PresetEditorBody` into `preset_cover_service.dart` (`pickPresetCover` / `deleteStoredPresetCover`) so the list menu can change a cover too.

## Multi-select

- `presetSelectionProvider` holds the selection, keyed by `presetMemberKey` so plain and agentic presets can be selected together.
- Long-press a row to enter selection mode; while selecting, the row's action buttons give way to a check mark and a tap anywhere on the card toggles it. A glass selection bar floats at the bottom, mirroring the chat's message-selection bar.
- Bulk actions: export, add to folder, remove from folder (inside a folder view) and delete. The built-in `default` agentic preset is skipped by bulk delete, since it is re-seeded on demand.
- `savePresetJson` / `saveStudioPresetJson` are split out of `exportPreset` / `exportStudioPreset` so bulk export reports one summary instead of a toast per file.

## Incidental

- `FolderNameDialog` moves to `lib/shared/widgets/` now that both lists use it; `character_list/widgets/widgets.dart` re-exports it from the new path.
- New translation keys in `en.json` / `ru.json`: `preset_filter_type`, `preset_type_normal`, `preset_type_agentic`, `label_no_presets`, `preset_folder_empty`, `preset_folder_delete_confirm`, `preset_delete_none_toast`, `preset_exported_toast`, `preset_delete_many_confirm`.
- `docs/rules/database.md`: v103 migration entry and current-version bump.

## Verification

- `test/db_migration_test.dart` schema-version assertion bumped 102 → 103.
- **`flutter analyze` and `flutter test` were not run** — this was written in an environment with no Flutter SDK, so nothing was executed locally and CI is the only check on this branch. The new Drift tables also need `build_runner`, which CI runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Rr7ZpuMGPEw2UaS1pYhM5)_