### PR TITLE
fix(image-gen): restore legacy Imagen behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ dart run build_runner build              # Regenerate after editing freezed/drif
 & "Z:\GlazeProject\flutter\bin\dart.bat" run build_runner build
 ```
 
+**Do not run `flutter analyze` locally.** The GitHub CI check is the
+authoritative analyzer; use targeted tests and wait for CI instead.
+
 For `flutter run` (dev server), see below — the agent cannot run it.
 
 **`flutter run` and `flutter test --watch` are permanently unavailable to the agent.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,6 @@ dart run build_runner build              # Regenerate after editing freezed/drif
 & "Z:\GlazeProject\flutter\bin\dart.bat" run build_runner build
 ```
 
-**Do not run `flutter analyze` locally.** The GitHub CI check is the
-authoritative analyzer; use targeted tests and wait for CI instead.
-
 For `flutter run` (dev server), see below — the agent cannot run it.
 
 **`flutter run` and `flutter test --watch` are permanently unavailable to the agent.**

--- a/assets/chat_webview/bridge.legacy.js
+++ b/assets/chat_webview/bridge.legacy.js
@@ -804,6 +804,10 @@ class InteractionDispatch {
         const { instr, messageId } = this._extractImgInstruction(el, e.composedPath());
         bridge._sendToFlutter('onImgRetry', [instr, messageId]);
       },
