### PR TITLE
fix(dev): hide developer settings on every channel

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -86,10 +86,11 @@ jobs:
           SAFE_BRANCH=$(echo "$BUILD_BRANCH" | sed 's#[/ ]#-#g')
           FILE_SLUG="G-$(date -u '+%d%m%Y-%H%M')-$SAFE_BRANCH"
 
-          # Release channel drives the in-app dev-tooling defaults (developer
-          # mode + build watermark) via --dart-define=BUILD_CHANNEL. Only the
-          # two release branches get a non-nightly channel; every other branch
-          # builds as nightly, i.e. with dev tooling on.
+          # Release channel drives the app identity, data folder, cloud root,
+          # update source and the build-watermark default via
+          # --dart-define=BUILD_CHANNEL. Developer mode is off on every channel
+          # and only unlocks via the About easter egg. Only the two release
+          # branches get a non-nightly channel; every other branch is nightly.
           case "$BUILD_BRANCH" in
             stable)  BUILD_CHANNEL=stable  ;;
             staging) BUILD_CHANNEL=staging ;;

--- a/docs/RELEASE_CHANNELS.md
+++ b/docs/RELEASE_CHANNELS.md
@@ -1,14 +1,20 @@
 # Release channels
 
-Three long-lived branches, one per build channel. The channel decides whether a
-build ships developer tooling — developer mode and the build watermark.
+Three long-lived branches, one per build channel. The channel decides packaging
+— app identity, data folder, cloud root and update source — and the watermark
+default. It no longer decides whether developer mode is on.
 
-| Branch    | Channel   | Dev mode default | Watermark default | Audience              |
-|-----------|-----------|------------------|-------------------|-----------------------|
-| `stable`  | `stable`  | off              | off               | public releases       |
-| `staging` | `staging` | **on**           | **on**            | testers / release RCs |
-| `nightly` | `nightly` | **on**           | **on**            | daily internal builds |
-| any other | `nightly` | **on**           | **on**            | feature branches      |
+| Branch    | Channel   | Dev mode default | Watermark default   | Audience              |
+|-----------|-----------|------------------|---------------------|-----------------------|
+| `stable`  | `stable`  | off              | on while `0.x`      | public releases       |
+| `staging` | `staging` | off              | **on**              | testers / release RCs |
+| `nightly` | `nightly` | off              | **on**              | daily internal builds |
+| any other | `nightly` | off              | **on**              | feature branches      |
+
+Developer mode is hidden on every channel, local `flutter run` included, and is
+unlocked only through the 7-tap easter egg on the version badge in About. The
+build watermark is shown on every current version — `stable` only drops it once
+the app leaves `0.x`, since a beta needs its screenshots identifiable.
 
 `stable` is the repository default branch. Branching and promotion rules live in
 [`WORKFLOW.md`](./WORKFLOW.md).
@@ -38,38 +44,53 @@ existing defines:
 ```dart
 const buildChannel = String.fromEnvironment('BUILD_CHANNEL', defaultValue: 'nightly');
 const isStableChannel = buildChannel == 'stable';
-const devToolingEnabledByDefault = !isStableChannel;
 ```
 
 The default is `nightly`, so a local `flutter run` — which never passes the
-define — keeps dev tooling on. Nothing about the developer experience changes.
+define — is packaged like an internal build.
 
-## What the channel actually controls
+## What the channel still controls
 
-Only the **defaults** of two persisted settings in
-`lib/core/state/dev_mode_provider.dart`:
+Of the two persisted settings in `lib/core/state/dev_mode_provider.dart`, only
+the watermark is channel-aware now:
 
 ```dart
-// devModeProvider
-return prefs?.getBool(_prefsKey) ?? devToolingEnabledByDefault;
+// devModeProvider — hidden until unlocked in About, on every channel
+return prefs?.getBool(prefsKey) ?? false;
 
-// hideBuildWatermarkProvider  (note: "hide", so stable → hidden)
-return prefs?.getBool(_prefsKey) ?? isStableChannel;
+// hideBuildWatermarkProvider (note: "hide") — only a non-beta stable hides it
+return prefs?.getBool(_prefsKey) ?? (isStableChannel && !isBetaVersion);
 ```
 
