### PR TITLE
docs: add UI_KIT.md and make building on the Glaze widget set a rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ flutter analyze 2>&1 | Tee-Object -FilePath analyze_full.txt -Encoding UTF8; Get
 ## Code Conventions
 
 ### Flutter Widgets
+- **Build on the Glaze UI kit** (`lib/shared/widgets/`) — `GlazeScaffold`, `SheetView` / `GlazeBottomSheet`, `GlazeTabBar`, `GlassSurface`, `MenuGroup`, `GlazeToast`… Reach for bare Material only when the kit has no equivalent. What-instead-of-what table: `docs/UI_KIT.md`
 - **ConsumerWidget / ConsumerStatefulWidget** for anything that reads Riverpod
 - **StatelessWidget / StatefulWidget** for pure UI with no state
 - Keep widgets small — extract sub-widgets when > 200 lines
@@ -164,6 +165,7 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 | Custom `==...==` markdown markers, message rendering | `docs/markdown-markers.md` |
 | Windows/build failures, dependency overrides | `docs/BUILD_NOTES.md` |
 | Class/file organization, decomposition | `docs/CODE_STYLE.md` |
+| Any screen, sheet or dialog — which widget to reach for | `docs/UI_KIT.md` |
 | JS extension bridge (`glaze.*`), panel iframe, headless engine, capability permissions, periodic/afterUser triggers, `executeCommand`, audio, connection profiles | `docs/ARCHITECTURE.md` § 9 + `docs/INVARIANTS.md` (INV-EG1–8, INV-JS1–6) |
 | Variable storage (`chat` / `character` / `global` / `message` scopes) | `docs/rules/database.md` (atomic repo methods) |
 | Build channels, dev-mode / watermark defaults, `--dart-define` wiring | `docs/RELEASE_CHANNELS.md` |
@@ -187,6 +189,7 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 - Store API keys in plain text in Drift
 - Mutate state directly — use immutable patterns with freezed
 - Forget `ref.watch` select for streaming UI (causes full rebuild per chunk)
+- Build a screen or sheet on bare Material (`TabBar`, `Card`, `OutlinedButton`, `Chip`, `SnackBar`, `AlertDialog`…) when `lib/shared/widgets/` has the Glaze equivalent — check `docs/UI_KIT.md` first
 - Commit directly to `nightly`, `staging` or `stable` — always use a feature branch
 - Bypass `_requireCapability` in the JS bridge — every `glaze.*` method must enforce the matching capability (default-deny)
 - Run user JS in a same-origin iframe — panel/sandbox scripts go in `sandbox="allow-scripts"` (no `allow-same-origin`)