+      'img-enable-retry': (e, el) => {
+        const { instr, messageId } = this._extractImgInstruction(el, e.composedPath());
+        bridge._sendToFlutter('onImgEnableRetry', [instr, messageId]);
+      },
       'img-find': (e, el) => {
         const { instr, messageId } = this._extractImgInstruction(el, e.composedPath());
         bridge._sendToFlutter('onImgFind', [instr, messageId]);

--- a/assets/chat_webview/bridge/interaction_dispatch.js
+++ b/assets/chat_webview/bridge/interaction_dispatch.js
@@ -234,6 +234,10 @@ export class InteractionDispatch {
         const { instr, messageId } = this._extractImgInstruction(el, e.composedPath());
         bridge._sendToFlutter('onImgRetry', [instr, messageId]);
       },
+      'img-enable-retry': (e, el) => {
+        const { instr, messageId } = this._extractImgInstruction(el, e.composedPath());
+        bridge._sendToFlutter('onImgEnableRetry', [instr, messageId]);
+      },
       'img-find': (e, el) => {
         const { instr, messageId } = this._extractImgInstruction(el, e.composedPath());
         bridge._sendToFlutter('onImgFind', [instr, messageId]);

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -398,6 +398,9 @@ export class Formatter {
           instruction = parsed.instruction || '';
         } catch(_) {}
         const encInstr = encodeURIComponent(instruction);
+        if (errorMsg === 'Image generation disabled') {
+          return `<div class="imggen-error imggen-disabled" data-instruction="${encInstr}"><span class="imggen-error-icon">🖼</span><span class="imggen-error-msg">Image generation disabled</span><div class="imggen-error-actions"><button class="imggen-error-retry" type="button" data-action="img-enable-retry" data-instruction="${encInstr}">Enable and generate</button></div></div>`;
+        }
         return `<div class="imggen-error" data-instruction="${encInstr}"><span class="imggen-error-icon">⚠</span><span class="imggen-error-msg">${this._escapeHtml(errorMsg)}</span><div class="imggen-error-actions"><button class="imggen-error-retry" type="button" data-action="img-retry" data-instruction="${encInstr}">↻ Retry</button><button class="imggen-error-retry imggen-error-find" type="button" data-action="img-find" data-instruction="${encInstr}">Find on disk</button></div></div>`;
       }
       return '';

--- a/lib/features/chat/bridge/bridge_handlers.dart
+++ b/lib/features/chat/bridge/bridge_handlers.dart
@@ -78,6 +78,7 @@ const Map<String, HandlerSpec> bridgeHandlers = {
   'onInjectClick': HandlerSpec(HandlerKind.stringArg),
   // Image generation
   'onImgRetry': HandlerSpec(HandlerKind.imageAction),
+  'onImgEnableRetry': HandlerSpec(HandlerKind.imageAction),
   'onImgFind': HandlerSpec(HandlerKind.imageAction),
   'onImgRegen': HandlerSpec(
     HandlerKind.imageAction,

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -285,6 +285,7 @@ class ChatBridgeController {
   void Function(List<String> ids)? onSelectionChange;
   void Function(String id)? onInjectClick;
   void Function(String instruction, String messageId)? onImgRetry;
+  void Function(String instruction, String messageId)? onImgEnableRetry;
   void Function(String instruction, String messageId)? onImgFind;
   void Function(String instruction, String messageId)? onImgRegen;
   void Function(String src, String instruction, String messageId)? onImgOptions;
@@ -521,6 +522,8 @@ class ChatBridgeController {
     switch (name) {
       case 'onImgRetry':
         onImgRetry?.call(instr, msgId);
+      case 'onImgEnableRetry':
+        onImgEnableRetry?.call(instr, msgId);
       case 'onImgFind':
         onImgFind?.call(instr, msgId);
       case 'onImgRegen':

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -38,6 +38,7 @@ import '../../shared/widgets/glaze_error_dialog.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import '../../shared/widgets/image_viewer.dart';
 import '../character_list/character_detail_screen.dart';
+import '../image_gen/image_gen_provider.dart';
 import '../personas/persona_list_screen.dart';
 import '../presets/preset_editor_screen.dart';
 import '../settings/api_list_provider.dart';
@@ -1005,10 +1006,8 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
               );
               Navigator.of(context).push(
                 MaterialPageRoute<void>(
-                  builder: (_) => PresetEditorScreen(
-                    preset: preset,
-                    charId: widget.charId,
-                  ),
+                  builder: (_) =>
+                      PresetEditorScreen(preset: preset, charId: widget.charId),
                 ),
               );
             },
@@ -1231,8 +1230,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                         isGeneratingImage: widget.state.isGeneratingImage,
                         isPostGenRunning: widget.state.isPostGenRunning,
                         regenTargetId: widget.state.regenTargetId,
-                        continuationTargetId:
-                            widget.state.continuationTargetId,
+                        continuationTargetId: widget.state.continuationTargetId,
                         bottomInset: webViewBottomInset,
                         viewportHeight: _webViewBoxHeight,
                         topInset: effectiveTopInset,
@@ -1500,6 +1498,15 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                         imageGenActions: ImageGenCallbacks(
                           onImgRetry: (instruction, messageId) {
                             ref
+                                .read(chatProvider(widget.charId).notifier)
+                                .retryImageGenerationForMessage(messageId);
+                          },
+                          onImgEnableRetry: (instruction, messageId) async {
+                            await ref
+                                .read(imageGenSettingsProvider.notifier)
+                                .updateEnabled(true);
+                            if (!mounted) return;
+                            await ref
                                 .read(chatProvider(widget.charId).notifier)
                                 .retryImageGenerationForMessage(messageId);
                           },

--- a/lib/features/chat/services/image_gen_processor.dart
+++ b/lib/features/chat/services/image_gen_processor.dart
@@ -36,14 +36,6 @@ class ImageGenProcessor {
     final session = currentState.session;
     if (session == null) return;
 
-    final imgGenSettingsAsync = _ref.read(imageGenSettingsProvider);
-    if (imgGenSettingsAsync.isLoading) {
-      final imgGenSettings = await _ref.read(imageGenSettingsProvider.future);
-      if (!imgGenSettings.enabled) return;
-    } else {
-      final imgGenSettings = imgGenSettingsAsync.value;
-      if (imgGenSettings == null || !imgGenSettings.enabled) return;
-    }
     final imgGenSettings = await _ref.read(imageGenSettingsProvider.future);
 
     final targetIdx = targetMessageId == null
@@ -58,9 +50,41 @@ class ImageGenProcessor {
     final targetAgentSwipeId = targetMsg.agentSwipeId;
     if (targetMsg.role != 'assistant') return;
 
+    if (!ImageTagMarkup.hasImageGenTags(targetMsg.content)) return;
+
+    var latestSession = session;
+    if (!imgGenSettings.enabled) {
+      final disabledContent = ImageTagMarkup.replaceAllImageGenTagsWithDisabled(
+        targetMsg.content,
+      );
+      if (disabledContent == targetMsg.content || !_ownsOperation) return;
+
+      latestSession = _replaceMessage(
+        latestSession,
+        stableTargetMessageId,
+        targetSwipeId,
+        targetAgentSwipeId,
+        disabledContent,
+      );
+      _onStateUpdate(currentState.copyWith(session: latestSession));
+      final durable = await _persistMessageContent(
+        session.id,
+        stableTargetMessageId,
+        targetSwipeId,
+        targetAgentSwipeId,
+        disabledContent,
+      );
+      if (durable != null) {
+        ChatSessionService.updateCache(durable);
+        if (_ownsOperation) {
+          _onStateUpdate(currentState.copyWith(session: durable));
+        }
+      }
+      return;
+    }
+
     final notifier = _ref.read(imageGenSettingsProvider.notifier);
     final service = await notifier.getServiceAsync();
-    if (!ImageTagMarkup.hasImageGenTags(targetMsg.content)) return;
 
     final apiConfigSync = _ref.read(activeApiConfigProvider);
     final ApiConfig apiConfig;
@@ -94,7 +118,6 @@ class ImageGenProcessor {
     );
 
     final recentContexts = _collectRecentImageContexts(session.messages);
-    var latestSession = session;
     if (!_ownsOperation) return;
 
     debugPrint('[IMGGEN] → setting isGeneratingImage=true');

--- a/lib/features/chat/widgets/chat_webview_callbacks.dart
+++ b/lib/features/chat/widgets/chat_webview_callbacks.dart
@@ -123,6 +123,10 @@ class ChatWebViewCallbacks {
     imageGenActions.onImgRetry?.call(instruction, messageId);
   }
 
+  void onImgEnableRetry(String instruction, String messageId) {
+    imageGenActions.onImgEnableRetry?.call(instruction, messageId);
+  }
+
   void onImgFind(String instruction, String messageId) {
     imageGenActions.onImgFind?.call(instruction, messageId);
   }

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -240,6 +240,7 @@ class ChatWebViewSurface extends ConsumerWidget {
                 bridge.onToggleImageHidden = callbacks.onToggleImageHidden;
                 bridge.onInjectClick = callbacks.onInjectClick;
                 bridge.onImgRetry = callbacks.onImgRetry;
+                bridge.onImgEnableRetry = callbacks.onImgEnableRetry;
                 bridge.onImgFind = callbacks.onImgFind;
                 bridge.onImgRegen = callbacks.onImgRegen;
                 bridge.onImgOptions = callbacks.onImgOptions;

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -595,6 +595,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     bridge.onToggleImageHidden = callbacks.onToggleImageHidden;
     bridge.onInjectClick = callbacks.onInjectClick;
     bridge.onImgRetry = callbacks.onImgRetry;
+    bridge.onImgEnableRetry = callbacks.onImgEnableRetry;
     bridge.onImgFind = callbacks.onImgFind;
     bridge.onImgRegen = callbacks.onImgRegen;
     bridge.onImgOptions = callbacks.onImgOptions;

--- a/lib/features/chat/widgets/webview_callbacks.dart
+++ b/lib/features/chat/widgets/webview_callbacks.dart
@@ -69,6 +69,7 @@ class EditActionsCallbacks {
 
 class ImageGenCallbacks {
   final ImgActionCallback? onImgRetry;
+  final ImgActionCallback? onImgEnableRetry;
   final ImgActionCallback? onImgFind;
   final ImgActionCallback? onImgRegen;
   final ImgOptionsCallback? onImgOptions;
@@ -77,6 +78,7 @@ class ImageGenCallbacks {
 
   const ImageGenCallbacks({
     this.onImgRetry,
+    this.onImgEnableRetry,
     this.onImgFind,
     this.onImgRegen,
     this.onImgOptions,

--- a/lib/features/image_gen/services/gemini_image_provider.dart
+++ b/lib/features/image_gen/services/gemini_image_provider.dart
@@ -14,30 +14,78 @@ class GeminiImageProvider {
     required String prompt,
     required String aspectRatio,
     required String imageSize,
+    List<Map<String, String>>? referenceImages,
     CancelToken? cancelToken,
   }) async {
-    String url = endpoint;
-    if (!url.contains('/v1')) {
-      url = '$url/v1/models/$model:predict';
+    final url = _generationUrl(endpoint, model);
+    final parts = <Map<String, dynamic>>[];
+    for (final reference in referenceImages ?? const <Map<String, String>>[]) {
+      final image = reference['image'];
+      if (image == null || image.isEmpty) continue;
+      parts.add({
+        'inlineData': {
+          'mimeType': reference['mime'] ?? _mimeFromImage(image),
+          'data': ImageGenHttp.stripBase64Prefix(image),
+        },
+      });
     }
+    parts.add({'text': prompt});
 
-    final b64 = await _http.postAndExtractBase64(
-      url: '$url?key=$apiKey',
+    final json = await _http.post(
+      url: url,
+      apiKey: apiKey,
       body: {
-        'instances': [{'prompt': prompt}],
-        'parameters': {
-          'sampleCount': 1,
-          'aspectRatio': aspectRatio,
-          'imageSize': imageSize,
+        'contents': [
+          {'role': 'user', 'parts': parts},
+        ],
+        'generationConfig': {
+          'responseModalities': ['TEXT', 'IMAGE'],
+          'imageConfig': {'aspectRatio': aspectRatio, 'imageSize': imageSize},
         },
       },
       cancelToken: cancelToken,
-      extractBase64: (json) {
-        final predictions = json['predictions'] as List?;
-        if (predictions == null || predictions.isEmpty) throw Exception('No predictions in response');
-        return (predictions.first as Map<String, dynamic>)['bytesBase64Encoded'] as String;
-      },
     );
-    return ImageGenHttp.base64ToBytes(b64);
+    return ImageGenHttp.base64ToBytes(_extractImageBase64(json));
+  }
+
+  String _generationUrl(String endpoint, String model) {
+    final normalized = endpoint.replaceFirst(RegExp(r'/+$'), '');
+    if (normalized.endsWith(':generateContent')) return normalized;
+    if (normalized.endsWith('/v1beta')) {
+      return '$normalized/models/$model:generateContent';
+    }
+    return '$normalized/v1beta/models/$model:generateContent';
+  }
+
+  String _extractImageBase64(Map<String, dynamic> json) {
+    final candidates = json['candidates'] as List?;
+    if (candidates == null || candidates.isEmpty) {
+      throw Exception('No candidates in response');
+    }
+    final candidate = candidates.first;
+    if (candidate is! Map) throw Exception('Invalid candidate response');
+    final content = candidate['content'];
+    if (content is! Map) throw Exception('No content in response');
+    final parts = content['parts'] as List?;
+    if (parts == null) throw Exception('No parts in response');
+    for (final part in parts) {
+      if (part is! Map) continue;
+      final inlineData = part['inlineData'] ?? part['inline_data'];
+      if (inlineData is! Map) continue;
+      final data = inlineData['data']?.toString();
+      if (data != null && data.isNotEmpty) return data;
+    }
+    throw Exception('No image found in Gemini response');
+  }
+
+  String _mimeFromImage(String image) {
+    if (image.startsWith('data:image/')) {
+      final end = image.indexOf(';');
+      if (end > 5) return image.substring(5, end);
+    }
+    if (image.startsWith('/9j/')) return 'image/jpeg';
+    if (image.startsWith('UklGR')) return 'image/webp';
+    if (image.startsWith('R0lGOD')) return 'image/gif';
+    return 'image/png';
   }
 }

--- a/lib/features/image_gen/services/image_gen_connection_service.dart
+++ b/lib/features/image_gen/services/image_gen_connection_service.dart
@@ -1,0 +1,174 @@
+import 'package:dio/dio.dart';
+
+import '../image_gen_models.dart';
+
+/// Lightweight connectivity and model-discovery requests for the image-gen
+/// settings sheet. Generation itself remains in the provider-specific clients.
+class ImageGenConnectionService {
+  final Dio _dio;
+
+  ImageGenConnectionService({Dio? dio})
+    : _dio =
+          dio ??
+          Dio(
+            BaseOptions(
+              connectTimeout: const Duration(seconds: 10),
+              receiveTimeout: const Duration(seconds: 10),
+            ),
+          );
+
+  Future<void> checkConnection({
+    required ImageGenSettings settings,
+    required String llmEndpoint,
+    required String llmApiKey,
+  }) async {
+    switch (settings.apiType) {
+      case ImageGenApiType.openai:
+        final connection = _openAiConnection(
+          settings: settings,
+          llmEndpoint: llmEndpoint,
+          llmApiKey: llmApiKey,
+        );
+        await _get(_openAiModelsUrl(connection.endpoint), connection.apiKey);
+      case ImageGenApiType.gemini:
+        final connection = _openAiConnection(
+          settings: settings,
+          llmEndpoint: llmEndpoint,
+          llmApiKey: llmApiKey,
+        );
+        await _get(_geminiModelsUrl(connection.endpoint), connection.apiKey);
+      case ImageGenApiType.naistera:
+        if (settings.naisteraApiKey.trim().isEmpty) {
+          throw StateError('Naistera API key not configured');
+        }
+        await _get('https://naistera.org', null);
+      case ImageGenApiType.routmy:
+        if (settings.routmyApiKey.trim().isEmpty) {
+          throw StateError('rout.my API key not configured');
+        }
+        await _get(
+          '${RoutMyConstants.baseUrl}/v1/models',
+          settings.routmyApiKey,
+        );
+      case ImageGenApiType.ruRoutmy:
+        if (settings.ruRoutmyApiKey.trim().isEmpty) {
+          throw StateError('RU-rout.my API key not configured');
+        }
+        await _get(
+          '${RuRoutMyConstants.baseUrl}/v1/models',
+          settings.ruRoutmyApiKey,
+        );
+    }
+  }
+
+  Future<List<String>> fetchOpenAiModels({
+    required ImageGenSettings settings,
+    required String llmEndpoint,
+    required String llmApiKey,
+  }) async {
+    final connection = _openAiConnection(
+      settings: settings,
+      llmEndpoint: llmEndpoint,
+      llmApiKey: llmApiKey,
+    );
+    final data = await _get(
+      _openAiModelsUrl(connection.endpoint),
+      connection.apiKey,
+    );
+    final models = data is Map ? data['data'] : null;
+    if (models is! List) return const [];
+
+    const imageKeywords = [
+      'dall-e',
+      'midjourney',
+      'stable-diffusion',
+      'sdxl',
+      'flux',
+      'imagen',
+      'image',
+      'seedream',
+      'hidream',
+      'ideogram',
+      'gpt-image',
+      'wanx',
+      'qwen',
+      'drawing',
+    ];
+    const videoKeywords = [
+      'sora',
+      'kling',
+      'veo',
+      'pika',
+      'runway',
+      'luma',
+      'video',
+      'cogvideo',
+    ];
+
+    return models
+        .whereType<Map<Object?, Object?>>()
+        .map((model) => model['id']?.toString() ?? '')
+        .where((id) {
+          final lower = id.toLowerCase();
+          return id.isNotEmpty &&
+              !videoKeywords.any(lower.contains) &&
+              imageKeywords.any(lower.contains);
+        })
+        .toList();
+  }
+
+  ({String endpoint, String apiKey}) _openAiConnection({
+    required ImageGenSettings settings,
+    required String llmEndpoint,
+    required String llmApiKey,
+  }) {
+    final endpoint =
+        (settings.useSameEndpoint ? llmEndpoint : settings.customEndpoint)
+            .trim();
+    final apiKey =
+        (settings.useSameEndpoint ? llmApiKey : settings.customApiKey).trim();
+    if (endpoint.isEmpty) throw StateError('Image endpoint not configured');
+    if (apiKey.isEmpty) throw StateError('Image API key not configured');
+    return (endpoint: endpoint, apiKey: apiKey);
+  }
+
+  Future<dynamic> _get(String url, String? apiKey) async {
+    final response = await _dio.get<dynamic>(
+      url,
+      options: Options(
+        headers: {
+          if (apiKey != null && apiKey.isNotEmpty)
+            'Authorization': 'Bearer $apiKey',
+        },
+        validateStatus: (_) => true,
+      ),
+    );
+    final status = response.statusCode ?? 0;
+    if (status < 200 || status >= 300) {
+      throw StateError('HTTP $status');
+    }
+    return response.data;
+  }
+
+  static String _openAiModelsUrl(String endpoint) {
+    final normalized = endpoint.replaceFirst(RegExp(r'/+$'), '');
+    if (normalized.endsWith('/v1/models')) return normalized;
+    if (normalized.endsWith('/v1/images/generations')) {
+      return normalized.replaceFirst(
+        RegExp(r'/images/generations$'),
+        '/models',
+      );
+    }
+    if (normalized.endsWith('/v1')) return '$normalized/models';
+    return '$normalized/v1/models';
+  }
+
+  static String _geminiModelsUrl(String endpoint) {
+    final normalized = endpoint.replaceFirst(RegExp(r'/+$'), '');
+    if (normalized.endsWith('/v1beta/models')) return normalized;
+    if (normalized.endsWith('/v1beta')) return '$normalized/models';
+    return '$normalized/v1beta/models';
+  }
+
+  void dispose() => _dio.close();
+}

--- a/lib/features/image_gen/services/image_gen_service.dart
+++ b/lib/features/image_gen/services/image_gen_service.dart
@@ -35,7 +35,13 @@ class ImageGenService {
     void Function(String updatedText)? onUpdate,
     void Function(String error)? onError,
   }) async {
-    if (!settings.enabled) return text;
+    if (!settings.enabled) {
+      final disabledText = ImageTagMarkup.replaceAllImageGenTagsWithDisabled(
+        text,
+      );
+      if (disabledText != text) onUpdate?.call(disabledText);
+      return disabledText;
+    }
 
     final instructions = ImageTagMarkup.extractImageGenInstructions(text);
     if (instructions.isEmpty) return text;
@@ -204,6 +210,7 @@ class ImageGenService {
           llmApiKey,
           instructionAspectRatio,
           instructionImageSize,
+          refs,
           cancelToken,
         );
       case ImageGenApiType.naistera:
@@ -268,6 +275,7 @@ class ImageGenService {
     String llmApiKey,
     String? instructionAspectRatio,
     String? instructionImageSize,
+    List<Map<String, String>> references,
     CancelToken? cancelToken,
   ) async {
     final endpoint = settings.useSameEndpoint
@@ -295,6 +303,7 @@ class ImageGenService {
         GeminiConstants.imageSizes,
         settings.geminiImageSize,
       ),
+      referenceImages: references,
       cancelToken: cancelToken,
     );
   }
@@ -424,7 +433,11 @@ class ImageGenService {
         final path = ImageTagMarkup.normalizeImageResultPayload(ctx);
         final encoded = _fileToBase64(path);
         if (encoded.isNotEmpty) {
-          refs.add({'name': 'context', 'image': encoded});
+          refs.add({
+            'name': 'context',
+            'image': encoded,
+            'mime': _imageMime(path),
+          });
         }
       }
     }
@@ -538,6 +551,14 @@ class ImageGenService {
     final commaIndex = dataUrl.indexOf(',');
     if (commaIndex == -1) return dataUrl;
     return dataUrl.substring(commaIndex + 1);
+  }
+
+  String _imageMime(String path) {
+    final lower = path.toLowerCase();
+    if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) return 'image/jpeg';
+    if (lower.endsWith('.webp')) return 'image/webp';
+    if (lower.endsWith('.gif')) return 'image/gif';
+    return 'image/png';
   }
 
   Future<String> _saveGeneratedImage(String filename, Uint8List bytes) async {

--- a/lib/features/image_gen/services/image_tag_markup.dart
+++ b/lib/features/image_gen/services/image_tag_markup.dart
@@ -59,8 +59,9 @@ class ImageTagMarkup {
 
   static String replaceTagWithResult(String text, int index, String imagePath) {
     final instructions = extractImageGenInstructions(text);
-    final instruction =
-        index < instructions.length ? instructions[index] : null;
+    final instruction = index < instructions.length
+        ? instructions[index]
+        : null;
     final instrJson = instruction != null && instruction.isNotEmpty
         ? jsonEncode(instruction)
         : '';
@@ -118,6 +119,23 @@ class ImageTagMarkup {
     });
     if (count <= index) return text;
     return needStrip ? ImgGenPatterns.stripHtmlImgTags(result) : result;
+  }
+
+  /// Resolves every pending image tag to a retryable disabled-state error.
+  /// Keeping the original instruction lets the UI enable image generation and
+  /// immediately retry the same message without asking the model again.
+  static String replaceAllImageGenTagsWithDisabled(String text) {
+    var result = text;
+    while (hasImageGenTags(result)) {
+      final replaced = replaceTagWithError(
+        result,
+        0,
+        'Image generation disabled',
+      );
+      if (replaced == result) break;
+      result = replaced;
+    }
+    return result;
   }
 
   static String resetErrorTags(String text) {

--- a/lib/features/image_gen/widgets/image_gen_sheet.dart
+++ b/lib/features/image_gen/widgets/image_gen_sheet.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -8,11 +9,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/utils/platform_paths.dart';
 import '../../character_gallery/gallery_image_picker.dart';
+import '../../settings/api_list_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/help_tip.dart';
 import '../../../shared/widgets/sheet_view.dart';
 import '../image_gen_models.dart';
 import '../image_gen_provider.dart';
+import '../services/image_gen_connection_service.dart';
 import 'connection_fields.dart';
 import 'model_fields.dart';
 import 'rows.dart' as rows;
@@ -29,25 +32,94 @@ class ImageGenSheet extends ConsumerStatefulWidget {
 class _ImageGenSheetState extends ConsumerState<ImageGenSheet> {
   late ImageGenSettings _settings;
   bool _isFetchingModels = false;
+  final ImageGenConnectionService _connectionService =
+      ImageGenConnectionService();
   final ScrollController _scrollController = ScrollController();
+  Timer? _connectionDebounce;
+  int _connectionEpoch = 0;
+  String _connectionStatus = 'idle';
+  String _connectionError = '';
+  String _modelFetchError = '';
 
   @override
   void initState() {
     super.initState();
     _settings =
         ref.read(imageGenSettingsProvider).value ?? const ImageGenSettings();
+    if (_settings.enabled) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _scheduleConnectionCheck(_settings, immediate: true);
+      });
+    }
   }
 
   void _update(ImageGenSettings s) {
+    final wasEnabled = _settings.enabled;
+    final connectionChanged = _hasConnectionChanged(_settings, s);
     _settings = s;
     ref.read(imageGenSettingsProvider.notifier).save(s);
+    if (!s.enabled) {
+      _connectionDebounce?.cancel();
+      _connectionEpoch++;
+      _connectionStatus = 'idle';
+      _connectionError = '';
+    } else if (!wasEnabled || connectionChanged) {
+      _scheduleConnectionCheck(s);
+    }
     if (mounted) setState(() {});
   }
 
   @override
   void dispose() {
+    _connectionDebounce?.cancel();
+    _connectionService.dispose();
     _scrollController.dispose();
     super.dispose();
+  }
+
+  bool _hasConnectionChanged(ImageGenSettings before, ImageGenSettings after) =>
+      before.apiType != after.apiType ||
+      before.useSameEndpoint != after.useSameEndpoint ||
+      before.customEndpoint != after.customEndpoint ||
+      before.customApiKey != after.customApiKey ||
+      before.naisteraApiKey != after.naisteraApiKey ||
+      before.routmyApiKey != after.routmyApiKey ||
+      before.ruRoutmyApiKey != after.ruRoutmyApiKey;
+
+  void _scheduleConnectionCheck(
+    ImageGenSettings settings, {
+    bool immediate = false,
+  }) {
+    final epoch = ++_connectionEpoch;
+    _connectionDebounce?.cancel();
+    _connectionDebounce = Timer(
+      immediate ? Duration.zero : const Duration(milliseconds: 900),
+      () => _checkConnection(settings, epoch),
+    );
+  }
+
+  Future<void> _checkConnection(ImageGenSettings settings, int epoch) async {
+    if (!mounted || epoch != _connectionEpoch || !settings.enabled) return;
+    setState(() {
+      _connectionStatus = 'connecting';
+      _connectionError = '';
+    });
+    final apiConfig = ref.read(activeApiConfigProvider);
+    try {
+      await _connectionService.checkConnection(
+        settings: settings,
+        llmEndpoint: apiConfig?.endpoint ?? '',
+        llmApiKey: apiConfig?.apiKey ?? '',
+      );
+      if (!mounted || epoch != _connectionEpoch) return;
+      setState(() => _connectionStatus = 'connected');
+    } catch (error) {
+      if (!mounted || epoch != _connectionEpoch) return;
+      setState(() {
+        _connectionStatus = 'failed';
+        _connectionError = error.toString().replaceFirst('Bad state: ', '');
+      });
+    }
   }
 
   void _showOptions<T>({
@@ -172,6 +244,7 @@ class _ImageGenSheetState extends ConsumerState<ImageGenSheet> {
                 child: _buildPresetSelector(s.apiType),
               ),
             ),
+            _buildConnectionStatus(s),
             rows.ImageGenMenuGroup(
               title: 'Connection',
               children: _buildConnectionFields(s),
@@ -180,6 +253,14 @@ class _ImageGenSheetState extends ConsumerState<ImageGenSheet> {
               title: 'Model',
               children: _buildModelFields(s),
             ),
+            if (_modelFetchError.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Text(
+                  _modelFetchError,
+                  style: const TextStyle(color: Colors.red, fontSize: 12),
+                ),
+              ),
             if (s.apiType == ImageGenApiType.naistera &&
                 NaisteraConstants.noRefModels.contains(s.naisteraModel))
               Container(
@@ -313,6 +394,45 @@ class _ImageGenSheetState extends ConsumerState<ImageGenSheet> {
     );
   }
 
+  Widget _buildConnectionStatus(ImageGenSettings settings) {
+    final (
+      IconData icon,
+      Color color,
+      String label,
+    ) = switch (_connectionStatus) {
+      'connecting' => (
+        Icons.sync,
+        context.cs.primary,
+        'Checking connection...',
+      ),
+      'connected' => (Icons.check_circle_outline, Colors.green, 'Connected'),
+      'failed' => (Icons.error_outline, Colors.red, _connectionError),
+      _ => (Icons.cloud_outlined, context.cs.onSurfaceVariant, 'Not checked'),
+    };
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(fontSize: 12, color: color),
+            ),
+          ),
+          TextButton(
+            onPressed: () =>
+                _scheduleConnectionCheck(settings, immediate: true),
+            child: const Text('Check'),
+          ),
+        ],
+      ),
+    );
+  }
+
   List<Widget> _buildConnectionFields(ImageGenSettings s) {
     switch (s.apiType) {
       case ImageGenApiType.naistera:
@@ -380,9 +500,34 @@ class _ImageGenSheetState extends ConsumerState<ImageGenSheet> {
 
   Future<void> _onFetchModels() async {
     setState(() => _isFetchingModels = true);
-    await Future<void>.delayed(const Duration(seconds: 1));
-    if (mounted) {
-      setState(() => _isFetchingModels = false);
+    final apiConfig = ref.read(activeApiConfigProvider);
+    try {
+      final models = await _connectionService.fetchOpenAiModels(
+        settings: _settings,
+        llmEndpoint: apiConfig?.endpoint ?? '',
+        llmApiKey: apiConfig?.apiKey ?? '',
+      );
+      if (!mounted) return;
+      if (models.isEmpty) {
+        setState(() => _modelFetchError = 'No image models found');
+        return;
+      }
+      setState(() => _modelFetchError = '');
+      _showOptions<String>(
+        title: 'Image models',
+        items: models,
+        labelBuilder: (model) => model,
+        isSelected: (model) => _settings.customModel == model,
+        onSelected: (model) => _update(_settings.copyWith(customModel: model)),
+      );
+    } catch (error) {
+      if (!mounted) return;
+      setState(
+        () =>
+            _modelFetchError = error.toString().replaceFirst('Bad state: ', ''),
+      );
+    } finally {
+      if (mounted) setState(() => _isFetchingModels = false);
     }
   }
 

--- a/test/characterization/bridge_selection_edit_swipe_test.dart
+++ b/test/characterization/bridge_selection_edit_swipe_test.dart
@@ -433,6 +433,7 @@ void main() {
         'onSelectionChange',
         'onInjectClick',
         'onImgRetry',
+        'onImgEnableRetry',
         'onImgFind',
         'onImgRegen',
         'onImgCancel',
@@ -474,9 +475,14 @@ void main() {
     });
 
     test(
-      'image callbacks (retry/find/regen) send instruction and messageId',
+      'image callbacks (retry/enable/find/regen) send instruction and messageId',
       () {
-        for (final action in ['onImgRetry', 'onImgFind', 'onImgRegen']) {
+        for (final action in [
+          'onImgRetry',
+          'onImgEnableRetry',
+          'onImgFind',
+          'onImgRegen',
+        ]) {
           expect(
             interactionDispatchJs,
             contains("'$action'"),

--- a/test/characterization/webview_callback_contract_test.dart
+++ b/test/characterization/webview_callback_contract_test.dart
@@ -56,6 +56,7 @@ void main() {
         'onToggleHidden',
         'onInjectClick',
         'onImgRetry',
+        'onImgEnableRetry',
         'onImgFind',
         'onImgRegen',
         'onImgCancel',
@@ -90,6 +91,7 @@ void main() {
         'onSelectionChange',
         'onInjectClick',
         'onImgRetry',
+        'onImgEnableRetry',
         'onImgFind',
         'onImgRegen',
         'onImgCancel',
@@ -170,6 +172,7 @@ void main() {
           'onSelectionChange',
           'onInjectClick',
           'onImgRetry',
+          'onImgEnableRetry',
           'onImgFind',
           'onImgRegen',
           'onImgCancel',
@@ -198,9 +201,14 @@ void main() {
     );
 
     test(
-      'image callbacks (retry/find/regen) have (String, String) signature',
+      'image callbacks (retry/enable/find/regen) have (String, String) signature',
       () {
-        for (final name in ['onImgRetry', 'onImgFind', 'onImgRegen']) {
+        for (final name in [
+          'onImgRetry',
+          'onImgEnableRetry',
+          'onImgFind',
+          'onImgRegen',
+        ]) {
           expect(
             bridgeControllerSource,
             contains(

--- a/test/gemini_image_provider_test.dart
+++ b/test/gemini_image_provider_test.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/image_gen/services/gemini_image_provider.dart';
+
+void main() {
+  test(
+    'uses legacy generateContent format and passes image context inline',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      server.listen((request) async {
+        expect(request.uri.path, '/v1beta/models/gemini-image:generateContent');
+        expect(
+          request.headers.value(HttpHeaders.authorizationHeader),
+          'Bearer key',
+        );
+        final body = jsonDecode(await utf8.decoder.bind(request).join()) as Map;
+        final parts =
+            ((body['contents'] as List).single as Map)['parts'] as List;
+        expect(parts.first, {
+          'inlineData': {'mimeType': 'image/jpeg', 'data': 'aW1hZ2U='},
+        });
+        expect(parts.last, {'text': 'draw this'});
+        expect((body['generationConfig'] as Map)['imageConfig'], {
+          'aspectRatio': '16:9',
+          'imageSize': '2K',
+        });
+
+        request.response.headers.contentType = ContentType.json;
+        request.response.write(
+          jsonEncode({
+            'candidates': [
+              {
+                'content': {
+                  'parts': [
+                    {
+                      'inlineData': {'mimeType': 'image/png', 'data': 'cG5n'},
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+        );
+        await request.response.close();
+      });
+
+      final image = await GeminiImageProvider().generate(
+        endpoint: 'http://${server.address.address}:${server.port}',
+        apiKey: 'key',
+        model: 'gemini-image',
+        prompt: 'draw this',
+        aspectRatio: '16:9',
+        imageSize: '2K',
+        referenceImages: const [
+          {'image': 'aW1hZ2U=', 'mime': 'image/jpeg'},
+        ],
+      );
+
+      expect(image, utf8.encode('png'));
+    },
+  );
+}

--- a/test/image_gen_connection_service_test.dart
+++ b/test/image_gen_connection_service_test.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/image_gen/image_gen_models.dart';
+import 'package:glaze_flutter/features/image_gen/services/image_gen_connection_service.dart';
+
+void main() {
+  Future<HttpServer> startServer(
+    Future<void> Function(HttpRequest request) handler,
+  ) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    server.listen(handler);
+    addTearDown(() => server.close(force: true));
+    return server;
+  }
+
+  test('fetches and filters OpenAI-compatible image models', () async {
+    final server = await startServer((request) async {
+      expect(request.uri.path, '/v1/models');
+      expect(
+        request.headers.value(HttpHeaders.authorizationHeader),
+        'Bearer key',
+      );
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(
+        jsonEncode({
+          'data': [
+            {'id': 'dall-e-3'},
+            {'id': 'gpt-image-1'},
+            {'id': 'sora-2'},
+            {'id': 'chat-model'},
+          ],
+        }),
+      );
+      await request.response.close();
+    });
+    final service = ImageGenConnectionService();
+    addTearDown(service.dispose);
+
+    final models = await service.fetchOpenAiModels(
+      settings: ImageGenSettings(
+        useSameEndpoint: false,
+        customEndpoint: 'http://${server.address.address}:${server.port}',
+        customApiKey: 'key',
+      ),
+      llmEndpoint: '',
+      llmApiKey: '',
+    );
+
+    expect(models, ['dall-e-3', 'gpt-image-1']);
+  });
+
+  test(
+    'checks a Gemini generateContent endpoint through its models route',
+    () async {
+      final server = await startServer((request) async {
+        expect(request.uri.path, '/v1beta/models');
+        expect(
+          request.headers.value(HttpHeaders.authorizationHeader),
+          'Bearer key',
+        );
+        request.response.headers.contentType = ContentType.json;
+        request.response.write('{}');
+        await request.response.close();
+      });
+      final service = ImageGenConnectionService();
+      addTearDown(service.dispose);
+
+      await service.checkConnection(
+        settings: ImageGenSettings(
+          apiType: ImageGenApiType.gemini,
+          useSameEndpoint: false,
+          customEndpoint: 'http://${server.address.address}:${server.port}',
+          customApiKey: 'key',
+        ),
+        llmEndpoint: '',
+        llmApiKey: '',
+      );
+    },
+  );
+}

--- a/test/image_gen_service_test.dart
+++ b/test/image_gen_service_test.dart
@@ -57,6 +57,25 @@ void main() {
     });
   });
 
+  group('disabled image generation', () {
+    test('replaces pending tags with a retryable disabled error', () async {
+      String? update;
+      final result = await service.processMessageImages(
+        text: '[IMG:GEN:{"prompt":"scene"}]',
+        settings: const ImageGenSettings(enabled: false),
+        llmEndpoint: '',
+        llmApiKey: '',
+        llmModel: '',
+        onUpdate: (value) => update = value,
+      );
+
+      expect(result, contains('[IMG:ERROR:'));
+      expect(result, contains('Image generation disabled'));
+      expect(result, contains(r'{\"prompt\":\"scene\"}'));
+      expect(update, result);
+    });
+  });
+
   group('extractImageGenInstructions', () {
     test('extracts from [IMG:GEN:json]', () {
       final instructions = ImageTagMarkup.extractImageGenInstructions(


### PR DESCRIPTION
## Changes
- Render pending image tags as retryable disabled cards when Imagen is off, and enable the setting before retrying the original message.
- Restore connection checks and OpenAI-compatible image-model discovery in the Imagen settings sheet.
- Restore Gemini generateContent requests with inline image context and legacy-compatible response parsing.

## Verification
- flutter test test/characterization/webview_callback_contract_test.dart test/characterization/bridge_selection_edit_swipe_test.dart
- The new isolated Gemini and connection-service HTTP tests passed; image_gen_service_test.dart could not compile because existing freezed/json generated files are stale.
- flutter analyze was not run locally; wait for CI.