### PR TITLE
fix(chat): show active preset in Magic Drawer

### DIFF
--- a/lib/features/chat/services/magic_drawer_stats_service.dart
+++ b/lib/features/chat/services/magic_drawer_stats_service.dart
@@ -7,9 +7,12 @@ import '../../../core/llm/context_calculator.dart';
 import '../../../core/llm/prompt_isolate.dart';
 import '../providers/prompt_build_providers.dart';
 import '../../../core/models/preset.dart';
+import '../../../core/state/active_studio_preset_provider.dart';
 import '../../../core/state/active_selection_provider.dart';
 import '../../../core/state/db_provider.dart';
+import '../../../core/state/preset_resolution.dart';
 import '../../../core/state/summary_providers.dart';
+import '../../../core/state/studio_feature_provider.dart';
 import '../../extensions/providers/extension_presets_provider.dart';
 import '../../extensions/providers/extensions_settings_provider.dart';
 import '../../image_gen/image_gen_provider.dart';
@@ -41,7 +44,6 @@ class MagicDrawerStatsService {
     final summaryService = _ref.read(summaryServiceProvider);
     final apiListFuture = _ref.read(apiListProvider.future);
     final activeRegexesFuture = _ref.read(activeRegexesProvider.future);
-    final activePresetId = _ref.read(activePresetIdProvider);
     final activePersonaId = _ref.read(activePersonaIdProvider);
     final chatApi = _ref.read(activeApiConfigProvider);
     final imageGenEnabled =
@@ -55,9 +57,26 @@ class MagicDrawerStatsService {
     final personas = await personaRepo.getAll();
     await apiListFuture;
     final lorebooks = await lorebookRepo.getAll();
-    final activePreset = activePresetId != null
-        ? presets.where((p) => p.id == activePresetId).firstOrNull
-        : presets.firstOrNull;
+    final activePreset = getEffectivePreset(
+      presets,
+      charId,
+      session?.id,
+      _ref.read(activePresetIdProvider),
+      _ref.read(presetConnectionsProvider),
+    );
+    String? activePresetDisplayName = activePreset?.name;
+    if (_ref.read(studioFeatureEnabledProvider)) {
+      try {
+        final studioPreset = await _ref
+            .read(studioPresetRepoProvider)
+            .getById(await _ref.read(activeStudioPresetProvider.future));
+        if (studioPreset != null) {
+          activePresetDisplayName = studioPreset.name;
+        }
+      } catch (e) {
+        debugPrint('[MagicDrawer] active Studio preset error: $e');
+      }
+    }
     final activePersona = activePersonaId != null
         ? personas.where((p) => p.id == activePersonaId).firstOrNull
         : personas.firstOrNull;
@@ -114,6 +133,7 @@ class MagicDrawerStatsService {
     return MagicDrawerStats(
       character: character,
       activePreset: activePreset,
+      activePresetDisplayName: activePresetDisplayName,
       activePersona: activePersona,
       apiConfig: chatApi,
       session: session,

--- a/lib/features/chat/widgets/magic_drawer.dart
+++ b/lib/features/chat/widgets/magic_drawer.dart
@@ -14,7 +14,9 @@ import '../../../core/models/chat_message.dart';
 import '../../../core/state/lorebook_provider.dart';
 import '../../../features/settings/app_settings_provider.dart';
 import '../../../core/state/active_selection_provider.dart';
+import '../../../core/state/active_studio_preset_provider.dart';
 import '../../../core/state/chat_session_ops_provider.dart';
+import '../../../core/state/preset_resolution.dart';
 import '../../../core/state/studio_feature_provider.dart';
 import '../../../core/state/summary_providers.dart';
 import '../../../features/chat_history/chat_history_provider.dart';
@@ -366,11 +368,11 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
             ? _stats.apiConfig!.name
             : _stats.apiConfig?.model,
       'presets' =>
-        _stats.activePreset == null
+        _stats.activePresetDisplayName == null
             ? 'label_default'.tr()
-            : _stats.presetTokens > 0
-            ? '${_stats.activePreset!.name} • ${_stats.presetTokens} tokens'
-            : _stats.activePreset!.name,
+        : _stats.presetTokens > 0
+            ? '${_stats.activePresetDisplayName} • ${_stats.presetTokens} tokens'
+            : _stats.activePresetDisplayName,
       'personas' => _stats.activePersona?.name ?? 'label_default'.tr(),
       'image-gen' => _stats.imageGenEnabled ? 'on'.tr() : 'off'.tr(),
       'authors-note' =>
@@ -775,6 +777,15 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
       }
     });
     ref.listen(activePresetIdProvider, (prev, next) {
+      if (prev != next) _scheduleRefresh();
+    });
+    ref.listen(presetConnectionsProvider, (prev, next) {
+      if (prev != next) _scheduleRefresh();
+    });
+    ref.listen(activeStudioPresetProvider, (prev, next) {
+      if (prev?.value != next.value) _scheduleRefresh();
+    });
+    ref.listen(studioFeatureEnabledProvider, (prev, next) {
       if (prev != next) _scheduleRefresh();
     });
     // Summary is written straight to its repo (not through chatProvider), so

--- a/lib/features/chat/widgets/magic_drawer_models.dart
+++ b/lib/features/chat/widgets/magic_drawer_models.dart
@@ -40,6 +40,7 @@ class MagicDrawerCardItem {
 class MagicDrawerStats {
   final Character? character;
   final Preset? activePreset;
+  final String? activePresetDisplayName;
   final Persona? activePersona;
   final ApiConfig? apiConfig;
   final ChatSession? session;
@@ -72,6 +73,7 @@ class MagicDrawerStats {
   const MagicDrawerStats({
     this.character,
     this.activePreset,
+    this.activePresetDisplayName,
     this.activePersona,
     this.apiConfig,
     this.session,
@@ -116,6 +118,7 @@ class MagicDrawerStats {
     return MagicDrawerStats(
       character: character,
       activePreset: activePreset,
+      activePresetDisplayName: activePresetDisplayName,
       activePersona: activePersona,
       apiConfig: apiConfig,
       session: session,


### PR DESCRIPTION
## Changes
- Resolve the effective normal preset from chat, character, and global bindings before rendering the Magic Drawer.
- Display the active Studio preset name while Studio is enabled.
- Refresh the displayed preset when its binding, the active Studio preset, or the Studio feature flag changes.

## Verification
- GitHub Actions CI (Analyze + test) pending; no local checks run at request.