### PR TITLE
Studio Direct preset fixes, ledger improvements, card rewriter observation journal, image gen fix

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -145,6 +145,8 @@
   "label_reasoning": "Show Native Reasoning",
   "label_include_last_reasoning": "Reasoning blocks (-1 = all, 0 = off)",
   "desc_include_last_reasoning": "Number of recent reasoning_content blocks from chat history",
+  "label_exclude_reasoning_from_budget": "Exclude reasoning from context budget",
+  "desc_exclude_reasoning_from_budget": "Reasoning blocks are sent but their tokens don't count toward the context trim limit, keeping more chat history visible",
   "label_prompt_cache_ttl": "Anthropic Prompt Cache",
   "desc_prompt_cache_ttl": "Inject cache_control: ephemeral for Anthropic or custom OpenAI-compatible backends. 1 hour keeps cache alive across long pauses (expensive write, cheap read).",
   "prompt_cache_ttl_off": "Off",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -144,6 +144,8 @@
   "label_reasoning": "Показывать нативное мышление",
   "label_include_last_reasoning": "Reasoning-блоки (-1 = все, 0 = не передавать)",
   "desc_include_last_reasoning": "Количество последних reasoning_content из истории",
+  "label_exclude_reasoning_from_budget": "Исключить рассуждения из лимита контекста",
+  "desc_exclude_reasoning_from_budget": "Reasoning-блоки отправляются, но их токены не учитываются при обрезке контекста — больше истории видно модели",
   "label_prompt_cache_ttl": "Кэш Anthropic",
   "desc_prompt_cache_ttl": "Пробрасывать cache_control: ephemeral для Anthropic или кастомных OpenAI-compatible бэкендов. 1 час — держит кэш между длинными паузами (стоит дороже write, дешевле read).",
   "prompt_cache_ttl_off": "Выключен",

--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -73,7 +73,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 106;
+  int get schemaVersion => 107;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1993,6 +1993,20 @@ class AppDatabase extends _$AppDatabase {
       }
       if (from < 106) {
         await _repairPresetBlockRouting();
+      }
+      if (from < 107) {
+        final columns = await customSelect(
+          "PRAGMA table_info('api_configs')",
+        ).get();
+        final names = columns
+            .map((column) => column.read<String>('name'))
+            .toSet();
+        if (!names.contains('exclude_reasoning_from_context_budget')) {
+          await m.addColumn(
+            apiConfigs,
+            apiConfigs.excludeReasoningFromContextBudget,
+          );
+        }
       }
     },
   );

--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -54,6 +54,7 @@ part 'app_db.g.dart';
     CardEvolutionClaims,
     CardEvolutionProposalRuns,
     CardEvolutionDebugRuns,
+    CardEvolutionObservations,
     CharacterKnowledgeFactRows,
     CharacterSessionBaselineRows,
     CharacterRevisionRows,
@@ -73,7 +74,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 107;
+  int get schemaVersion => 108;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2007,6 +2008,9 @@ class AppDatabase extends _$AppDatabase {
             apiConfigs.excludeReasoningFromContextBudget,
           );
         }
+      }
+      if (from < 108) {
+        await m.createTable(cardEvolutionObservations);
       }
     },
   );

