### PR TITLE
fix(regex): recover prompt worker after hangs

### DIFF
--- a/lib/core/llm/prompt_worker.dart
+++ b/lib/core/llm/prompt_worker.dart
@@ -23,6 +23,7 @@ import 'tokenizer.dart';
 /// maintains a persistent token cache across requests.
 class PromptWorker {
   static PromptWorker? _instance;
+  static Completer<PromptWorker>? _initGuard;
 
   final Isolate _isolate;
   final ReceivePort _commandPort;
@@ -40,7 +41,18 @@ class PromptWorker {
 
   static Future<PromptWorker> ensureInitialized() async {
     if (_instance != null) return _instance!;
-    _instance = await _create();
+    // Serialize concurrent first-init / respawn attempts.
+    if (_initGuard != null) return _initGuard!.future;
+    _initGuard = Completer<PromptWorker>();
+    try {
+      _instance = await _create();
+      _initGuard!.complete(_instance!);
+    } catch (e, st) {
+      _initGuard!.completeError(e, st);
+      _initGuard = null;
+      rethrow;
+    }
+    _initGuard = null;
     return _instance!;
   }
 
@@ -90,12 +102,36 @@ class PromptWorker {
       const Duration(seconds: 60),
       onTimeout: () {
         _pending.remove(id);
+        // A synchronous regex (ReDoS) or other runaway computation can hang
+        // the isolate forever. Kill it so it stops burning CPU and so the
+        // next ensureInitialized() respawns a fresh worker — otherwise every
+        // subsequent prompt request would also time out.
+        _killAndInvalidate();
         throw TimeoutException(
           'PromptWorker request timed out after 60s',
           const Duration(seconds: 60),
         );
       },
     );
+  }
+
+  /// Kills the isolate, closes ports, errors out all pending requests, and
+  /// clears the singleton so the next [ensureInitialized] recreates it.
+  void _killAndInvalidate() {
+    _isolate.kill(priority: Isolate.immediate);
+    _commandPort.close();
+    _responsePort.close();
+    for (final c in _pending.values) {
+      if (!c.isCompleted) {
+        c.completeError(
+          TimeoutException('PromptWorker isolate killed after timeout'),
+        );
+      }
+    }
+    _pending.clear();
+    if (_instance == this) {
+      _instance = null;
+    }
   }
 
   Future<PromptResult> buildPrompt(PromptPayload payload) async {

--- a/lib/core/llm/regex_service.dart
+++ b/lib/core/llm/regex_service.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/foundation.dart';
+
 import '../models/preset.dart';
 import '../models/character.dart';
 import '../models/persona.dart';
 import '../models/chat_message.dart' show TriggeredEntry;
 import 'macro_engine.dart';
+import 'regex_validator.dart';
 
 class RegexApplyContext {
   final Character? char;
@@ -118,6 +121,12 @@ String _applySingleScript(String text, PresetRegex script, RegexApplyContext ctx
   }
 
   if (pattern.isEmpty) return processed;
+
+  final safety = classifyRegexSafety(pattern);
+  if (safety == RegexSafety.pathological) {
+    debugPrint('[regex] skipping pathological pattern "${script.name}": $pattern');
+    return processed;
+  }
 
   final parsed = _parseRegexPattern(pattern);
   try {

--- a/lib/core/llm/regex_validator.dart
+++ b/lib/core/llm/regex_validator.dart
@@ -1,0 +1,187 @@
+// Heuristic detection of catastrophic-backtracking (ReDoS) regex patterns.
+//
+// Dart's `RegExp` is synchronous with no timeout API. A pattern with nested
+// quantifiers (e.g. `(.+)*`, `(a+)+`, `(?:X*)*`) can hang the isolate
+// indefinitely on modest input. This checker scans the raw pattern string
+// and classifies it so callers can skip risky scripts before they run.
+//
+// This is a **heuristic** — it trades precision for breadth. It will not
+// catch every pathological pattern, but it catches the common signatures
+// that SillyTavern preset imports have been observed to carry.
+
+/// Result of a regex safety check.
+enum RegexSafety {
+  /// No known-bad structure detected.
+  safe,
+
+  /// Likely slow (quadratic) on long input with no match, but not necessarily
+  /// exponential. Allowed to run; the isolate-timeout is the safety net.
+  risky,
+
+  /// Contains nested quantifiers that cause exponential backtracking.
+  /// Should be skipped at runtime.
+  pathological,
+}
+
+/// Stripped pattern + parsed flags.
+class ParsedRegex {
+  final String pattern;
+  final bool multiLine;
+  final bool dotAll;
+  final bool caseSensitive;
+  const ParsedRegex({
+    required this.pattern,
+    required this.multiLine,
+    required this.dotAll,
+    required this.caseSensitive,
+  });
+}
+
+/// Parses a `/pattern/flags` or bare `pattern` string into components.
+ParsedRegex parseRegexPattern(String raw) {
+  if (raw.startsWith('/') && raw.length > 1) {
+    final lastSlash = raw.lastIndexOf('/');
+    if (lastSlash > 0) {
+      return ParsedRegex(
+        pattern: raw.substring(1, lastSlash),
+        multiLine: raw.substring(lastSlash + 1).contains('m'),
+        dotAll: raw.substring(lastSlash + 1).contains('s'),
+        caseSensitive: !raw.substring(lastSlash + 1).contains('i'),
+      );
+    }
+  }
+  return ParsedRegex(
+    pattern: raw,
+    multiLine: false,
+    dotAll: false,
+    caseSensitive: true,
+  );
+}
+
+/// Classifies a raw regex pattern string for ReDoS risk.
+RegexSafety classifyRegexSafety(String rawPattern) {
+  final parsed = parseRegexPattern(rawPattern);
+  final p = parsed.pattern;
+  if (p.isEmpty) return RegexSafety.safe;
+
+  if (_hasNestedQuantifiers(p)) return RegexSafety.pathological;
+  if (_hasLazyDotAllWithAnchor(p, parsed.dotAll)) return RegexSafety.risky;
+
+  return RegexSafety.safe;
+}
+
+/// Detects a quantifier (`+`, `*`, or `{n,}`) applied to a group that itself
+/// contains a quantifier — the classic exponential-backtracking structure.
+///
+/// Examples caught: `(.+)*`, `(a+)+`, `(?:\\w*)*`, `(\"[^\"]*\")+`.
+/// `?` as the outer quantifier is excluded (0-or-1 does not compound).
+bool _hasNestedQuantifiers(String p) {
+  final groupStarts = <int>[];
+  var inClass = false;
+
+  for (var i = 0; i < p.length; i++) {
+    final ch = p[i];
+
+    if (ch == '\\' && i + 1 < p.length) {
+      i++;
+      continue;
+    }
+
+    if (inClass) {
+      if (ch == ']') inClass = false;
+      continue;
+    }
+
+    if (ch == '[') {
+      inClass = true;
+      continue;
+    }
+
+    if (ch == '(') {
+      groupStarts.add(i);
+    } else if (ch == ')' && groupStarts.isNotEmpty) {
+      final open = groupStarts.removeLast();
+      final inner = p.substring(open + 1, i);
+      if (_containsQuantifier(inner) && _isOuterQuantifier(p, i + 1)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// Whether the character at [pos] starts a compounding quantifier (`+`, `*`,
+/// or an unbounded `{n,}`). `?` is excluded.
+bool _isOuterQuantifier(String p, int pos) {
+  if (pos >= p.length) return false;
+  final ch = p[pos];
+  if (ch == '+' || ch == '*') return true;
+  if (ch == '{') {
+    final close = p.indexOf('}', pos);
+    if (close > pos) {
+      final body = p.substring(pos + 1, close);
+      // {n,} with no upper bound, or {n,m} where m is very large.
+      final comma = body.indexOf(',');
+      if (comma >= 0) {
+        final after = body.substring(comma + 1).trim();
+        if (after.isEmpty) return true;
+        final m = int.tryParse(after);
+        if (m != null && m > 100) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// Whether [s] contains any quantifier (`+`, `*`, `?`, or unbounded `{n,}`).
+/// Character classes `[...]` and escapes are skipped.
+bool _containsQuantifier(String s) {
+  var inClass = false;
+  for (var i = 0; i < s.length; i++) {
+    final ch = s[i];
+    if (ch == '\\' && i + 1 < s.length) {
+      i++;
+      continue;
+    }
+    if (inClass) {
+      if (ch == ']') inClass = false;
+      continue;
+    }
+    if (ch == '[') {
+      inClass = true;
+      continue;
+    }
+    if (ch == '+' || ch == '*' || ch == '?') return true;
+    if (ch == '{') {
+      final close = s.indexOf('}', i);
+      if (close > i) {
+        final body = s.substring(i + 1, close);
+        final comma = body.indexOf(',');
+        if (comma >= 0 && body.substring(comma + 1).trim().isEmpty) {
+          return true; // {n,}
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/// Detects `[\s\S]*?` (or `.*?` with dotAll) combined with a `$` anchor —
+/// quadratic on input that has no match: at each start position the lazy
+/// quantifier extends to the end before failing.
+bool _hasLazyDotAllWithAnchor(String p, bool dotAll) {
+  final hasLazyBroadMatch =
+      p.contains(r'[\s\S]*?') ||
+      p.contains(r'[\s\S]+?') ||
+      (dotAll && (p.contains('.*?') || p.contains('.+?')));
+  if (!hasLazyBroadMatch) return false;
+
+  for (var i = 0; i < p.length; i++) {
+    if (p[i] == '\\' && i + 1 < p.length) {
+      i++;
+      continue;
+    }
+    if (p[i] == '\$') return true;
+  }
+  return false;
+}

--- a/test/regex_validator_test.dart
+++ b/test/regex_validator_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/regex_validator.dart';
+
+void main() {
+  group('regex_validator — ReDoS detection', () {
+    test('nested quantifier (.+)* is pathological', () {
+      expect(classifyRegexSafety(r'/(.+)*/gi'), RegexSafety.pathological);
+    });
+
+    test('nested quantifier (a+)+ is pathological', () {
+      expect(classifyRegexSafety(r'/(a+)+/'), RegexSafety.pathological);
+    });
+
+    test('nested quantifier (?:\\w*)* is pathological', () {
+      expect(classifyRegexSafety(r'/(?:\w*)*/'), RegexSafety.pathological);
+    });
+
+    test('Celia Assist - Inside pattern is pathological', () {
+      expect(
+        classifyRegexSafety(r'/@(do|say|pen|wild):\s*(.+)*/gi'),
+        RegexSafety.pathological,
+      );
+    });
+
+    test('Celia Hidden Block Details pattern is pathological', () {
+      expect(
+        classifyRegexSafety(
+          r'/`([^`]+)` - (「[^」]*」(?:「[^」]*」)*)*/gi',
+        ),
+        RegexSafety.pathological,
+      );
+    });
+
+    test('lazy [\\s\\S]*? with \$ anchor is risky', () {
+      expect(
+        classifyRegexSafety(
+          r'/([\s\S]*?)(<progress>[\s\S]*?<\/progress>)([\s\S]*?$)/g',
+        ),
+        RegexSafety.risky,
+      );
+    });
+
+    test('0-or-1 outer quantifier (? after group) is safe', () {
+      expect(classifyRegexSafety(r'/(\d+)?/'), RegexSafety.safe);
+    });
+
+    test('simple tag strip is safe', () {
+      expect(
+        classifyRegexSafety(r'/<progress>[\s\S]*?<\/progress>/g'),
+        RegexSafety.safe,
+      );
+    });
+
+    test('anchored tag strip without \$ is safe', () {
+      expect(
+        classifyRegexSafety(
+          r'/<master_ledger>\s*<details>[\s\S]*?<\/details>\s*<\/master_ledger>/g',
+        ),
+        RegexSafety.safe,
+      );
+    });
+
+    test('plain word replace is safe', () {
+      expect(classifyRegexSafety(r'/foo/g'), RegexSafety.safe);
+    });
+
+    test('empty pattern is safe', () {
+      expect(classifyRegexSafety(''), RegexSafety.safe);
+    });
+
+    test('dotAll .*? with \$ is risky', () {
+      expect(classifyRegexSafety(r'/.*?$/s'), RegexSafety.risky);
+    });
+
+    test('dotAll .*? without \$ is safe', () {
+      expect(classifyRegexSafety(r'/.*?/s'), RegexSafety.safe);
+    });
+  });
+}


### PR DESCRIPTION
## Regex safety
- Add `classifyRegexSafety` to identify nested quantifier patterns with catastrophic backtracking and broad lazy matches anchored to the end of input.
- Skip known pathological patterns before they can block prompt assembly.
- Add coverage for unsafe patterns found in imported SillyTavern presets and safe compatibility cases.

## Worker recovery
- Kill and invalidate the prompt worker isolate after a 60-second request timeout, so a runaway synchronous computation cannot block every subsequent prompt build.
- Serialize worker initialization and respawn attempts.

## Verification
- `flutter analyze` completed with no errors; it reported 8 pre-existing info/warning diagnostics in unrelated card-rewriter and Studio test files.
- `flutter test` passed: 2,363 tests.
