### PR TITLE
fix(studio): disable cleaner when post_clean agent toggle is off

### DIFF
--- a/lib/core/llm/studio_turn_config_snapshot.dart
+++ b/lib/core/llm/studio_turn_config_snapshot.dart
@@ -21,7 +21,11 @@ class StudioTurnConfigSnapshot {
   }) : pipelineSettings = config?.enabled == true && preset != null
            ? pipelineSettings.copyWith(
                studioAgent: preset.runtime.agents,
-               cleaner: preset.runtime.cleaner,
+               cleaner: preset.agentEnabled['post_clean'] == false
+                   ? preset.runtime.cleaner.copyWith(
+                       postCleanerEnabled: false,
+                     )
+                   : preset.runtime.cleaner,
                ledger: preset.runtime.ledger,
              )
            : pipelineSettings;

--- a/test/studio_turn_config_snapshot_test.dart
+++ b/test/studio_turn_config_snapshot_test.dart
@@ -410,4 +410,66 @@ void main() {
       expect(ids, contains('agent_final'));
     },
   );
+
+  test(
+    'disabling the post_clean agent toggle also disables the cleaner stage',
+    () {
+      final snapshot = StudioTurnConfigSnapshot(
+        config: const StudioConfig(sessionId: 'session', enabled: true),
+        preset: const StudioPreset(
+          id: 'preset',
+          agentEnabled: {'post_clean': false},
+          runtime: StudioRuntimeSettings(
+            cleaner: CleanerSettings(postCleanerEnabled: true),
+          ),
+        ),
+        pipelineSettings: const PipelineSettings(),
+        apiConfigs: const [],
+        activeApiConfig: null,
+      );
+
+      expect(snapshot.pipelineSettings.cleaner.postCleanerEnabled, isFalse);
+    },
+  );
+
+  test(
+    'enabling the post_clean agent toggle preserves the cleaner runtime setting',
+    () {
+      final snapshot = StudioTurnConfigSnapshot(
+        config: const StudioConfig(sessionId: 'session', enabled: true),
+        preset: const StudioPreset(
+          id: 'preset',
+          agentEnabled: {'post_clean': true},
+          runtime: StudioRuntimeSettings(
+            cleaner: CleanerSettings(postCleanerEnabled: true),
+          ),
+        ),
+        pipelineSettings: const PipelineSettings(),
+        apiConfigs: const [],
+        activeApiConfig: null,
+      );
+
+      expect(snapshot.pipelineSettings.cleaner.postCleanerEnabled, isTrue);
+    },
+  );
+
+  test(
+    'post_clean agent toggle defaults to on when absent, preserving cleaner runtime',
+    () {
+      final snapshot = StudioTurnConfigSnapshot(
+        config: const StudioConfig(sessionId: 'session', enabled: true),
+        preset: const StudioPreset(
+          id: 'preset',
+          runtime: StudioRuntimeSettings(
+            cleaner: CleanerSettings(postCleanerEnabled: true),
+          ),
+        ),
+        pipelineSettings: const PipelineSettings(),
+        apiConfigs: const [],
+        activeApiConfig: null,
+      );
+
+      expect(snapshot.pipelineSettings.cleaner.postCleanerEnabled, isTrue);
+    },
+  );
 }


### PR DESCRIPTION
## Problem

When Studio is enabled, `StudioTurnConfigSnapshot` replaces `pipelineSettings.cleaner` with `preset.runtime.cleaner`, so the preset's `postCleanerEnabled` fully overrides the global cleaner toggle.

The Studio UI exposes the `post_clean` controller toggle (`agentEnabled['post_clean']`) but there is **no UI toggle for `runtime.cleaner.postCleanerEnabled`**. Users turning off "Post Clean" in the preset expect the entire post-clean lane to stop, but only the pre-generation controller was disabled — the cleaner stage kept running.

## Fix

In `StudioTurnConfigSnapshot`'s constructor, when Studio is enabled and `agentEnabled['post_clean'] == false`, force `cleaner.postCleanerEnabled = false`. This makes the existing `post_clean` agent toggle the single switch for the whole post-clean lane (controller + cleaner stage + fact checker, since `factCheckEnabled` already depends on `postCleanerEnabled`).

## Changes

- `lib/core/llm/studio_turn_config_snapshot.dart`: constructor now checks `preset.agentEnabled['post_clean']` and overrides `cleaner.postCleanerEnabled` accordingly.
- `test/studio_turn_config_snapshot_test.dart`: 3 new tests covering disabled toggle, enabled toggle, and default-on when absent.

## Verification

- `flutter test test/studio_turn_config_snapshot_test.dart` — 8 passed (5 existing + 3 new)
- `dart analyze` on changed files — no issues
- `flutter test test/studio_post_processing_test.dart test/cleaner_disabled_post_gen_test.dart test/continue_message_test.dart` — 16 passed