--- a/lib/core/db/repositories/api_config_repo.dart
+++ b/lib/core/db/repositories/api_config_repo.dart
@@ -64,6 +64,7 @@ class ApiConfigRepo implements SyncApiConfigStore {
     useResponsesApi: c.useResponsesApi,
     showNativeReasoning: c.showNativeReasoning,
     reasoningHistoryCount: c.reasoningHistoryCount,
+    excludeReasoningFromContextBudget: c.excludeReasoningFromContextBudget,
     reasoningTagStart: c.reasoningTagStart,
     reasoningTagEnd: c.reasoningTagEnd,
     embeddingUseSame: c.embeddingUseSame,
@@ -116,6 +117,9 @@ class ApiConfigRepo implements SyncApiConfigStore {
     showNativeReasoning: Value(m.showNativeReasoning),
     includeLastReasoning: Value(m.reasoningHistoryCount != 0),
     reasoningHistoryCount: Value(m.reasoningHistoryCount),
+    excludeReasoningFromContextBudget: Value(
+      m.excludeReasoningFromContextBudget,
+    ),
     reasoningTagStart: Value(m.reasoningTagStart),
     reasoningTagEnd: Value(m.reasoningTagEnd),
     embeddingUseSame: Value(m.embeddingUseSame),

--- a/lib/core/db/repositories/card_evolution_observation_repo.dart
+++ b/lib/core/db/repositories/card_evolution_observation_repo.dart
@@ -1,0 +1,205 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import '../../models/card_evolution_observation.dart';
+import '../app_db.dart';
+
+/// Repository for the Card Rewriter observation journal. Observations are
+/// session-scoped candidate durable changes recorded by the observation pass.
+/// One active observation per `(sessionId, semanticScopeKey)` is enforced by a
+/// unique key; confirmations bump `repeatCount`/`lastConfirmedRun`, promotion
+/// flips `status` to `promoted`, and a successful apply marks it `consumed`.
+class CardEvolutionObservationRepo {
+  CardEvolutionObservationRepo(this.db);
+
+  final AppDatabase db;
+
+  Future<CardEvolutionObservation?> findByScopeKey(
+    String sessionId,
+    String semanticScopeKey,
+  ) => db.transaction(() async {
+    final row =
+        await (db.select(db.cardEvolutionObservations)
+              ..where((r) => r.sessionId.equals(sessionId))
+              ..where((r) => r.semanticScopeKey.equals(semanticScopeKey)))
+            .getSingleOrNull();
+    return row == null ? null : _toModel(row);
+  });
+
+  Future<CardEvolutionObservation?> findById(String id) =>
+      db.transaction(() async {
+        final row = await (db.select(
+          db.cardEvolutionObservations,
+        )..where((r) => r.id.equals(id))).getSingleOrNull();
+        return row == null ? null : _toModel(row);
+      });
+
+  Future<void> insertObservation(CardEvolutionObservation observation) => db
+      .into(db.cardEvolutionObservations)
+      .insert(
+        CardEvolutionObservationsCompanion.insert(
+          id: observation.id,
+          sessionId: observation.sessionId,
+          characterId: observation.characterId,
+          runOrdinal: observation.runOrdinal,
+          semanticScopeKey: observation.semanticScopeKey,
+          observedChange: observation.observedChange,
+          canonicalClaim: Value(observation.canonicalClaim),
+          evidenceMessageIds: jsonEncode(observation.evidenceMessageIds),
+          cardFieldPath: Value(observation.cardFieldPath),
+          lorebookEntryId: Value(observation.lorebookEntryId),
+          confidence: observation.confidence,
+          status: observation.status,
+          firstSeenRun: observation.firstSeenRun,
+          repeatCount: Value(observation.repeatCount),
+          lastConfirmedRun: Value(observation.lastConfirmedRun),
+          createdAt: observation.createdAt,
+          updatedAt: observation.updatedAt,
+        ),
+      );
+
+  Future<void> confirmObservation({
+    required String id,
+    required int runOrdinal,
+    required double confidence,
+    required int now,
+  }) => db.transaction(() async {
+    final row = await (db.select(
+      db.cardEvolutionObservations,
+    )..where((r) => r.id.equals(id))).getSingleOrNull();
+    if (row == null) return;
+    await (db.update(
+      db.cardEvolutionObservations,
+    )..where((r) => r.id.equals(id))).write(
+      CardEvolutionObservationsCompanion(
+        repeatCount: Value(row.repeatCount + 1),
+        lastConfirmedRun: Value(runOrdinal),
+        confidence: Value(confidence),
+        updatedAt: Value(now),
+      ),
+    );
+  });
+
+  Future<void> promoteObservation(String id, {required int now}) =>
+      (db.update(db.cardEvolutionObservations)
+            ..where((r) => r.id.equals(id))
+            ..where((r) => r.status.equals('active')))
+          .write(
+            CardEvolutionObservationsCompanion(
+              status: const Value('promoted'),
+              updatedAt: Value(now),
+            ),
+          );
+
+  Future<void> expireObservation(String id, {required int now}) =>
+      (db.update(db.cardEvolutionObservations)
+            ..where((r) => r.id.equals(id))
+            ..where((r) => r.status.equals('active')))
+          .write(
+            CardEvolutionObservationsCompanion(
+              status: const Value('expired'),
+              updatedAt: Value(now),
+            ),
+          );
+
+  Future<void> consumeObservation(String id, {required int now}) =>
+      (db.update(db.cardEvolutionObservations)
+            ..where((r) => r.id.equals(id))
+            ..where((r) => r.status.equals('promoted')))
+          .write(
+            CardEvolutionObservationsCompanion(
+              status: const Value('consumed'),
+              updatedAt: Value(now),
+            ),
+          );
+
+  Future<List<CardEvolutionObservation>> getActiveObservations(
+    String sessionId,
+  ) => db.transaction(() async {
+    final rows =
+        await (db.select(db.cardEvolutionObservations)
+              ..where((r) => r.sessionId.equals(sessionId))
+              ..where((r) => r.status.equals('active'))
+              ..orderBy([(r) => OrderingTerm.asc(r.createdAt)]))
+            .get();
+    return [for (final row in rows) _toModel(row)];
+  });
+
+  Future<List<CardEvolutionObservation>> getPromotedObservations(
+    String sessionId,
+  ) => db.transaction(() async {
+    final rows =
+        await (db.select(db.cardEvolutionObservations)
+              ..where((r) => r.sessionId.equals(sessionId))
+              ..where((r) => r.status.equals('promoted'))
+              ..orderBy([(r) => OrderingTerm.asc(r.createdAt)]))
+            .get();
+    return [for (final row in rows) _toModel(row)];
+  });
+
+  Future<List<CardEvolutionObservation>> getPromotableObservations(
+    String sessionId, {
+    required int minRepeatCount,
+    required double minConfidence,
+  }) => db.transaction(() async {
+    final rows =
+        await (db.select(db.cardEvolutionObservations)
+              ..where((r) => r.sessionId.equals(sessionId))
+              ..where((r) => r.status.equals('active'))
+              ..where((r) => r.repeatCount.isBiggerOrEqualValue(minRepeatCount))
+              ..where((r) => r.confidence.isBiggerOrEqualValue(minConfidence)))
+            .get();
+    return [for (final row in rows) _toModel(row)];
+  });
+
+  Future<List<CardEvolutionObservation>> getExpiryCandidates(
+    String sessionId, {
+    required int currentRunOrdinal,
+    required int expiryRuns,
+  }) => db.transaction(() async {
+    final rows =
+        await (db.select(db.cardEvolutionObservations)
+              ..where((r) => r.sessionId.equals(sessionId))
+              ..where((r) => r.status.equals('active'))
+              ..where((r) => r.lastConfirmedRun.isNotNull()))
+            .get();
+    return [
+      for (final row in rows)
+        if (currentRunOrdinal - (row.lastConfirmedRun ?? currentRunOrdinal) >=
+            expiryRuns)
+          _toModel(row),
+    ];
+  });
+
+  static CardEvolutionObservation _toModel(CardEvolutionObservationRow row) {
+    List<String> evidence;
+    try {
+      final decoded = jsonDecode(row.evidenceMessageIds);
+      evidence = decoded is List
+          ? [for (final item in decoded) item.toString()]
+          : const [];
+    } catch (_) {
+      evidence = const [];
+    }
+    return CardEvolutionObservation(
+      id: row.id,
+      sessionId: row.sessionId,
+      characterId: row.characterId,
+      runOrdinal: row.runOrdinal,
+      semanticScopeKey: row.semanticScopeKey,
+      observedChange: row.observedChange,
+      canonicalClaim: row.canonicalClaim,
+      evidenceMessageIds: evidence,
+      cardFieldPath: row.cardFieldPath,
+      lorebookEntryId: row.lorebookEntryId,
+      confidence: row.confidence,
+      status: row.status,
+      firstSeenRun: row.firstSeenRun,
+      repeatCount: row.repeatCount,
+      lastConfirmedRun: row.lastConfirmedRun,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    );
+  }
+}

--- a/lib/core/db/repositories/card_evolution_repo.dart
+++ b/lib/core/db/repositories/card_evolution_repo.dart
@@ -14,7 +14,7 @@ import '../app_db.dart';
 import 'manual_rewrite_job_repo.dart';
 import 'session_lorebook_evolution_repo.dart';
 
-const _maxChatHistoryMessages = 20;
+const _maxChatHistoryMessages = 40;
 
 final class CardEvolutionClaim {
   const CardEvolutionClaim({
@@ -50,6 +50,19 @@ final class CardEvolutionFinalizeOutcome {
   final RewriteJobRow? job;
   final String? detail;
   bool get isPersisted => kind == 'persisted' || kind == 'alreadyCompleted';
+}
+
+/// Read-only context for the observation pass: the character and the canonical
+/// selected input (chat history, card snapshot, effective canon). Unlike
+/// [CardEvolutionPromptSnapshot] this does not require a live claim lease.
+final class CardEvolutionObservationSnapshot {
+  const CardEvolutionObservationSnapshot({
+    required this.character,
+    required this.selectedInputJson,
+  });
+
+  final Character character;
+  final String selectedInputJson;
 }
 
 /// Owns eligibility, lease ownership and the all-or-nothing automated proposal
@@ -106,11 +119,12 @@ class CardEvolutionRepo {
       // An expired owner cannot finalize (finalize checks the same lease). Do
       // not reuse its snapshot: chat/canon may have advanced while the app was
       // closed, so drop the stale lease and create a fresh claim below.
-      final deleted = await (db.delete(db.cardEvolutionClaims)
-            ..where((row) => row.id.equals(existing.id))
-            ..where((row) => row.status.equals('claimed'))
-            ..where((row) => row.leaseExpiresAt.isSmallerOrEqualValue(now)))
-          .go();
+      final deleted =
+          await (db.delete(db.cardEvolutionClaims)
+                ..where((row) => row.id.equals(existing.id))
+                ..where((row) => row.status.equals('claimed'))
+                ..where((row) => row.leaseExpiresAt.isSmallerOrEqualValue(now)))
+              .go();
       if (deleted != 1) {
         return const CardEvolutionClaimOutcome('busy');
       }
@@ -247,8 +261,8 @@ class CardEvolutionRepo {
     final allowedLoreTargets = _loreTargetsFromInput(selected);
     if (allowedLoreTargets == null ||
         lorebookOperations.any((operation) {
-          final target = allowedLoreTargets[
-              '${operation.lorebookId}\u0000${operation.entryId}'];
+          final target =
+              allowedLoreTargets['${operation.lorebookId}\u0000${operation.entryId}'];
           return target == null ||
               target.$1 != operation.baseContent ||
               target.$2 != operation.expectedContentHash;
@@ -261,7 +275,8 @@ class CardEvolutionRepo {
     };
     for (final operation in cardOperations) {
       if (operation.patches.any(
-        (patch) => patch.anchor.trim().length < _minimumEvolutionAnchorCodeUnits,
+        (patch) =>
+            patch.anchor.trim().length < _minimumEvolutionAnchorCodeUnits,
       )) {
         return CardEvolutionFinalizeOutcome(
           'invalidOperation',
@@ -279,7 +294,7 @@ class CardEvolutionRepo {
           'invalidOperation',
           null,
           '${operation.field.wireName}: '
-          '${validation.violations.map((violation) => violation.name).join(', ')}',
+              '${validation.violations.map((violation) => violation.name).join(', ')}',
         );
       }
     }
@@ -392,7 +407,7 @@ class CardEvolutionRepo {
           ..where((row) => row.id.equals(claimId))
           ..where((row) => row.ownerId.equals(ownerId))
           ..where((row) => row.status.equals('claimed')))
-         .go();
+        .go();
   });
 
   /// Replaces the session's diagnostic record after every writer call. It is
@@ -406,17 +421,71 @@ class CardEvolutionRepo {
     required String? output,
     required String attemptsJson,
     required int updatedAt,
-  }) => db.into(db.cardEvolutionDebugRuns).insertOnConflictUpdate(
-    CardEvolutionDebugRunsCompanion.insert(
-      sessionId: sessionId,
-      stage: stage,
-      status: status,
-      model: model,
-      output: Value(output),
-      attemptsJson: attemptsJson,
-      updatedAt: updatedAt,
-    ),
-  );
+  }) => db
+      .into(db.cardEvolutionDebugRuns)
+      .insertOnConflictUpdate(
+        CardEvolutionDebugRunsCompanion.insert(
+          sessionId: sessionId,
+          stage: stage,
+          status: status,
+          model: model,
+          output: Value(output),
+          attemptsJson: attemptsJson,
+          updatedAt: updatedAt,
+        ),
+      );
+
+  /// Builds a read-only observation snapshot (character + canonical selected
+  /// input) without claiming a lease. Used by the observation pass which runs
+  /// before the regular claim/finalize card-writer flow.
+  Future<CardEvolutionObservationSnapshot?> buildObservationSnapshot(
+    String sessionId,
+  ) => db.transaction(() async {
+    final selected = await _selectInput(sessionId);
+    if (selected == null) return null;
+    final session = await (db.select(
+      db.chatSessions,
+    )..where((row) => row.sessionId.equals(sessionId))).getSingleOrNull();
+    if (session == null) return null;
+    final assembled = await _assemble(sessionId, session.characterId);
+    if (assembled == null || assembled.$2.requiresBaselineDecision) {
+      return null;
+    }
+    return CardEvolutionObservationSnapshot(
+      character: assembled.$2.character,
+      selectedInputJson: selected,
+    );
+  });
+
+  /// Counts successful Ledger reconciliations for the session. The observation
+  /// pass runs on every even count (every 2nd reconciliation cadence).
+  Future<int> countSuccessfulReconciliations(String sessionId) async {
+    final result = await db
+        .customSelect(
+          'SELECT COUNT(*) AS cnt FROM reconciliation_successful_runs '
+          'WHERE session_id = ?',
+          variables: [Variable.withString(sessionId)],
+        )
+        .getSingle();
+    return result.read<int>('cnt');
+  }
+
+  /// Marks all promoted observations for the session as consumed after a
+  /// successful card writer apply. Promoted observations that were not
+  /// referenced by the proposal remain promoted for the next cycle.
+  Future<void> consumePromotedObservations(
+    String sessionId, {
+    required int now,
+  }) =>
+      (db.update(db.cardEvolutionObservations)
+            ..where((r) => r.sessionId.equals(sessionId))
+            ..where((r) => r.status.equals('promoted')))
+          .write(
+            CardEvolutionObservationsCompanion(
+              status: const Value('consumed'),
+              updatedAt: Value(now),
+            ),
+          );
 
   Future<String?> _selectedInputForClaim(CardEvolutionClaimRow claim) async {
     final selected = await _selectInput(claim.sessionId);
@@ -432,10 +501,9 @@ class CardEvolutionRepo {
 
   Future<String?> _selectInput(String sessionId) async {
     try {
-      final session =
-           await (db.select(db.chatSessions)
-                ..where((row) => row.sessionId.equals(sessionId)))
-               .getSingleOrNull();
+      final session = await (db.select(
+        db.chatSessions,
+      )..where((row) => row.sessionId.equals(sessionId))).getSingleOrNull();
       if (session == null) return null;
       final messages = jsonDecode(session.messagesJson);
       if (messages is! List) return null;
@@ -466,11 +534,15 @@ class CardEvolutionRepo {
       final writableFields = CardRewritePolicy.nonEmptyEvolutionFields(
         assembled.$2.character,
       );
+      final promotedObservations =
+          await (db.select(db.cardEvolutionObservations)
+                ..where((r) => r.sessionId.equals(sessionId))
+                ..where((r) => r.status.equals('promoted'))
+                ..orderBy([(r) => OrderingTerm.asc(r.createdAt)]))
+              .get();
       return _canonicalJson({
         'contractVersion': 7,
-        'fields': [
-          for (final field in writableFields) field.wireName,
-        ],
+        'fields': [for (final field in writableFields) field.wireName],
         'chatHistoryHash': computeHash(historyJson),
         'effectiveCanonIdentity': assembled.$2.identity,
         'limits': {
@@ -481,6 +553,20 @@ class CardEvolutionRepo {
         'card': _evolutionCardSnapshot(assembled.$2.character),
         'effectiveCanon': jsonDecode(canonEvidence),
         'injectedLorebookEntries': lorebookEntries,
+        'validatedTargets': [
+          for (final obs in promotedObservations)
+            {
+              'scopeKey': obs.semanticScopeKey,
+              'observedChange': obs.observedChange,
+              'canonicalClaim': obs.canonicalClaim,
+              'evidenceMessageIds': _decodeJsonArray(obs.evidenceMessageIds),
+              'cardFieldPath': obs.cardFieldPath,
+              'lorebookEntryId': obs.lorebookEntryId,
+              'confidence': obs.confidence,
+              'repeatCount': obs.repeatCount,
+              'firstSeenRun': obs.firstSeenRun,
+            },
+        ],
       });
     } catch (_) {
       return null;
@@ -500,20 +586,19 @@ class CardEvolutionRepo {
       if (messageId is! String || swipeId is! int || agentSwipeId is! int) {
         return null;
       }
-      final row = await (db.select(db.lorebookUseManifests)
-            ..where((value) => value.sessionId.equals(sessionId))
-            ..where((value) => value.messageId.equals(messageId))
-            ..where((value) => value.swipeId.equals(swipeId))
-            ..where((value) => value.agentSwipeId.equals(agentSwipeId)))
-          .getSingleOrNull();
+      final row =
+          await (db.select(db.lorebookUseManifests)
+                ..where((value) => value.sessionId.equals(sessionId))
+                ..where((value) => value.messageId.equals(messageId))
+                ..where((value) => value.swipeId.equals(swipeId))
+                ..where((value) => value.agentSwipeId.equals(agentSwipeId)))
+              .getSingleOrNull();
       if (row == null) continue;
       try {
-        final manifest = ExactLorebookManifest.decodeDurable(
-          {
-            ...Map<String, dynamic>.from(jsonDecode(row.manifestJson) as Map),
-            'canonicalHash': row.manifestHash,
-          },
-        );
+        final manifest = ExactLorebookManifest.decodeDurable({
+          ...Map<String, dynamic>.from(jsonDecode(row.manifestJson) as Map),
+          'canonicalHash': row.manifestHash,
+        });
         for (final entry in manifest.entries) {
           selected['${entry.lorebookId}\u0000${entry.entryId}'] = entry;
         }
@@ -566,9 +651,7 @@ class CardEvolutionRepo {
             ..limit(1))
           .getSingleOrNull();
 
-  List<Object?>? _selectChatHistory({
-    required List<dynamic> messages,
-  }) {
+  List<Object?>? _selectChatHistory({required List<dynamic> messages}) {
     final candidates = <Map<String, Object?>>[];
     for (var index = 0; index < messages.length; index++) {
       final message = messages[index];
@@ -596,7 +679,10 @@ class CardEvolutionRepo {
     if (stableCandidates.length >= 2 &&
         stableCandidates[stableCandidates.length - 2]['role'] == 'user' &&
         stableCandidates.last['role'] == 'assistant') {
-      stableCandidates.removeRange(stableCandidates.length - 2, stableCandidates.length);
+      stableCandidates.removeRange(
+        stableCandidates.length - 2,
+        stableCandidates.length,
+      );
     }
     final start = stableCandidates.length > _maxChatHistoryMessages
         ? stableCandidates.length - _maxChatHistoryMessages
@@ -663,9 +749,7 @@ bool _hasEvolutionOperations(
       allowedCardFields.containsAll(fields);
 }
 
-Map<String, (String, String)>? _loreTargetsFromInput(
-  String selectedInputJson,
-) {
+Map<String, (String, String)>? _loreTargetsFromInput(String selectedInputJson) {
   try {
     final input = jsonDecode(selectedInputJson) as Map;
     final entries = input['injectedLorebookEntries'];
@@ -687,6 +771,15 @@ Map<String, (String, String)>? _loreTargetsFromInput(
     return result;
   } catch (_) {
     return null;
+  }
+}
+
+List<Object?> _decodeJsonArray(String encoded) {
+  try {
+    final decoded = jsonDecode(encoded);
+    return decoded is List ? decoded : const [];
+  } catch (_) {
+    return const [];
   }
 }
 

--- a/lib/core/db/repositories/character_knowledge_fact_repo.dart
+++ b/lib/core/db/repositories/character_knowledge_fact_repo.dart
@@ -328,6 +328,36 @@ class CharacterKnowledgeFactRepo {
     return rows.map(_fromRow).toList(growable: false);
   }
 
+  /// Compact entity-alias registry for the ledger prompt.
+  ///
+  /// Returns `{subjectKey: subjectName}` for every distinct entity that
+  /// appears as a subject in active/tentative facts. This lets the ledger
+  /// agent issue `rename_entity` ops to merge descriptive aliases
+  /// ("беловолосая женщина") into canonical identities ("Люси") without
+  /// injecting full fact content (which would grow the prompt unboundedly).
+  /// Capped at [maxEntities] entries, sorted by most-recently-updated first.
+  Future<Map<String, String>> getEntityAliases(
+    String sessionId, {
+    int maxEntities = 40,
+  }) async {
+    final rows =
+        await (db.select(db.characterKnowledgeFactRows)
+              ..where((row) => row.chatSessionId.equals(sessionId))
+              ..where(
+                (row) => row.lifecycle.isIn(const ['active', 'tentative']),
+              )
+              ..orderBy([(row) => OrderingTerm.desc(row.updatedAt)]))
+            .get();
+    final result = <String, String>{};
+    for (final row in rows) {
+      final key = row.subjectKey;
+      if (result.containsKey(key)) continue;
+      result[key] = row.subjectName;
+      if (result.length >= maxEntities) break;
+    }
+    return result;
+  }
+
   Future<int> applyReconciliationCleanup({
     required String sessionId,
     required List<KnowledgeCleanupOp> ops,

--- a/lib/core/db/repositories/ledger_reconciliation_run_repo.dart
+++ b/lib/core/db/repositories/ledger_reconciliation_run_repo.dart
@@ -323,6 +323,59 @@ class LedgerReconciliationRunRepo {
             ..limit(1))
           .getSingleOrNull();
 
+  /// Copies all reconciliation runs from [fromSessionId] to [toSessionId],
+  /// preserving the ordinal chain. Only runs whose endpoint message falls
+  /// within the branched slice ([messageIds]) are copied. The chain hashes
+  /// remain valid because ordinals are preserved and the physical order is
+  /// unchanged. Used by `branchSession` so the cadence gate continues from
+  /// the parent's reconciliation count instead of resetting to zero.
+  Future<void> copyForSessionBranch({
+    required String fromSessionId,
+    required String toSessionId,
+    required Set<String> messageIds,
+  }) async {
+    if (messageIds.isEmpty) return;
+    final rows =
+        await (_db.select(_db.ledgerReconciliationSuccessfulRuns)
+              ..where((r) => r.sessionId.equals(fromSessionId))
+              ..where((r) => r.endMessageId.isIn(messageIds))
+              ..orderBy([(r) => OrderingTerm.asc(r.ordinal)]))
+            .get();
+    if (rows.isEmpty) return;
+    await _db.batch((batch) {
+      for (final row in rows) {
+        batch.insert(
+          _db.ledgerReconciliationSuccessfulRuns,
+          LedgerReconciliationSuccessfulRunsCompanion.insert(
+            id: row.id,
+            sessionId: toSessionId,
+            ordinal: row.ordinal,
+            startMessageId: row.startMessageId,
+            startSwipeId: row.startSwipeId,
+            startAgentSwipeId: row.startAgentSwipeId,
+            endMessageId: row.endMessageId,
+            endSwipeId: row.endSwipeId,
+            endAgentSwipeId: row.endAgentSwipeId,
+            anchorsJson: row.anchorsJson,
+            rangeHash: row.rangeHash,
+            acceptedManifestRefsJson: row.acceptedManifestRefsJson,
+            effectiveCanonStamp: row.effectiveCanonStamp,
+            effectiveCanonRevision: row.effectiveCanonRevision,
+            effectiveCanonHash: row.effectiveCanonHash,
+            canonicalResultJson: row.canonicalResultJson,
+            contentHash: row.contentHash,
+            predecessorChainHash: row.predecessorChainHash,
+            chainHash: row.chainHash,
+            contractVersion: row.contractVersion,
+            opsAppliedJson: row.opsAppliedJson,
+            createdAt: row.createdAt,
+          ),
+          mode: InsertMode.insertOrReplace,
+        );
+      }
+    });
+  }
+
   /// A head is authoritative only if the whole durable chain is canonical and
   /// the latest run remains valid in the public read projection.
   Future<LedgerReconciliationSuccessfulRunRow?> getHead(
@@ -387,21 +440,25 @@ class LedgerReconciliationRunRepo {
     return rows;
   }
 
-  Future<bool> _cursorEndpointMatches(LedgerReconciliationCursorRow cursor) async {
-    final run = await (_db.select(_db.ledgerReconciliationSuccessfulRuns)
-          ..where((row) => row.id.equals(cursor.throughRunId))
-          ..where((row) => row.sessionId.equals(cursor.sessionId)))
-        .getSingleOrNull();
+  Future<bool> _cursorEndpointMatches(
+    LedgerReconciliationCursorRow cursor,
+  ) async {
+    final run =
+        await (_db.select(_db.ledgerReconciliationSuccessfulRuns)
+              ..where((row) => row.id.equals(cursor.throughRunId))
+              ..where((row) => row.sessionId.equals(cursor.sessionId)))
+            .getSingleOrNull();
     if (run == null ||
         run.ordinal != cursor.throughRunOrdinal ||
         run.chainHash != cursor.throughRunChainHash) {
       return false;
     }
-    final invalidation = await (_db.select(_db.ledgerReconciliationRunInvalidations)
-          ..where((row) => row.sessionId.equals(cursor.sessionId))
-          ..where((row) => row.runId.equals(cursor.throughRunId))
-          ..limit(1))
-        .getSingleOrNull();
+    final invalidation =
+        await (_db.select(_db.ledgerReconciliationRunInvalidations)
+              ..where((row) => row.sessionId.equals(cursor.sessionId))
+              ..where((row) => row.runId.equals(cursor.throughRunId))
+              ..limit(1))
+            .getSingleOrNull();
     return invalidation == null;
   }
 

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -1123,6 +1123,51 @@ class CardEvolutionDebugRuns extends Table {
   ];
 }
 
+/// Observation journal entries recording candidate durable character changes
+/// surfaced by the observation pass. One active observation per semantic scope
+/// per session; confirmations bump `repeatCount`/`lastConfirmedRun`. Promotion
+/// flips `status` to `promoted`; expiry to `consumed` after a successful apply.
+@DataClassName('CardEvolutionObservationRow')
+@TableIndex(
+  name: 'idx_card_evolution_observation_session',
+  columns: {#sessionId, #status},
+)
+class CardEvolutionObservations extends Table {
+  @override
+  String get tableName => 'card_evolution_observations';
+  TextColumn get id => text()();
+  TextColumn get sessionId => text()();
+  TextColumn get characterId => text()();
+  IntColumn get runOrdinal => integer()();
+  TextColumn get semanticScopeKey => text()();
+  TextColumn get observedChange => text()();
+  TextColumn get canonicalClaim => text().nullable()();
+  TextColumn get evidenceMessageIds => text()();
+  TextColumn get cardFieldPath => text().nullable()();
+  TextColumn get lorebookEntryId => text().nullable()();
+  RealColumn get confidence => real()();
+  TextColumn get status => text()();
+  IntColumn get firstSeenRun => integer()();
+  IntColumn get repeatCount => integer().withDefault(const Constant(1))();
+  IntColumn get lastConfirmedRun => integer().nullable()();
+  IntColumn get createdAt => integer()();
+  IntColumn get updatedAt => integer()();
+  @override
+  Set<Column> get primaryKey => {id};
+  @override
+  List<Set<Column>> get uniqueKeys => [
+    {sessionId, semanticScopeKey},
+  ];
+  @override
+  List<String> get customConstraints => [
+    "CHECK (status IN ('active', 'promoted', 'expired', 'consumed'))",
+    "CHECK (id <> '' AND session_id <> '' AND character_id <> '' "
+        "AND semantic_scope_key <> '' AND observed_change <> '' "
+        "AND evidence_message_ids <> '' AND confidence >= 0.0 "
+        "AND confidence <= 1.0 AND first_seen_run > 0 AND repeat_count > 0)",
+  ];
+}
+
 /// Immutable canonical lorebook-use manifest at one message variation anchor.
 @DataClassName('LorebookUseManifestRow')
 @TableIndex(

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -789,6 +789,8 @@ class ApiConfigs extends Table {
       boolean().withDefault(const Constant(false))();
   IntColumn get reasoningHistoryCount =>
       integer().withDefault(const Constant(0))();
+  BoolColumn get excludeReasoningFromContextBudget =>
+      boolean().withDefault(const Constant(false))();
   TextColumn get reasoningTagStart => text().nullable()();
   TextColumn get reasoningTagEnd => text().nullable()();
   BoolColumn get omitTemperature =>

--- a/lib/core/llm/context_calculator.dart
+++ b/lib/core/llm/context_calculator.dart
@@ -16,11 +16,13 @@ class ContextCalculator {
   final int contextSize;
   final int maxTokens;
   final int reasoningHistoryCount;
+  final bool excludeReasoningFromContextBudget;
 
   ContextCalculator({
     required this.contextSize,
     required this.maxTokens,
     this.reasoningHistoryCount = 0,
+    this.excludeReasoningFromContextBudget = false,
   });
 
   /// Context window available for the *prompt*, i.e. everything we send.
@@ -145,7 +147,9 @@ class ContextCalculator {
           (includeAllReasoning || remainingReasoning > 0) &&
           message.role == 'assistant' &&
           reasoning?.isNotEmpty == true;
-      if (includesReasoning) tokens += estimateTokens(reasoning!);
+      if (includesReasoning && !excludeReasoningFromContextBudget) {
+        tokens += estimateTokens(reasoning!);
+      }
       if (used + tokens > budget) break;
       used += tokens;
       kept.insert(0, message);

--- a/lib/core/llm/fallback_prompt_builder.dart
+++ b/lib/core/llm/fallback_prompt_builder.dart
@@ -53,6 +53,8 @@ PromptResult buildFallbackPrompt(PromptPayload payload) {
     contextSize: payload.apiConfig.contextSize,
     maxTokens: payload.apiConfig.maxTokens,
     reasoningHistoryCount: payload.apiConfig.reasoningHistoryCount,
+    excludeReasoningFromContextBudget:
+        payload.apiConfig.excludeReasoningFromContextBudget,
   );
   final breakdown = calculator.calculate(
     staticBlocks: const [
@@ -68,9 +70,17 @@ PromptResult buildFallbackPrompt(PromptPayload payload) {
     messages: [
       systemMessage,
       if (canon?.characterKnowledge case final content? when content.isNotEmpty)
-        PromptMessage(role: 'system', content: content, blockId: 'current_character_state'),
+        PromptMessage(
+          role: 'system',
+          content: content,
+          blockId: 'current_character_state',
+        ),
       if (canon?.sessionState case final content? when content.isNotEmpty)
-        PromptMessage(role: 'system', content: content, blockId: 'studio_session_state'),
+        PromptMessage(
+          role: 'system',
+          content: content,
+          blockId: 'studio_session_state',
+        ),
       ...breakdown.trimmedHistory,
     ],
     breakdown: breakdown,
@@ -80,5 +90,8 @@ PromptResult buildFallbackPrompt(PromptPayload payload) {
 }
 
 String _latestText(List<ChatMessage> history, String role) => history
-    .lastWhere((message) => message.role == role, orElse: () => const ChatMessage(id: '', role: '', content: ''))
+    .lastWhere(
+      (message) => message.role == role,
+      orElse: () => const ChatMessage(id: '', role: '', content: ''),
+    )
     .content;

--- a/lib/core/llm/knowledge_cleanup_parser.dart
+++ b/lib/core/llm/knowledge_cleanup_parser.dart
@@ -11,17 +11,20 @@ class KnowledgeCleanupParser {
 
   List<KnowledgeCleanupOp> parse({
     required String output,
-    required List<CharacterKnowledgeFact> offeredFacts,
+    List<CharacterKnowledgeFact> offeredFacts = const [],
     required String reviewText,
+    Set<String>? entityKeys,
   }) {
     final decodedOps = _decodeOps(output);
     if (decodedOps == null) return const [];
 
     final factIds = offeredFacts.map((fact) => fact.id).toSet();
-    final entityKeys = <String>{
-      for (final fact in offeredFacts) fact.knowerKey,
-      for (final fact in offeredFacts) fact.subjectKey,
-    };
+    final effectiveEntityKeys =
+        entityKeys ??
+        <String>{
+          for (final fact in offeredFacts) fact.knowerKey,
+          for (final fact in offeredFacts) fact.subjectKey,
+        };
     final normalizedReview = reviewText.toLowerCase();
     final result = <KnowledgeCleanupOp>[];
     for (final rawOp in decodedOps.take(50)) {
@@ -37,7 +40,7 @@ class KnowledgeCleanupParser {
       final to = rawOp['toKey']?.toString() ?? '';
       final name = rawOp['canonicalName']?.toString().trim() ?? '';
       final validKey = RegExp(r'^entity:[a-z0-9_:-]+$');
-      if (!entityKeys.contains(from) ||
+      if (!effectiveEntityKeys.contains(from) ||
           !_isResolvableAliasKey(from) ||
           !validKey.hasMatch(to) ||
           from == to ||

--- a/lib/core/llm/prompt_builder.dart
+++ b/lib/core/llm/prompt_builder.dart
@@ -740,6 +740,8 @@ PromptResult _assembleMessages({
     contextSize: payload.apiConfig.contextSize,
     maxTokens: payload.apiConfig.maxTokens,
     reasoningHistoryCount: payload.apiConfig.reasoningHistoryCount,
+    excludeReasoningFromContextBudget:
+        payload.apiConfig.excludeReasoningFromContextBudget,
   );
   var historyOnly = messages.where((m) => m.isHistory).toList();
 

--- a/lib/core/llm/studio/studio_aux_prompt_assembler.dart
+++ b/lib/core/llm/studio/studio_aux_prompt_assembler.dart
@@ -1,5 +1,6 @@
 import '../macro_engine.dart';
 import '../../models/studio_config.dart';
+import '../../models/studio_preset_block_groups.dart';
 
 /// Assembles an auxiliary-stage prompt (cleaner or ledger) from preset blocks
 /// preset blocks instead of hardcoded text.
@@ -44,12 +45,13 @@ class StudioAuxPromptAssembler {
     String runtimeSuffix = '',
     Set<String> skipBlockIds = const {},
   }) {
-    final sectionBlocks =
+    final routedBlocks =
         blocks
-            .where((b) => b.enabled && b.injectionPoint == injectionPoint)
+            .where((b) => b.injectionPoint == injectionPoint)
             .where((b) => !skipBlockIds.contains(b.id))
             .toList()
           ..sort((a, b) => a.order.compareTo(b.order));
+    final sectionBlocks = resolveEnabledStudioPresetBlocks(routedBlocks);
 
     final parts = <String>[];
     for (final block in sectionBlocks) {

--- a/lib/core/llm/studio/studio_history_limiter.dart
+++ b/lib/core/llm/studio/studio_history_limiter.dart
@@ -36,6 +36,7 @@ class StudioHistoryLimiter {
     StudioPreset preset, {
     int pipelineOverride = 0,
     int reasoningHistoryCount = 0,
+    bool excludeReasoningFromContextBudget = false,
   }) {
     final msgLimit = pipelineOverride > 0
         ? pipelineOverride
@@ -56,7 +57,9 @@ class StudioHistoryLimiter {
       if ((includeAllReasoning || remainingReasoning > 0) &&
           m.role == 'assistant' &&
           reasoning?.isNotEmpty == true) {
-        tokens += estimateTokens(reasoning!);
+        if (!excludeReasoningFromContextBudget) {
+          tokens += estimateTokens(reasoning!);
+        }
         if (!includeAllReasoning) remainingReasoning--;
       }
       // Always keep at least the last message.

--- a/lib/core/llm/studio_agent_executor.dart
+++ b/lib/core/llm/studio_agent_executor.dart
@@ -293,7 +293,7 @@ class StudioAgentExecutor {
       reasoningHistoryCount:
           settings.studioAgent.studioFinalReasoningHistoryCount,
       excludeReasoningFromContextBudget:
-          apiConfig.excludeReasoningFromContextBudget,
+          settings.studioAgent.studioFinalExcludeReasoningFromContextBudget,
     );
     onMessagesBuilt?.call(messages);
     return _runner.runAgent(

--- a/lib/core/llm/studio_agent_executor.dart
+++ b/lib/core/llm/studio_agent_executor.dart
@@ -292,6 +292,8 @@ class StudioAgentExecutor {
       finalContextOverride: settings.studioAgent.studioFinalContextSize,
       reasoningHistoryCount:
           settings.studioAgent.studioFinalReasoningHistoryCount,
+      excludeReasoningFromContextBudget:
+          apiConfig.excludeReasoningFromContextBudget,
     );
     onMessagesBuilt?.call(messages);
     return _runner.runAgent(

--- a/lib/core/llm/studio_ledger_prompt.dart
+++ b/lib/core/llm/studio_ledger_prompt.dart
@@ -39,12 +39,18 @@ class StudioLedgerPrompt {
   /// [character] — the character card for this session. Name, description, and
   /// personality are injected as a reference section so the ledger can resolve
   /// aliases and placeholders to the canonical identity.
+  ///
+  /// [entityAliases] — compact `{subjectKey: subjectName}` map of entities
+  /// that already appear in active knowledge facts. Lets the ledger issue
+  /// `rename_entity` ops to merge descriptive aliases into canonical
+  /// identities immediately, without waiting for reconciliation.
   String build({
     required String finalAssistantText,
     required String recentHistoryText,
     required List<Tracker> currentTrackers,
     required List<MemoryEntry> recentMemoryEntries,
     Character? character,
+    Map<String, String> entityAliases = const {},
   }) {
     final trackerBlock = buildCurrentStateBlock(
       currentTrackers,
@@ -53,6 +59,7 @@ class StudioLedgerPrompt {
     final keyCatalog = buildExistingKeyCatalog(currentTrackers);
     final memoryBlock = _buildMemoryBlock(recentMemoryEntries);
     final cardBlock = buildCharacterCardSection(character);
+    final entityBlock = buildEntityAliasSection(entityAliases);
 
     return '''$_systemPrompt
 
@@ -65,7 +72,7 @@ $trackerBlock
 $keyCatalog
 </existing_keys>
 
-<existing_memory>
+$entityBlock<existing_memory>
 $memoryBlock
 </existing_memory>
 
@@ -85,6 +92,9 @@ Required response template (follow this exact structure):
 <glaze_memory_export>
 {"ops":[],"knowledgeFacts":[]}
 </glaze_memory_export>
+<glaze_knowledge_cleanup>
+{"ops":[]}
+</glaze_knowledge_cleanup>
 <studio_ledger>
 Compact continuity snapshot here.
 </studio_ledger>
@@ -93,6 +103,14 @@ The <glaze_memory_export> block MUST come first, before <studio_ledger>.
 It must contain a single JSON object with "ops" and "knowledgeFacts" arrays.
 When there are no state changes or knowledge facts, output empty arrays —
 do NOT skip the block.
+
+The <glaze_knowledge_cleanup> block is OPTIONAL. Include it only when you
+need to rename a descriptive alias entity to a canonical identity. Use:
+{"ops":[{"op":"rename_entity","fromKey":"entity:descriptive_alias","toKey":"entity:canonical","canonicalName":"Name"}]}
+Only rename placeholder/descriptive identities listed in
+<existing_fact_entities>. Never rename an already-named entity to a
+different name. The canonicalName must appear in the final assistant
+response or recent chat.
 
 Ops format:
 {"ops":[{"op":"set","key":"npc:Name.field","value":"…","evidence":"…","eventState":"completed"},…],"knowledgeFacts":[{"knowerKey":"entity:lucy","knowerName":"Lucy","subjectKey":"entity:danvi","subjectName":"Danvi","factClass":"relationship","scopeKey":"relationship:danvi","predicate":"trusts","object":"Trusts Danvi.","epistemicState":"confirmed","confidence":0.9,"importance":0.8,"entities":["Lucy"],"topics":["trust"],"supersedesId":null}]}
@@ -215,6 +233,18 @@ knowledgeFacts rules:
       );
     }
     return '<character_card>\n${parts.join('\n')}\n</character_card>\n\n';
+  }
+
+  /// Compact `<existing_fact_entities>` section — entity keys and display
+  /// names only, no fact content. Lets the ledger issue `rename_entity` ops
+  /// to merge aliases without injecting full fact bodies (which would grow
+  /// the prompt unboundedly with fact count).
+  static String buildEntityAliasSection(Map<String, String> entityAliases) {
+    if (entityAliases.isEmpty) return '';
+    final lines = entityAliases.entries
+        .map((e) => '- ${e.key}: ${e.value}')
+        .join('\n');
+    return '<existing_fact_entities>\n$lines\n</existing_fact_entities>\n\n';
   }
 
   static const String _systemPrompt =

--- a/lib/core/llm/studio_ledger_prompt.dart
+++ b/lib/core/llm/studio_ledger_prompt.dart
@@ -1,3 +1,4 @@
+import '../models/character.dart';
 import '../models/memory_book.dart';
 import '../models/tracker.dart';
 
@@ -34,11 +35,16 @@ class StudioLedgerPrompt {
   ///
   /// [recentMemoryEntries] — up to 20 active MemoryBook entries (title + keys
   /// only, content omitted to keep prompt lean).
+  ///
+  /// [character] — the character card for this session. Name, description, and
+  /// personality are injected as a reference section so the ledger can resolve
+  /// aliases and placeholders to the canonical identity.
   String build({
     required String finalAssistantText,
     required String recentHistoryText,
     required List<Tracker> currentTrackers,
     required List<MemoryEntry> recentMemoryEntries,
+    Character? character,
   }) {
     final trackerBlock = buildCurrentStateBlock(
       currentTrackers,
@@ -46,9 +52,11 @@ class StudioLedgerPrompt {
     );
     final keyCatalog = buildExistingKeyCatalog(currentTrackers);
     final memoryBlock = _buildMemoryBlock(recentMemoryEntries);
+    final cardBlock = buildCharacterCardSection(character);
 
     return '''$_systemPrompt
 
+$cardBlock
 <current_state>
 $trackerBlock
 </current_state>
@@ -179,6 +187,34 @@ knowledgeFacts rules:
           return '- ${e.title.isNotEmpty ? e.title : e.id}$keys$locked';
         })
         .join('\n');
+  }
+
+  /// Compact `<character_card>` section for the ledger prompt.
+  ///
+  /// Includes name, description, and personality (each capped at 2000 chars)
+  /// so the ledger agent can resolve descriptive aliases ("беловолосая
+  /// женщина") and transliteration variants ("Lucy" / "Люси") to the canonical
+  /// character identity from the card.
+  static String buildCharacterCardSection(Character? character) {
+    if (character == null) return '';
+    final parts = <String>[];
+    final name = (character.displayName?.isNotEmpty ?? false)
+        ? character.displayName!
+        : character.name;
+    parts.add('Name: $name');
+    if (character.description != null && character.description!.isNotEmpty) {
+      final desc = character.description!;
+      parts.add(
+        'Description: ${desc.length > 2000 ? '${desc.substring(0, 2000)}…' : desc}',
+      );
+    }
+    if (character.personality != null && character.personality!.isNotEmpty) {
+      final pers = character.personality!;
+      parts.add(
+        'Personality: ${pers.length > 2000 ? '${pers.substring(0, 2000)}…' : pers}',
+      );
+    }
+    return '<character_card>\n${parts.join('\n')}\n</character_card>\n\n';
   }
 
   static const String _systemPrompt =

--- a/lib/core/llm/studio_ledger_reconciliation.dart
+++ b/lib/core/llm/studio_ledger_reconciliation.dart
@@ -3,10 +3,12 @@ import 'dart:convert';
 import 'package:crypto/crypto.dart';
 
 import '../db/repositories/ledger_reconciliation_checkpoint_repo.dart';
+import '../models/character.dart';
 import '../models/character_knowledge_fact.dart';
 import '../models/chat_message.dart';
 import '../models/knowledge_cleanup.dart';
 import '../models/tracker.dart';
+import 'studio_ledger_prompt.dart';
 
 const ledgerReconciliationPromptBlockId = 'ledger_reconciliation_prompt';
 
@@ -144,6 +146,7 @@ class StudioLedgerReconciliationPrompt {
     required LedgerReconciliationPlan plan,
     required List<Tracker> trackers,
     List<CharacterKnowledgeFact> knowledgeFacts = const [],
+    Character? character,
   }) {
     final chat = plan.messages
         .map(
@@ -165,10 +168,11 @@ class StudioLedgerReconciliationPrompt {
     final factLines = facts.isEmpty
         ? '(no reviewable knowledge facts)'
         : facts.map(_factLine).join('\n');
+    final cardSection = StudioLedgerPrompt.buildCharacterCardSection(character);
 
     return '''$systemPrompt
 
-<review_range start="${plan.startMessageId}" end="${plan.endMessage.id}">
+$cardSection<review_range start="${plan.startMessageId}" end="${plan.endMessage.id}">
 $chat
 </review_range>
 

--- a/lib/core/llm/studio_ledger_service.dart
+++ b/lib/core/llm/studio_ledger_service.dart
@@ -210,6 +210,7 @@ class StudioLedgerService {
         plan: plan,
         trackers: promptTrackers,
         knowledgeFacts: offeredFacts,
+        character: canon.source,
       );
       await _throwIfReconciliationAborted(token, isStillCurrent);
       final outcome = await _llm.callOnceWithLog(
@@ -547,6 +548,7 @@ class StudioLedgerService {
         recentMemoryEntries: recentEntries,
         ledgerBlocks: ledgerBlocks,
         macroCtx: macroCtx,
+        character: canon.source,
       );
 
       debugPrint(
@@ -805,6 +807,7 @@ class StudioLedgerService {
     required List<MemoryEntry> recentMemoryEntries,
     List<StudioPresetBlock> ledgerBlocks = const [],
     MacroContext? macroCtx,
+    Character? character,
   }) {
     final hasActiveLedgerBlocks = ledgerBlocks.any(
       (block) =>
@@ -819,6 +822,7 @@ class StudioLedgerService {
         recentHistoryText: recentHistoryText,
         currentTrackers: currentTrackers,
         recentMemoryEntries: recentMemoryEntries,
+        character: character,
       );
     }
 
@@ -828,10 +832,11 @@ class StudioLedgerService {
     );
     final keyCatalog = _promptBuilder.buildExistingKeyCatalog(currentTrackers);
     final memoryBlock = _buildMemoryBlock(recentMemoryEntries);
+    final cardSection = StudioLedgerPrompt.buildCharacterCardSection(character);
 
     final runtimeSuffix =
         '''
-<current_state>
+$cardSection<current_state>
 $trackerBlock
 </current_state>
 

--- a/lib/core/llm/studio_ledger_service.dart
+++ b/lib/core/llm/studio_ledger_service.dart
@@ -532,6 +532,9 @@ class StudioLedgerService {
       final recentEntries =
           book?.entries.where((e) => e.status == 'active').take(20).toList() ??
           const <MemoryEntry>[];
+      final entityAliases = await _knowledgeFactRepo.getEntityAliases(
+        sessionId,
+      );
 
       if (token.isCancelled || await _isStillCurrent(isStillCurrent) == false) {
         return LedgerRunResult.aborted;
@@ -549,6 +552,7 @@ class StudioLedgerService {
         ledgerBlocks: ledgerBlocks,
         macroCtx: macroCtx,
         character: canon.source,
+        entityAliases: entityAliases,
       );
 
       debugPrint(
@@ -648,6 +652,14 @@ class StudioLedgerService {
         swipeId: swipeId,
         agentSwipeId: agentSwipeId,
         content: finalAssistantText,
+      );
+      // Parse optional knowledge cleanup (rename_entity) from the same
+      // response. Applied after the main transaction so a cleanup failure
+      // does not roll back tracker/fact writes — the reconciler will retry.
+      final cleanupOps = const KnowledgeCleanupParser().parse(
+        output: rawResponse,
+        reviewText: '$recentHistoryText\n$finalAssistantText',
+        entityKeys: entityAliases.keys.toSet(),
       );
       final facts = export.knowledgeFacts
           .map(
@@ -758,6 +770,28 @@ class StudioLedgerService {
         '[StudioLedger] applied $opsApplied/${export.ops.length} ops session=$sessionId',
       );
 
+      // ── 7. Apply knowledge cleanup (rename_entity) ─────────────────────
+      if (cleanupOps.isNotEmpty) {
+        try {
+          final cleanupApplied = await _knowledgeFactRepo
+              .applyReconciliationCleanup(
+                sessionId: sessionId,
+                ops: cleanupOps,
+                endpointMessageId: null,
+              );
+          opsApplied += cleanupApplied;
+          debugPrint(
+            '[StudioLedger] cleanup ops=${cleanupOps.length} '
+            'applied=$cleanupApplied session=$sessionId',
+          );
+        } catch (e) {
+          // Cleanup failure is non-fatal — reconciler will retry.
+          debugPrint(
+            '[StudioLedger] cleanup failed (non-fatal) session=$sessionId: $e',
+          );
+        }
+      }
+
       sw.stop();
       debugPrint(
         '[StudioLedger] done session=$sessionId '
@@ -808,6 +842,7 @@ class StudioLedgerService {
     List<StudioPresetBlock> ledgerBlocks = const [],
     MacroContext? macroCtx,
     Character? character,
+    Map<String, String> entityAliases = const {},
   }) {
     final hasActiveLedgerBlocks = ledgerBlocks.any(
       (block) =>
@@ -823,6 +858,7 @@ class StudioLedgerService {
         currentTrackers: currentTrackers,
         recentMemoryEntries: recentMemoryEntries,
         character: character,
+        entityAliases: entityAliases,
       );
     }
 
@@ -833,10 +869,13 @@ class StudioLedgerService {
     final keyCatalog = _promptBuilder.buildExistingKeyCatalog(currentTrackers);
     final memoryBlock = _buildMemoryBlock(recentMemoryEntries);
     final cardSection = StudioLedgerPrompt.buildCharacterCardSection(character);
+    final entitySection = StudioLedgerPrompt.buildEntityAliasSection(
+      entityAliases,
+    );
 
     final runtimeSuffix =
         '''
-$cardSection<current_state>
+$cardSection$entitySection<current_state>
 $trackerBlock
 </current_state>
 

--- a/lib/core/llm/studio_ledger_service.dart
+++ b/lib/core/llm/studio_ledger_service.dart
@@ -903,6 +903,9 @@ Required response template (follow this exact structure):
 <glaze_memory_export>
 {"ops":[],"knowledgeFacts":[]}
 </glaze_memory_export>
+<glaze_knowledge_cleanup>
+{"ops":[]}
+</glaze_knowledge_cleanup>
 <studio_ledger>
 Compact continuity snapshot here.
 </studio_ledger>
@@ -911,6 +914,14 @@ The <glaze_memory_export> block MUST come first, before <studio_ledger>.
 It must contain a single JSON object with "ops" and "knowledgeFacts" arrays.
 When there are no state changes or knowledge facts, output empty arrays —
 do NOT skip the block.
+
+The <glaze_knowledge_cleanup> block is OPTIONAL. Include it only when you
+need to rename a descriptive alias entity to a canonical identity. Use:
+{"ops":[{"op":"rename_entity","fromKey":"entity:descriptive_alias","toKey":"entity:canonical","canonicalName":"Name"}]}
+Only rename placeholder/descriptive identities listed in
+<existing_fact_entities>. Never rename an already-named entity to a
+different name. The canonicalName must appear in the final assistant
+response or recent chat.
 
 Ops format:
 {"ops":[{"op":"set","key":"npc:Name.field","value":"…","evidence":"…","eventState":"completed"},…],"knowledgeFacts":[]}

--- a/lib/core/llm/studio_message_builder.dart
+++ b/lib/core/llm/studio_message_builder.dart
@@ -40,6 +40,7 @@ class StudioMessageBuilder {
     // its own (§4).
     int trackerContextOverride = 0,
     int reasoningHistoryCount = 0,
+    bool excludeReasoningFromContextBudget = false,
   }) {
     final point = _blockExpander.injectionPointForRun(agent, isFinalResponse);
     final spec = StudioControllerOntology.specForAgent(agent);
@@ -79,6 +80,8 @@ class StudioMessageBuilder {
                 studioPreset,
                 pipelineOverride: finalContextOverride,
                 reasoningHistoryCount: reasoningHistoryCount,
+                excludeReasoningFromContextBudget:
+                    excludeReasoningFromContextBudget,
               )
             : StudioHistoryLimiter.limitTrackerHistory(
                 context.history,
@@ -140,6 +143,8 @@ class StudioMessageBuilder {
                   studioPreset,
                   pipelineOverride: finalContextOverride,
                   reasoningHistoryCount: reasoningHistoryCount,
+                  excludeReasoningFromContextBudget:
+                      excludeReasoningFromContextBudget,
                 )
               : StudioHistoryLimiter.limitTrackerHistory(
                   context.history,

--- a/lib/core/llm/studio_message_builder.dart
+++ b/lib/core/llm/studio_message_builder.dart
@@ -58,7 +58,7 @@ class StudioMessageBuilder {
             })
             .toList()
           ..sort((a, b) => a.order.compareTo(b.order));
-    final blocks = _attachGroupBoundaries(routedBlocks);
+    final blocks = resolveEnabledStudioPresetBlocks(routedBlocks);
     final hasExplicitBriefMacros =
         isFinalResponse &&
         blocks.any(
@@ -264,76 +264,6 @@ class StudioMessageBuilder {
     return messages;
   }
 
-  /// Boundary rows stay independently editable in Studio, but XML tags belong
-  /// to the authored prompt they wrap on the wire. Prefix the opening tag to
-  /// the header prompt and suffix the closing tag to the last enabled block in
-  /// the group without merging the intervening prompt blocks.
-  List<StudioPresetBlock> _attachGroupBoundaries(
-    List<StudioPresetBlock> blocks,
-  ) {
-    final output = <StudioPresetBlock>[];
-    String? pendingOpen;
-    int? groupStart;
-    var groupEnabled = true;
-
-    for (final block in blocks) {
-      if (isStudioGroupOpen(block)) {
-        pendingOpen = block.content.trim();
-        continue;
-      }
-      if (isStudioGroupClose(block)) {
-        final start = groupStart;
-        if (groupEnabled && start != null) {
-          for (var index = output.length - 1; index >= start; index--) {
-            if (!output[index].enabled) continue;
-            output[index] = output[index].copyWith(
-              content: _joinBoundary(output[index].content, block.content),
-            );
-            break;
-          }
-        } else if (start == null && output.isNotEmpty) {
-          output[output.length - 1] = output.last.copyWith(
-            content: _joinBoundary(output.last.content, block.content),
-          );
-        }
-        pendingOpen = null;
-        groupStart = null;
-        groupEnabled = true;
-        continue;
-      }
-
-      if (isStudioPresetGroupHeader(block)) {
-        groupEnabled = block.enabled;
-        groupStart = output.length;
-        if (groupEnabled) {
-          final opening = pendingOpen;
-          output.add(
-            opening == null || opening.isEmpty
-                ? block
-                : block.copyWith(
-                    content: _joinBoundary(opening, block.content),
-                  ),
-          );
-        }
-        pendingOpen = null;
-        continue;
-      }
-
-      if (groupStart != null && !groupEnabled) continue;
-      if (block.enabled) output.add(block);
-    }
-
-    return output;
-  }
-
-  String _joinBoundary(String first, String second) {
-    final left = first.trim();
-    final right = second.trim();
-    if (left.isEmpty) return right;
-    if (right.isEmpty) return left;
-    return '$left\n$right';
-  }
-
   void _addInstructionMessage(
     List<Map<String, dynamic>> messages,
     String role,
@@ -426,9 +356,8 @@ class StudioMessageBuilder {
     required StudioContext context,
   }) {
     final specId = StudioControllerOntology.specForAgent(agent)?.id;
-    final blocks =
+    final routedBlocks =
         studioPreset.blocks
-            .where((b) => b.enabled)
             .where(
               (b) =>
                   b.injectionPoint == 'specificAgent' &&
@@ -437,6 +366,7 @@ class StudioMessageBuilder {
             .where((b) => !_blockExpander.isRuntimeComputedBlock(b))
             .toList()
           ..sort((a, b) => a.order.compareTo(b.order));
+    final blocks = resolveEnabledStudioPresetBlocks(routedBlocks);
     final buffer = StringBuffer();
     for (final block in blocks) {
       final content = _blockExpander
@@ -465,13 +395,14 @@ class StudioMessageBuilder {
     StudioPreset studioPreset,
     StudioContext context,
   ) {
-    final blocks =
+    final routedBlocks =
         studioPreset.blocks
-            .where((b) => b.enabled && b.injectionPoint == 'pregen')
+            .where((b) => b.injectionPoint == 'pregen')
             .where((b) => b.mode == 'direct')
             .where((b) => !_blockExpander.isRuntimeComputedBlock(b))
             .toList()
           ..sort((a, b) => a.order.compareTo(b.order));
+    final blocks = resolveEnabledStudioPresetBlocks(routedBlocks);
     final buffer = StringBuffer();
     for (final block in blocks) {
       final content = _blockExpander

--- a/lib/core/models/api_config.dart
+++ b/lib/core/models/api_config.dart
@@ -29,6 +29,7 @@ abstract class ApiConfig with _$ApiConfig {
     @Default(false) bool useResponsesApi,
     @Default(true) bool showNativeReasoning,
     @Default(0) int reasoningHistoryCount,
+    @Default(false) bool excludeReasoningFromContextBudget,
     String? reasoningTagStart,
     String? reasoningTagEnd,
     @Default(false) bool omitTemperature,

--- a/lib/core/models/card_evolution_observation.dart
+++ b/lib/core/models/card_evolution_observation.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'card_evolution_observation.freezed.dart';
+part 'card_evolution_observation.g.dart';
+
+/// One observation-journal entry for the Card Rewriter. An observation is a
+/// candidate durable character change recorded by the observation pass; it is
+/// not itself a card edit. Confirmations bump `repeatCount`; promotion flips
+/// `status` to `promoted` so the next card writer call receives it as a
+/// validated target. After a successful apply the status becomes `consumed`.
+@freezed
+abstract class CardEvolutionObservation with _$CardEvolutionObservation {
+  const factory CardEvolutionObservation({
+    required String id,
+    required String sessionId,
+    required String characterId,
+    required int runOrdinal,
+    required String semanticScopeKey,
+    required String observedChange,
+    String? canonicalClaim,
+    required List<String> evidenceMessageIds,
+    String? cardFieldPath,
+    String? lorebookEntryId,
+    required double confidence,
+    required String status,
+    required int firstSeenRun,
+    @Default(1) int repeatCount,
+    int? lastConfirmedRun,
+    required int createdAt,
+    required int updatedAt,
+  }) = _CardEvolutionObservation;
+
+  factory CardEvolutionObservation.fromJson(Map<String, dynamic> json) =>
+      _$CardEvolutionObservationFromJson(json);
+}

--- a/lib/core/models/card_rewriter_settings.dart
+++ b/lib/core/models/card_rewriter_settings.dart
@@ -17,6 +17,14 @@ abstract class CardRewriterSettings with _$CardRewriterSettings {
     @Default(180000) int timeoutMs,
     @Default('') String apiConfigId,
     @Default('') String modelOverride,
+    // Confirmations required before an observation is promoted to a validated
+    // target injected into the next card writer call.
+    @Default(3) int observationPromotionThreshold,
+    // Minimum confidence for an observation to become a validated target.
+    @Default(0.7) double observationMinConfidence,
+    // Observation passes without confirmation before an active observation
+    // expires. 4 passes ~ 48 turns ~ 96 messages.
+    @Default(4) int observationExpiryRuns,
   }) = _CardRewriterSettings;
 
   factory CardRewriterSettings.fromJson(Map<String, dynamic> json) =>

--- a/lib/core/models/studio_agent_settings.dart
+++ b/lib/core/models/studio_agent_settings.dart
@@ -55,6 +55,11 @@ abstract class StudioAgentSettings with _$StudioAgentSettings {
     // Include reasoning_content from the N most recent assistant messages in
     // final-generator history. -1 includes all retained history; 0 disables it.
     @Default(0) int studioFinalReasoningHistoryCount,
+    // When true, reasoning tokens are still sent to the provider but are NOT
+    // counted toward the history trim budget for the final generator. This
+    // lets more chat history fit when reasoning blocks are large. Overrides
+    // the API config flag when the Studio final slot is active.
+    @Default(false) bool studioFinalExcludeReasoningFromContextBudget,
     // When true, the final generator's request forces requestReasoning=false
     // and omitReasoning=true regardless of the ApiConfig. Targeted at Gemini
     // Flash thinking models that spend most of the token budget on a
@@ -115,7 +120,8 @@ Map<String, dynamic> _normalizeStudioAgentSettingsJson(
   Map<String, dynamic> json,
 ) {
   final n = Map<String, dynamic>.from(json);
-  for (final oldKey in n.keys.where((k) => k.startsWith('studioTracker')).toList()) {
+  for (final oldKey
+      in n.keys.where((k) => k.startsWith('studioTracker')).toList()) {
     final newKey = oldKey.replaceFirst('studioTracker', 'studioController');
     if (!n.containsKey(newKey)) {
       n[newKey] = n[oldKey];

--- a/lib/core/models/studio_preset_block_groups.dart
+++ b/lib/core/models/studio_preset_block_groups.dart
@@ -49,7 +49,7 @@ const _exclusiveStudioHeaders = <String>{
   'cot selections',
 };
 
-const _narrativeStyleAddonTitles = <String>{
+const _independentNarrativeStyleTitles = <String>{
   'bratty ass narrative',
   'doujinshi narrative',
   'emotional deflections',
@@ -191,35 +191,15 @@ List<StudioPresetBlockGroup> groupStudioPresetBlocks(
   void flush() {
     final current = header;
     if (current == null) return;
-    final isNarrativeStyles =
-        _normalizedHeaderTitle(current.title) == 'narrative styles';
-    final groupedChildren = isNarrativeStyles
-        ? children
-              .where(
-                (block) => !_narrativeStyleAddonTitles.contains(
-                  block.title.trim().toLowerCase(),
-                ),
-              )
-              .toList(growable: false)
-        : children;
     result.add(
       StudioPresetBlockGroup.section(
         header: current,
         openingBoundary: boundaries['${current.id}_group_open'],
         closingBoundary: boundaries['${current.id}_group_close'],
-        children: List.unmodifiable(groupedChildren),
+        children: List.unmodifiable(children),
         exclusive: _isExclusiveHeader(current.title),
       ),
     );
-    if (isNarrativeStyles) {
-      for (final child in children) {
-        if (_narrativeStyleAddonTitles.contains(
-          child.title.trim().toLowerCase(),
-        )) {
-          result.add(StudioPresetBlockGroup.standalone(child));
-        }
-      }
-    }
     header = null;
     children = <StudioPresetBlock>[];
   }
@@ -263,30 +243,100 @@ List<StudioPresetBlockGroup> groupStudioPresetBlocks(
   return result;
 }
 
-/// Enables or disables a visual group. Exclusive groups normally require one
-/// choice, except when the whole group is deliberately disabled (for example
-/// CoT selections).
+/// Enables or disables a visual group while preserving all child selections.
 List<StudioPresetBlock> toggleStudioPresetBlockGroup(
   List<StudioPresetBlock> blocks,
   StudioPresetBlockGroup group,
   bool enabled,
 ) {
-  final ids = <String>{
-    group.header?.id ?? '',
-    ...group.children.map((block) => block.id),
-  }..remove('');
-  if (ids.isEmpty) return blocks;
-  final selectedId = group.children.firstOrNull?.id;
+  final headerId = group.header?.id;
+  if (headerId == null) return blocks;
   return blocks
-      .map((block) {
-        if (!ids.contains(block.id)) return block;
-        if (block.id == group.header?.id) {
-          return block.copyWith(enabled: enabled);
-        }
-        if (!enabled) return block.copyWith(enabled: false);
-        return block.copyWith(enabled: block.id == selectedId);
-      })
+      .map(
+        (block) =>
+            block.id == headerId ? block.copyWith(enabled: enabled) : block,
+      )
       .toList(growable: false);
+}
+
+bool isIndependentStudioGroupChild(
+  StudioPresetBlockGroup group,
+  StudioPresetBlock block,
+) {
+  return _normalizedHeaderTitle(group.header?.title ?? '') ==
+          'narrative styles' &&
+      _independentNarrativeStyleTitles.contains(
+        block.title.trim().toLowerCase(),
+      );
+}
+
+/// Applies folder enablement and folds structural boundary rows into the
+/// authored blocks they wrap.
+List<StudioPresetBlock> resolveEnabledStudioPresetBlocks(
+  List<StudioPresetBlock> blocks,
+) {
+  final sorted = [...blocks]..sort((a, b) => a.order.compareTo(b.order));
+  final output = <StudioPresetBlock>[];
+  String? pendingOpen;
+  int? groupStart;
+  var groupEnabled = true;
+
+  for (final block in sorted) {
+    if (isStudioGroupOpen(block)) {
+      pendingOpen = block.content.trim();
+      continue;
+    }
+    if (isStudioGroupClose(block)) {
+      final start = groupStart;
+      if (groupEnabled && start != null) {
+        for (var index = output.length - 1; index >= start; index--) {
+          if (!output[index].enabled) continue;
+          output[index] = output[index].copyWith(
+            content: _joinStudioBoundary(output[index].content, block.content),
+          );
+          break;
+        }
+      } else if (start == null && output.isNotEmpty) {
+        output[output.length - 1] = output.last.copyWith(
+          content: _joinStudioBoundary(output.last.content, block.content),
+        );
+      }
+      pendingOpen = null;
+      groupStart = null;
+      groupEnabled = true;
+      continue;
+    }
+
+    if (isStudioPresetGroupHeader(block)) {
+      groupEnabled = block.enabled;
+      groupStart = output.length;
+      if (groupEnabled) {
+        final opening = pendingOpen;
+        output.add(
+          opening == null || opening.isEmpty
+              ? block
+              : block.copyWith(
+                  content: _joinStudioBoundary(opening, block.content),
+                ),
+        );
+      }
+      pendingOpen = null;
+      continue;
+    }
+
+    if (groupStart != null && !groupEnabled) continue;
+    if (block.enabled) output.add(block);
+  }
+
+  return output;
+}
+
+String _joinStudioBoundary(String first, String second) {
+  final left = first.trim();
+  final right = second.trim();
+  if (left.isEmpty) return right;
+  if (right.isEmpty) return left;
+  return '$left\n$right';
 }
 
 /// Enables [selectedId] and disables every sibling in an exclusive group.
@@ -296,10 +346,17 @@ List<StudioPresetBlock> selectExclusiveStudioBlock(
   String selectedId,
 ) {
   if (!group.exclusive) return blocks;
-  final ids = group.children.map((block) => block.id).toSet();
+  final ids = group.children
+      .where((block) => !isIndependentStudioGroupChild(group, block))
+      .map((block) => block.id)
+      .toSet();
   if (!ids.contains(selectedId)) return blocks;
   if (group.children.any(
-    (block) => block.locked && block.enabled && block.id != selectedId,
+    (block) =>
+        ids.contains(block.id) &&
+        block.locked &&
+        block.enabled &&
+        block.id != selectedId,
   )) {
     return blocks;
   }
@@ -329,6 +386,7 @@ List<StudioPresetBlock> updateStudioPresetBlockRespectingGroups(
   if (!updated.enabled) return result;
   for (final group in groupStudioPresetBlocks(result)) {
     if (group.exclusive &&
+        !isIndependentStudioGroupChild(group, updated) &&
         group.children.any((block) => block.id == updated.id)) {
       result = selectExclusiveStudioBlock(result, group, updated.id);
       break;

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -3,10 +3,12 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 
+import '../../db/repositories/card_evolution_observation_repo.dart';
 import '../../db/repositories/card_evolution_repo.dart';
 import '../../llm/card_rewrite_slot_resolver.dart';
 import '../../llm/aux_retry_runner.dart';
 import '../../models/agent_operation_record.dart';
+import '../../models/card_evolution_observation.dart';
 import '../../utils/id_generator.dart';
 import '../../utils/time_helpers.dart';
 import 'card_rewrite_operation_parser.dart';
@@ -28,15 +30,24 @@ class AutomatedCardEvolutionService {
     this.isLorebookEvolutionEnabled,
     this.timeoutMs = 180000,
     this.leaseSeconds = 300,
-  });
+    CardEvolutionObservationRepo? observationRepo,
+    this.observationPromotionThreshold,
+    this.observationMinConfidence,
+    this.observationExpiryRuns,
+  }) : observationRepo =
+           observationRepo ?? CardEvolutionObservationRepo(repo.db);
 
   final CardEvolutionRepo repo;
+  final CardEvolutionObservationRepo observationRepo;
   final CardRewriteModelResolver resolveModel;
   final CardRewriteLlmExecutor _executor;
   final bool Function()? isEnabled;
   final bool Function()? isLorebookEvolutionEnabled;
   final int timeoutMs;
   final int leaseSeconds;
+  final int Function()? observationPromotionThreshold;
+  final double Function()? observationMinConfidence;
+  final int Function()? observationExpiryRuns;
   final Map<String, CancelToken> _tokens = {};
   final Map<String, Future<CardEvolutionFinalizeOutcome>> _inFlight = {};
 
@@ -52,6 +63,7 @@ class AutomatedCardEvolutionService {
   }
 
   Future<CardEvolutionFinalizeOutcome> _run(String sessionId) async {
+    await _maybeRunObservationPass(sessionId);
     final owner = 'evolution-owner-${generateId()}';
     final now = currentTimestampSeconds();
     final claimed = await repo.claim(
@@ -84,8 +96,11 @@ class AutomatedCardEvolutionService {
       final cardOperations = <CardRewriteOperationSnapshot>[];
       String? cardOutput;
       if (allowedCardFields.isNotEmpty) {
+        final validatedTargets = _extractValidatedTargets(
+          snapshot.selectedInputJson,
+        );
         final cardPrompt =
-            '${CardRewriterPromptBuilder.buildEvolution(character: snapshot.character, instruction: 'Use the available non-empty card fields, the 20 latest immutable chat messages, and the current Ledger-backed factual context below to infer durable character evolution. Ledger supports the chat evidence; it does not replace it. Return patches only for fields with a durable, supported change. Change the smallest exact fragments possible; do not rewrite a whole field or card. Do not invent canon.')}\n\n# Immutable chat history and effective canon\n${snapshot.selectedInputJson}';
+            '${CardRewriterPromptBuilder.buildEvolution(character: snapshot.character, instruction: 'Use the available non-empty card fields, the 40 latest immutable chat messages, and the current Ledger-backed factual context below to infer durable character evolution. Ledger supports the chat evidence; it does not replace it. Return patches only for fields with a durable, supported change. Change the smallest exact fragments possible; do not rewrite a whole field or card. Do not invent canon.', validatedTargets: validatedTargets)}\n\n# Immutable chat history and effective canon\n${snapshot.selectedInputJson}';
         final cardOutcome = await _executor(
           config: config,
           prompt: cardPrompt,
@@ -105,17 +120,19 @@ class AutomatedCardEvolutionService {
             !cardOutcome.isOk ||
             cardOutcome.text == null) {
           return CardEvolutionFinalizeOutcome(
-            token.isCancelled || cardOutcome.status == AgentOperationStatus.aborted
+            token.isCancelled ||
+                    cardOutcome.status == AgentOperationStatus.aborted
                 ? 'cancelled'
                 : 'cardModelFailed',
             null,
             _modelFailureDetail(cardOutcome),
           );
         }
-        final parsedCardOperations = CardRewriteOperationParser.parseEvolutionBatch(
-          cardOutcome.text!,
-          allowedFields: allowedCardFields,
-        );
+        final parsedCardOperations =
+            CardRewriteOperationParser.parseEvolutionBatch(
+              cardOutcome.text!,
+              allowedFields: allowedCardFields,
+            );
         if (parsedCardOperations == null) {
           return CardEvolutionFinalizeOutcome(
             'invalidCardOutput',
@@ -139,7 +156,7 @@ class AutomatedCardEvolutionService {
         final lorebookOutcome = await _executor(
           config: config,
           prompt:
-               '${CardRewriterPromptBuilder.buildLorebookEvolution(instruction: 'Use the shared card, chat, and Ledger context to keep only the supplied injected lorebook entries current. Prefer the card for character relationships and enduring behavior; prefer lorebook entries for their specific locations, people, objects, or setting facts. Do not duplicate a current or proposed card fact into lorebook. Return a patch whenever the chat supports a durable update that belongs in an injected entry and is not already covered by the card.')}\n\n# Shared immutable context\n$sharedContext\n\n# Proposed card operations (read-only)\n${_cardProposalContext(cardOperations)}',
+              '${CardRewriterPromptBuilder.buildLorebookEvolution(instruction: 'Use the shared card, chat, and Ledger context to keep only the supplied injected lorebook entries current. Prefer the card for character relationships and enduring behavior; prefer lorebook entries for their specific locations, people, objects, or setting facts. Do not duplicate a current or proposed card fact into lorebook. Return a patch whenever the chat supports a durable update that belongs in an injected entry and is not already covered by the card.')}\n\n# Shared immutable context\n$sharedContext\n\n# Proposed card operations (read-only)\n${_cardProposalContext(cardOperations)}',
           maxTokens: _writerMaxTokens,
           temperature: 0.2,
           timeoutMs: timeoutMs,
@@ -193,6 +210,12 @@ class AutomatedCardEvolutionService {
         operations: operations,
       );
       finalized = result.isPersisted;
+      if (finalized) {
+        await repo.consumePromotedObservations(
+          sessionId,
+          now: currentTimestampSeconds(),
+        );
+      }
       return result;
     } on CardRewriteModelNotConfigured {
       return const CardEvolutionFinalizeOutcome('modelNotConfigured');
@@ -209,6 +232,7 @@ class AutomatedCardEvolutionService {
   }
 
   void cancelSession(String sessionId) {
+    _tokens['observation-$sessionId']?.cancel('generationAborted');
     _tokens[sessionId]?.cancel('generationAborted');
   }
 
@@ -229,6 +253,243 @@ class AutomatedCardEvolutionService {
     }
   }
 
+  /// Runs the observation pass when the cadence gate is active (every 2nd
+  /// successful reconciliation). Failures are non-blocking: the card writer
+  /// continues without validated targets.
+  Future<void> _maybeRunObservationPass(String sessionId) async {
+    try {
+      final count = await repo.countSuccessfulReconciliations(sessionId);
+      if (count == 0 || count % 2 != 0) return;
+      final runOrdinal = count ~/ 2;
+      await _runObservationPass(sessionId, runOrdinal);
+      await _checkPromotionsAndExpiry(sessionId, runOrdinal);
+    } catch (_) {
+      // Observation pass failures are intentionally non-blocking.
+    }
+  }
+
+  Future<void> _runObservationPass(String sessionId, int runOrdinal) async {
+    final snapshot = await repo.buildObservationSnapshot(sessionId);
+    if (snapshot == null) return;
+    final config = await resolveModel();
+    final active = await observationRepo.getActiveObservations(sessionId);
+    final activeMaps = active
+        .map(
+          (o) => <String, Object?>{
+            'scopeKey': o.semanticScopeKey,
+            'observedChange': o.observedChange,
+            'canonicalClaim': o.canonicalClaim,
+            'repeatCount': o.repeatCount,
+            'firstSeenRun': o.firstSeenRun,
+            'lastConfirmedRun': o.lastConfirmedRun,
+            'confidence': o.confidence,
+          },
+        )
+        .toList();
+    final prompt =
+        '${CardRewriterPromptBuilder.buildObservationPass(character: snapshot.character, activeObservations: activeMaps, instruction: 'Review the last 40 immutable chat messages and the current Ledger-backed canon below. For each active observation, decide whether the chat history still supports it. Identify any new repeatedly demonstrated shift in preference, attitude, relationship dynamics, or lasting character development. Do not record one-off events or temporary state. Be conservative.')}\n\n# Immutable chat history and effective canon\n${snapshot.selectedInputJson}';
+    final token = CancelToken();
+    _tokens['observation-$sessionId'] = token;
+    try {
+      if (token.isCancelled) return;
+      final outcome = await _executor(
+        config: config,
+        prompt: prompt,
+        maxTokens: _writerMaxTokens,
+        temperature: 0.2,
+        timeoutMs: timeoutMs,
+        cancelToken: token,
+      );
+      if (token.isCancelled ||
+          outcome.status == AgentOperationStatus.aborted ||
+          !outcome.isOk ||
+          outcome.text == null) {
+        return;
+      }
+      final actions = _parseObservationResponse(outcome.text!);
+      if (actions == null) return;
+      final now = currentTimestampSeconds();
+      for (final action in actions) {
+        await _applyObservationAction(
+          sessionId: sessionId,
+          characterId: snapshot.character.id,
+          runOrdinal: runOrdinal,
+          now: now,
+          action: action,
+        );
+      }
+    } finally {
+      if (identical(_tokens['observation-$sessionId'], token)) {
+        _tokens.remove('observation-$sessionId');
+      }
+    }
+  }
+
+  Future<void> _applyObservationAction({
+    required String sessionId,
+    required String characterId,
+    required int runOrdinal,
+    required int now,
+    required _ParsedObservationAction action,
+  }) async {
+    switch (action.action) {
+      case 'confirm':
+        final existing = await observationRepo.findByScopeKey(
+          sessionId,
+          action.scopeKey,
+        );
+        if (existing != null && existing.status == 'active') {
+          await observationRepo.confirmObservation(
+            id: existing.id,
+            runOrdinal: runOrdinal,
+            confidence: action.confidence,
+            now: now,
+          );
+        }
+        break;
+      case 'new':
+        final existing = await observationRepo.findByScopeKey(
+          sessionId,
+          action.scopeKey,
+        );
+        if (existing == null) {
+          await observationRepo.insertObservation(
+            CardEvolutionObservation(
+              id: 'observation-${generateId()}',
+              sessionId: sessionId,
+              characterId: characterId,
+              runOrdinal: runOrdinal,
+              semanticScopeKey: action.scopeKey,
+              observedChange: action.observedChange,
+              canonicalClaim: action.canonicalClaim,
+              evidenceMessageIds: action.evidenceMessageIds,
+              cardFieldPath: action.cardFieldPath,
+              lorebookEntryId: action.lorebookEntryId,
+              confidence: action.confidence,
+              status: 'active',
+              firstSeenRun: runOrdinal,
+              createdAt: now,
+              updatedAt: now,
+            ),
+          );
+        }
+        break;
+      case 'expire':
+        final existing = await observationRepo.findByScopeKey(
+          sessionId,
+          action.scopeKey,
+        );
+        if (existing != null && existing.status == 'active') {
+          await observationRepo.expireObservation(existing.id, now: now);
+        }
+        break;
+    }
+  }
+
+  Future<void> _checkPromotionsAndExpiry(
+    String sessionId,
+    int runOrdinal,
+  ) async {
+    final now = currentTimestampSeconds();
+    final threshold = observationPromotionThreshold?.call() ?? 3;
+    final minConfidence = observationMinConfidence?.call() ?? 0.7;
+    final expiryRuns = observationExpiryRuns?.call() ?? 4;
+    final promotable = await observationRepo.getPromotableObservations(
+      sessionId,
+      minRepeatCount: threshold,
+      minConfidence: minConfidence,
+    );
+    for (final obs in promotable) {
+      await observationRepo.promoteObservation(obs.id, now: now);
+    }
+    final expired = await observationRepo.getExpiryCandidates(
+      sessionId,
+      currentRunOrdinal: runOrdinal,
+      expiryRuns: expiryRuns,
+    );
+    for (final obs in expired) {
+      await observationRepo.expireObservation(obs.id, now: now);
+    }
+  }
+
+  static List<Map<String, Object?>> _extractValidatedTargets(
+    String selectedInputJson,
+  ) {
+    try {
+      final input = jsonDecode(selectedInputJson) as Map;
+      final targets = input['validatedTargets'];
+      if (targets is! List) return const [];
+      return [
+        for (final target in targets)
+          if (target is Map<String, Object?>) target,
+      ];
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  static List<_ParsedObservationAction>? _parseObservationResponse(
+    String output,
+  ) {
+    try {
+      final cleaned = output
+          .replaceAll(RegExp(r'^```(?:json)?\s*'), '')
+          .replaceAll(RegExp(r'\s*```$'), '')
+          .trim();
+      final decoded = jsonDecode(cleaned);
+      if (decoded is! Map) return null;
+      final observations = decoded['observations'];
+      if (observations is! List) return null;
+      final result = <_ParsedObservationAction>[];
+      for (final raw in observations) {
+        if (raw is! Map) return null;
+        final action = raw['action'];
+        final scopeKey = raw['scopeKey'];
+        final observedChange = raw['observedChange'];
+        final confidence = raw['confidence'];
+        if (action is! String ||
+            !const {'confirm', 'new', 'expire'}.contains(action) ||
+            scopeKey is! String ||
+            scopeKey.isEmpty ||
+            observedChange is! String ||
+            observedChange.isEmpty) {
+          return null;
+        }
+        final conf = confidence is num ? confidence.toDouble() : 0.5;
+        final clampedConf = conf < 0.0
+            ? 0.0
+            : conf > 1.0
+            ? 1.0
+            : conf;
+        final evidenceRaw = raw['evidenceMessageIds'];
+        final evidence = evidenceRaw is List
+            ? [for (final item in evidenceRaw) item.toString()]
+            : const <String>[];
+        result.add(
+          _ParsedObservationAction(
+            action: action,
+            scopeKey: scopeKey,
+            observedChange: observedChange,
+            canonicalClaim: raw['canonicalClaim'] is String
+                ? raw['canonicalClaim'] as String
+                : null,
+            evidenceMessageIds: evidence,
+            cardFieldPath: raw['cardFieldPath'] is String
+                ? raw['cardFieldPath'] as String
+                : null,
+            lorebookEntryId: raw['lorebookEntryId'] is String
+                ? raw['lorebookEntryId'] as String
+                : null,
+            confidence: clampedConf,
+          ),
+        );
+      }
+      return result;
+    } catch (_) {
+      return null;
+    }
+  }
+
   static String _cardProposalContext(
     List<CardRewriteOperationSnapshot> operations,
   ) => jsonEncode([
@@ -238,7 +499,9 @@ class AutomatedCardEvolutionService {
 
   static String _diagnostic(String? reason, String output) {
     final compact = output.replaceAll(RegExp(r'\s+'), ' ').trim();
-    final preview = compact.length > 240 ? '${compact.substring(0, 240)}...' : compact;
+    final preview = compact.length > 240
+        ? '${compact.substring(0, 240)}...'
+        : compact;
     return '${reason ?? 'unrecognized response'}; response: $preview';
   }
 
@@ -270,4 +533,26 @@ class AutomatedCardEvolutionService {
     ]),
     updatedAt: currentTimestampSeconds(),
   );
+}
+
+final class _ParsedObservationAction {
+  const _ParsedObservationAction({
+    required this.action,
+    required this.scopeKey,
+    required this.observedChange,
+    required this.canonicalClaim,
+    required this.evidenceMessageIds,
+    required this.cardFieldPath,
+    required this.lorebookEntryId,
+    required this.confidence,
+  });
+
+  final String action;
+  final String scopeKey;
+  final String observedChange;
+  final String? canonicalClaim;
+  final List<String> evidenceMessageIds;
+  final String? cardFieldPath;
+  final String? lorebookEntryId;
+  final double confidence;
 }

--- a/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
+++ b/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
@@ -15,13 +15,18 @@ abstract final class CardRewriterPromptBuilder {
   static String buildEvolution({
     required Character character,
     required String instruction,
+    List<Map<String, Object?>> validatedTargets = const [],
   }) {
     final writableFields = CardRewritePolicy.nonEmptyEvolutionFields(character);
-    final snapshot = Map<String, Object?>.from(CardCanonicalizer.snapshot(character));
+    final snapshot = Map<String, Object?>.from(
+      CardCanonicalizer.snapshot(character),
+    );
     for (final field in CardRewritePolicy.evolutionFields) {
       if (!writableFields.contains(field)) snapshot.remove(field.wireName);
     }
-    final writableFieldNames = writableFields.map((field) => field.wireName).join(', ');
+    final writableFieldNames = writableFields
+        .map((field) => field.wireName)
+        .join(', ');
     final buffer = StringBuffer()
       ..writeln(
         'You are the Glaze card rewriter. Propose small anchored scalar patches '
@@ -55,27 +60,27 @@ abstract final class CardRewriterPromptBuilder {
         'to omit a card patch. Use one or more exact anchors per changed field, '
         'never a full-field rewrite.',
       )
-       ..writeln(
-         'Prefer replacing or refining an existing outdated card fragment over '
-         'appending a new standalone fact. Append only when no existing fragment '
-         'can accurately absorb the durable development. This keeps the card '
-         'compact while allowing it to grow gradually when necessary.',
-       )
-       ..writeln(
-         'The card is a long-term character reference, not an event log. Keep '
-         'one-off actions, recent scene beats, invitations, travel, meals, and '
-         'the current state of a relationship in Ledger. Do not patch the card '
-         'merely because {{user}} and the character went somewhere or did '
-         'something together. Patch it only when the evidence establishes a '
-         'lasting change in personality, relationship pattern, enduring goal, '
-         'boundary, worldview, or baseline premise that future scenes need.',
-       )
-       ..writeln(
-         'For example, accepting a drink is a Ledger event; a repeatedly '
-         'demonstrated shift from guarded distrust to cautious trust may justify '
-         'a small card refinement. Do not turn a single event into a permanent '
-         'trait or relationship claim.',
-       )
+      ..writeln(
+        'Prefer replacing or refining an existing outdated card fragment over '
+        'appending a new standalone fact. Append only when no existing fragment '
+        'can accurately absorb the durable development. This keeps the card '
+        'compact while allowing it to grow gradually when necessary.',
+      )
+      ..writeln(
+        'The card is a long-term character reference, not an event log. Keep '
+        'one-off actions, recent scene beats, invitations, travel, meals, and '
+        'the current state of a relationship in Ledger. Do not patch the card '
+        'merely because {{user}} and the character went somewhere or did '
+        'something together. Patch it only when the evidence establishes a '
+        'lasting change in personality, relationship pattern, enduring goal, '
+        'boundary, worldview, or baseline premise that future scenes need.',
+      )
+      ..writeln(
+        'For example, accepting a drink is a Ledger event; a repeatedly '
+        'demonstrated shift from guarded distrust to cautious trust may justify '
+        'a small card refinement. Do not turn a single event into a permanent '
+        'trait or relationship claim.',
+      )
       ..writeln()
       ..writeln('# Patch rules')
       ..writeln(
@@ -85,25 +90,25 @@ abstract final class CardRewriterPromptBuilder {
         'only: for example relationship:danvi, never relationship:Danvi.',
       )
       ..writeln(
-         '- Each anchor must occur exactly once in its current field and its '
-         'anchorSha256 must be present as a string; the application recomputes '
-         'it from the anchor bytes. '
-         'Empty anchors are forbidden. Use a meaningful literal phrase of at '
-         'least 12 code units, never an isolated word, number, punctuation mark, '
-         'or identifier. Never '
-         'use chat-history text as an anchor: anchors are copied only from the '
-         'canonical card field you are patching.',
+        '- Each anchor must occur exactly once in its current field and its '
+        'anchorSha256 must be present as a string; the application recomputes '
+        'it from the anchor bytes. '
+        'Empty anchors are forbidden. Use a meaningful literal phrase of at '
+        'least 12 code units, never an isolated word, number, punctuation mark, '
+        'or identifier. Never '
+        'use chat-history text as an anchor: anchors are copied only from the '
+        'canonical card field you are patching.',
       )
       ..writeln(
         '- Preserve every {{...}} macro token byte-for-byte in a replacement.',
       )
-       ..writeln(
-         '- Treat the immutable chat history and Ledger facts as evidence for '
-         'card evolution. Ledger may establish the evidence, but its event '
-         'records are not themselves card content. Avoid duplication only '
-         'against the supplied injected lorebook entries, not against chat '
-         'history or Ledger.',
-       )
+      ..writeln(
+        '- Treat the immutable chat history and Ledger facts as evidence for '
+        'card evolution. Ledger may establish the evidence, but its event '
+        'records are not themselves card content. Avoid duplication only '
+        'against the supplied injected lorebook entries, not against chat '
+        'history or Ledger.',
+      )
       ..writeln('- Emit no keys beyond those shown above.')
       ..writeln()
       ..writeln('# User instruction')
@@ -111,6 +116,97 @@ abstract final class CardRewriterPromptBuilder {
       ..writeln()
       ..writeln('# Canonical character card snapshot (read-only)')
       ..write(jsonEncode(snapshot));
+    if (validatedTargets.isNotEmpty) {
+      buffer
+        ..writeln()
+        ..writeln('# Validated targets from observation journal')
+        ..writeln(
+          'These changes have been confirmed durable across multiple '
+          'observation passes. Produce patches for them with priority. You '
+          'may also propose additional changes from the current chat window, '
+          'but validated targets take precedence. A validated target may be '
+          'omitted only when the current chat window clearly contradicts it.',
+        )
+        ..write(jsonEncode(validatedTargets));
+    }
+    return buffer.toString();
+  }
+
+  static String buildObservationPass({
+    required Character character,
+    required List<Map<String, Object?>> activeObservations,
+    required String instruction,
+  }) {
+    final buffer = StringBuffer()
+      ..writeln(
+        'You are an observation journal keeper for a roleplay character card. '
+        'You do NOT edit the card. You record and confirm observations about '
+        'durable character changes.',
+      )
+      ..writeln()
+      ..writeln('# Rules')
+      ..writeln(
+        '- An observation is a candidate durable change, NOT a confirmed edit.',
+      )
+      ..writeln(
+        '- One-off events (going somewhere, eating, single conversations) are '
+        'NOT observations.',
+      )
+      ..writeln(
+        '- Temporary state (current mood, location, clothing, injury) is NOT '
+        'an observation.',
+      )
+      ..writeln(
+        '- Repeatedly demonstrated shifts in preference, attitude, relationship '
+        'dynamics, or lasting character development ARE observations.',
+      )
+      ..writeln(
+        '- Each observation has a narrow semantic scope key '
+        '(e.g. character.preference.X).',
+      )
+      ..writeln(
+        '- Confidence 0.0-1.0 reflects how strongly the chat history supports '
+        'this change.',
+      )
+      ..writeln()
+      ..writeln('# Active observations from previous passes')
+      ..writeln(jsonEncode(activeObservations))
+      ..writeln()
+      ..writeln('# Actions')
+      ..writeln('For each existing observation, choose:')
+      ..writeln(
+        '- "confirm": the latest chat history still supports this change. '
+        'Update confidence.',
+      )
+      ..writeln(
+        '- "expire": the latest chat history contradicts or no longer supports '
+        'this change.',
+      )
+      ..writeln('For new observations, choose:')
+      ..writeln(
+        '- "new": a new candidate durable change is evident from the chat '
+        'history.',
+      )
+      ..writeln()
+      ..writeln('# Response format')
+      ..writeln(
+        'Respond with exactly one JSON object and nothing else: '
+        '{"observations":[{"action":"confirm|new|expire","scopeKey":"...",'
+        '"observedChange":"...","canonicalClaim":"...",'
+        '"evidenceMessageIds":[],"cardFieldPath":"personality"|null,'
+        '"lorebookEntryId":"bookId:entryId"|null,"confidence":0.0-1.0}]}.',
+      )
+      ..writeln(
+        'Return an empty "observations" list ONLY when the chat history '
+        'contains no new durable changes and no existing observation needs '
+        'confirmation or expiry.',
+      )
+      ..writeln()
+      ..writeln('# Instruction')
+      ..writeln(instruction)
+      ..writeln()
+      ..writeln('# Canonical character card snapshot (read-only)')
+      ..write(jsonEncode(CardCanonicalizer.snapshot(character)));
     return buffer.toString();
   }
 

--- a/lib/features/chat/chat_session_service.dart
+++ b/lib/features/chat/chat_session_service.dart
@@ -289,6 +289,13 @@ class ChatSessionService {
             messageIds: messageIds,
           );
       await _ref
+          .read(ledgerReconciliationRunRepoProvider)
+          .copyForSessionBranch(
+            fromSessionId: current.id,
+            toSessionId: branch.id,
+            messageIds: messageIds,
+          );
+      await _ref
           .read(infoBlocksRepoProvider)
           .copyForSessionBranch(
             fromSessionId: current.id,

--- a/lib/features/image_gen/services/image_gen_http.dart
+++ b/lib/features/image_gen/services/image_gen_http.dart
@@ -6,10 +6,13 @@ import 'package:flutter/foundation.dart';
 class ImageGenHttp {
   final Dio _dio;
 
-  ImageGenHttp() : _dio = Dio(BaseOptions(
-    connectTimeout: const Duration(seconds: 60),
-    receiveTimeout: const Duration(seconds: 300),
-  ));
+  ImageGenHttp()
+    : _dio = Dio(
+        BaseOptions(
+          connectTimeout: const Duration(seconds: 60),
+          receiveTimeout: const Duration(seconds: 300),
+        ),
+      );
 
   Future<Map<String, dynamic>> post({
     required String url,
@@ -45,8 +48,67 @@ class ImageGenHttp {
     CancelToken? cancelToken,
     required String Function(Map<String, dynamic>) extractBase64,
   }) async {
-    final json = await post(url: url, body: body, apiKey: apiKey, extraHeaders: extraHeaders, cancelToken: cancelToken);
+    final json = await post(
+      url: url,
+      body: body,
+      apiKey: apiKey,
+      extraHeaders: extraHeaders,
+      cancelToken: cancelToken,
+    );
     final b64 = extractBase64(json);
+    return b64;
+  }
+
+  /// Generic post + extract that allows the caller to return [Uint8List]
+  /// directly — supports both base64 and URL-download paths.
+  Future<Uint8List> postAndExtract({
+    required String url,
+    required Map<String, dynamic> body,
+    String? apiKey,
+    Map<String, String>? extraHeaders,
+    CancelToken? cancelToken,
+    required Future<Uint8List> Function(Map<String, dynamic>) extract,
+  }) async {
+    final json = await post(
+      url: url,
+      body: body,
+      apiKey: apiKey,
+      extraHeaders: extraHeaders,
+      cancelToken: cancelToken,
+    );
+    return await extract(json);
+  }
+
+  /// Downloads raw bytes from a URL (for endpoints that return `url` instead
+  /// of `b64_json`).
+  static Future<Uint8List> downloadImage(
+    String url, {
+    CancelToken? cancelToken,
+  }) async {
+    final dio = Dio(
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 30),
+        receiveTimeout: const Duration(seconds: 120),
+      ),
+    );
+    try {
+      final response = await dio.get<Uint8List>(
+        url,
+        options: Options(responseType: ResponseType.bytes),
+        cancelToken: cancelToken,
+      );
+      return response.data ?? Uint8List(0);
+    } finally {
+      dio.close();
+    }
+  }
+
+  /// Strips an optional `data:image/...;base64,` prefix from a base64 string.
+  static String stripBase64Prefix(String b64) {
+    final commaIdx = b64.indexOf(',');
+    if (commaIdx >= 0 && b64.startsWith('data:')) {
+      return b64.substring(commaIdx + 1);
+    }
     return b64;
   }
 
@@ -54,7 +116,10 @@ class ImageGenHttp {
     return base64Decode(b64);
   }
 
-  Future<Response<Uint8List>> getRaw(String url, {CancelToken? cancelToken}) async {
+  Future<Response<Uint8List>> getRaw(
+    String url, {
+    CancelToken? cancelToken,
+  }) async {
     return _dio.get<Uint8List>(
       url,
       options: Options(responseType: ResponseType.bytes),
@@ -81,13 +146,20 @@ class ImageGenHttp {
       formData.fields.add(MapEntry(entry.key, entry.value));
     }
     for (final (fieldName, bytes, filename, mime) in imageFields) {
-      formData.files.add(MapEntry(
-        fieldName,
-        MultipartFile.fromBytes(bytes, filename: filename, contentType: DioMediaType.parse(mime)),
-      ));
+      formData.files.add(
+        MapEntry(
+          fieldName,
+          MultipartFile.fromBytes(
+            bytes,
+            filename: filename,
+            contentType: DioMediaType.parse(mime),
+          ),
+        ),
+      );
     }
     final headers = <String, String>{
-      if (apiKey != null && apiKey.isNotEmpty) 'Authorization': 'Bearer $apiKey',
+      if (apiKey != null && apiKey.isNotEmpty)
+        'Authorization': 'Bearer $apiKey',
     };
     try {
       final response = await _dio.post<Map<String, dynamic>>(

--- a/lib/features/image_gen/services/image_gen_service.dart
+++ b/lib/features/image_gen/services/image_gen_service.dart
@@ -246,9 +246,9 @@ class ImageGenService {
         ? llmEndpoint
         : settings.customEndpoint;
     final apiKey = settings.useSameEndpoint ? llmApiKey : settings.customApiKey;
-    final model = settings.useSameEndpoint
+    final model = settings.customModel.isEmpty
         ? 'dall-e-3'
-        : (settings.customModel.isEmpty ? 'dall-e-3' : settings.customModel);
+        : settings.customModel;
 
     return OpenaiImageProvider().generate(
       endpoint: endpoint,

--- a/lib/features/image_gen/services/openai_image_provider.dart
+++ b/lib/features/image_gen/services/openai_image_provider.dart
@@ -23,7 +23,7 @@ class OpenaiImageProvider {
       url = '$url/images/generations';
     }
 
-    final b64 = await _http.postAndExtractBase64(
+    return _http.postAndExtract(
       url: url,
       apiKey: apiKey,
       body: {
@@ -35,12 +35,30 @@ class OpenaiImageProvider {
         'response_format': 'b64_json',
       },
       cancelToken: cancelToken,
-      extractBase64: (json) {
+      extract: (json) async {
         final data = json['data'] as List?;
-        if (data == null || data.isEmpty) throw Exception('No image data in response');
-        return (data.first as Map<String, dynamic>)['b64_json'] as String;
+        if (data == null || data.isEmpty) {
+          throw Exception('No image data in response');
+        }
+        for (final item in data) {
+          if (item is! Map) continue;
+          final imageObj = Map<String, dynamic>.from(item);
+          final b64 = imageObj['b64_json'] as String?;
+          if (b64 != null && b64.isNotEmpty) {
+            return ImageGenHttp.base64ToBytes(
+              ImageGenHttp.stripBase64Prefix(b64),
+            );
+          }
+          final imgUrl = imageObj['url'] as String?;
+          if (imgUrl != null && imgUrl.isNotEmpty) {
+            return await ImageGenHttp.downloadImage(
+              imgUrl,
+              cancelToken: cancelToken,
+            );
+          }
+        }
+        throw Exception('No b64_json or url in image response');
       },
     );
-    return ImageGenHttp.base64ToBytes(b64);
   }
 }

--- a/lib/features/settings/api_settings_screen.dart
+++ b/lib/features/settings/api_settings_screen.dart
@@ -68,6 +68,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
   bool _requestReasoning = false;
   bool _useResponsesApi = false;
   bool _showNativeReasoning = true;
+  bool _excludeReasoningFromContextBudget = false;
   String _reasoningEffort = 'medium';
   bool _omitTemperature = false;
   bool _omitTopP = false;
@@ -226,6 +227,8 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
       _requestReasoning = values.requestReasoning;
       _useResponsesApi = values.useResponsesApi;
       _showNativeReasoning = values.showNativeReasoning;
+      _excludeReasoningFromContextBudget =
+          values.excludeReasoningFromContextBudget;
       _reasoningEffort = values.reasoningEffort;
       _omitTemperature = values.omitTemperature;
       _omitTopP = values.omitTopP;
@@ -261,6 +264,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
         requestReasoning: _requestReasoning,
         useResponsesApi: _useResponsesApi,
         showNativeReasoning: _showNativeReasoning,
+        excludeReasoningFromContextBudget: _excludeReasoningFromContextBudget,
         reasoningEffort: _reasoningEffort,
         omitTemperature: _omitTemperature,
         omitTopP: _omitTopP,
@@ -774,6 +778,17 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
                   keyboardType: const TextInputType.numberWithOptions(
                     signed: true,
                   ),
+                ),
+              if (_supportsReasoning)
+                MenuSwitchItem(
+                  label: 'label_exclude_reasoning_from_budget'.tr(),
+                  helpTerm: 'reasoning-budget',
+                  description: 'desc_exclude_reasoning_from_budget'.tr(),
+                  value: _excludeReasoningFromContextBudget,
+                  onChanged: (v) {
+                    setState(() => _excludeReasoningFromContextBudget = v);
+                    _scheduleSave();
+                  },
                 ),
               if (_supportsPromptCache)
                 MenuSelectorItem(

--- a/lib/features/studio/widgets/studio_block_row.dart
+++ b/lib/features/studio/widgets/studio_block_row.dart
@@ -638,11 +638,10 @@ class _StudioBlockGroupRowState extends State<StudioBlockGroupRow> {
                       ),
                     ),
                   ),
-                  if (_isCoTGroup(group))
-                    Switch.adaptive(
-                      value: header.enabled,
-                      onChanged: widget.onToggleGroup,
-                    ),
+                  Switch.adaptive(
+                    value: header.enabled,
+                    onChanged: widget.onToggleGroup,
+                  ),
                   SizedBox(
                     width: 36,
                     height: 44,
@@ -702,10 +701,20 @@ class _StudioBlockGroupRowState extends State<StudioBlockGroupRow> {
                   isLast:
                       i == group.children.length - 1 && closingBoundary == null,
                   onEdit: () => widget.onEdit(group.children[i]),
-                  onToggle: group.exclusive
+                  onToggle:
+                      group.exclusive &&
+                          !isIndependentStudioGroupChild(
+                            group,
+                            group.children[i],
+                          )
                       ? null
                       : (v) => widget.onToggle(group.children[i], v),
-                  trailing: group.exclusive
+                  trailing:
+                      group.exclusive &&
+                          !isIndependentStudioGroupChild(
+                            group,
+                            group.children[i],
+                          )
                       ? _radio(context, group.children[i])
                       : null,
                   onLongPress: () => widget.onDelete(group.children[i]),
@@ -738,17 +747,4 @@ class _StudioBlockGroupRowState extends State<StudioBlockGroupRow> {
       ),
     );
   }
-}
-
-/// Whether [group] is the CoT Selections section, the only exclusive group the
-/// user can turn off wholesale (every other exclusive group keeps its radio
-/// behaviour — exactly one option must stay picked).
-bool _isCoTGroup(StudioPresetBlockGroup group) {
-  final header = group.header;
-  if (header == null) return false;
-  final normalized = header.title
-      .replaceFirst(RegExp(r'^━[^\p{L}\p{N}]*', unicode: true), '')
-      .trim()
-      .toLowerCase();
-  return normalized == 'cot selections';
 }

--- a/lib/features/studio/widgets/studio_slot_settings_dialog.dart
+++ b/lib/features/studio/widgets/studio_slot_settings_dialog.dart
@@ -33,6 +33,7 @@ class StudioSlotSettings {
   final bool omitReasoning;
   final bool omitReasoningEffort;
   final int reasoningHistoryCount;
+  final bool excludeReasoningFromContextBudget;
   final int maxTokens;
   final int timeoutMs;
   final List<ExtraRequestParameter> extraRequestParameters;
@@ -51,6 +52,7 @@ class StudioSlotSettings {
     required this.omitReasoning,
     required this.omitReasoningEffort,
     this.reasoningHistoryCount = 0,
+    this.excludeReasoningFromContextBudget = false,
     required this.maxTokens,
     required this.timeoutMs,
     required this.extraRequestParameters,
@@ -74,6 +76,8 @@ class StudioSlotSettings {
             studioFinalOmitReasoning: omitReasoning,
             studioFinalOmitReasoningEffort: omitReasoningEffort,
             studioFinalReasoningHistoryCount: reasoningHistoryCount,
+            studioFinalExcludeReasoningFromContextBudget:
+                excludeReasoningFromContextBudget,
             studioFinalMaxTokens: maxTokens,
             studioFinalTimeoutMs: timeoutMs,
             studioFinalExtraRequestParameters: extraRequestParameters,
@@ -164,6 +168,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
   late bool _omitTopP;
   late bool _omitReasoning;
   late bool _omitReasoningEffort;
+  late bool _excludeReasoningFromContextBudget;
   late TextEditingController _reasoningHistoryCountCtrl;
   late TextEditingController _maxTokensCtrl;
   late TextEditingController _timeoutCtrl;
@@ -190,6 +195,8 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         _omitTopP = a.studioFinalOmitTopP;
         _omitReasoning = a.studioFinalOmitReasoning;
         _omitReasoningEffort = a.studioFinalOmitReasoningEffort;
+        _excludeReasoningFromContextBudget =
+            a.studioFinalExcludeReasoningFromContextBudget;
         _reasoningHistoryCountCtrl = TextEditingController(
           text: '${a.studioFinalReasoningHistoryCount}',
         );
@@ -216,6 +223,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         _omitTopP = a.studioControllerOmitTopP;
         _omitReasoning = a.studioControllerOmitReasoning;
         _omitReasoningEffort = a.studioControllerOmitReasoningEffort;
+        _excludeReasoningFromContextBudget = false;
         _reasoningHistoryCountCtrl = TextEditingController(text: '0');
         _maxTokensCtrl = TextEditingController(
           text: a.studioControllerMaxTokens > 0
@@ -242,6 +250,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         _omitTopP = c.postCleanerOmitTopP;
         _omitReasoning = c.postCleanerOmitReasoning;
         _omitReasoningEffort = c.postCleanerOmitReasoningEffort;
+        _excludeReasoningFromContextBudget = false;
         _reasoningHistoryCountCtrl = TextEditingController(text: '0');
         _maxTokensCtrl = TextEditingController(
           text: c.postCleanerMaxTokens > 0 ? '${c.postCleanerMaxTokens}' : '',
@@ -352,6 +361,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         reasoningHistoryCount: reasoningHistoryCount < -1
             ? 0
             : reasoningHistoryCount,
+        excludeReasoningFromContextBudget: _excludeReasoningFromContextBudget,
         maxTokens: maxTokens,
         timeoutMs: timeoutMs,
         extraRequestParameters: _extraRequestParameters,
@@ -494,6 +504,14 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
                     keyboardType: const TextInputType.numberWithOptions(
                       signed: true,
                     ),
+                  ),
+                if (widget.slot == StudioSlot.finalGenerator)
+                  MenuSwitchItem(
+                    label: 'label_exclude_reasoning_from_budget'.tr(),
+                    description: 'desc_exclude_reasoning_from_budget'.tr(),
+                    value: _excludeReasoningFromContextBudget,
+                    onChanged: (v) =>
+                        setState(() => _excludeReasoningFromContextBudget = v),
                   ),
               ],
             ),

--- a/lib/features/studio/widgets/studio_slot_settings_dialog.dart
+++ b/lib/features/studio/widgets/studio_slot_settings_dialog.dart
@@ -335,7 +335,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         int.tryParse(_reasoningHistoryCountCtrl.text.trim()) ?? 0;
     final seconds = int.tryParse(_timeoutCtrl.text.trim()) ?? 0;
     final timeoutMs = seconds > 0 ? seconds * 1000 : 0;
-    Navigator.of(context).pop(
+    Navigator.of(context, rootNavigator: true).pop(
       StudioSlotSettings(
         temperature: _temperature,
         topP: _topP,

--- a/test/card_evolution_observation_repo_test.dart
+++ b/test/card_evolution_observation_repo_test.dart
@@ -1,0 +1,139 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/card_evolution_observation_repo.dart';
+import 'package:glaze_flutter/core/models/card_evolution_observation.dart';
+
+void main() {
+  late AppDatabase db;
+  late CardEvolutionObservationRepo repo;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = CardEvolutionObservationRepo(db);
+  });
+  tearDown(() => db.close());
+
+  test('insert and find by scope key', () async {
+    await repo.insertObservation(_observation());
+    final found = await repo.findByScopeKey(
+      'session',
+      'character.preference.X',
+    );
+    expect(found, isNotNull);
+    expect(found!.status, 'active');
+    expect(found.repeatCount, 1);
+    expect(found.lastConfirmedRun, isNull);
+    expect(found.evidenceMessageIds, ['msg:1', 'msg:2']);
+  });
+
+  test('confirm bumps repeat count and last confirmed run', () async {
+    await repo.insertObservation(_observation());
+    await repo.confirmObservation(
+      id: 'obs-1',
+      runOrdinal: 2,
+      confidence: 0.8,
+      now: 20,
+    );
+    final found = await repo.findByScopeKey(
+      'session',
+      'character.preference.X',
+    );
+    expect(found!.repeatCount, 2);
+    expect(found.lastConfirmedRun, 2);
+    expect(found.confidence, 0.8);
+    expect(found.updatedAt, 20);
+  });
+
+  test('promote flips status and excludes from active', () async {
+    await repo.insertObservation(_observation());
+    await repo.promoteObservation('obs-1', now: 20);
+    expect(await repo.getActiveObservations('session'), isEmpty);
+    final promoted = await repo.getPromotedObservations('session');
+    expect(promoted, hasLength(1));
+    expect(promoted.first.status, 'promoted');
+  });
+
+  test('expire flips status and excludes from active', () async {
+    await repo.insertObservation(_observation());
+    await repo.expireObservation('obs-1', now: 20);
+    expect(await repo.getActiveObservations('session'), isEmpty);
+  });
+
+  test('consume flips promoted to consumed', () async {
+    await repo.insertObservation(_observation());
+    await repo.promoteObservation('obs-1', now: 20);
+    await repo.consumeObservation('obs-1', now: 30);
+    expect(await repo.getPromotedObservations('session'), isEmpty);
+  });
+
+  test('getPromotable filters by repeat count and confidence', () async {
+    await repo.insertObservation(_observation(repeatCount: 2, confidence: 0.6));
+    await repo.insertObservation(
+      _observation(
+        id: 'obs-2',
+        scopeKey: 'character.attitude.Y',
+        repeatCount: 3,
+        confidence: 0.8,
+      ),
+    );
+    final promotable = await repo.getPromotableObservations(
+      'session',
+      minRepeatCount: 3,
+      minConfidence: 0.7,
+    );
+    expect(promotable, hasLength(1));
+    expect(promotable.first.id, 'obs-2');
+  });
+
+  test('getExpiryCandidates filters by last confirmed run gap', () async {
+    await repo.insertObservation(_observation(lastConfirmedRun: 1));
+    await repo.insertObservation(
+      _observation(
+        id: 'obs-2',
+        scopeKey: 'character.attitude.Y',
+        lastConfirmedRun: 5,
+      ),
+    );
+    final expired = await repo.getExpiryCandidates(
+      'session',
+      currentRunOrdinal: 6,
+      expiryRuns: 4,
+    );
+    expect(expired, hasLength(1));
+    expect(expired.first.id, 'obs-1');
+  });
+
+  test('unique key collision on insert throws', () async {
+    await repo.insertObservation(_observation());
+    await expectLater(
+      repo.insertObservation(_observation()),
+      throwsA(isA<Object>()),
+    );
+  });
+}
+
+CardEvolutionObservation _observation({
+  String id = 'obs-1',
+  String scopeKey = 'character.preference.X',
+  int repeatCount = 1,
+  double confidence = 0.5,
+  int? lastConfirmedRun,
+}) => CardEvolutionObservation(
+  id: id,
+  sessionId: 'session',
+  characterId: 'character',
+  runOrdinal: 1,
+  semanticScopeKey: scopeKey,
+  observedChange: 'Alice is becoming more trusting',
+  canonicalClaim: 'Alice has become more trusting over time',
+  evidenceMessageIds: const ['msg:1', 'msg:2'],
+  cardFieldPath: 'personality',
+  confidence: confidence,
+  status: 'active',
+  firstSeenRun: 1,
+  repeatCount: repeatCount,
+  lastConfirmedRun: lastConfirmedRun,
+  createdAt: 10,
+  updatedAt: 10,
+);

--- a/test/card_evolution_observation_test.dart
+++ b/test/card_evolution_observation_test.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/models/card_evolution_observation.dart';
+
+void main() {
+  test('fromJson/toJson round-trip with all fields', () {
+    final observation = CardEvolutionObservation(
+      id: 'obs-1',
+      sessionId: 'session',
+      characterId: 'character',
+      runOrdinal: 3,
+      semanticScopeKey: 'character.preference.X',
+      observedChange: 'Alice is becoming more trusting',
+      canonicalClaim: 'Alice has become more trusting over time',
+      evidenceMessageIds: const ['msg:1', 'msg:2', 'msg:3'],
+      cardFieldPath: 'personality',
+      lorebookEntryId: 'book:entry',
+      confidence: 0.85,
+      status: 'promoted',
+      firstSeenRun: 1,
+      repeatCount: 3,
+      lastConfirmedRun: 3,
+      createdAt: 100,
+      updatedAt: 200,
+    );
+    final json = observation.toJson();
+    final restored = CardEvolutionObservation.fromJson(
+      jsonDecode(jsonEncode(json)) as Map<String, dynamic>,
+    );
+    expect(restored, observation);
+  });
+
+  test('fromJson/toJson round-trip with nullable fields null', () {
+    final observation = CardEvolutionObservation(
+      id: 'obs-2',
+      sessionId: 'session',
+      characterId: 'character',
+      runOrdinal: 1,
+      semanticScopeKey: 'character.attitude.Y',
+      observedChange: 'Bob is more reserved',
+      evidenceMessageIds: const [],
+      confidence: 0.5,
+      status: 'active',
+      firstSeenRun: 1,
+      createdAt: 10,
+      updatedAt: 10,
+    );
+    final json = observation.toJson();
+    final restored = CardEvolutionObservation.fromJson(
+      jsonDecode(jsonEncode(json)) as Map<String, dynamic>,
+    );
+    expect(restored, observation);
+    expect(restored.canonicalClaim, isNull);
+    expect(restored.cardFieldPath, isNull);
+    expect(restored.lorebookEntryId, isNull);
+    expect(restored.lastConfirmedRun, isNull);
+    expect(restored.repeatCount, 1);
+  });
+}

--- a/test/card_rewrite_observation_pass_test.dart
+++ b/test/card_rewrite_observation_pass_test.dart
@@ -1,0 +1,424 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/applied_canon_transition_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/canon_transition_fact_ref_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/card_evolution_observation_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/card_evolution_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/character_knowledge_fact_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/character_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/character_revision_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/character_session_baseline_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/ledger_raw_tracker_state_reader.dart';
+import 'package:glaze_flutter/core/db/repositories/manual_rewrite_job_repo.dart';
+import 'package:glaze_flutter/core/llm/aux_llm_client.dart';
+import 'package:glaze_flutter/core/llm/aux_retry_runner.dart';
+import 'package:glaze_flutter/core/models/agent_operation_record.dart';
+import 'package:glaze_flutter/core/models/card_evolution_observation.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/services/card_rewriter/automated_card_evolution_service.dart';
+import 'package:glaze_flutter/core/services/card_rewriter/card_rewriter_contracts.dart';
+import 'package:glaze_flutter/core/services/card_rewriter/effective_canon_read_repository.dart';
+
+void main() {
+  late _Fixture fixture;
+
+  setUp(() async {
+    fixture = await _Fixture.create();
+  });
+  tearDown(() => fixture.db.close());
+
+  test('zero reconciliation runs skips observation pass', () async {
+    var calls = 0;
+    await fixture
+        .service((_, prompt) async {
+          calls++;
+          return _ok(fixture.cardBatchOutput);
+        })
+        .runOneBatch('session');
+    expect(calls, 1);
+    expect(
+      await fixture.observationRepo.getActiveObservations('session'),
+      isEmpty,
+    );
+  });
+
+  test('odd reconciliation count skips observation pass', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
+    var calls = 0;
+    await fixture
+        .service((_, prompt) async {
+          calls++;
+          return _ok(fixture.cardBatchOutput);
+        })
+        .runOneBatch('session');
+    expect(calls, 1);
+  });
+
+  test(
+    'even reconciliation count runs observation pass before card writer',
+    () async {
+      await fixture.seedReconciliationRun(ordinal: 1);
+      await fixture.seedReconciliationRun(ordinal: 2);
+      final prompts = <String>[];
+      await fixture
+          .service((_, prompt) async {
+            prompts.add(prompt);
+            if (prompt.contains('observation journal keeper')) {
+              return _ok(fixture.observationNewOutput);
+            }
+            return _ok(fixture.cardBatchOutput);
+          })
+          .runOneBatch('session');
+      expect(prompts, hasLength(2));
+      expect(prompts.first, contains('observation journal keeper'));
+      expect(prompts.last, contains('Glaze card rewriter'));
+      final active = await fixture.observationRepo.getActiveObservations(
+        'session',
+      );
+      expect(active, hasLength(1));
+      expect(active.first.semanticScopeKey, 'character.preference.trust');
+      expect(active.first.status, 'active');
+      expect(active.first.repeatCount, 1);
+    },
+  );
+
+  test(
+    'promoted observation appears as validated target in card writer prompt',
+    () async {
+      await fixture.observationRepo.insertObservation(
+        CardEvolutionObservation(
+          id: 'obs-promoted',
+          sessionId: 'session',
+          characterId: 'character',
+          runOrdinal: 1,
+          semanticScopeKey: 'character.preference.trust',
+          observedChange: 'Alice is consistently more trusting',
+          canonicalClaim: 'Alice has become more trusting',
+          evidenceMessageIds: const ['a1', 'u1'],
+          cardFieldPath: 'personality',
+          confidence: 0.9,
+          status: 'promoted',
+          firstSeenRun: 1,
+          repeatCount: 3,
+          lastConfirmedRun: 3,
+          createdAt: 10,
+          updatedAt: 10,
+        ),
+      );
+      String? cardPrompt;
+      await fixture
+          .service((_, prompt) async {
+            if (!prompt.contains('observation journal keeper')) {
+              cardPrompt = prompt;
+            }
+            return _ok(fixture.cardBatchOutput);
+          })
+          .runOneBatch('session');
+      expect(cardPrompt, isNotNull);
+      expect(
+        cardPrompt,
+        contains('Validated targets from observation journal'),
+      );
+      expect(cardPrompt, contains('character.preference.trust'));
+    },
+  );
+
+  test('promotion after threshold confirmations', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
+    await fixture.seedReconciliationRun(ordinal: 2);
+    await fixture.observationRepo.insertObservation(
+      CardEvolutionObservation(
+        id: 'obs-1',
+        sessionId: 'session',
+        characterId: 'character',
+        runOrdinal: 1,
+        semanticScopeKey: 'character.preference.trust',
+        observedChange: 'Alice is becoming more trusting',
+        canonicalClaim: 'Alice has become more trusting',
+        evidenceMessageIds: const ['a1'],
+        cardFieldPath: 'personality',
+        confidence: 0.8,
+        status: 'active',
+        firstSeenRun: 1,
+        repeatCount: 2,
+        lastConfirmedRun: 1,
+        createdAt: 10,
+        updatedAt: 10,
+      ),
+    );
+    await fixture
+        .service((_, prompt) async {
+          if (prompt.contains('observation journal keeper')) {
+            return _ok(fixture.observationConfirmOutput);
+          }
+          return _ok(fixture.cardBatchOutput);
+        })
+        .runOneBatch('session');
+    // The observation goes through the full cycle: confirm (repeatCount 3)
+    // → promote → consume (after successful card writer apply).
+    final obs = await fixture.observationRepo.findById('obs-1');
+    expect(obs, isNotNull);
+    expect(obs!.status, 'consumed');
+    expect(obs.repeatCount, 3);
+  });
+
+  test('successful apply consumes promoted observations', () async {
+    await fixture.observationRepo.insertObservation(
+      CardEvolutionObservation(
+        id: 'obs-promoted',
+        sessionId: 'session',
+        characterId: 'character',
+        runOrdinal: 1,
+        semanticScopeKey: 'character.preference.trust',
+        observedChange: 'Alice is consistently more trusting',
+        evidenceMessageIds: const ['a1'],
+        confidence: 0.9,
+        status: 'promoted',
+        firstSeenRun: 1,
+        repeatCount: 3,
+        lastConfirmedRun: 3,
+        createdAt: 10,
+        updatedAt: 10,
+      ),
+    );
+    final result = await fixture
+        .service((_, _) async => _ok(fixture.cardBatchOutput))
+        .runOneBatch('session');
+    expect(result.kind, 'persisted');
+    expect(
+      await fixture.observationRepo.getPromotedObservations('session'),
+      isEmpty,
+    );
+  });
+
+  test('observation pass failure does not block card writer', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
+    await fixture.seedReconciliationRun(ordinal: 2);
+    var calls = 0;
+    final result = await fixture
+        .service((_, prompt) async {
+          calls++;
+          if (prompt.contains('observation journal keeper')) {
+            return _ok('not valid json');
+          }
+          return _ok(fixture.cardBatchOutput);
+        })
+        .runOneBatch('session');
+    expect(calls, 2);
+    expect(result.kind, 'persisted');
+    expect(
+      await fixture.observationRepo.getActiveObservations('session'),
+      isEmpty,
+    );
+  });
+
+  test('expiry after runs without confirmation', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
+    await fixture.seedReconciliationRun(ordinal: 2);
+    await fixture.observationRepo.insertObservation(
+      CardEvolutionObservation(
+        id: 'obs-stale',
+        sessionId: 'session',
+        characterId: 'character',
+        runOrdinal: 1,
+        semanticScopeKey: 'character.preference.trust',
+        observedChange: 'Alice is becoming more trusting',
+        evidenceMessageIds: const ['a1'],
+        confidence: 0.6,
+        status: 'active',
+        firstSeenRun: 1,
+        repeatCount: 1,
+        lastConfirmedRun: 1,
+        createdAt: 10,
+        updatedAt: 10,
+      ),
+    );
+    await fixture
+        .service(
+          (_, _) async => _ok(fixture.cardBatchOutput),
+          observationExpiryRuns: () => 4,
+        )
+        .runOneBatch('session');
+    // runOrdinal = 2~/2 = 1. 1 - 1 = 0 < 4, so NOT expired yet.
+    final active = await fixture.observationRepo.getActiveObservations(
+      'session',
+    );
+    expect(active, hasLength(1));
+  });
+}
+
+AuxCallOutcome _ok(String text) =>
+    AuxCallOutcome(status: AgentOperationStatus.ok, text: text);
+
+final class _Fixture {
+  _Fixture(this.db, this.repo, this.observationRepo);
+
+  final AppDatabase db;
+  final CardEvolutionRepo repo;
+  final CardEvolutionObservationRepo observationRepo;
+
+  static Future<_Fixture> create() async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final characters = CharacterRepo(db);
+    final revisions = CharacterRevisionRepo(db);
+    const character = Character(
+      id: 'character',
+      name: 'Card',
+      description: 'Alice is cautious.',
+    );
+    await characters.put(character);
+    final hash = CardCanonicalizer.sha256(character);
+    await revisions.insert(
+      CharacterRevisionRecord(
+        characterId: 'character',
+        revision: 1,
+        revisionHash: hash,
+        parentRevisionHash: '',
+        snapshotJson: jsonEncode(character.toJson()),
+        createdAt: 1,
+      ),
+    );
+    await db.customStatement(
+      'INSERT INTO chat_sessions (session_id, character_id, session_index, messages_json) VALUES (?, ?, 0, ?)',
+      ['session', 'character', jsonEncode(_messages)],
+    );
+    final reader = EffectiveCanonReadRepository(
+      db: db,
+      characterRepo: characters,
+      revisionRepo: revisions,
+      baselineRepo: CharacterSessionBaselineRepo(db),
+      factRepo: CharacterKnowledgeFactRepo(db),
+      transitionRepo: AppliedCanonTransitionRepo(db),
+      transitionFactRefRepo: CanonTransitionFactRefRepo(db),
+    );
+    final jobs = ManualRewriteJobRepo(
+      db: db,
+      rawTrackerStateReader: LedgerRawTrackerStateReader(db),
+    );
+    final repo = CardEvolutionRepo(db: db, canonReader: reader, jobRepo: jobs);
+    final observationRepo = CardEvolutionObservationRepo(db);
+    return _Fixture(db, repo, observationRepo);
+  }
+
+  Future<void> seedReconciliationRun({required int ordinal}) async {
+    await db.customStatement(
+      'INSERT INTO reconciliation_successful_runs '
+      '(id, session_id, ordinal, start_message_id, start_swipe_id, '
+      'start_agent_swipe_id, end_message_id, end_swipe_id, '
+      'end_agent_swipe_id, anchors_json, range_hash, '
+      'accepted_manifest_refs_json, effective_canon_stamp, '
+      'effective_canon_revision, effective_canon_hash, '
+      'canonical_result_json, content_hash, predecessor_chain_hash, '
+      'chain_hash, contract_version, ops_applied_json, created_at) '
+      'VALUES (?, ?, ?, ?, 0, 0, ?, 0, 0, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, 1, ?, ?)',
+      [
+        'run-$ordinal',
+        'session',
+        ordinal,
+        'a1',
+        'a1',
+        '[]',
+        'range-$ordinal',
+        '[]',
+        'canon-stamp-$ordinal',
+        'canon-hash-$ordinal',
+        '{"result":"ok"}',
+        'content-$ordinal',
+        '',
+        'chain-$ordinal',
+        '[]',
+        ordinal * 10,
+      ],
+    );
+  }
+
+  String get cardBatchOutput => jsonEncode({
+    'operations': [
+      {
+        'field': CardRewriteField.description.wireName,
+        'patches': [
+          {
+            'scopeKey': 'npc:alice',
+            'anchor': 'Alice is cautious.',
+            'anchorSha256': CardCanonicalizer.scalarSha256(
+              'Alice is cautious.',
+            ),
+            'value': 'Alice is increasingly trusting.',
+          },
+        ],
+        'transition': {
+          'id': 'transition',
+          'scopeKey': 'npc:alice',
+          'canonicalClaim': 'Alice is increasingly trusting.',
+          'promotionDestination': 'card',
+          'affectedTrackerKeys': <String>[],
+          'factIds': <String>[],
+          'chatSessionId': null,
+        },
+      },
+    ],
+  });
+
+  String get observationNewOutput => jsonEncode({
+    'observations': [
+      {
+        'action': 'new',
+        'scopeKey': 'character.preference.trust',
+        'observedChange': 'Alice is becoming more trusting',
+        'canonicalClaim': 'Alice has become more trusting over time',
+        'evidenceMessageIds': ['a1', 'u1'],
+        'cardFieldPath': 'personality',
+        'confidence': 0.8,
+      },
+    ],
+  });
+
+  String get observationConfirmOutput => jsonEncode({
+    'observations': [
+      {
+        'action': 'confirm',
+        'scopeKey': 'character.preference.trust',
+        'observedChange': 'Alice is becoming more trusting',
+        'confidence': 0.85,
+      },
+    ],
+  });
+
+  AutomatedCardEvolutionService service(
+    Future<AuxCallOutcome> Function(CancelToken? token, String prompt)
+    executor, {
+    int Function()? observationExpiryRuns,
+  }) => AutomatedCardEvolutionService(
+    repo: repo,
+    observationRepo: observationRepo,
+    resolveModel: () async => const AuxApiConfig(
+      endpoint: 'https://rewrite.example',
+      apiKey: 'key',
+      model: 'model',
+      protocol: 'openai',
+    ),
+    executor:
+        ({
+          required config,
+          required prompt,
+          required maxTokens,
+          required temperature,
+          required timeoutMs,
+          cancelToken,
+        }) => executor(cancelToken, prompt),
+    observationPromotionThreshold: () => 3,
+    observationMinConfidence: () => 0.7,
+    observationExpiryRuns: observationExpiryRuns ?? () => 4,
+  );
+}
+
+const _messages = [
+  {'id': 'a1', 'role': 'assistant', 'content': 'assistant 1'},
+  {'id': 'u1', 'role': 'user', 'content': 'user 1'},
+  {'id': 'a2', 'role': 'assistant', 'content': 'assistant 2'},
+  {'id': 'u2', 'role': 'user', 'content': 'user 2'},
+];

--- a/test/characterization/context_calculator_completion_budget_test.dart
+++ b/test/characterization/context_calculator_completion_budget_test.dart
@@ -93,6 +93,45 @@ void main() {
       );
     });
 
+    test(
+      'excludeReasoningFromContextBudget keeps reasoning without trimming',
+      () {
+        final messages = [
+          userTurn('m1', 'older message'),
+          const PromptMessage(
+            role: 'assistant',
+            content: 'recent reply',
+            reasoningContent:
+                'one two three four five six seven eight nine ten',
+            isHistory: true,
+            sourceMessageId: 'm2',
+          ),
+        ];
+        // Without the flag, reasoning tokens eat budget and the older message
+        // is trimmed (same as the test above).
+        final withReasoning = ContextCalculator(
+          contextSize: 20,
+          maxTokens: 5,
+          reasoningHistoryCount: 1,
+        ).calculate(staticBlocks: const [], historyMessages: messages);
+        expect(withReasoning.trimmedHistory, hasLength(1));
+
+        // With the flag, reasoning tokens are excluded from the trim budget
+        // so the older message is retained alongside the reasoning block.
+        final excluded = ContextCalculator(
+          contextSize: 20,
+          maxTokens: 5,
+          reasoningHistoryCount: 1,
+          excludeReasoningFromContextBudget: true,
+        ).calculate(staticBlocks: const [], historyMessages: messages);
+        expect(excluded.trimmedHistory, hasLength(2));
+        // historyTokens still includes reasoning for accurate reporting.
+        expect(
+          excluded.historyTokens,
+          greaterThan(withReasoning.historyTokens),
+        );
+      },
+    );
     test('minus one budgets every retained reasoning block', () {
       const messages = [
         PromptMessage(

--- a/test/studio_block_group_row_test.dart
+++ b/test/studio_block_group_row_test.dart
@@ -84,8 +84,9 @@ void main() {
     await tester.pumpAndSettle();
     expect(edited?.id, 'pov_header');
 
-    // Exclusive children carry radios, not switches.
-    expect(find.byType(Switch), findsNothing);
+    // Exclusive children carry radios, not switches. The folder header is
+    // the only Switch in this expanded exclusive group.
+    expect(find.byType(Switch), findsOneWidget);
     await tester.tap(find.byIcon(Icons.radio_button_off));
     await tester.pumpAndSettle();
     expect(selected, 'second_person');
@@ -119,8 +120,14 @@ void main() {
     await tester.tap(find.text('Core'));
     await tester.pumpAndSettle();
 
-    final toggle = tester.widget<Switch>(find.byType(Switch));
-    expect(toggle.onChanged, isNull);
+    // Two switches after expansion: the folder header toggle and the child
+    // toggle. The locked child's switch is the one with onChanged == null.
+    final switches = tester.widgetList<Switch>(find.byType(Switch)).toList();
+    expect(switches, hasLength(2));
+    final lockedChildSwitch = switches.singleWhere(
+      (s) => s.onChanged == null,
+    );
+    expect(lockedChildSwitch.value, isTrue);
     expect(toggled, isFalse);
   });
 
@@ -177,15 +184,13 @@ void main() {
       ),
     );
 
-    // The CoT group carries a whole-group switch, unlike other exclusive
-    // groups which only expose per-child radios.
     expect(find.byType(Switch), findsOneWidget);
     await tester.tap(find.byType(Switch));
     await tester.pumpAndSettle();
     expect(groupToggled, isTrue);
   });
 
-  testWidgets('non-CoT exclusive group has no whole-group switch', (
+  testWidgets('non-CoT exclusive group has a whole-group switch', (
     tester,
   ) async {
     const blocks = [
@@ -216,7 +221,7 @@ void main() {
       ),
     );
 
-    expect(find.byType(Switch), findsNothing);
+    expect(find.byType(Switch), findsOneWidget);
   });
 
   testWidgets('folder delete icon triggers onDeleteGroup', (tester) async {

--- a/test/studio_preset_block_groups_test.dart
+++ b/test/studio_preset_block_groups_test.dart
@@ -362,7 +362,7 @@ void main() {
     );
   });
 
-  test('renders narrative modifiers as independent add-on switches', () {
+  test('keeps narrative modifiers independent inside their folder', () {
     const narrativeBlocks = [
       StudioPresetBlock(
         id: 'style_header',
@@ -404,18 +404,23 @@ void main() {
 
     final items = groupStudioPresetBlocks(narrativeBlocks);
 
-    expect(items, hasLength(4));
-    expect(items.first.exclusive, isTrue);
-    expect(items.first.children.map((block) => block.id), [
+    expect(items, hasLength(1));
+    final group = items.single;
+    expect(group.exclusive, isTrue);
+    expect(group.children.map((block) => block.id), [
       'ao3',
       'endless',
-      'anime',
-    ]);
-    expect(items.skip(1).map((item) => item.standalone?.id), [
       'bratty',
+      'anime',
       'doujinshi',
       'deflections',
     ]);
+    expect(
+      group.children
+          .where((block) => isIndependentStudioGroupChild(group, block))
+          .map((block) => block.id),
+      ['bratty', 'doujinshi', 'deflections'],
+    );
 
     final withBratty = updateStudioPresetBlockRespectingGroups(
       narrativeBlocks,
@@ -428,6 +433,70 @@ void main() {
       withBratty.firstWhere((block) => block.id == 'bratty').enabled,
       isTrue,
     );
+
+    final withAnime = selectExclusiveStudioBlock(
+      withBratty,
+      groupStudioPresetBlocks(withBratty).single,
+      'anime',
+    );
+    expect(withAnime.firstWhere((block) => block.id == 'ao3').enabled, isFalse);
+    expect(
+      withAnime.firstWhere((block) => block.id == 'anime').enabled,
+      isTrue,
+    );
+    expect(
+      withAnime.firstWhere((block) => block.id == 'bratty').enabled,
+      isTrue,
+    );
+  });
+
+  test('folder toggle preserves child selections and suppresses injection', () {
+    const folderBlocks = [
+      StudioPresetBlock(
+        id: 'folder_group_open',
+        content: '<folder>',
+        groupBoundary: 'open',
+        order: 0,
+      ),
+      StudioPresetBlock(
+        id: 'folder',
+        title: '━ Folder',
+        content: 'Header',
+        order: 1,
+      ),
+      StudioPresetBlock(id: 'first', content: 'First', order: 2),
+      StudioPresetBlock(
+        id: 'second',
+        content: 'Second',
+        enabled: false,
+        order: 3,
+      ),
+      StudioPresetBlock(
+        id: 'folder_group_close',
+        content: '</folder>',
+        groupBoundary: 'close',
+        order: 4,
+      ),
+      StudioPresetBlock(id: 'outside', content: 'Outside', order: 5),
+    ];
+    final group = groupStudioPresetBlocks(folderBlocks).first;
+
+    final disabled = toggleStudioPresetBlockGroup(folderBlocks, group, false);
+    expect(disabled.firstWhere((block) => block.id == 'first').enabled, isTrue);
+    expect(
+      disabled.firstWhere((block) => block.id == 'second').enabled,
+      isFalse,
+    );
+    expect(
+      resolveEnabledStudioPresetBlocks(disabled).map((block) => block.id),
+      ['outside'],
+    );
+
+    final restored = toggleStudioPresetBlockGroup(disabled, group, true);
+    final resolved = resolveEnabledStudioPresetBlocks(restored);
+    expect(resolved.map((block) => block.id), ['folder', 'first', 'outside']);
+    expect(resolved.first.content, '<folder>\nHeader');
+    expect(resolved[1].content, 'First\n</folder>');
   });
 
   test('repairs a mismatched legacy close from the owned opening tag', () {


### PR DESCRIPTION
## Summary

10 commits fixing Studio Direct preset, ledger agent, card rewriter, and image generation.

### Studio Direct preset (b2)
- **8dabf73a** — Folder toggle (header-only, preserves child selections), prose blocks (Bratty Ass/Doujinshi/Emotional Deflections) kept inside Narrative Styles folder with independent toggles, unified boundary resolver (esolveEnabledStudioPresetBlocks) applied to all prompt paths (final/batch/cleaner/ledger)
- **5d163723** — Fix Responses API toggle not persisting: Navigator.pop now uses ootNavigator: true to match showModalBottomSheet(useRootNavigator: true) in nested StatefulShellRoute

### Reasoning budget (b4)
- **9197cc30** — New excludeReasoningFromContextBudget toggle on ApiConfig: reasoning_content still sent to provider but tokens excluded from history trim budget. Applied in ContextCalculator and StudioHistoryLimiter
- **15bc222a** — Per-slot override studioFinalExcludeReasoningFromContextBudget in Studio final generator settings

### Card rewriter observation journal (b5)
- **cb55711** — History window 20→40 messages, observation pass every 2nd successful reconciliation (every 12 turns), promotion threshold 3 confirmations + confidence ≥ 0.7, expiry 4 runs without confirmation. New CardEvolutionObservations table (schema 107→108), CardEvolutionObservationRepo, observation pass prompt builder, validatedTargets injection into card writer prompt

### Ledger improvements (b6-b7, b9)
- **75d06274** — Character card injected into ledger and reconciler prompts (was missing since original 361cc293). Ledger agent can now resolve aliases against canonical identity
- **41b98d48** — Regular ledger agent can issue ename_entity ops via optional <glaze_knowledge_cleanup> block. Compact <existing_fact_entities> section (entity keys + display names only, max 40) lets ledger merge descriptive aliases immediately on reveal, without waiting for reconciler
- **26ebc41b** — Knowledge cleanup block added to preset-path response template (was only in fallback path)
- **b01de82** — Fork sessions now copy econciliation_successful_runs so cadence gate doesn't reset to zero on branch

### Image generation (b10)
- **e6208ac2** — Null-safe response parsing for custom OpenAI-compatible endpoints (tries 64_json, falls back to url download). Custom model respected regardless of useSameEndpoint (was hardcoded to dall-e-3)

## Test plan
- [x] studio_preset_block_groups_test.dart — 16 tests
- [x] studio_block_group_row_test.dart — 5 tests
- [x] studio_prompt_filtering_test.dart — 32 tests
- [x] studio_typed_message_builder_test.dart — 5 tests
- [x] openai_responses_transport_test.dart — 4 tests
- [x] studio_ledger_test.dart + studio_ledger_transaction_test.dart — 69 tests
- [x] context_calculator_completion_budget_test.dart — 39 tests
- [x] card_evolution_observation_repo_test.dart — 8 tests
- [x] card_evolution_observation_test.dart — 2 tests
- [x] card_rewrite_observation_pass_test.dart — 8 tests
- [x] dart analyze clean on all changed files

## Notes
- DB changes are not part of this PR (preset block reordering was done directly in nightly DB)
- LlmRequestDump.enabled remains alse (was temporarily enabled for diagnostics, reverted)
- Card rewriter observation journal linking via predecessorCursorHash/predecessorRunOrdinal deferred (low priority, stubs remain)
