### PR TITLE
docs: drop the gh CLI ban

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,6 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 - Mutate state directly — use immutable patterns with freezed
 - Forget `ref.watch` select for streaming UI (causes full rebuild per chunk)
 - Commit directly to `nightly`, `staging` or `stable` — always use a feature branch
-- Use the `gh` CLI — GitHub operations go through GitHub MCP tools
 - Bypass `_requireCapability` in the JS bridge — every `glaze.*` method must enforce the matching capability (default-deny)
 - Run user JS in a same-origin iframe — panel/sandbox scripts go in `sandbox="allow-scripts"` (no `allow-same-origin`)
 - Read-modify-write a `ChatSession` / `Character` from outside the dedicated atomic repo methods (chat/character variable scopes)

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -34,7 +34,7 @@ git checkout -b feat/xxx
 git push -u origin feat/xxx
 ```
 
-Open the PR against `hydall/Glaze:nightly`, not a fork's branch. Use the **GitHub MCP tools** (`mcp__plugin_github_github__create_pull_request`) or the GitHub web UI. Do **not** use the `gh` CLI — GitHub operations go through GitHub MCP (project + global convention).
+Open the PR against `hydall/Glaze:nightly`, not a fork's branch. Use whatever is at hand: the `gh` CLI (`gh pr create --base nightly`), the GitHub MCP tools when they are connected, or the web UI.
 
 ## PR title and body
 


### PR DESCRIPTION
The rule routed every GitHub operation through the GitHub MCP tools. When that
server is not connected to a session, an agent can push a branch and then do
nothing but hand back a compare link for the maintainer to click.

- Remove `Use the \`gh\` CLI — GitHub operations go through GitHub MCP tools`
  from CLAUDE.md's **Do NOT** list.
- `docs/WORKFLOW.md` now names `gh pr create --base nightly`, the GitHub MCP
  tools and the web UI as equally acceptable ways to open the PR.
- The constraint that actually matters is untouched: the PR targets
  `hydall/Glaze:nightly`, never a fork's branch.

## Verification

Documentation only — no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