-Two consequences worth being explicit about:
-
+- **Dev settings are opt-in everywhere.** The Dev group in
+  `lib/features/menu/menu_screen.dart` is gated on `devModeProvider`, and the
+  only thing that flips it is tapping the version badge seven times in
+  `lib/features/menu/about_screen.dart`. A nightly build looks exactly like a
+  stable one until someone does that — no channel gives it away for free.
+- **The watermark ships on every current version.** `isBetaVersion` is true for
+  the whole `0.x` line (`lib/core/constants/app_version.dart`), so even a stable
+  build stamps its date and branch today; the stamp disappears from `stable` on
+  its own at `1.0`. Turning it off before then means unlocking dev mode first.
 - **A user's own choice still wins.** Both values are persisted in
-  `SharedPreferences`; the channel only supplies the value used when nothing has
-  been stored yet.
-- **`stable` is not a lockout.** The 7-tap easter egg on the version badge
-  (`lib/features/menu/about_screen.dart`) still unlocks dev mode on a stable
-  build, and the watermark can then be switched back on from the Dev group for
-  diagnostics. This is deliberate — it keeps production builds debuggable.
+  `SharedPreferences`; the defaults above are only used when nothing has been
+  stored yet, so an install that already toggled either setting keeps what it
+  had.
 
-If you ever need the watermark to be genuinely unreachable on `stable`, gate the
-widget itself on `!isStableChannel` in `lib/app.dart` rather than changing the
-default — that is a behaviour change, not a default change.
+### One-time dev-mode reset
+
+Older `nightly`/`staging` builds defaulted dev mode to **on**, and that `true`
+was written to `SharedPreferences` the moment the user touched any dev toggle —
+a stored value outranks the new default, so those installs would have kept the
+Dev group forever. `resetLegacyDevModeFlag`
+(`lib/core/services/dev_mode_flag_migration.dart`) removes the `devModeEnabled`
+key once at startup, guarded by a `devModeDefaultResetV1` marker, and runs after
+`migrateLegacyWindowsPreferences` because that one rewrites the preferences file
+on disk before `SharedPreferences` is first opened. After the marker is written
+the flag is the user's own again and is never touched.
+
+If a future channel ever needs different behaviour here, add a derived `const`
+to `build_channel.dart` and use it for the default rather than reading
+`buildChannel` in feature code.
 
 ## Side-by-side installs
 
@@ -198,8 +219,9 @@ trade rather than a gap worth closing.
    workflows (all three build jobs each) if it gets its own Dropbox app key,
    and to `_foreignChannelFolders` in `dropbox_adapter.dart` so a wipe from
    `stable` leaves it alone.
-4. If it needs different dev-tooling behaviour, extend
-   `build_channel.dart` — keep the derived flags `const` so they tree-shake.
+4. If it needs dev-tooling behaviour that differs from the "hidden everywhere,
+   watermark everywhere" default, extend `build_channel.dart` — keep the derived
+   flags `const` so they tree-shake.
 
 Do not read `buildChannel` directly in feature code; depend on the derived
 booleans instead, so the channel list stays in one place.

--- a/lib/core/constants/build_channel.dart
+++ b/lib/core/constants/build_channel.dart
@@ -3,15 +3,20 @@
 /// Injected by the CI workflow (`--dart-define=BUILD_CHANNEL=<name>`), which
 /// derives it from the branch being built:
 ///
-/// | branch    | channel   | dev tooling |
-/// |-----------|-----------|-------------|
-/// | `stable`  | `stable`  | off         |
-/// | `staging` | `staging` | on          |
-/// | `nightly` | `nightly` | on          |
-/// | anything else       | `nightly` | on |
+/// | branch        | channel   |
+/// |---------------|-----------|
+/// | `stable`      | `stable`  |
+/// | `staging`     | `staging` |
+/// | `nightly`     | `nightly` |
+/// | anything else | `nightly` |
 ///
 /// Defaults to `nightly` so that local developer builds — which never pass the
