### PR TITLE
fix(formatter): keep inline markdown on same line

### DIFF
--- a/assets/chat_webview/formatter/text_format.js
+++ b/assets/chat_webview/formatter/text_format.js
@@ -44,7 +44,21 @@ export function renderStyledSegment(seg, processRichText) {
   // dialogue inside *"..."* gets the quote color (colored italic), not the
   // gray italic default. Color markers above keep skipQuotes=true (default)
   // so chat-quote color does not override their fill.
-  const rq = (raw) => processRichText ? processRichText(raw, false) : raw;
+  const rq = (raw) => {
+    if (!processRichText) return raw;
+    const rich = processRichText(raw, false);
+    // _processText treats every standalone fragment as a paragraph. Styled
+    // markers are inline, though, so keeping that wrapper would produce
+    // invalid block-in-inline markup such as <em><p>action</p></em>. Browsers
+    // then lay every *action* out on its own line even when the source contains
+    // no newline. Unwrap only a single paragraph; preserve genuinely
+    // multi-paragraph content as-is.
+    const paragraph = rich.match(/^\s*<p>([\s\S]*)<\/p>\s*$/i);
+    if (paragraph && !/<\/?p(?:\s|>)/i.test(paragraph[1])) {
+      return paragraph[1];
+    }
+    return rich;
+  };
   m = seg.match(/^\*\*\*(.+?)\*\*\*$/s);
   if (m) return `<strong><em>${rq(m[1])}</em></strong>`;
   m = seg.match(/^\*\*(.+?)\*\*$/s);

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -29,6 +29,7 @@ void main() {
   late String rendererMessageJs;
   late String formatterIndexJs;
   late String formatterFormatterJs;
+  late String formatterTextFormatJs;
   late String bridgeIndexJs;
   late String bridgeControllerJs;
   late String editControllerJs;
@@ -48,6 +49,7 @@ void main() {
     rendererMessageJs = _rendererAsset('message_renderer.js');
     formatterIndexJs = _formatterAsset('index.js');
     formatterFormatterJs = _formatterAsset('formatter.js');
+    formatterTextFormatJs = _formatterAsset('text_format.js');
     rendererJs = [
       _rendererAsset('shadow_style.js'),
       _rendererAsset('markdown.js'),
@@ -359,6 +361,19 @@ void main() {
 
     test('legacy formatter shim points at active module entrypoint', () {
       expect(_asset('formatter.js'), contains('formatter/index.js'));
+    });
+
+    test('inline markdown does not keep a generated paragraph wrapper', () {
+      expect(
+        formatterTextFormatJs,
+        contains(r'const paragraph = rich.match(/^\s*<p>([\s\S]*)<\/p>\s*$/i)'),
+      );
+      expect(
+        formatterTextFormatJs,
+        contains(r'!/<\/?p(?:\s|>)/i.test(paragraph[1])'),
+        reason: 'only a single outer paragraph may be unwrapped',
+      );
+      expect(formatterTextFormatJs, contains('return paragraph[1]'));
     });
   });
 


### PR DESCRIPTION
## Summary
- unwrap the synthetic single-paragraph wrapper inside inline styled markdown
- preserve genuinely multi-paragraph rich content
- add a WebView asset regression test for the formatter contract

## Testing
- git diff --check upstream/nightly...HEAD