### PR TITLE
fix(chat): stop timer when streaming ends

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -124,7 +124,7 @@ export class Bridge {
   setGenerating(value) {
     const wasGenerating = this.isGenerating;
     this.isGenerating = !!value;
-    this._syncGenerationActivity();
+    this._syncGenerationTimer();
     // updateHeader() early-returns for the whole streaming window, so the
     // scroll-hide header is frozen at whatever state it had when generation
     // started. If it was hidden — and especially if the chat then shrank (a
@@ -141,11 +141,10 @@ export class Bridge {
 
   setPostGenRunning(value) {
     this.isPostGenRunning = !!value;
-    this._syncGenerationActivity();
   }
 
-  _syncGenerationActivity() {
-    if (this.isGenerating || this.isPostGenRunning) {
+  _syncGenerationTimer() {
+    if (this.isGenerating) {
       this._genTimer.start();
     } else {
       this._genTimer.stop();

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -1010,17 +1010,19 @@ void main() {
       expect(bridgeControllerJs, contains('new GenTimer('));
     });
 
-    test('setGenerating delegates to generation activity reconciliation', () {
+    test('setGenerating delegates to generation timer reconciliation', () {
       final marker = 'setGenerating(value) {';
       final idx = bridgeControllerJs.indexOf(marker);
       expect(idx, isNot(-1));
       final body = _extractBlockBody(bridgeControllerJs, idx);
-      expect(body, contains('this._syncGenerationActivity()'));
+      expect(body, contains('this._syncGenerationTimer()'));
     });
 
     test('upward scroll restores a hidden header during generation', () {
       final marker = 'if (this.isGenerating) {';
-      final idx = bridgeControllerJs.indexOf(marker);
+      final updateHeaderIdx = bridgeControllerJs.indexOf('const updateHeader = () => {');
+      expect(updateHeaderIdx, isNot(-1));
+      final idx = bridgeControllerJs.indexOf(marker, updateHeaderIdx);
       expect(idx, isNot(-1));
       final body = _extractBlockBody(bridgeControllerJs, idx);
       expect(body, contains('st < this._headerLastTop - 3'));
@@ -1054,13 +1056,19 @@ void main() {
       expect(body, contains('Date.now() < this._headerRebaselineUntil'));
     });
 
-    test('post-gen activity keeps the generation timer active separately', () {
+    test('post-gen activity does not keep the generation timer running', () {
       expect(bridgeControllerJs, contains('setPostGenRunning(value)'));
-      final marker = '_syncGenerationActivity() {';
+      final postGenIdx = bridgeControllerJs.indexOf('setPostGenRunning(value) {');
+      expect(postGenIdx, isNot(-1));
+      final postGenBody = _extractBlockBody(bridgeControllerJs, postGenIdx);
+      expect(postGenBody, isNot(contains('_syncGenerationTimer')));
+
+      final marker = '_syncGenerationTimer() {';
       final idx = bridgeControllerJs.indexOf(marker);
       expect(idx, isNot(-1));
       final body = _extractBlockBody(bridgeControllerJs, idx);
-      expect(body, contains('this.isGenerating || this.isPostGenRunning'));
+      expect(body, contains('this.isGenerating'));
+      expect(body, isNot(contains('this.isPostGenRunning')));
       expect(body, contains('this._genTimer.start()'));
       expect(body, contains('this._genTimer.stop()'));
     });


### PR DESCRIPTION
## Summary
- stop the chat generation timer as soon as streaming ends
- keep post-generation work independent from the timer lifecycle
- cover the behavior with WebView asset tests

## Verification
- `flutter test test/webview_assets_test.dart`