### PR TITLE
fix(ci): keep the pre-release suffix in APP_VERSION

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Compute metadata
         id: meta
         run: |
-          VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | sed 's/+.*//' | sed 's/-.*//')
+          VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | sed 's/+.*//')
           BUILD_DATE=$(date -u '+%d/%m/%Y %H:%M')
           BUILD_BRANCH="${{ github.ref_name }}"
           # Branch names may contain "/" or spaces which are unsafe in file

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Compute metadata
         id: meta
         run: |
-          VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | sed 's/+.*//' | sed 's/-.*//')
+          VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | sed 's/+.*//')
           BUILD_DATE=$(date -u '+%d/%m/%Y %H:%M')
           BUILD_BRANCH="${{ github.ref_name }}"
 


### PR DESCRIPTION
## Changes
- Stop stripping the pre-release suffix (`-a`, `-beta`, etc.) from `pubspec.yaml`'s version when computing `APP_VERSION` for `--dart-define` in `build-branch.yml` / `build-release.yml`. Only the build-metadata segment (after `+`) is still stripped.

## Why
`VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | sed 's/+.*//' | sed 's/-.*//')` cut everything after the first `-`, so a pubspec version of `0.7.0-a` always produced `APP_VERSION=0.7.0`. The About screen (`lib/features/menu/about_screen.dart`) shows this dart-define verbatim as `v$appVersion`, so it kept displaying `v0.7.0` even after the version was bumped to `0.7.0-a` — the in-app label silently diverged from `pubspec.yaml` and from the OS-level app version (Android `versionName` / iOS `CFBundleShortVersionString`), which Flutter reads straight from pubspec and never had this suffix stripped.

## Verified
- `UpdateCheckService.parseVersion` already drops any `-`/`+`/space-delimited suffix itself before comparing versions (`lib/core/services/update_check_service.dart`), so passing the full `0.7.0-a` string through no longer affects the update-check numeric comparison — confirmed by reading `parseVersion`/`compareVersions`.
- `flutter analyze` / `flutter test` were not run locally — no Flutter SDK in this environment, and the change is YAML/shell only (no Dart touched). CI on this PR is the only execution.

---
_Generated by [Claude Code](https://claude.ai/code/session_0113ohhS4XZUZN1JsCJhaUyc)_