--- a/docs/UI_KIT.md
+++ b/docs/UI_KIT.md
@@ -1,0 +1,152 @@
+# UI Kit
+
+Glaze has its own widget set in `lib/shared/widgets/`. **Build screens, sheets
+and dialogs out of it — do not reach for the raw Material equivalent when a
+Glaze widget already covers the case.**
+
+This is a real rule, not a preference: the kit is what carries the app's look
+(glass surfaces, the theme preset's `elementOpacity` / `elementBlur` /
+`noiseOpacity`, the ripple, the header blur, the overscroll stretch). A screen
+assembled from bare `Card` / `TabBar` / `OutlinedButton` renders in stock
+Material grey no matter what theme preset is active, and it silently opts out
+of things the kit already solved — battery-saver degradation, backdrop-blur
+interaction with the Android overscroll stretch, safe-area and nav-bar insets,
+haptics on tap.
+
+Until this file existed the rule was unwritten, and it showed: the memory books
+sheet shipped on `DefaultTabController` + `TabBar` + `OutlinedButton` +
+`FilterChip` without breaking any documented convention. If you find yourself
+styling a Material widget with `Colors.white.withValues(alpha: 0.05)` and
+`BorderRadius.circular(12)` to make it "look Glaze", stop — that is a
+`GlassSurface` or a `MenuGroup`.
+
+## What to use instead of what
+
+| Instead of | Use | Notes |
+|---|---|---|
+| `Scaffold` + `AppBar` | `GlazeScaffold` (`glaze_scaffold.dart`) | Floating glass header for screens **outside** the shell. Screens inside a shell branch pass `useShellHeader: true` + `headerBranchIndex` and publish into the shell's persistent header instead. |
+| `showModalBottomSheet` with a hand-rolled body | `SheetView` (`sheet_view.dart`) or `GlazeBottomSheet.show` (`glaze_bottom_sheet.dart`) | See "Which sheet" below. |
+| `TabBar` / `TabBarView` / `DefaultTabController` | `GlazeTabBar` + `SwipeTabSwitcher` + `TabSlideSwitcher` | The segmented control. `GlazeTabBar` handles tap, swipe-on-the-strip and scrolling past ~2.35 tabs; `SwipeTabSwitcher` adds body swipe; `TabSlideSwitcher` animates the body in the swipe's direction. |
+| `Card` / `Container` with a translucent fill | `GlassSurface` (`glass_surface.dart`) | Reads the active theme preset. Give it `onTap` for a `GlowInkWell` ripple, or `enableRipple: true` for the hover glow without a tap handler. |
+| `ListTile` groups, settings rows | `MenuGroup` + `MenuItem` / `MenuSwitchItem` / `MenuSelectorItem` / `MenuFieldItem` / `MenuRangeItem` / `MenuScriptItem` / `MenuSubHeader` / `MenuCollapsibleSection` (`menu_group.dart`) | The standard settings/form row set. `MenuGroup` already supplies the surface, the border and the 16 px horizontal margin. |
+| `ElevatedButton` / `OutlinedButton` / `FilledButton` in a toolbar | `GlassSurface` tile with `onTap`, or `GlazePillButton` (`glaze_scaffold.dart`) | There is no generic Glaze button — a tile built on `GlassSurface` *is* the button. |
+| `Chip` / `FilterChip` / `ChoiceChip` | `GlazeFilterChipBar` (`glaze_filter_chip_bar.dart`), `GlazeDropdownChip` / `GlazeFilterIconButton` (`list_controls.dart`), `CardTagChips`, `VariationChip`, `ConnectionChip` / `ConnectionScopeChip` | Pick the one that matches the role; a bare toggle in a form is usually a `MenuSwitchItem`, not a chip. |
+| `DropdownButton` / `PopupMenuButton` | `GlazeDropdownChip` + `showGlazePickerSheet` (`list_controls.dart`), or `MenuSelectorItem` inside a `MenuGroup` | |
+| `TextField` | `GlazeTextField` (`glaze_text_field.dart`) standalone, `MenuFieldItem` inside a menu group, `GenericEditor` for a whole form | |
+| A hand-built settings form | `GenericEditor` + `GenericEditorSection` / `GenericEditorField` (`generic_editor.dart`) | Declarative field list (`text` / `number` / `tags` / `textarea` / `select` / `greeting_list` / `info`), renders as `MenuGroup`s, debounced save. |
+| A full-screen text editor route | `FullscreenEditorScreen.show` (`fullscreen_editor.dart`) | |
+| `SnackBar` | `GlazeToast.show` (`glaze_toast.dart`) | Overlay-based, so it survives a popped route. `showWithoutContext` exists for background work. |
+| `AlertDialog` for a failure | `GlazeErrorDialog.show` (`glaze_error_dialog.dart`) or `GlazeErrorBlock` (`glaze_error_block.dart`) | Dialog when the error interrupts; inline block when the failure should stay on screen next to the action that caused it. |
+| `AlertDialog` for a confirm | `GlazeBottomSheet.show` with `bigInfo` + destructive/cancel `items` | The app confirms in sheets, not dialogs. |
+| `BottomNavigationBar` / `NavigationBar` | `GlassNavBar` (`glass_nav_bar.dart`) | Shell only. |
+| A `Tooltip` explaining a term | `HelpTip` (`help_tip.dart`) | Opens the glossary at that term, and respects the `hideTooltips` setting. |
+| `AnimatedDefaultTextStyle` on a counter | `RollingNumber` (`rolling_number.dart`) | |
+| A raw `Scrollbar` / overscroll glow | Nothing — `GlazeScrollBehavior` (`stretch_overscroll.dart`) is applied app-wide | Do not re-add the framework stretch indicator: it renders through an offscreen layer, which kills every `BackdropFilter` inside the scroll view for the duration of the stretch. |
+
+Supporting pieces you normally get for free (via the widgets above) but may
+need directly: `GlazeBackground`, `TopEdgeBlur`, `NoiseOverlay`,
+`GlowInkWell` / `GlowRippleOverlay`, `FilterSheet`, `ImageViewer`,
+`FolderNameDialog`, `ConnectionSection` and friends, and the `InlineMd`
+renderers in `colored_markdown.dart`.
+
+## Which sheet
+
+Both are correct Glaze chrome; they solve different shapes.
+
+**`GlazeBottomSheet.show`** — a menu or a short form. You hand it declarative
+content (`items`, `itemsAsCards`, `cardItems`, `sessionItems`, `bigInfo`,
+`input`) or a `child`, and it renders a glass sheet with a handle, an optional
+title header, and its own scroll view. Height follows the content up to 95 %.
+
+Because its body is a `SingleChildScrollView`, `child` is laid out with an
+**unbounded height** — anything needing a bounded viewport (`Expanded`,
+`TabBarView`, a nested `ListView`) does not belong here.
+
+**`SheetView`** — a screen-like sheet. Draggable between ~85 % and full height,
+its own header with back button, `actions`, and a `headerBottom` slot for a tab
+strip; the body gets a bounded height and the header height is handed down as
+`MediaQuery.padding.top`. Present it yourself:
+
+```dart
+showModalBottomSheet<void>(
+  context: context,
+  useRootNavigator: true,
+  isScrollControlled: true,
+  backgroundColor: Colors.transparent,
+  builder: (_) => MySheet(...),
+);
+```
+
+The same widget also renders as a full-screen route (it detects whether it is
+inside a `ModalBottomSheetRoute`), which is why sheets and pushed sub-screens
+share one class.
+
+### The header inset
+
+`SheetView` reports its measured header height through
+`MediaQuery.padding.top`, and paints a blurred, surface-tinted strip
+(`TopEdgeBlur`) that tall over the top of the body. **A scrollable body must
+consume that padding**, or its first card sits under the strip and reads as a
+pale veil across the content:
+
+```dart
+ListView(
+  padding: EdgeInsets.fromLTRB(
+    0,
+    MediaQuery.paddingOf(context).top + 12,
+    0,
+    MediaQuery.paddingOf(context).bottom + 24,
+  ),
+  ...
+)
+```
+
+The bottom padding is the nav-bar / keyboard inset, delivered the same way so
+list rows scroll *behind* the nav bar while the last row rests above it.
+
+## Colours
+
+- Always through `context.cs` (`ColorScheme`) or `context.colors`
+  (`GlazeColors` theme extension) from `lib/shared/theme/app_colors.dart`.
+- Never a literal that duplicates a token: `context.cs.outlineVariant`, not
+  `Colors.white.withValues(alpha: 0.1)`; `context.cs.primary`, not a hex.
+- Literal accent colours are acceptable for **semantic status** that has no
+  token — green "active", orange "needs rebuild", amber "generating", red
+  "destructive". Hoist them to file-level `const` rather than repeating the hex
+  inline.
+- `Colors.green` / `Colors.orange` / `Colors.redAccent` &co are Material's
+  palette, not Glaze's. Prefer explicit `Color(0xFF…)` constants so the accent
+  is deliberate and greppable.
+
+## Performance notes
+
+`GlassSurface` is a `ConsumerWidget` that watches the theme preset and, unless
+battery-saver is on, wraps its child in a `BackdropFilter`.
+
+- Fine for structural chrome: a hero card, a toolbar tile, a section container,
+  an empty-state box — a handful per screen.
+- **Not** fine per row of a long list. A blur pass on each of fifty cards (and
+  three chips inside each) is a real frame cost. List rows in this codebase use
+  `Material` + `InkWell` over a `DecoratedBox` instead — see `GlazeSessionRow`
+  and `_CardRow` in `glaze_bottom_sheet.dart`.
+
+Same reasoning applies to `NoiseOverlay` and `GlowRippleOverlay`: they are
+already inside `GlassSurface`, so do not stack another copy on top.
+
+## Adding to the kit
+
+Follow `docs/CODE_STYLE.md` § *UI Files*: a private helper widget belongs next
+to its screen. Promote it to `lib/shared/widgets/` only once a **second**
+screen needs it. A widget used by one feature but shared by several files
+inside it goes in that feature's own folder — e.g.
+`lib/features/chat/widgets/memory/memory_books_controls.dart`.
+
+When you do promote one, name it `glaze_*.dart` / `Glaze*` if it is a general
+primitive, and give it a doc comment saying what it replaces and why.
+
+## Related
+
+- `docs/CODE_STYLE.md` — when to split a UI file, what to extract from it.
+- `docs/ARCHITECTURE.md` § 7 — the theme-preset system `GlassSurface` reads.
+- `CLAUDE.md` § Theme, § Navigation — colour/theme file locations and the
+  explicit-back-button rule for sub-screens.


