### PR TITLE
fix: preserve quote styling and honor Ledger timeout settings

### DIFF
--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -230,7 +230,9 @@ export class Formatter {
     // 9. Restore styled segments with Glaze marker rendering
     html = html.replace(/\x01S_(\d+)\x01/g, (_, i) => {
       const seg = styledSegments[parseInt(i)];
-      return renderStyledSegment(seg, (innerRaw) => this._processText(innerRaw, false, true));
+      // skipQuotes defaults to true (preserve color markers' fills);
+      // plain formatting (italic/bold/strike) opts out via the second arg.
+      return renderStyledSegment(seg, (innerRaw, skipQuotes = true) => this._processText(innerRaw, false, skipQuotes));
     });
 
     // 10. Markdown Parsing

--- a/assets/chat_webview/formatter/text_format.js
+++ b/assets/chat_webview/formatter/text_format.js
@@ -40,18 +40,23 @@ export function renderStyledSegment(seg, processRichText) {
   m = seg.match(/^==active==(.+?)==$/s);
   if (m) return `<span class="glaze-active">${m[1]}</span>`;
 
+  // Plain formatting markers (bold/italic/strike) process inner quotes so
+  // dialogue inside *"..."* gets the quote color (colored italic), not the
+  // gray italic default. Color markers above keep skipQuotes=true (default)
+  // so chat-quote color does not override their fill.
+  const rq = (raw) => processRichText ? processRichText(raw, false) : raw;
   m = seg.match(/^\*\*\*(.+?)\*\*\*$/s);
-  if (m) return `<strong><em>${m[1]}</em></strong>`;
+  if (m) return `<strong><em>${rq(m[1])}</em></strong>`;
   m = seg.match(/^\*\*(.+?)\*\*$/s);
-  if (m) return `<strong>${m[1]}</strong>`;
+  if (m) return `<strong>${rq(m[1])}</strong>`;
   m = seg.match(/^\*(.+?)\*$/s);
-  if (m) return `<em class="chat-italic">${m[1]}</em>`;
+  if (m) return `<em class="chat-italic">${rq(m[1])}</em>`;
   m = seg.match(/^__(.+?)__$/s);
-  if (m) return `<strong>${m[1]}</strong>`;
+  if (m) return `<strong>${rq(m[1])}</strong>`;
   m = seg.match(/^_(.+?)_$/s);
-  if (m) return `<em class="chat-italic">${m[1]}</em>`;
+  if (m) return `<em class="chat-italic">${rq(m[1])}</em>`;
   m = seg.match(/^~~(.+?)~~$/s);
-  if (m) return `<del>${m[1]}</del>`;
+  if (m) return `<del>${rq(m[1])}</del>`;
 
   return seg;
 }

--- a/lib/core/llm/aux_llm_client.dart
+++ b/lib/core/llm/aux_llm_client.dart
@@ -270,6 +270,7 @@ class AuxLlmClient {
           omitReasoning: omitReasoning,
           omitReasoningEffort: omitReasoningEffort,
           extraRequestParameters: config.extraRequestParameters,
+          receiveTimeoutMs: timeoutMs,
         ),
         cancelToken: cancelToken,
         onUpdate: (delta, reasoningDelta) {

--- a/lib/features/studio/widgets/studio_slot_settings_dialog.dart
+++ b/lib/features/studio/widgets/studio_slot_settings_dialog.dart
@@ -277,6 +277,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         _omitTopP = false;
         _omitReasoning = true;
         _omitReasoningEffort = true;
+        _excludeReasoningFromContextBudget = false;
         _reasoningHistoryCountCtrl = TextEditingController(text: '0');
         _maxTokensCtrl = TextEditingController(
           text: l.studioLedgerMaxTokens > 0 ? '${l.studioLedgerMaxTokens}' : '',


### PR DESCRIPTION
## Why

This fixes three independent regressions found in formatter and Studio Ledger flows:

- Quotes nested inside italic, bold, or strike markers could lose the surrounding text color.
- Non-streaming auxiliary LLM calls did not pass the configured timeout to the transport, leaving Dio's 120-second receive timeout active even when Ledger was configured for 180 seconds.
- Saving Ledger slot settings could throw a LateInitializationError because excludeReasoningFromContextBudget was not initialized for that slot.

## Changes

- Preserve quote coloring inside italic, bold, and strike formatting.
- Pass receiveTimeoutMs to non-streaming ChatTransportRequest calls so the transport matches the resolved auxiliary timeout.
- Initialize excludeReasoningFromContextBudget for StudioSlot.ledger.

## Verification

- flutter analyze lib/core/llm/aux_llm_client.dart
- flutter analyze lib/features/studio/widgets/studio_slot_settings_dialog.dart
- git diff --check upstream/nightly...HEAD