### PR TITLE
fix(presets): decode imported Studio presets through the codec

### DIFF
--- a/lib/core/models/studio_preset_validation.dart
+++ b/lib/core/models/studio_preset_validation.dart
@@ -49,8 +49,13 @@ abstract final class StudioPresetValidator {
         issues.add(_error(block, 'Block id "$id" is duplicated.'));
       }
       if (!supportedSections.contains(block.section)) {
+        // A block in an unknown section is never assembled into a prompt, so
+        // it is inert rather than broken — and retired sections (`writeloop`)
+        // still sit in long-lived DBs, which migrations deliberately preserve
+        // as inert data. Erroring here would make a preset the app itself
+        // stores and exports impossible to import back.
         issues.add(
-          _error(block, 'Unsupported Studio section "${block.section}".'),
+          _warning(block, 'Unsupported Studio section "${block.section}".'),
         );
       }
 
@@ -71,7 +76,14 @@ abstract final class StudioPresetValidator {
           if (block.enabled &&
               block.content.trim().isEmpty &&
               !_isGroupBoundary(block.id)) {
-            issues.add(_error(block, 'Instruction content must not be empty.'));
+            // The editor lets a block carry only a title (headers and
+            // separators are built that way), and prompt assembly just emits
+            // nothing for it. Contributing nothing is not the same as being
+            // malformed, so this stays a warning — as an error it made those
+            // presets un-importable after export.
+            issues.add(
+              _warning(block, 'Instruction content must not be empty.'),
+            );
           }
         case StudioBlockType.context:
           if (block.contextSlot == null) {
@@ -135,6 +147,15 @@ abstract final class StudioPresetValidator {
     String message,
   ) => StudioPresetValidationIssue(
     severity: StudioPresetValidationSeverity.error,
+    blockId: block.id,
+    message: message,
+  );
+
+  static StudioPresetValidationIssue _warning(
+    StudioPresetBlock block,
+    String message,
+  ) => StudioPresetValidationIssue(
+    severity: StudioPresetValidationSeverity.warning,
     blockId: block.id,
     message: message,
   );

--- a/lib/features/presets/preset_list_screen.dart
+++ b/lib/features/presets/preset_list_screen.dart
@@ -12,6 +12,7 @@ import '../../core/import/silly_tavern_preset_parser.dart';
 import '../../core/models/preset.dart';
 import '../../core/models/preset_folder.dart';
 import '../../core/models/studio_config.dart';
+import '../../core/models/studio_preset_codec.dart';
 import '../../core/services/featured_presets.dart';
 import '../../core/state/active_selection_provider.dart';
 import '../../core/state/db_provider.dart';
@@ -729,6 +730,7 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
     final imported = <String>[];
     Object? lastError;
     var unreadable = 0;
+    var adjusted = 0;
 
     for (final picked in result.files) {
       try {
@@ -745,12 +747,20 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
         final json = jsonDecode(jsonString) as Map<String, dynamic>;
 
         if (json.containsKey('agentEnabled')) {
-          final studioPreset = StudioPreset.fromJson(json);
+          // Decode through the codec, not `StudioPreset.fromJson`: exported
+          // files can carry the pre-typed block shape (`kind` instead of
+          // `type`/`contextSlot`), and only the codec maps it. Without it every
+          // block silently lands as a plain instruction — context, history and
+          // memory slots included — and the validator then rejects the ones
+          // that are legitimately blank. Every other entry point (cloud sync,
+          // backup import, the repo's read path) already goes through it.
+          final decoded = StudioPresetCodec.decodePreset(json);
+          adjusted += decoded.warnings.length;
           await studioWorkflow.importPreset(
-            imported: studioPreset,
-            name: studioPreset.name,
+            imported: decoded.preset,
+            name: decoded.preset.name,
           );
-          imported.add(studioPreset.name);
+          imported.add(decoded.preset.name);
         } else {
           final preset = parseSillyTavernPreset(json, picked.name);
           await notifier.add(preset);
@@ -773,11 +783,14 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
     }
 
     final name = imported.first;
+    // Blocks the codec could not honour are carried over disabled rather than
+    // dropped, so say so instead of letting them look lost.
+    final suffix = adjusted > 0 ? ' — $adjusted block(s) adjusted' : '';
     GlazeToast.show(
       ctx,
       imported.length == 1
-          ? 'Imported "$name"'
-          : 'Imported ${imported.length} presets',
+          ? 'Imported "$name"$suffix'
+          : 'Imported ${imported.length} presets$suffix',
     );
   }
 

--- a/test/studio_preset_validation_test.dart
+++ b/test/studio_preset_validation_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glaze_flutter/core/llm/studio/studio_context.dart';
 import 'package:glaze_flutter/core/models/studio_config.dart';
+import 'package:glaze_flutter/core/models/studio_preset_codec.dart';
 import 'package:glaze_flutter/core/models/studio_preset_validation.dart';
 
 void main() {
@@ -54,6 +55,61 @@ void main() {
         'Context blocks cannot target an agent.',
         'Instruction blocks cannot select context.',
         'Unknown target agent "unknown".',
+      ]),
+    );
+  });
+
+  test('an exported legacy preset decodes into an importable preset', () {
+    // Shape of a Studio preset exported before blocks became typed: `kind`
+    // instead of `type`/`contextSlot`, runtime-injected slots with no content,
+    // a title-only separator, and the retired `writeloop` section. Import used
+    // to bypass the codec and then fail validation on all four.
+    final decoded = StudioPresetCodec.decodePreset({
+      'id': 'legacy_export',
+      'name': 'Legacy export',
+      'agentEnabled': <String, dynamic>{},
+      'blocks': [
+        {
+          'id': 'note',
+          'kind': 'authors_note',
+          'content': '',
+          'section': 'final',
+        },
+        {
+          'id': 'history',
+          'kind': 'chat_history',
+          'content': '',
+          'section': 'final',
+        },
+        {
+          'id': 'header',
+          'kind': 'custom_text',
+          'title': '━ Final Response',
+          'content': '',
+          'section': 'final',
+        },
+        {
+          'id': 'writeloop_system',
+          'kind': 'instruction',
+          'content': 'Retired write-loop prompt',
+          'section': 'writeloop',
+        },
+      ],
+    });
+
+    final blocks = decoded.preset.blocks;
+    expect(blocks[0].type, StudioBlockType.context);
+    expect(blocks[0].contextSlot, StudioContextSlot.authorsNote);
+    expect(blocks[1].type, StudioBlockType.history);
+
+    final issues = StudioPresetValidator.validate(decoded.preset);
+
+    expect(StudioPresetValidator.hasErrors(issues), isFalse);
+    expect(
+      issues.map((issue) => issue.message),
+      containsAll([
+        'Instruction content must not be empty.',
+        'Unsupported Studio section "writeloop".',
       ]),
     );
   });