### PR DESCRIPTION
Nothing in the docs said that screens and sheets should be built on the widget set in `lib/shared/widgets/`. The closest existing lines are `docs/CODE_STYLE.md:40` (when to *move* a widget into `shared/widgets/`, not to consume from it) and `CLAUDE.md` § Theme (colour file locations). So `memory_books_tab.dart` could ship on `DefaultTabController` + `TabBar` + `OutlinedButton` + `FilterChip` without breaking a single stated convention. This writes the rule down.

## `docs/UI_KIT.md` (new)

- States the rule and why it is not cosmetic: the kit carries the theme preset's `elementOpacity` / `elementBlur` / `noiseOpacity`, the ripple, the header blur, battery-saver degradation, safe-area and nav-bar insets, and haptics. Bare Material opts out of all of it silently.
- A what-instead-of-what table covering `Scaffold`/`AppBar`, modal sheets, `TabBar`, `Card`, `ListTile` groups, buttons, chips, dropdowns, `TextField`, forms, `SnackBar`, `AlertDialog` (error and confirm cases separately), `BottomNavigationBar`, `Tooltip`, and the overscroll indicator.
- **Which sheet**: `GlazeBottomSheet.show` for menus and short forms — and the fact that its `child` gets an *unbounded* height, so `Expanded` / nested scrollables do not belong in it — versus `SheetView` for screen-like sheets, with the presentation snippet.
- **The header inset**: `SheetView` reports its header height as `MediaQuery.padding.top` and paints a `TopEdgeBlur` strip that tall; a scrollable body that does not consume it puts its first card under the strip, which reads as a pale veil over the content. Includes the padding snippet.
- **Colours**: always `context.cs` / `context.colors`; no literal that duplicates a token; literal accents allowed for semantic status with no token, hoisted to file-level `const`; `Colors.green` &co are Material's palette, not Glaze's.
- **Performance**: `GlassSurface` watches the theme preset and wraps its child in a `BackdropFilter` — fine for structural chrome, not per row of a long list. Points at `GlazeSessionRow` / `_CardRow` in `glaze_bottom_sheet.dart` as the list-row pattern.
- **Adding to the kit**: defers to `docs/CODE_STYLE.md` § *UI Files* — promote on the second consumer, name general primitives `Glaze*`, document what the widget replaces.

## `CLAUDE.md`

- First bullet under § Code Conventions → Flutter Widgets, naming the main entry points and linking the table.
- Row in the Context-Sensitive Rules table: *Any screen, sheet or dialog — which widget to reach for → `docs/UI_KIT.md`*.
- Do NOT entry: don't build a screen or sheet on bare Material when `lib/shared/widgets/` has the equivalent.

## Verification

- Every widget class, file path and doc path named in `UI_KIT.md` was checked to exist in this tree (scripted grep over `lib/shared/widgets/` and `docs/`).
- Docs-only change; `flutter analyze` reports the same 13 pre-existing issues as an untouched `nightly`.

Related: #228 does the corresponding rewrite of the Memory sheet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmUEPd3jLZr4RvfyCMcJhm)_