-/// define — keep the dev tooling switched on.
+/// define — behave like an internal build.
+///
+/// The channel no longer decides whether developer mode is on — that is off by
+/// default everywhere and is unlocked through the version-badge easter egg in
+/// About. What is left is packaging (data folder, cloud root, update source)
+/// and the build-watermark default.
 const buildChannel = String.fromEnvironment(
   'BUILD_CHANNEL',
   defaultValue: 'nightly',
@@ -19,13 +24,6 @@ const buildChannel = String.fromEnvironment(
 
 /// Whether this is a production (`stable`) build.
 const isStableChannel = buildChannel == 'stable';
-
-/// Whether this build ships developer tooling turned on out of the box.
-///
-/// Drives the *defaults* of `devModeProvider` and `hideBuildWatermarkProvider`
-/// only — on every channel the user's own choice, once made, still wins, and
-/// the version-badge easter egg can unlock dev mode on a stable build too.
-const devToolingEnabledByDefault = !isStableChannel;
 
 /// Name of the Glaze data folder on desktop (`%APPDATA%\<name>` on Windows,
 /// `~/.local/share/<name>` on Linux, `~/Library/Application Support/<name>` on

--- a/lib/core/services/dev_mode_flag_migration.dart
+++ b/lib/core/services/dev_mode_flag_migration.dart
@@ -1,0 +1,26 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../state/dev_mode_provider.dart';
+
+/// Marker for the one-time reset below. Its presence — not its value — is what
+/// says the reset already ran, so a user who unlocks dev mode afterwards keeps
+/// it across launches.
+const _markerKey = 'devModeDefaultResetV1';
+
+/// Clears a `devModeEnabled` left over from the builds where `nightly` and
+/// `staging` switched developer mode on by default.
+///
+/// Dev mode is now off on every channel and is only reachable through the
+/// 7-tap easter egg on the version badge in About. Without this those installs
+/// would keep a persisted `true` forever and still show the Dev group, since a
+/// stored value always wins over the default.
+///
+/// Runs exactly once per install: after the marker is written the stored flag
+/// is the user's own choice and is never touched again.
+Future<void> resetLegacyDevModeFlag({SharedPreferences? preferences}) async {
+  final prefs = preferences ?? await SharedPreferences.getInstance();
+  if (prefs.containsKey(_markerKey)) return;
+
+  await prefs.remove(DevModeNotifier.prefsKey);
+  await prefs.setBool(_markerKey, true);
+}

--- a/lib/core/state/dev_mode_provider.dart
+++ b/lib/core/state/dev_mode_provider.dart
@@ -7,26 +7,31 @@ import 'shared_prefs_provider.dart';
 /// Whether developer mode (hidden dev tools / settings) is unlocked.
 /// Persisted across launches so the chosen state is remembered.
 ///
-/// Defaults to on for the `staging` and `nightly` channels and off for
-/// `stable`; see [devToolingEnabledByDefault]. The version-badge easter egg
-/// still unlocks it on a stable build.
+/// Off by default on **every** channel — including `nightly` and local
+/// developer builds. The only way in is the 7-tap easter egg on the version
+/// badge in About (`lib/features/menu/about_screen.dart`).
+///
+/// Installs that ran a build from back when `nightly`/`staging` turned this on
+/// by default have the stale `true` cleared once at startup by
+/// `resetLegacyDevModeFlag` (`lib/core/services/dev_mode_flag_migration.dart`).
 final devModeProvider = NotifierProvider<DevModeNotifier, bool>(
   DevModeNotifier.new,
 );
 
 class DevModeNotifier extends Notifier<bool> {
-  static const _prefsKey = 'devModeEnabled';
+  /// Public so the startup migration can clear the same key.
+  static const prefsKey = 'devModeEnabled';
 
   @override
   bool build() {
     final prefs = ref.watch(sharedPreferencesProvider).value;
-    return prefs?.getBool(_prefsKey) ?? devToolingEnabledByDefault;
+    return prefs?.getBool(prefsKey) ?? false;
   }
 
   Future<void> set(bool value) async {
     state = value;
     final prefs = await ref.read(sharedPreferencesProvider.future);
-    await prefs.setBool(_prefsKey, value);
+    await prefs.setBool(prefsKey, value);
   }
 
   Future<void> toggle() => set(!state);
@@ -35,9 +40,10 @@ class DevModeNotifier extends Notifier<bool> {
 /// Dev setting: hide the build-date watermark pinned to the bottom-right
 /// corner of the screen.
 ///
-/// Visible by default on the `staging` and `nightly` channels, hidden by
-/// default on `stable` — production builds ship without the build stamp. A
-/// user who unlocks dev mode can still turn it back on for diagnostics.
+/// Visible by default everywhere except a `stable` build of a non-beta
+/// version — while the app is on a `0.x` version even stable ships the build
+/// stamp, because that is what makes a bug report identifiable. Hiding it is a
+/// dev setting, so it takes unlocking dev mode in About first.
 final hideBuildWatermarkProvider =
     NotifierProvider<HideBuildWatermarkNotifier, bool>(
   HideBuildWatermarkNotifier.new,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
 import 'core/debug/perf_debug.dart';
+import 'core/services/dev_mode_flag_migration.dart';
 import 'core/services/windows_preferences_migration.dart';
 
 final appRestartKey = GlobalKey();
@@ -21,6 +22,20 @@ Future<void> main() async {
         stack: stackTrace,
         library: 'startup',
         context: ErrorDescription('Windows preferences migration failed'),
+      ),
+    );
+  }
+  // After the Windows migration: that one rewrites the preferences file on
+  // disk, so it has to land before SharedPreferences is first opened here.
+  try {
+    await resetLegacyDevModeFlag();
+  } catch (error, stackTrace) {
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception: error,
+        stack: stackTrace,
+        library: 'startup',
+        context: ErrorDescription('dev mode flag reset failed'),
       ),
     );
   }

--- a/lib/shared/widgets/build_watermark.dart
+++ b/lib/shared/widgets/build_watermark.dart
@@ -7,10 +7,10 @@ import '../../core/state/dev_mode_provider.dart';
 /// Persistent build watermark pinned to the bottom-right of the screen.
 ///
 /// Shows the build branch (when injected) above the build date, both aligned
-/// to the right edge. Visible by default on the `staging` and `nightly`
-/// channels and hidden on `stable`; either way it follows
-/// [hideBuildWatermarkProvider], which is toggleable from the Dev settings.
-/// Must be placed as a direct child of a [Stack].
+/// to the right edge. Visible by default everywhere except a `stable` build of
+/// a non-beta version; it follows [hideBuildWatermarkProvider], which can only
+/// be switched off from the Dev settings — and those need dev mode unlocked in
+/// About first. Must be placed as a direct child of a [Stack].
 class BuildWatermark extends ConsumerWidget {
   const BuildWatermark({super.key});
 

--- a/test/dev_mode_flag_migration_test.dart
+++ b/test/dev_mode_flag_migration_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/core/services/dev_mode_flag_migration.dart';
+import 'package:glaze_flutter/core/state/dev_mode_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<SharedPreferences> prefsWith(Map<String, Object> values) async {
+    SharedPreferences.setMockInitialValues(values);
+    return SharedPreferences.getInstance();
+  }
+
+  test('clears a dev mode flag left over from the old channel defaults',
+      () async {
+    final prefs = await prefsWith({DevModeNotifier.prefsKey: true});
+
+    await resetLegacyDevModeFlag(preferences: prefs);
+
+    expect(prefs.containsKey(DevModeNotifier.prefsKey), isFalse);
+  });
+
+  test('runs once — a later unlock survives the next startup', () async {
+    final prefs = await prefsWith({DevModeNotifier.prefsKey: true});
+
+    await resetLegacyDevModeFlag(preferences: prefs);
+    await prefs.setBool(DevModeNotifier.prefsKey, true);
+    await resetLegacyDevModeFlag(preferences: prefs);
+
+    expect(prefs.getBool(DevModeNotifier.prefsKey), isTrue);
+  });
+
+  test('is a no-op when nothing was stored', () async {
+    final prefs = await prefsWith({});
+
+    await resetLegacyDevModeFlag(preferences: prefs);
+
+    expect(prefs.containsKey(DevModeNotifier.prefsKey), isFalse);
+  });
+}


### PR DESCRIPTION
Developer mode no longer depends on the build channel: it is off by default everywhere, including nightly, staging and local runs, and is unlocked only through the 7-tap easter egg on the version badge in About.

- Drop devToolingEnabledByDefault; devModeProvider defaults to false
- Reset a devModeEnabled left over from the old nightly/staging defaults once at startup, guarded by a devModeDefaultResetV1 marker
- Keep the build watermark on every current version (0.x is beta, so stable ships it too) and update the channel docs accordingly