### PR DESCRIPTION
Importing an exported agentic preset fails with:

> Import failed: FormatException: Invalid Studio preset: Instruction content must not be empty. Instruction content must not be empty. Unsupported Studio section "writeloop". Instruction content must not be empty. Instruction content must not be empty.

The app is refusing a file it wrote itself.

## Root cause

`PresetListScreen._importPreset` calls `StudioPreset.fromJson(json)` directly — the only Studio entry point that bypasses `StudioPresetCodec`. Cloud sync (`sync_engine.dart`), backup import (`flutter_backup_importer.dart`), the schema migration (`_migrateStudioPresetBlocksToExplicitSemantics`) and the repo's own read path (`StudioPresetRepo._rowToModel`) all go through it.

Exported files can carry the pre-typed block shape — `kind` instead of `type` / `contextSlot` — and `StudioPreset.fromJson` ignores `kind` entirely. So every block in the sample file (327 of them) decoded as `type: instruction` with no context slot: `authors_note`, `chat_history`, `memory`, `summary`, `lorebooks`, `scenario` and the rest lost their meaning, and the four that are legitimately blank (runtime-injected slots, title-only separators) then failed validation.

## Changes

- Import now decodes with `StudioPresetCodec.decodePreset`, which maps the legacy `kind` shape onto the typed model, and reports how many blocks the codec had to adjust in the import toast rather than leaving them to look lost. Legacy files also carry no `agents` key, so this additionally gets them the ontology's default agents instead of an empty list.
- `StudioPresetValidator`: **unsupported section** and **blank enabled instruction content** are now warnings, not errors. Neither breaks a preset — both are simply never assembled into a prompt — while the editor happily creates title-only separator blocks and long-lived DBs still carry retired `writeloop` blocks that migrations deliberately preserve as inert data (see `docs/rules/database.md` v56). As errors they made those presets impossible to import back after export. Everything that genuinely can't run — empty/duplicate ids, unsupported role, context block without a slot, instruction selecting context, unknown target agent — stays an error.

## Verification

- New regression test in `test/studio_preset_validation_test.dart`: decodes a legacy-shaped export (kind-based blocks, blank runtime slots, retired `writeloop` section), asserts the codec restores `context` / `history` types and that the validator reports no errors — only the two expected warnings.
- Replayed the codec + validator rules against the reported 327-block file offline: 0 errors, 3 warnings (`writeloop` section, two title-only header blocks).
- **`flutter analyze` and `flutter test` were not run** — no Flutter SDK in this environment, so CI is the only executed check.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Rr7ZpuMGPEw2UaS1pYhM5)_