### PR TITLE
Move prompt inspector tabs to the Glaze segmented control

### DIFF
--- a/lib/features/chat/widgets/prompt_inspector_sheet.dart
+++ b/lib/features/chat/widgets/prompt_inspector_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
+import '../../../shared/widgets/glaze_tab_bar.dart';
 import '../../../shared/widgets/sheet_view.dart';
 import 'tokenizer_sheet.dart';
 import 'prompt_preview_screen.dart';
@@ -60,25 +61,17 @@ class _PromptInspectorSheetState extends State<PromptInspectorSheet> {
       showBack: true,
       startExpanded: true,
       onBack: () => Navigator.of(context).maybePop(),
-      tabs: [
-        SheetViewTab(
-          id: PromptInspectorSheet._tabContext,
-          label: 'tab_context'.tr(),
-          icon: Icons.segment,
-        ),
-        SheetViewTab(
-          id: PromptInspectorSheet._tabPreview,
-          label: 'tab_request'.tr(),
-          icon: Icons.visibility,
-        ),
-        SheetViewTab(
-          id: PromptInspectorSheet._tabCoverage,
-          label: 'tab_coverage'.tr(),
-          icon: Icons.search,
-        ),
-      ],
-      activeTabId: _activeTabId,
-      onTabSelected: (id) => setState(() => _activeTabId = id),
+      // Glaze's segmented control instead of SheetView's plain tab pills, so
+      // the inspector matches the tab strip used by the rest of the app.
+      headerBottom: GlazeTabBar(
+        tabs: [
+          GlazeTabItem(label: 'tab_context'.tr(), icon: Icons.segment),
+          GlazeTabItem(label: 'tab_request'.tr(), icon: Icons.visibility),
+          GlazeTabItem(label: 'tab_coverage'.tr(), icon: Icons.search),
+        ],
+        activeIndex: _activeIndex,
+        onChanged: (i) => setState(() => _activeTabId = _order[i]),
+      ),
       body: body,
     );
   }


### PR DESCRIPTION
Switches the Prompt Inspector's tab strip from `SheetView`'s plain tab pills to `GlazeTabBar`, the segmented control used everywhere else in the app.

## Changes

- Replace `SheetView.tabs` / `activeTabId` / `onTabSelected` in `PromptInspectorSheet` with `headerBottom: GlazeTabBar(...)`, matching the pattern already used by the request preview (`prompt_preview_screen.dart`), chat stats and character detail screens
- Map the segmented control's index back to the existing tab ids through the state's `_order` list, so the `initialTabId` entry points from the Magic Drawer and the state-preserving `IndexedStack` body keep working unchanged
- Icons (`segment` / `visibility` / `search`) and localization keys (`tab_context`, `tab_request`, `tab_coverage`) are unchanged

## Notes

With three tabs the strip crosses `GlazeTabBar`'s `_kVisibleTabs = 2.35` threshold, so it scrolls: the third tab is half-cut at the edge and the active tab auto-scrolls into view on selection. This is the widget's existing behaviour, shared with the three-tab `GlazeTabBar` in `character_detail_screen.dart` — no changes were made to the widget itself.

## Verification

- Change is confined to one widget's build method; verified by hand against the `GlazeTabBar` API on `nightly`
- `flutter analyze` / `flutter test` were not run locally — no Flutter SDK in this environment, so CI is the gate

---
_Generated by [Claude Code](https://claude.ai/code/session_017ymu5XYd6FXPvwqBtuBwa3)_