### PR TITLE
fix(test): align cleaner-disabled ledger assertions with the new reconciliation cadence

### DIFF
--- a/test/cleaner_disabled_post_gen_test.dart
+++ b/test/cleaner_disabled_post_gen_test.dart
@@ -94,14 +94,17 @@ void main() {
                 ),
           );
 
+      // The turn just generated is the 6th assistant, i.e. the reconciliation
+      // cadence boundary: the planner fires on the Nth assistant and reviews
+      // up to a(N-1), leaving the fresh aN out of the range.
       const assistant = ChatMessage(
-        id: 'a7',
+        id: 'a6',
         role: 'assistant',
         content: 'Raw direct response',
         timestamp: 1,
       );
       final messages = <ChatMessage>[
-        for (var turn = 1; turn <= 6; turn++) ...[
+        for (var turn = 1; turn <= 5; turn++) ...[
           ChatMessage(id: 'u$turn', role: 'user', content: 'User turn $turn'),
           ChatMessage(
             id: 'a$turn',
@@ -109,7 +112,7 @@ void main() {
             content: 'Assistant turn $turn',
           ),
         ],
-        const ChatMessage(id: 'u7', role: 'user', content: 'User turn 7'),
+        const ChatMessage(id: 'u6', role: 'user', content: 'User turn 6'),
         assistant,
       ];
       const session = ChatSession(
@@ -174,7 +177,7 @@ void main() {
         currentAssistantMessageId: ledger.targetMessage!.id,
       );
       expect(plan, isNotNull);
-      expect(plan!.endMessage.id, 'a6');
+      expect(plan!.endMessage.id, 'a5');
     },
   );
 }


### PR DESCRIPTION
`nightly` is currently red: `test/cleaner_disabled_post_gen_test.dart: disabled cleaner still runs ExtBlocks and Ledger without a MemoryBook` fails on every PR run (it failed on #209 before that PR was merged, and on #210 which changes only preset/catalog widgets).

#208 changed `LedgerReconciliationPlanner.plan` to `(acceptedAssistants.length + 1) % interval != 0`: reconciliation now fires on the Nth accepted assistant and reviews up to `a(N-1)`, leaving the freshly generated `aN` out of the range. `studio_ledger_test.dart` was updated for that ("runs on the Nth assistant once for the previous N-1 turns": current `a6` → end `a5`), but this test still built a fixture whose current turn is the 7th assistant, so `plan` now returns null and `expect(plan, isNotNull)` fails.

## Changes

- Shorten the fixture to five prior turns so the generated turn is the 6th assistant — the cadence boundary — instead of the 7th.
- Expect the review range to end at `a5`, matching the planner's rule and the dedicated cadence test.

Only the assertions' fixture changes; the cleaner/ExtBlocks/Ledger expectations around it are untouched.

## Verification

- Derived from the planner's cadence rule in `lib/core/llm/studio_ledger_reconciliation.dart` (with the old fixture, `accepted = a1..a6` → `(6+1) % 6 = 1` → no plan). The CI log only exposes its tail, which no longer contains the assertion text, and no Flutter SDK is available in this session's container — so CI on this PR is the verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdeFoyr5LYBfgq8czvzeJR)_