### PR TITLE
perf(chat): stop the Quick Access drawer reloading from scratch on every open

### DIFF
--- a/lib/core/db/repositories/chat_repo.dart
+++ b/lib/core/db/repositories/chat_repo.dart
@@ -51,6 +51,20 @@ class ChatRepo implements SyncChatStore {
     return rows.map(_toMetadata).toList();
   }
 
+  /// How many chat sessions one character has, aggregated in SQL.
+  ///
+  /// The Quick Access session card needs the number and nothing else;
+  /// [getByCharacterId] would decode every message of every session just to
+  /// read `.length` off the result.
+  Future<int> countByCharacterId(String charId) async {
+    final countExpr = _db.chatSessions.sessionId.count();
+    final query = _db.selectOnly(_db.chatSessions)
+      ..addColumns([countExpr])
+      ..where(_db.chatSessions.characterId.equals(charId));
+    final row = await query.getSingleOrNull();
+    return row?.read(countExpr) ?? 0;
+  }
+
   /// Number of chat sessions per character id, aggregated in SQL.
   ///
   /// Feeds the variations sheet, where "how many chats does this variation

--- a/lib/core/llm/lorebook_activation.dart
+++ b/lib/core/llm/lorebook_activation.dart
@@ -1,0 +1,74 @@
+import '../models/lorebook.dart';
+
+/// Which lorebooks apply to a given character/chat pair.
+///
+/// A book is active when it is globally enabled, when it was explicitly
+/// activated for this character or this chat (the `lorebookActivations`
+/// prefs maps), when its own `activationScope`/`activationTargetId` points at
+/// this character or chat, or when its name matches the character's `world`
+/// field (SillyTavern character-book convention).
+///
+/// This is the single definition of "active lorebook": the keyword scanner
+/// ([scanLorebooks]), the vector search ([LorebookVectorSearch.search]) and
+/// the Quick Access lorebook card all resolve activation through here, so a
+/// card can never disagree with what generation actually injects.
+List<Lorebook> activeLorebooksFor({
+  required List<Lorebook> lorebooks,
+  required String? charId,
+  required String? charWorld,
+  required String? chatId,
+  required LorebookActivations? activations,
+}) {
+  return lorebooks.where((lb) {
+    if (lb.enabled) return true;
+    if (charId != null &&
+        activations?.character[charId]?.contains(lb.id) == true) {
+      return true;
+    }
+    if (chatId != null && activations?.chat[chatId]?.contains(lb.id) == true) {
+      return true;
+    }
+    if (charId != null &&
+        lb.activationScope == 'character' &&
+        lb.activationTargetId == charId) {
+      return true;
+    }
+    if (chatId != null &&
+        lb.activationScope == 'chat' &&
+        lb.activationTargetId == chatId) {
+      return true;
+    }
+    if (charWorld != null && charWorld.isNotEmpty && lb.name == charWorld) {
+      return true;
+    }
+    return false;
+  }).toList();
+}
+
+/// Enabled entries across every book active for this character/chat.
+///
+/// Disabled entries are excluded because they can never be injected. Entries
+/// that only activate through vector search are counted — they are still live
+/// for the chat, just via a different retrieval path.
+int activeLorebookEntryCount({
+  required List<Lorebook> lorebooks,
+  required String? charId,
+  required String? charWorld,
+  required String? chatId,
+  required LorebookActivations? activations,
+}) {
+  final active = activeLorebooksFor(
+    lorebooks: lorebooks,
+    charId: charId,
+    charWorld: charWorld,
+    chatId: chatId,
+    activations: activations,
+  );
+  var count = 0;
+  for (final lb in active) {
+    for (final entry in lb.entries) {
+      if (entry.enabled) count++;
+    }
+  }
+  return count;
+}

--- a/lib/core/llm/lorebook_scanner.dart
+++ b/lib/core/llm/lorebook_scanner.dart
@@ -4,6 +4,7 @@ import '../models/character.dart';
 import '../models/chat_message.dart';
 import '../models/lorebook.dart';
 import 'glaze_matcher.dart';
+import 'lorebook_activation.dart';
 
 final _rng = Random();
 
