### PR TITLE
fix(ledger): trigger reconciliation after Nth assistant and gate card-rewriter to every 2nd run

### DIFF
--- a/lib/core/llm/studio_ledger_reconciliation.dart
+++ b/lib/core/llm/studio_ledger_reconciliation.dart
@@ -61,14 +61,18 @@ class LedgerReconciliationPlanner {
         .take(currentIndex)
         .where(_isAcceptedAssistant)
         .toList(growable: false);
+    // Trigger once the Nth assistant has just been generated
+    // (N = interval, 2*interval, ...). acceptedAssistants holds a1..a(N-1);
+    // the freshly generated aN is the current message and is excluded from
+    // the review range so its brand-new snapshot cannot be rewritten. A
+    // reroll of aN produces the same boundary (a1..a(N-1)) and is
+    // deduplicated by the checkpoint; a(N+1) must never re-run or rewrite
+    // the older boundary.
     if (acceptedAssistants.isEmpty ||
-        acceptedAssistants.length % interval != 0) {
+        (acceptedAssistants.length + 1) % interval != 0) {
       return null;
     }
 
-    // Review boundary N only while N+1 is being generated. A reroll of N+1
-    // has the same boundary and is deduplicated by the checkpoint; N+2 must
-    // never re-run or rewrite the older boundary.
     final endIndex = messages.indexWhere(
       (message) => message.id == acceptedAssistants.last.id,
     );

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -245,10 +245,22 @@ class LedgerStage {
           if (reconciliationResult.status == 'ok' &&
               pipeline.cardRewriter.enabled &&
               isCurrent()) {
-            await ctx.ref
-                .read(automatedCardEvolutionServiceProvider)
-                .runOneBatch(sessionId);
-            if (!isCurrent()) return;
+            // Card-rewriter runs on every 2nd successful reconciliation
+            // (plan §Automated Card Evolution cadence). Counting via the run
+            // repo head ordinal keeps the cadence durable across rerolls and
+            // app restarts; the single-row checkpoint cannot do this.
+            final runHead = await ctx
+                .ref
+                .read(ledgerReconciliationRunRepoProvider)
+                .getHead(sessionId);
+            if (runHead != null &&
+                runHead.ordinal % 2 == 0 &&
+                isCurrent()) {
+              await ctx.ref
+                  .read(automatedCardEvolutionServiceProvider)
+                  .runOneBatch(sessionId);
+              if (!isCurrent()) return;
+            }
           }
           if (!isCurrent()) return;
         }

--- a/test/studio_ledger_test.dart
+++ b/test/studio_ledger_test.dart
@@ -212,22 +212,22 @@ void main() {
 
     const planner = LedgerReconciliationPlanner();
 
-    test('runs on N+1 once for the previous six assistant turns', () {
+    test('runs on the Nth assistant once for the previous N-1 turns', () {
       final messages = [
-        ..._conversation(6),
-        const ChatMessage(id: 'u7', role: 'user', content: 'User turn 7'),
+        ..._conversation(5),
+        const ChatMessage(id: 'u6', role: 'user', content: 'User turn 6'),
         const ChatMessage(
-          id: 'a7',
+          id: 'a6',
           role: 'assistant',
-          content: 'Assistant turn 7',
+          content: 'Assistant turn 6',
         ),
       ];
       final plan = planner.plan(
         messages: messages,
-        currentAssistantMessageId: 'a7',
+        currentAssistantMessageId: 'a6',
       );
       expect(plan, isNotNull);
-      expect(plan!.endMessage.id, 'a6');
+      expect(plan!.endMessage.id, 'a5');
 
       final checkpoint = LedgerReconciliationCheckpoint(
         sessionId: 's',
@@ -241,7 +241,7 @@ void main() {
       expect(
         planner.plan(
           messages: messages,
-          currentAssistantMessageId: 'a7',
+          currentAssistantMessageId: 'a6',
           checkpoint: checkpoint,
         ),
         isNull,
@@ -249,10 +249,10 @@ void main() {
       expect(
         planner.plan(
           messages: [
-            ..._conversation(7),
-            const ChatMessage(id: 'a8', role: 'assistant', content: 'Current'),
+            ..._conversation(6),
+            const ChatMessage(id: 'a7', role: 'assistant', content: 'Current'),
           ],
-          currentAssistantMessageId: 'a8',
+          currentAssistantMessageId: 'a7',
           checkpoint: checkpoint,
         ),
         isNull,
@@ -261,12 +261,17 @@ void main() {
 
     test('changed accepted content invalidates the range fingerprint', () {
       final messages = [
-        ..._conversation(6),
-        const ChatMessage(id: 'a7', role: 'assistant', content: 'Current'),
+        ..._conversation(5),
+        const ChatMessage(id: 'u6', role: 'user', content: 'User turn 6'),
+        const ChatMessage(
+          id: 'a6',
+          role: 'assistant',
+          content: 'Assistant turn 6',
+        ),
       ];
       final original = planner.plan(
         messages: messages,
-        currentAssistantMessageId: 'a7',
+        currentAssistantMessageId: 'a6',
       )!;
       final checkpoint = LedgerReconciliationCheckpoint(
         sessionId: 's',
@@ -278,11 +283,11 @@ void main() {
         rangeHash: original.rangeHash,
       );
       final changed = [...messages];
-      changed[11] = changed[11].copyWith(content: 'Changed accepted swipe');
+      changed[9] = changed[9].copyWith(content: 'Changed accepted swipe');
       expect(
         planner.plan(
           messages: changed,
-          currentAssistantMessageId: 'a7',
+          currentAssistantMessageId: 'a6',
           checkpoint: checkpoint,
         ),
         isNotNull,
@@ -291,47 +296,54 @@ void main() {
 
     test('hidden assistant messages do not advance cadence', () {
       final messages = [
-        ..._conversation(6),
+        ..._conversation(5),
         const ChatMessage(
           id: 'hidden',
           role: 'assistant',
           content: 'Internal',
           isHidden: true,
         ),
-        const ChatMessage(id: 'a7', role: 'assistant', content: 'Current'),
+        const ChatMessage(id: 'u6', role: 'user', content: 'User turn 6'),
+        const ChatMessage(
+          id: 'a6',
+          role: 'assistant',
+          content: 'Assistant turn 6',
+        ),
       ];
       final plan = planner.plan(
         messages: messages,
-        currentAssistantMessageId: 'a7',
+        currentAssistantMessageId: 'a6',
       );
       expect(plan, isNotNull);
-      expect(plan!.endMessage.id, 'a6');
+      expect(plan!.endMessage.id, 'a5');
       expect(plan.messageIds, isNot(contains('hidden')));
     });
 
     test('review range is bounded to twenty messages', () {
-      final messages = [
-        ..._conversation(12),
-        const ChatMessage(id: 'a13', role: 'assistant', content: 'Current'),
-      ];
+      final messages = _conversation(12);
       final plan = planner.plan(
         messages: messages,
-        currentAssistantMessageId: 'a13',
+        currentAssistantMessageId: 'a12',
       )!;
       expect(plan.messages, hasLength(20));
-      expect(plan.endMessage.id, 'a12');
+      expect(plan.endMessage.id, 'a11');
     });
 
     test(
       'prompt includes stale placeholder state outside direct name match',
       () {
         final messages = [
-          ..._conversation(6),
-          const ChatMessage(id: 'a7', role: 'assistant', content: 'Current'),
+          ..._conversation(5),
+          const ChatMessage(id: 'u6', role: 'user', content: 'User turn 6'),
+          const ChatMessage(
+            id: 'a6',
+            role: 'assistant',
+            content: 'Assistant turn 6',
+          ),
         ];
         final plan = planner.plan(
           messages: messages,
-          currentAssistantMessageId: 'a7',
+          currentAssistantMessageId: 'a6',
         )!;
         final prompt = const StudioLedgerReconciliationPrompt().build(
           systemPrompt: 'DB PROMPT',
@@ -667,12 +679,17 @@ void main() {
 
     test('prompt offers relevant inferred and placeholder facts', () {
       final messages = [
-        ..._conversation(6),
-        const ChatMessage(id: 'a7', role: 'assistant', content: 'Current'),
+        ..._conversation(5),
+        const ChatMessage(id: 'u6', role: 'user', content: 'User turn 6'),
+        const ChatMessage(
+          id: 'a6',
+          role: 'assistant',
+          content: 'Assistant turn 6',
+        ),
       ];
       final plan = planner.plan(
         messages: messages,
-        currentAssistantMessageId: 'a7',
+        currentAssistantMessageId: 'a6',
       )!;
       const placeholder = CharacterKnowledgeFact(
         id: 'placeholder',


### PR DESCRIPTION
## Why

Reconciliation and card-rewriter never fired automatically on `nightly`: the cadence fix lived only on `fix/ledger-recon-cadence` and was never merged. Sessions on the current build show zero `reconciliation_successful_runs` / `card_evolution_*` rows despite many assistant turns, confirming the pipeline is dormant.

## Changes

### Reconciliation cadence (`lib/core/llm/studio_ledger_reconciliation.dart`)

- Reconciliation now triggers once the **Nth** assistant is generated (N = `interval`, `2*interval`, … — default every 6th), instead of waiting for assistant `N+1`.
- The review range covers accepted assistants `a1..a(N-1)`, so the freshly generated `aN` snapshot cannot be rewritten by the reconciler. A reroll of `aN` produces the same boundary and is deduplicated by the checkpoint; `a(N+1)` must never re-run or rewrite the older boundary.
- Planner condition changed from `acceptedAssistants.length % interval != 0` to `(acceptedAssistants.length + 1) % interval != 0`.

### Card-rewriter gate (`lib/features/chat/services/stages/ledger_stage.dart`)

- Card-rewriter now runs only on **every 2nd successful reconciliation** (run-head ordinal `% 2 == 0`), matching the plan's "Automated Card Evolution cadence".
- Counting via the run-repo head ordinal keeps the cadence durable across rerolls and app restarts; the single-row checkpoint cannot.
- The existing `cardRewriter.enabled` opt-out gate is preserved.

### Tests (`test/studio_ledger_test.dart`)

- Updated cadence tests to reflect the new Nth-assistant boundary (`a6` instead of `a7`, review range ending at `a5`).
- Adjusted message fixtures, `currentAssistantMessageId`, and index references in the "changed accepted content invalidates the range fingerprint", "hidden assistant messages do not advance cadence", "review range is bounded to twenty messages", and prompt-building tests.

## Verification

- `flutter test` on CI (this PR triggers `.github/workflows/ci.yml` — `flutter analyze` + `flutter test`).
- Could not run `flutter analyze` / `flutter test` locally (no Flutter SDK in this agent environment); relying on the CI gate per `docs/WORKFLOW.md`.
- Rebased on top of `upstream/nightly` (`4b6e506e`) so the PR carries only its own commit.

## Notes

- Discovered during investigation of session `1785923269230_1` (Serena Arc): 10 assistant turns produced a single manual reconciliation run and zero card-evolution activity, matching the missing-cadence symptom.
