### PR TITLE
fix(chat): unstick message variation switching

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -539,6 +539,7 @@ export class Bridge {
     if (msg.agentSwipeIndex !== undefined) section.dataset.agentSwipeId = String(msg.agentSwipeIndex);
     if (msg.agentSwipeTotal !== undefined) section.dataset.agentSwipeTotal = String(msg.agentSwipeTotal);
     if (msg.greetingTotal !== undefined) section.dataset.greetingTotal = String(msg.greetingTotal);
+    if (msg.greetingIndex !== undefined) section.dataset.greetingId = String(msg.greetingIndex);
 
     // Restore data-is-last on char sections after generation ends.
     // setLastMessage(null) clears this flag at generation start; without
@@ -579,7 +580,7 @@ export class Bridge {
     const agentSwipeIndex = msg.agentSwipeIndex !== undefined ? msg.agentSwipeIndex : parseInt(section.dataset.agentSwipeId || '0', 10);
     const agentSwipeTotal = msg.agentSwipeTotal !== undefined ? msg.agentSwipeTotal : parseInt(section.dataset.agentSwipeTotal || '0', 10);
     const agentSwipeFinalCount = msg.agentSwipeFinalCount !== undefined ? msg.agentSwipeFinalCount : 0;
-    const greetingIndex = msg.greetingIndex !== undefined ? msg.greetingIndex : 0;
+    const greetingIndex = msg.greetingIndex !== undefined ? msg.greetingIndex : parseInt(section.dataset.greetingId || '0', 10);
     const greetingTotal = msg.greetingTotal !== undefined ? msg.greetingTotal : parseInt(section.dataset.greetingTotal || '0', 10);
     const messageIndex = parseInt(section.dataset.messageIndex || '-1', 10);
     const hasSwipes = isChar && swipeTotal > 1;

--- a/assets/chat_webview/bridge/interaction_dispatch.js
+++ b/assets/chat_webview/bridge/interaction_dispatch.js
@@ -139,6 +139,32 @@ export class InteractionDispatch {
     return null;
   }
 
+  /* Reads the variation state a switcher arrow needs off the message section.
+   * Every arrow consults this before animating: the slide/fade in
+   * `animateVariantSwap` is driven by Flutter pushing an `updateMessage` back,
+   * so firing it for a request Dart will refuse (edge of the list, or a
+   * generation in flight) leaves the bubble faded out until the fallback timer
+   * expires. `busy` covers the generation window, where every swipe/agent-swipe
+   * handler in ChatSwipeController bails out. */
+  _swipeState(messageId) {
+    const section = document.querySelector(`[data-message-id="${messageId}"]`);
+    const num = (value, fallback) => {
+      const parsed = parseInt(value, 10);
+      return Number.isNaN(parsed) ? fallback : parsed;
+    };
+    return {
+      section,
+      swipeId: section ? num(section.dataset.swipeId, 0) : 0,
+      swipeTotal: section ? num(section.dataset.swipeTotal, 1) : 1,
+      agentSwipeId: section ? num(section.dataset.agentSwipeId, 0) : 0,
+      agentSwipeTotal: section ? num(section.dataset.agentSwipeTotal, 1) : 1,
+      greetingId: section ? num(section.dataset.greetingId, 0) : 0,
+      greetingTotal: section ? num(section.dataset.greetingTotal, 1) : 1,
+      isLast: section ? section.dataset.isLast === 'true' : false,
+      busy: !!(this.bridge.isGenerating || this.bridge.isPostGenRunning || this.bridge.isGeneratingImage),
+    };
+  }
+
   _extractImgInstruction(el, path) {
     const sec = path.find(e => e.dataset?.messageId);
     const messageId = sec ? sec.dataset.messageId : '';
@@ -166,6 +192,12 @@ export class InteractionDispatch {
       },
       'swipe-left': (e, el) => {
         const id = el.dataset.messageId;
+        // First variation → hard edge, no wrap to the last one and no
+        // animation. Dart answers such a request with a no-op, so animating
+        // would fade the bubble out and hold it blank until the 300 ms
+        // fallback timer put it back — the "stuck message" symptom.
+        const { swipeId, busy } = this._swipeState(id);
+        if (busy || swipeId <= 0) return;
         bridge._swipeHandler.animateVariantSwap(id, 'prev', () =>
           bridge._sendToFlutter('onSwipe', [JSON.stringify({ id, direction: 'left' })])
         );
@@ -176,10 +208,8 @@ export class InteractionDispatch {
         // next arrow is pressed while already on the last variation of the last
         // message, kick off a regeneration into a fresh swipe instead of a no-op
         // — unless swipe-regeneration is disabled in settings.
-        const section = document.querySelector(`[data-message-id="${id}"]`);
-        const swipeId = section ? parseInt(section.dataset.swipeId || '0', 10) : 0;
-        const swipeTotal = section ? parseInt(section.dataset.swipeTotal || '1', 10) : 1;
-        const isLast = section ? section.dataset.isLast === 'true' : false;
+        const { swipeId, swipeTotal, isLast, busy } = this._swipeState(id);
+        if (busy) return;
         if (swipeId >= swipeTotal - 1) {
           if (isLast && !bridge.disableSwipeRegeneration) {
             bridge._sendToFlutter('onRegenerate', [id, 'new_variant']);
@@ -192,24 +222,32 @@ export class InteractionDispatch {
       },
       'agent-swipe-left': (e, el) => {
         const id = el.dataset.messageId;
+        const { agentSwipeId, busy } = this._swipeState(id);
+        if (busy || agentSwipeId <= 0) return;
         bridge._swipeHandler.animateVariantSwap(id, 'prev', () =>
           bridge._sendToFlutter('onAgentSwipe', [JSON.stringify({ id, direction: 'left' })])
         );
       },
       'agent-swipe-right': (e, el) => {
         const id = el.dataset.messageId;
+        const { agentSwipeId, agentSwipeTotal, busy } = this._swipeState(id);
+        if (busy || agentSwipeId >= agentSwipeTotal - 1) return;
         bridge._swipeHandler.animateVariantSwap(id, 'next', () =>
           bridge._sendToFlutter('onAgentSwipe', [JSON.stringify({ id, direction: 'right' })])
         );
       },
       'greeting-prev': (e, el) => {
         const id = el.dataset.messageId;
+        const { greetingId, busy } = this._swipeState(id);
+        if (busy || greetingId <= 0) return;
         bridge._swipeHandler.animateVariantSwap(id, 'prev', () =>
           bridge._sendToFlutter('onChangeGreeting', [id, -1])
         );
       },
       'greeting-next': (e, el) => {
         const id = el.dataset.messageId;
+        const { greetingId, greetingTotal, busy } = this._swipeState(id);
+        if (busy || greetingId >= greetingTotal - 1) return;
         bridge._swipeHandler.animateVariantSwap(id, 'next', () =>
           bridge._sendToFlutter('onChangeGreeting', [id, 1])
         );

--- a/assets/chat_webview/bridge/swipe_gesture_handler.js
+++ b/assets/chat_webview/bridge/swipe_gesture_handler.js
@@ -87,12 +87,20 @@ export class SwipeGestureHandler {
       const swipeTotal = parseInt(activeSection.dataset.swipeTotal || '1', 10);
       const isLast = activeSection.dataset.isLast === 'true';
       const greetingTotal = parseInt(activeSection.dataset.greetingTotal || '0', 10);
+      const greetingId = parseInt(activeSection.dataset.greetingId || '0', 10);
       const isFirstMsg = activeSection.dataset.messageIndex === '0';
       const canSwitchGreeting = isFirstMsg && greetingTotal > 1;
 
       const blockLastRegen = isLast && self._disableRegen();
-      if (dx < 0 && !canSwitchGreeting && (blockLastRegen || !isLast) && swipeId >= swipeTotal - 1) return;
-      if (dx > 0 && !canSwitchGreeting && swipeId <= 0) return;
+      // Greetings navigate their own list and no longer wrap, so they get the
+      // same hard edges as the swipes: nothing to switch to → no drag.
+      if (canSwitchGreeting) {
+        if (dx < 0 && greetingId >= greetingTotal - 1) return;
+        if (dx > 0 && greetingId <= 0) return;
+      } else {
+        if (dx < 0 && (blockLastRegen || !isLast) && swipeId >= swipeTotal - 1) return;
+        if (dx > 0 && swipeId <= 0) return;
+      }
 
       if (e.cancelable) e.preventDefault();
       activeBody.style.transform = `translateX(${dx}px)`;
@@ -113,14 +121,15 @@ export class SwipeGestureHandler {
       const swipeTotal = parseInt(section.dataset.swipeTotal || '1', 10);
       const isLast = section.dataset.isLast === 'true';
       const greetingTotal = parseInt(section.dataset.greetingTotal || '0', 10);
+      const greetingId = parseInt(section.dataset.greetingId || '0', 10);
       const isFirstMsg = section.dataset.messageIndex === '0';
       const canSwitchGreeting = isFirstMsg && greetingTotal > 1;
       const msgId = section.dataset.messageId;
 
       if (canSwitchGreeting) {
-        if (dx < -THRESHOLD) {
+        if (dx < -THRESHOLD && greetingId < greetingTotal - 1) {
           self.animateVariantSwap(msgId, 'next', () => self._sendToFlutter('onChangeGreeting', [msgId, 1]), dx);
-        } else if (dx > THRESHOLD) {
+        } else if (dx > THRESHOLD && greetingId > 0) {
           self.animateVariantSwap(msgId, 'prev', () => self._sendToFlutter('onChangeGreeting', [msgId, -1]), dx);
         } else {
           reset(body);
@@ -172,6 +181,17 @@ export class SwipeGestureHandler {
     const body = section?.querySelector('.msg-body');
     if (!body) { after(); return; }
 
+    // Tapping the arrow again before the previous swap settled used to leave
+    // two runs fighting over the same inline styles: the older run's cleanup
+    // timer would fire mid-flight and strip the newer run's transition, or the
+    // newer run would measure a height that was still locked — either way the
+    // bubble could stay faded out or keep a frozen height. Tear the previous
+    // run down (timers, observer, inline styles) before starting a new one.
+    if (body._variantSwap) {
+      body._variantSwap.abort();
+      body._variantSwap = null;
+    }
+
     // dir: 'next' → exit to left, enter from right.  'prev' → mirror.
     const sign = dir === 'next' ? -1 : (dir === 'prev' ? 1 : 0);
     // Exit: continue past current drag position; click case uses a small hint.
@@ -180,6 +200,8 @@ export class SwipeGestureHandler {
     const inX = sign * -28;
 
     // Lock current height so the (async) content swap doesn't reflow the page.
+    // Measured with any leftover lock cleared, so a swap that starts on top of
+    // an aborted one still reads the real content height.
     const startHeight = body.offsetHeight;
     body.style.height = `${startHeight}px`;
     body.style.overflow = 'hidden';
@@ -187,14 +209,52 @@ export class SwipeGestureHandler {
     body.style.opacity = '0';
     if (outX) body.style.transform = `translateX(${outX}px)`;
 
-    setTimeout(() => {
-      let done = false;
-      let fallback;
+    // Everything this run schedules, so a superseding run can tear it down.
+    const run = {
+      timers: [],
+      mo: null,
+      done: false,
+      sent: false,
+      send: () => {
+        if (run.sent) return;
+        run.sent = true;
+        after();
+      },
+      abort: () => {
+        run.done = true;
+        run.timers.forEach(clearTimeout);
+        run.timers.length = 0;
+        if (run.mo) run.mo.disconnect();
+        // The switch request itself is not the animation's to drop: a second
+        // tap that lands inside the 130 ms exit window must still reach Dart,
+        // in order, or one of the two steps is silently swallowed.
+        run.send();
+        // Hand the element back in a neutral state; the new run re-locks it.
+        body.style.transition = '';
+        body.style.transform = '';
+        body.style.height = '';
+        body.style.overflow = '';
+        body.style.opacity = '1';
+      },
+    };
+    body._variantSwap = run;
+
+    const schedule = (fn, ms) => {
+      const t = setTimeout(() => {
+        run.timers = run.timers.filter(id => id !== t);
+        fn();
+      }, ms);
+      run.timers.push(t);
+      return t;
+    };
+
+    schedule(() => {
       const finish = () => {
-        if (done) return;
-        done = true;
-        mo.disconnect();
-        clearTimeout(fallback);
+        if (run.done) return;
+        run.done = true;
+        run.mo.disconnect();
+        run.timers.forEach(clearTimeout);
+        run.timers.length = 0;
 
         // Measure new content's natural height
         body.style.height = 'auto';
@@ -202,27 +262,30 @@ export class SwipeGestureHandler {
         body.style.height = `${startHeight}px`;
 
         requestAnimationFrame(() => {
+          // A newer swap took over between the frame request and this callback.
+          if (body._variantSwap !== run) return;
           body.style.transition = 'opacity 0.22s ease, transform 0.22s ease, height 0.22s ease';
           body.style.opacity = '1';
           body.style.transform = '';
           body.style.height = `${targetHeight}px`;
-          setTimeout(() => {
+          schedule(() => {
             body.style.transition = '';
             body.style.transform = '';
             body.style.height = '';
             body.style.overflow = '';
+            if (body._variantSwap === run) body._variantSwap = null;
           }, 240);
         });
       };
 
       // The renderer rewrites section dataset (rawText / swipeId / etc) when
       // Flutter's updateMessage arrives — that's our cue to animate in.
-      const mo = new MutationObserver(finish);
-      mo.observe(section, { attributes: true });
+      run.mo = new MutationObserver(finish);
+      run.mo.observe(section, { attributes: true });
       // Fallback in case the update is a no-op or attribute setter is skipped.
-      fallback = setTimeout(finish, 300);
+      schedule(finish, 300);
 
-      after();
+      run.send();
       body.style.transition = 'none';
       if (inX) body.style.transform = `translateX(${inX}px)`;
     }, 130);

--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -104,6 +104,9 @@ export class Renderer {
     if (messageData.agentSwipeIndex != null) section.dataset.agentSwipeId = String(messageData.agentSwipeIndex);
     if (messageData.agentSwipeTotal != null) section.dataset.agentSwipeTotal = String(messageData.agentSwipeTotal);
     if (messageData.greetingTotal != null) section.dataset.greetingTotal = String(messageData.greetingTotal);
+    // Mirrors swipeId: the greeting arrows need the current index to know when
+    // they sit on an edge, since greeting navigation no longer wraps around.
+    if (messageData.greetingIndex != null) section.dataset.greetingId = String(messageData.greetingIndex);
 
     const classes = ['message-section', this._roleKey(role), `layout-${layout}`];
     if (isError) classes.push('error');

--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -929,17 +929,18 @@ class ChatMessageService {
         ? (dir > 0 ? 'slide-next' : 'slide-prev')
         : 'fade';
 
-    var newIndex = msg.agentSwipeId + dir;
+    final newIndex = msg.agentSwipeId + dir;
 
-    // Wrap-around: index < 0 → last; index >= length → 0.
-    if (newIndex < 0) {
-      newIndex = msg.agentSwipes.length - 1;
-    } else if (newIndex >= msg.agentSwipes.length) {
+    // No wrap-around, same as the green swipes above: the first variation is a
+    // hard left edge and the last one a hard right edge. Wrapping made a tap on
+    // an already-exhausted arrow jump to the opposite end of the list, which
+    // reads as the switcher glitching rather than as navigation.
+    if (newIndex >= msg.agentSwipes.length && isLastMessage) {
       // Right-edge on the last message → full regen (new green swipe).
-      if (isLastMessage) {
-        return const ChangeSwipeResult.needsRegen();
-      }
-      newIndex = 0;
+      return const ChangeSwipeResult.needsRegen();
+    }
+    if (newIndex < 0 || newIndex >= msg.agentSwipes.length) {
+      return const ChangeSwipeResult.noop();
     }
 
     final swipe = msg.agentSwipes[newIndex];
@@ -974,9 +975,10 @@ class ChatMessageService {
       return session;
     }
     if (resolvedGreetings.length <= 1) return session;
-    var idx = newGreetingIndex;
-    if (idx < 0) idx = resolvedGreetings.length - 1;
-    if (idx >= resolvedGreetings.length) idx = 0;
+    // Hard edges, no wrap — the first greeting stays put on a back step and the
+    // last one on a forward step, matching the swipe switchers.
+    final idx = newGreetingIndex;
+    if (idx < 0 || idx >= resolvedGreetings.length) return session;
 
     final msg = session.messages[messageIndex];
     final newText = resolvedGreetings[idx];

--- a/lib/features/chat/chat_provider.dart
+++ b/lib/features/chat/chat_provider.dart
@@ -575,6 +575,24 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     final regenTargetId = prevAssistant.id;
     _abortHandler.restorationMessage = prevAssistant;
 
+    // The reply always lands as a *new* variation (`SavedMessageWriter`
+    // appends it to `swipes[]`), so open that slot the moment the run starts
+    // instead of when the text arrives: the counter steps N/N → N+1/N+1 on the
+    // tap. This is UI-only — `saveSession` below is the untouched pre-regen
+    // session, so nothing extra is persisted. Cancelling puts it back: the
+    // abort path reloads the durable row when nothing streamed, and rebuilds
+    // `swipes[]` from `restorationMessage` + the partial text when it did.
+    final pendingSwipes = [
+      ...(prevAssistant.swipes.isNotEmpty
+          ? prevAssistant.swipes
+          : [prevAssistant.content]),
+      '',
+    ];
+    final pendingSwipesMeta = [
+      ...?_previousSwipesMetaForRegen(prevAssistant),
+      <String, dynamic>{},
+    ];
+
     final clearedMsg = prevAssistant.copyWith(
       content: '',
       reasoning: null,
@@ -582,6 +600,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       genTime: null,
       tokens: null,
       isError: false,
+      swipes: pendingSwipes,
+      swipeId: pendingSwipes.length - 1,
+      swipesMeta: pendingSwipesMeta,
     );
     final clearedMessages = [...current.messages];
     clearedMessages[lastIdx] = clearedMsg;

--- a/lib/features/chat/controllers/chat_swipe_controller.dart
+++ b/lib/features/chat/controllers/chat_swipe_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/models/chat_message.dart';
 import '../../../core/state/db_provider.dart';
 import '../chat_message_service.dart';
 import '../chat_session_service.dart';
@@ -13,6 +14,14 @@ class ChatSwipeController {
   final AsyncValue<ChatState> Function() _getState;
   final void Function() _invalidateHistory;
 
+  /// Tail of the variation-switch queue. Every public method runs through
+  /// [_serialize] so two taps (or a tap racing a swipe gesture) cannot
+  /// interleave their read → commit → publish cycles: the second one would
+  /// read the state the first has not published yet, and whichever `_setState`
+  /// landed last would win — leaving the counter or the bubble one step behind
+  /// the durable session, which is exactly the "stuck variation" symptom.
+  Future<void> _queue = Future<void>.value();
+
   ChatSwipeController({
     required this._ref,
     required this._charId,
@@ -23,113 +32,144 @@ class ChatSwipeController {
 
   ChatMessageService get _messageSvc => ChatMessageService(_ref);
 
-  Future<void> setSwipe(int messageIndex, int swipeId) async {
-    final current = _getState().value;
-    if (current == null || current.session == null) return;
-    final updated = await _messageSvc.commitMessageMutation(
-      current.session!,
-      messageIndex,
-      (latest, latestIndex) =>
-          _messageSvc.setSwipe(latest, latestIndex, swipeId),
-    );
+  Future<void> _serialize(Future<void> Function() operation) {
+    final previous = _queue;
+    final next = () async {
+      try {
+        await previous;
+      } catch (_) {
+        // A failed switch must not permanently poison the queue.
+      }
+      await operation();
+    }();
+    _queue = next.then((_) {}, onError: (_) {});
+    return next;
+  }
+
+  /// Publishes [updated] on top of the *latest* state rather than the snapshot
+  /// the operation started from, so flags another path flipped mid-await
+  /// (generation, session switch) are not rolled back. Drops the write when the
+  /// chat moved to a different session while the commit was in flight.
+  void _publish(ChatSession updated) {
+    final latest = _getState().value;
+    if (latest == null || latest.session == null) return;
+    if (latest.session!.id != updated.id) return;
     _invalidateHistory();
-    _setState(AsyncData(current.copyWith(session: updated)));
+    _setState(AsyncData(latest.copyWith(session: updated)));
   }
 
-  Future<void> setAgentSwipe(int messageIndex, int agentSwipeId) async {
-    final current = _getState().value;
-    if (current == null || current.session == null) return;
-    final updated = await _messageSvc.commitMessageMutation(
-      current.session!,
-      messageIndex,
-      (latest, latestIndex) =>
-          _messageSvc.setAgentSwipe(latest, latestIndex, agentSwipeId),
-    );
-    _invalidateHistory();
-    _setState(AsyncData(current.copyWith(session: updated)));
+  Future<void> setSwipe(int messageIndex, int swipeId) {
+    return _serialize(() async {
+      final current = _getState().value;
+      if (current == null || current.session == null) return;
+      final updated = await _messageSvc.commitMessageMutation(
+        current.session!,
+        messageIndex,
+        (latest, latestIndex) =>
+            _messageSvc.setSwipe(latest, latestIndex, swipeId),
+      );
+      _publish(updated);
+    });
   }
 
-  Future<void> deleteActiveSwipe(int messageIndex) async {
-    await _deleteVariation(messageIndex, deleteAgentSwipe: false);
+  Future<void> setAgentSwipe(int messageIndex, int agentSwipeId) {
+    return _serialize(() async {
+      final current = _getState().value;
+      if (current == null || current.session == null) return;
+      final updated = await _messageSvc.commitMessageMutation(
+        current.session!,
+        messageIndex,
+        (latest, latestIndex) =>
+            _messageSvc.setAgentSwipe(latest, latestIndex, agentSwipeId),
+      );
+      _publish(updated);
+    });
   }
 
-  Future<void> deleteActiveAgentSwipe(int messageIndex) async {
-    await _deleteVariation(messageIndex, deleteAgentSwipe: true);
+  Future<void> deleteActiveSwipe(int messageIndex) {
+    return _deleteVariation(messageIndex, deleteAgentSwipe: false);
+  }
+
+  Future<void> deleteActiveAgentSwipe(int messageIndex) {
+    return _deleteVariation(messageIndex, deleteAgentSwipe: true);
   }
 
   Future<void> _deleteVariation(
     int messageIndex, {
     required bool deleteAgentSwipe,
-  }) async {
-    final current = _getState().value;
-    if (current == null ||
-        current.session == null ||
-        current.isGenerating ||
-        current.isGeneratingImage ||
-        current.isPostGenRunning ||
-        messageIndex < 0 ||
-        messageIndex >= current.messages.length ||
-        current.messages[messageIndex].role != 'assistant') {
-      return;
-    }
-    final updated = deleteAgentSwipe
-        ? await _messageSvc.deleteActiveAgentSwipe(
-            current.session!,
-            messageIndex,
-          )
-        : await _messageSvc.deleteActiveSwipe(current.session!, messageIndex);
-    if (identical(updated, current.session)) return;
-    _invalidateHistory();
-    _setState(AsyncData(current.copyWith(session: updated)));
+  }) {
+    return _serialize(() async {
+      final current = _getState().value;
+      if (current == null ||
+          current.session == null ||
+          current.isGenerating ||
+          current.isGeneratingImage ||
+          current.isPostGenRunning ||
+          messageIndex < 0 ||
+          messageIndex >= current.messages.length ||
+          current.messages[messageIndex].role != 'assistant') {
+        return;
+      }
+      final updated = deleteAgentSwipe
+          ? await _messageSvc.deleteActiveAgentSwipe(
+              current.session!,
+              messageIndex,
+            )
+          : await _messageSvc.deleteActiveSwipe(current.session!, messageIndex);
+      if (identical(updated, current.session)) return;
+      _publish(updated);
+    });
   }
 
   Future<void> changeSwipe(
     int messageIndex,
     int dir, {
     bool fromSwipe = false,
-  }) async {
-    final current = _getState().value;
-    if (current == null ||
-        current.session == null ||
-        current.isGenerating ||
-        current.isGeneratingImage ||
-        current.isPostGenRunning) {
-      return;
-    }
-    if (messageIndex < 0 || messageIndex >= current.messages.length) return;
+  }) {
+    return _serialize(() async {
+      final current = _getState().value;
+      if (current == null ||
+          current.session == null ||
+          current.isGenerating ||
+          current.isGeneratingImage ||
+          current.isPostGenRunning) {
+        return;
+      }
+      if (messageIndex < 0 || messageIndex >= current.messages.length) return;
 
-    final isLast = messageIndex == current.messages.length - 1;
-    final preview = _messageSvc.changeSwipe(
-      current.session!,
-      messageIndex,
-      dir,
-      fromSwipe: fromSwipe,
-      isLastMessage: isLast,
-    );
-
-    if (preview.needsRegen) {
-      // This will be handled by the parent provider calling regenerateLastAssistant
-      return;
-    }
-    if (preview.isUpdated) {
-      final result = await _messageSvc.commitMessageMutation(
+      final isLast = messageIndex == current.messages.length - 1;
+      final preview = _messageSvc.changeSwipe(
         current.session!,
         messageIndex,
-        (latest, latestIndex) =>
-            _messageSvc
-                .changeSwipe(
-                  latest,
-                  latestIndex,
-                  dir,
-                  fromSwipe: fromSwipe,
-                  isLastMessage: latestIndex == latest.messages.length - 1,
-                )
-                .session ??
-            latest,
+        dir,
+        fromSwipe: fromSwipe,
+        isLastMessage: isLast,
       );
-      _invalidateHistory();
-      _setState(AsyncData(current.copyWith(session: result)));
-    }
+
+      if (preview.needsRegen) {
+        // This will be handled by the parent provider calling
+        // regenerateLastAssistant
+        return;
+      }
+      if (preview.isUpdated) {
+        final result = await _messageSvc.commitMessageMutation(
+          current.session!,
+          messageIndex,
+          (latest, latestIndex) =>
+              _messageSvc
+                  .changeSwipe(
+                    latest,
+                    latestIndex,
+                    dir,
+                    fromSwipe: fromSwipe,
+                    isLastMessage: latestIndex == latest.messages.length - 1,
+                  )
+                  .session ??
+              latest,
+        );
+        _publish(result);
+      }
+    });
   }
 
   /// Navigate blue sub-swipes (agentSwipes). Right-edge on the last message
@@ -138,85 +178,87 @@ class ChatSwipeController {
     int messageIndex,
     int dir, {
     bool fromSwipe = false,
-  }) async {
-    final current = _getState().value;
-    if (current == null ||
-        current.session == null ||
-        current.isGenerating ||
-        current.isGeneratingImage ||
-        current.isPostGenRunning) {
-      return;
-    }
-    if (messageIndex < 0 || messageIndex >= current.messages.length) return;
+  }) {
+    return _serialize(() async {
+      final current = _getState().value;
+      if (current == null ||
+          current.session == null ||
+          current.isGenerating ||
+          current.isGeneratingImage ||
+          current.isPostGenRunning) {
+        return;
+      }
+      if (messageIndex < 0 || messageIndex >= current.messages.length) return;
 
-    final isLast = messageIndex == current.messages.length - 1;
-    final preview = _messageSvc.changeAgentSwipe(
-      current.session!,
-      messageIndex,
-      dir,
-      fromSwipe: fromSwipe,
-      isLastMessage: isLast,
-    );
-
-    if (preview.needsRegen) {
-      return;
-    }
-    if (preview.isUpdated) {
-      final result = await _messageSvc.commitMessageMutation(
+      final isLast = messageIndex == current.messages.length - 1;
+      final preview = _messageSvc.changeAgentSwipe(
         current.session!,
         messageIndex,
-        (latest, latestIndex) =>
-            _messageSvc
-                .changeAgentSwipe(
-                  latest,
-                  latestIndex,
-                  dir,
-                  fromSwipe: fromSwipe,
-                  isLastMessage: latestIndex == latest.messages.length - 1,
-                )
-                .session ??
-            latest,
+        dir,
+        fromSwipe: fromSwipe,
+        isLastMessage: isLast,
       );
-      _invalidateHistory();
-      _setState(AsyncData(current.copyWith(session: result)));
-    }
+
+      if (preview.needsRegen) {
+        return;
+      }
+      if (preview.isUpdated) {
+        final result = await _messageSvc.commitMessageMutation(
+          current.session!,
+          messageIndex,
+          (latest, latestIndex) =>
+              _messageSvc
+                  .changeAgentSwipe(
+                    latest,
+                    latestIndex,
+                    dir,
+                    fromSwipe: fromSwipe,
+                    isLastMessage: latestIndex == latest.messages.length - 1,
+                  )
+                  .session ??
+              latest,
+        );
+        _publish(result);
+      }
+    });
   }
 
-  Future<void> setGreeting(int messageIndex, int direction) async {
-    final current = _getState().value;
-    if (current == null ||
-        current.session == null ||
-        current.isGenerating ||
-        current.isPostGenRunning) {
-      return;
-    }
-    if (messageIndex != 0) return;
-    if (messageIndex >= current.messages.length) return;
-    final msg = current.messages[messageIndex];
-    if (msg.role != 'assistant') return;
+  Future<void> setGreeting(int messageIndex, int direction) {
+    return _serialize(() async {
+      final current = _getState().value;
+      if (current == null ||
+          current.session == null ||
+          current.isGenerating ||
+          current.isPostGenRunning) {
+        return;
+      }
+      if (messageIndex != 0) return;
+      if (messageIndex >= current.messages.length) return;
+      final msg = current.messages[messageIndex];
+      if (msg.role != 'assistant') return;
 
-    final character = await _ref.read(characterRepoProvider).getById(_charId);
-    if (character == null) return;
-    final persona = await ChatSessionService(_ref).resolvePersona(_charId);
-    final greetings = InitialMessageBuilder.resolveGreetings(
-      character: character,
-      persona: persona,
-      sessionId: current.session!.id,
-    );
-    if (greetings.length <= 1) return;
+      final character = await _ref.read(characterRepoProvider).getById(_charId);
+      if (character == null) return;
+      final persona = await ChatSessionService(_ref).resolvePersona(_charId);
+      final greetings = InitialMessageBuilder.resolveGreetings(
+        character: character,
+        persona: persona,
+        sessionId: current.session!.id,
+      );
+      if (greetings.length <= 1) return;
 
-    final currentIdx = msg.greetingIndex ?? 0;
-    final updated = await _messageSvc.commitMessageMutation(
-      current.session!,
-      messageIndex,
-      (latest, latestIndex) => _messageSvc.setGreeting(
-        latest,
-        latestIndex,
-        currentIdx + direction,
-        greetings,
-      ),
-    );
-    _invalidateHistory();
-    _setState(AsyncData(current.copyWith(session: updated)));
+      final currentIdx = msg.greetingIndex ?? 0;
+      final updated = await _messageSvc.commitMessageMutation(
+        current.session!,
+        messageIndex,
+        (latest, latestIndex) => _messageSvc.setGreeting(
+          latest,
+          latestIndex,
+          currentIdx + direction,
+          greetings,
+        ),
+      );
+      _publish(updated);
+    });
   }
 }


### PR DESCRIPTION
Switching message variations could leave the counter or the bubble stuck, the left arrow wrapped around from the first variation, and a regeneration only revealed its new slot once the reply arrived.

## Stuck counter / stuck bubble

- Serialize every variation switch in `ChatSwipeController` through one queue, and publish the result on top of the *latest* state instead of the snapshot read before the `await`. Two quick taps used to read the same state, commit to the DB in either order, and let whichever `_setState` landed last win — leaving the UI one step behind the durable session.
- Stop the switcher arrows from animating a request Dart will refuse (edge of the list, or a generation / post-gen / image run in flight). `animateVariantSwap` faded the bubble to `opacity: 0` and waited for an `updateMessage` that never came, so it stayed blank until the 300 ms fallback timer fired.
- Make `animateVariantSwap` re-entrant: a new swap tears down the previous run's timers, observer and inline styles. Overlapping swaps used to fight over the same styles — an older cleanup timer would strip the newer run's transition mid-flight. A superseded run still forwards its request to Dart so a fast second tap is not swallowed.

## No wrap-around at the first variation

- `changeAgentSwipe` (blue sub-swipes) and `setGreeting` no longer wrap: the first variation is a hard left edge and the last one a hard right edge, matching the green swipes.
- Mirror the greeting index into `data-greeting-id` on the message section so the greeting arrows and the touch gesture can see their own edges; `_syncMessageControls` now falls back to it instead of resetting the greeting counter to 1/N.

## Counter steps up when the regeneration starts

- `regenerateLastAssistant` opens the new variation slot at the moment the run starts, so the counter goes N/N → N+1/N+1 on the tap instead of when the text lands. This covers both the swipe/arrow-into-regen path and the Regenerate button, which share `onRegenerate`.
- UI-only: `saveSession` is still the untouched pre-regen session, so nothing extra is persisted. Cancelling reverts it — the abort path reloads the durable row when nothing streamed, and rebuilds `swipes[]` from `restorationMessage` plus the partial text when it did, which lands on the same N+1.

## Verification

Not verified locally — no analyze or test run on this machine. CI (`flutter analyze` + `flutter test`) is the gate; this PR is set to auto-merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)