@@ -67,33 +68,13 @@ List<ScannedEntry> scanLorebooks({
 }) {
   if (globalSettings.searchType == 'vector') return [];
 
-  final charId = char?.id;
-  final charWorld = char?.world;
-
-  final activeLorebooks = lorebooks.where((lb) {
-    if (lb.enabled) return true;
-    if (charId != null &&
-        activations.character[charId]?.contains(lb.id) == true) {
-      return true;
-    }
-    if (chatId != null && activations.chat[chatId]?.contains(lb.id) == true) {
-      return true;
-    }
-    if (charId != null &&
-        lb.activationScope == 'character' &&
-        lb.activationTargetId == charId) {
-      return true;
-    }
-    if (chatId != null &&
-        lb.activationScope == 'chat' &&
-        lb.activationTargetId == chatId) {
-      return true;
-    }
-    if (charWorld != null && charWorld.isNotEmpty && lb.name == charWorld) {
-      return true;
-    }
-    return false;
-  }).toList();
+  final activeLorebooks = activeLorebooksFor(
+    lorebooks: lorebooks,
+    charId: char?.id,
+    charWorld: char?.world,
+    chatId: chatId,
+    activations: activations,
+  );
 
   if (activeLorebooks.isEmpty) return [];
 

--- a/lib/core/llm/lorebook_vector_search.dart
+++ b/lib/core/llm/lorebook_vector_search.dart
@@ -6,6 +6,7 @@ import '../utils/cast_helpers.dart';
 import 'package:dio/dio.dart';
 import 'embedding_service.dart';
 import 'embedding_types.dart';
+import 'lorebook_activation.dart';
 import 'lorebook_embedding_service.dart';
 import 'vector_math.dart';
 
@@ -42,32 +43,13 @@ class LorebookVectorSearch {
   }) async {
     if (settings.searchType == 'keyword') return [];
 
-    final charId = character?.id;
-    final activeLorebooks = lorebooks.where((lb) {
-      if (lb.enabled) return true;
-      if (charId != null &&
-          activations?.character[charId]?.contains(lb.id) == true) {
-        return true;
-      }
-      if (chatId != null &&
-          activations?.chat[chatId]?.contains(lb.id) == true) {
-        return true;
-      }
-      if (charId != null &&
-          lb.activationScope == 'character' &&
-          lb.activationTargetId == charId) {
-        return true;
-      }
-      if (chatId != null &&
-          lb.activationScope == 'chat' &&
-          lb.activationTargetId == chatId) {
-        return true;
-      }
-      if (charWorld != null && charWorld.isNotEmpty && lb.name == charWorld) {
-        return true;
-      }
-      return false;
-    }).toList();
+    final activeLorebooks = activeLorebooksFor(
+      lorebooks: lorebooks,
+      charId: character?.id,
+      charWorld: charWorld,
+      chatId: chatId,
+      activations: activations,
+    );
 
     activeLorebooks.removeWhere((lb) {
       final lbSettings = lb.settings;

--- a/lib/features/chat/services/magic_drawer_stats_service.dart
+++ b/lib/features/chat/services/magic_drawer_stats_service.dart
@@ -4,9 +4,13 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/llm/context_calculator.dart';
+import '../../../core/llm/lorebook_activation.dart';
 import '../../../core/llm/prompt_isolate.dart';
 import '../providers/prompt_build_providers.dart';
+import '../../../core/models/lorebook.dart';
+import '../../../core/models/persona.dart';
 import '../../../core/models/preset.dart';
+import '../../../core/state/lorebook_provider.dart';
 import '../../../core/state/active_studio_preset_provider.dart';
 import '../../../core/state/active_selection_provider.dart';
 import '../../../core/state/db_provider.dart';
@@ -32,9 +36,28 @@ class MagicDrawerStatsService {
   String? _pendingCharId;
   MagicDrawerStats? _pendingBase;
 
+  /// Awaits [future], swallowing failures into `null` so one broken read
+  /// cannot take down the whole parallel batch in [computeStats].
+  Future<T?> _guarded<T>(Future<T> future, String label) async {
+    try {
+      return await future;
+    } catch (e) {
+      debugPrint('[MagicDrawer] $label error: $e');
+      return null;
+    }
+  }
+
+  Future<String?> _resolveStudioPresetName() async {
+    final studioPreset = await _ref
+        .read(studioPresetRepoProvider)
+        .getById(await _ref.read(activeStudioPresetProvider.future));
+    return studioPreset?.name;
+  }
+
   Future<MagicDrawerStats> computeStats(String charId) async {
     final chatState = _ref.read(chatProvider(charId)).value;
     final session = chatState?.session;
+    final sessionId = session?.id;
     final charRepo = _ref.read(characterRepoProvider);
     final presetRepo = _ref.read(presetRepoProvider);
     final personaRepo = _ref.read(personaRepoProvider);
@@ -42,8 +65,6 @@ class MagicDrawerStatsService {
     final memoryRepo = _ref.read(memoryBookRepoProvider);
     final chatRepo = _ref.read(chatRepoProvider);
     final summaryService = _ref.read(summaryServiceProvider);
-    final apiListFuture = _ref.read(apiListProvider.future);
-    final activeRegexesFuture = _ref.read(activeRegexesProvider.future);
     final activePersonaId = _ref.read(activePersonaIdProvider);
     final chatApi = _ref.read(activeApiConfigProvider);
     final imageGenEnabled =
@@ -51,68 +72,70 @@ class MagicDrawerStatsService {
     final extSettings = _ref.read(extensionsSettingsProvider);
     final extPresets = _ref.read(extensionPresetsProvider);
     final cached = _ref.read(cachedTokenBreakdownProvider(charId));
+    final activations = _ref.read(lorebookActivationsProvider);
 
-    final character = await charRepo.getById(charId);
-    final presets = await presetRepo.getAll();
-    final personas = await personaRepo.getAll();
+    // Every read below is independent, so all of them are started before the
+    // first await. Awaiting them one at a time serialised a dozen DB
+    // round-trips and is what kept the drawer behind its spinner on open.
+    final characterFuture = _guarded(charRepo.getById(charId), 'character');
+    final presetsFuture = _guarded(presetRepo.getAll(), 'presets');
+    final personasFuture = _guarded(personaRepo.getAll(), 'personas');
+    final lorebooksFuture = _guarded(lorebookRepo.getAll(), 'lorebooks');
+    final apiListFuture = _guarded(
+      _ref.read(apiListProvider.future),
+      'apiList',
+    );
+    final regexesFuture = _guarded(
+      _ref.read(activeRegexesProvider.future),
+      'activeRegexesProvider',
+    );
+    final studioNameFuture = _ref.read(studioFeatureEnabledProvider)
+        ? _guarded(_resolveStudioPresetName(), 'active Studio preset')
+        : null;
+    final summaryFuture = sessionId == null
+        ? null
+        : _guarded(summaryService.getSummary(sessionId), 'summary');
+    final memoryFuture = sessionId == null
+        ? null
+        : _guarded(memoryRepo.getBySessionId(sessionId), 'memory book');
+    // Session count comes from a SQL COUNT — the old
+    // `getByCharacterId(charId).length` decoded every message of every
+    // session of this character just to read the list length.
+    final sessionCountFuture = sessionId == null
+        ? null
+        : _guarded(chatRepo.countByCharacterId(charId), 'session count');
+
     await apiListFuture;
-    final lorebooks = await lorebookRepo.getAll();
+    final character = await characterFuture;
+    final presets = await presetsFuture ?? const <Preset>[];
+    final personas = await personasFuture ?? const <Persona>[];
+    final lorebooks = await lorebooksFuture ?? const <Lorebook>[];
+    final regexes = await regexesFuture ?? const <PresetRegex>[];
+
     final activePreset = getEffectivePreset(
       presets,
       charId,
-      session?.id,
+      sessionId,
       _ref.read(activePresetIdProvider),
       _ref.read(presetConnectionsProvider),
     );
-    String? activePresetDisplayName = activePreset?.name;
-    if (_ref.read(studioFeatureEnabledProvider)) {
-      try {
-        final studioPreset = await _ref
-            .read(studioPresetRepoProvider)
-            .getById(await _ref.read(activeStudioPresetProvider.future));
-        if (studioPreset != null) {
-          activePresetDisplayName = studioPreset.name;
-        }
-      } catch (e) {
-        debugPrint('[MagicDrawer] active Studio preset error: $e');
-      }
-    }
+    final studioName = studioNameFuture == null
+        ? null
+        : await studioNameFuture;
+    final activePresetDisplayName = studioName ?? activePreset?.name;
+
     final activePersona = activePersonaId != null
         ? personas.where((p) => p.id == activePersonaId).firstOrNull
         : personas.firstOrNull;
-    List<PresetRegex> regexes;
-    try {
-      regexes = await activeRegexesFuture;
-    } catch (e) {
-      debugPrint('[MagicDrawer] activeRegexesProvider error: $e');
-      regexes = [];
-    }
 
-    var summaryChars = 0;
-    var memoryEntries = 0;
-    var sessionCount = 0;
-    var messageCount = 0;
-    String? summaryContent;
-
-    if (session != null) {
-      try {
-        final summary = await summaryService.getSummary(session.id);
-        summaryContent = summary;
-        summaryChars = summary?.length ?? 0;
-      } catch (e) {
-        debugPrint('[MagicDrawer] summary error: $e');
-      }
-
-      try {
-        final memoryBook = await memoryRepo.getBySessionId(session.id);
-        memoryEntries = memoryBook?.entries.length ?? 0;
-        sessionCount =
-            (await chatRepo.getByCharacterId(charId)).length;
-        messageCount = session.messages.length;
-      } catch (e) {
-        debugPrint('[MagicDrawer] session stats error: $e');
-      }
-    }
+    final summaryContent = summaryFuture == null ? null : await summaryFuture;
+    final summaryChars = summaryContent?.length ?? 0;
+    final memoryBook = memoryFuture == null ? null : await memoryFuture;
+    final memoryEntries = memoryBook?.entries.length ?? 0;
+    final sessionCount = sessionCountFuture == null
+        ? 0
+        : await sessionCountFuture ?? 0;
+    final messageCount = session?.messages.length ?? 0;
 
     final extActivePresetName = extSettings.activePresetId == null
         ? null
@@ -127,8 +150,17 @@ class MagicDrawerStatsService {
               .fold<int>(0, (sum, m) => sum + (m.content.length / 4).round())
         : 0;
 
-    final lastMsg = session?.messages.lastOrNull;
-    final lorebookEntryCount = lastMsg?.triggeredLorebooks.length ?? 0;
+    // Enabled entries across every lorebook active for this character/chat —
+    // the same activation rules generation uses. The card used to show
+    // `triggeredLorebooks` of the last message instead, which is the number of
+    // *books* that fired on one message, not the entries available to the chat.
+    final lorebookEntryCount = activeLorebookEntryCount(
+      lorebooks: lorebooks,
+      charId: charId,
+      charWorld: character?.world,
+      chatId: sessionId,
+      activations: activations,
+    );
 
     return MagicDrawerStats(
       character: character,
@@ -161,7 +193,6 @@ class MagicDrawerStatsService {
           ((cached?.sourceTokens['lorebook'] ?? 0) +
           (cached?.macroTokens['lorebooks'] ?? 0)),
       imageGenEnabled: imageGenEnabled,
-      lorebooks: lorebooks,
       summaryContent: summaryContent,
       extBlocksEnabled: extSettings.enabled,
       extBlocksActivePresetName: extActivePresetName,

--- a/lib/features/chat/state/magic_drawer_stats_cache.dart
+++ b/lib/features/chat/state/magic_drawer_stats_cache.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/legacy.dart';
+
+import '../widgets/magic_drawer_models.dart';
+
+/// Last computed Quick Access stats, per character.
+///
+/// The drawer panel is unmounted the moment the drawer closes (see
+/// `renderDrawer` in `chat_screen.dart`), so its widget state cannot survive
+/// between opens and every open would otherwise recompute the card subtitles
+/// from scratch behind a blocking spinner. These providers keep the previous
+/// snapshot alive at app scope: an open paints it immediately and the real
+/// recomputation lands on top a moment later (stale-while-revalidate).
+final magicDrawerStatsCacheProvider =
+    StateProvider.family<MagicDrawerStats?, String>((ref, _) => null);
+
+/// Last resolved card layout (order + deleted ids). Not per-character — the
+/// layout is a single app-wide preference.
+final magicDrawerLayoutCacheProvider =
+    StateProvider<({List<String> itemIds, Set<String> deletedIds})?>(
+      (ref) => null,
+    );

--- a/lib/features/chat/widgets/magic_drawer.dart
+++ b/lib/features/chat/widgets/magic_drawer.dart
@@ -45,6 +45,7 @@ import '../services/magic_drawer_stats_service.dart';
 import 'magic_drawer_widgets.dart';
 import 'memory_sheet.dart';
 import 'prompt_inspector_sheet.dart';
+import '../state/magic_drawer_stats_cache.dart';
 import '../state/token_breakdown_cache.dart';
 import '../../glossary/glossary_sheet.dart';
 import '../../extensions/models/extension_preset.dart';
@@ -190,6 +191,20 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
   @override
   void initState() {
     super.initState();
+    // Stale-while-revalidate. The panel is destroyed on every drawer close, so
+    // without a cache each open would sit behind the spinner until a full
+    // layout read and stats recomputation finished. Paint the previous
+    // snapshot right away instead; _loadDrawer() refreshes it underneath.
+    final cachedLayout = ref.read(magicDrawerLayoutCacheProvider);
+    if (cachedLayout != null) {
+      _itemIds.addAll(cachedLayout.itemIds);
+      _deletedIds.addAll(cachedLayout.deletedIds);
+    }
+    final cachedStats = ref.read(magicDrawerStatsCacheProvider(widget.charId));
+    if (cachedStats != null) _stats = cachedStats;
+    // The spinner is now only for the first open of an app run, when there is
+    // genuinely nothing to show.
+    _loading = cachedLayout == null || cachedStats == null;
     _loadDrawer();
   }
 
@@ -224,10 +239,21 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
     _itemIds
       ..clear()
       ..addAll(layout.itemIds);
+    if (mounted) _cacheLayout();
   }
 
   Future<void> _saveLayout() async {
+    _cacheLayout();
     await MagicDrawerLayoutService(ref).saveLayout(_itemIds, _deletedIds);
+  }
+
+  /// Keeps the app-scoped layout cache in step with the local lists, so the
+  /// next open starts from the order the user is looking at right now.
+  void _cacheLayout() {
+    ref.read(magicDrawerLayoutCacheProvider.notifier).state = (
+      itemIds: List<String>.unmodifiable(_itemIds),
+      deletedIds: Set<String>.unmodifiable(_deletedIds),
+    );
   }
 
   Future<void> _loadStats() async {
@@ -235,7 +261,14 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
     final stats = await MagicDrawerStatsService(
       ref,
     ).computeStats(widget.charId);
-    if (request == _statsRequest) _stats = stats;
+    if (request != _statsRequest) return;
+    _stats = stats;
+    // The drawer can be closed mid-load, which disposes this state and with it
+    // `ref` — only touch the cache while still mounted.
+    if (mounted) {
+      ref.read(magicDrawerStatsCacheProvider(widget.charId).notifier).state =
+          stats;
+    }
   }
 
   void _scheduleTokenStats() {
@@ -261,6 +294,8 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
       return;
     }
     if (!mounted || request != _statsRequest) return;
+    ref.read(magicDrawerStatsCacheProvider(widget.charId).notifier).state =
+        updated;
     setState(() {
       _stats = updated;
       _loadingTokens = false;

--- a/lib/features/chat/widgets/magic_drawer_models.dart
+++ b/lib/features/chat/widgets/magic_drawer_models.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import '../../../core/models/api_config.dart';
 import '../../../core/models/character.dart';
 import '../../../core/models/chat_message.dart';
-import '../../../core/models/lorebook.dart';
 import '../../../core/models/persona.dart';
 import '../../../core/models/preset.dart';
 
@@ -60,7 +59,6 @@ class MagicDrawerStats {
   final int vectorLoreTokens;
   final int keywordLoreTokens;
   final bool imageGenEnabled;
-  final List<Lorebook> lorebooks;
   final String? summaryContent;
   final String? memoryContent;
   final String? memoryMacroContent;
@@ -93,7 +91,6 @@ class MagicDrawerStats {
     this.vectorLoreTokens = 0,
     this.keywordLoreTokens = 0,
     this.imageGenEnabled = false,
-    this.lorebooks = const [],
     this.summaryContent,
     this.memoryContent,
     this.memoryMacroContent,
@@ -138,13 +135,14 @@ class MagicDrawerStats {
       vectorLoreTokens: vectorLoreTokens ?? this.vectorLoreTokens,
       keywordLoreTokens: keywordLoreTokens ?? this.keywordLoreTokens,
       imageGenEnabled: imageGenEnabled,
-      lorebooks: lorebooks,
       summaryContent: summaryContent,
       memoryContent: memoryContent,
       memoryMacroContent: memoryMacroContent,
       memoryInjectionTarget: memoryInjectionTarget,
       memoryCoverage: memoryCoverage,
       triggeredMemories: triggeredMemories,
+      extBlocksEnabled: extBlocksEnabled,
+      extBlocksActivePresetName: extBlocksActivePresetName,
     );
   }
 }

--- a/test/magic_drawer_refresh_test.dart
+++ b/test/magic_drawer_refresh_test.dart
@@ -9,7 +9,11 @@ void main() {
         'lib/features/chat/services/magic_drawer_stats_service.dart',
       ).readAsStringSync();
 
-      expect(source, contains('final apiListFuture = _ref.read(apiListProvider.future);'));
+      // The API list is warmed through its provider and the active config is
+      // read from activeApiConfigProvider — never straight from the repo.
+      // Matched loosely: computeStats starts the read as one of a batch of
+      // parallel futures, so the exact call formatting is not the contract.
+      expect(source, contains('_ref.read(apiListProvider.future)'));
       expect(source, contains('await apiListFuture;'));
       expect(source, contains('_ref.read(activeApiConfigProvider)'));
       expect(source, isNot(contains('apiConfigRepoProvider')));


### PR DESCRIPTION
The Quick Access panel is unmounted whenever the drawer closes (`renderDrawer`
in `chat_screen.dart`), so every open rebuilt its card subtitles from zero
behind a blocking spinner overlay — a couple of seconds each time on a
character with a long history.

## Cache

- Add `magicDrawerStatsCacheProvider` (per character) and
  `magicDrawerLayoutCacheProvider` in
  `lib/features/chat/state/magic_drawer_stats_cache.dart`. `MagicDrawerPanel`
  seeds itself from them in `initState`, so a reopen paints the previous
  snapshot immediately and the recomputation lands on top
  (stale-while-revalidate). The spinner now only shows on the first open of an
  app run, when there is genuinely nothing to display.
- `_cacheLayout()` is also called from `_saveLayout()`, so a reorder or a
  deleted card is reflected in the cache right away.
- Cache writes are guarded by `mounted` — the drawer can be closed mid-load,
  which disposes the state and with it `ref`.

## Stats computation

- `ChatRepo.countByCharacterId()` counts sessions with a SQL `COUNT`.
  `MagicDrawerStatsService.computeStats` used
  `(await chatRepo.getByCharacterId(charId)).length`, which decoded every
  message of every session of the character just to read the list length —
  exactly what `getByCharacterId`'s own doc comment warns about.
- `computeStats` now starts every independent read before the first `await`
  instead of awaiting a dozen DB round-trips one at a time. Each read goes
  through a `_guarded` helper so one failure degrades a single card instead of
  aborting the whole batch (the previous code had ad-hoc try/catch around some
  reads and none around others).

## Lorebook card

- The card showed `lastMsg.triggeredLorebooks.length` — the number of *books*
  that fired on the last message, labelled "entries". It now shows the enabled
  entries across every lorebook active for this character/chat.
- The "which lorebooks are active" predicate was duplicated verbatim in
  `scanLorebooks` and `LorebookVectorSearch.search`. Extracted to
  `lib/core/llm/lorebook_activation.dart` (`activeLorebooksFor` /
  `activeLorebookEntryCount`); both generation call sites now share it, so the
  card cannot disagree with what generation actually injects. The extraction is
  behaviour-preserving.

## Cleanup

- Drop `MagicDrawerStats.lorebooks` — it was populated on every recompute (a
  full `lorebookRepo.getAll()` with all entries) and never read. With the new
  cache it would have pinned every lorebook in memory.
- `MagicDrawerStats.copyWith` silently dropped `extBlocksEnabled` and
  `extBlocksActivePresetName`; restored.

## Verification

- `test/magic_drawer_refresh_test.dart` asserted on the exact source line
  `final apiListFuture = _ref.read(apiListProvider.future);`, which the
  parallelisation reshapes. Loosened to
  `contains('_ref.read(apiListProvider.future)')` — the contract (warm the list
  through its provider, read the active config from `activeApiConfigProvider`,
  never from the repo) is unchanged.
- **Not verified locally** — no Flutter SDK run on this machine. `flutter analyze`
  and `flutter test` were not executed; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
