### PR TITLE
feat(ui): new rounded GlazeSpinner, used app-wide

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1749,6 +1749,7 @@
   "studio_hint": "Multi-agent pipeline that tracks state, cleans replies, and manages memory after each turn.",
   "menu_hide_build_date_watermark": "Hide build date watermark",
   "menu_menu_group_demo": "MenuGroup Demo",
+  "menu_spinner_demo": "Spinner Demo",
   "menu_test_error_dialog": "Test Error Dialog",
   "tools_api_subtitle": "Endpoints & models",
   "tools_lorebooks_subtitle": "World info",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -1785,6 +1785,7 @@
   "studio_hint": "Мульти-агентный конвейер: отслеживает состояние, чистит ответы и управляет памятью после каждого хода.",
   "menu_hide_build_date_watermark": "Скрыть водяной знак даты сборки",
   "menu_menu_group_demo": "Демо MenuGroup",
+  "menu_spinner_demo": "Демо спиннера",
   "menu_menu_title": "Меню",
   "menu_test_error_dialog": "Тест диалога ошибки",
   "regex_depth_range": "Диапазон глубины",

--- a/lib/features/backup/backup_screen.dart
+++ b/lib/features/backup/backup_screen.dart
@@ -9,6 +9,7 @@ import '../../core/services/backup/backup_cancel.dart';
 import '../../core/services/onboarding_service.dart';
 import '../../shared/theme/app_colors.dart';
 import '../../shared/widgets/glaze_error_dialog.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import '../../shared/widgets/sheet_view.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
@@ -387,10 +388,7 @@ class _BsButton extends StatelessWidget {
                   SizedBox(
                     width: 22,
                     height: 22,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2.4,
-                      valueColor: AlwaysStoppedAnimation<Color>(fg),
-                    ),
+                    child: GlazeSpinner(color: fg),
                   )
                 else
                   Icon(icon, size: 22, color: fg),
@@ -512,10 +510,7 @@ class _ProgressView extends StatelessWidget {
               child: SizedBox(
                 width: 48,
                 height: 48,
-                child: CircularProgressIndicator(
-                  strokeWidth: 3,
-                  valueColor: AlwaysStoppedAnimation<Color>(accent),
-                ),
+                child: GlazeSpinner(color: accent),
               ),
             ),
           ),

--- a/lib/features/card_rewrite/card_rewriter_studio_sheet.dart
+++ b/lib/features/card_rewrite/card_rewriter_studio_sheet.dart
@@ -14,6 +14,7 @@ import '../../core/state/card_rewriter_providers.dart';
 import '../../core/state/pipeline_settings_provider.dart';
 import '../../shared/utils/time_formatter.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import '../settings/api_list_provider.dart';
 
@@ -275,7 +276,7 @@ class _CardRewriterStudioSheetState
             icon: _running
                 ? const SizedBox.square(
                     dimension: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: GlazeSpinner(),
                   )
                 : const Icon(Icons.auto_fix_high_outlined),
             label: Text(_running ? 'Preparing proposal...' : 'Run now'),
@@ -286,7 +287,7 @@ class _CardRewriterStudioSheetState
           jobs.when(
             loading: () => const Padding(
               padding: EdgeInsets.all(12),
-              child: Center(child: CircularProgressIndicator()),
+              child: Center(child: GlazeSpinner()),
             ),
             error: (_, _) => const Text('Could not load rewrite history.'),
             data: (items) {

--- a/lib/features/card_rewrite/rewrite_review_screen.dart
+++ b/lib/features/card_rewrite/rewrite_review_screen.dart
@@ -11,6 +11,7 @@ import '../../shared/theme/app_colors.dart';
 import '../../shared/widgets/glass_surface.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../shared/widgets/glaze_scaffold.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import 'rewrite_review_provider.dart';
 import 'widgets/rewrite_operation_card.dart';
@@ -44,7 +45,7 @@ class RewriteReviewScreen extends ConsumerWidget {
       title: 'rewrite_title'.tr(),
       onBack: () => context.go(backLocation),
       body: snapshot.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(child: GlazeSpinner()),
         error: (_, _) => _MessageState(
           icon: Icons.error_outline,
           text: 'rewrite_load_failed'.tr(),

--- a/lib/features/catalog/widgets/catalog_detail_launcher.dart
+++ b/lib/features/catalog/widgets/catalog_detail_launcher.dart
@@ -6,6 +6,7 @@ import '../../../core/models/character.dart';
 import '../../../core/utils/error_format.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_error_dialog.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../character_list/character_detail_screen.dart';
 import '../../settings/app_settings_provider.dart';
 import '../catalog_models.dart';
@@ -244,7 +245,7 @@ class _LoadingView extends StatelessWidget {
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
       child: Center(
-        child: CircularProgressIndicator(color: context.cs.primary),
+        child: GlazeSpinner(color: context.cs.primary),
       ),
     );
   }

--- a/lib/features/catalog/widgets/catalog_grid.dart
+++ b/lib/features/catalog/widgets/catalog_grid.dart
@@ -10,6 +10,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../../chat/bridge/chat_webview_environment.dart';
 import '../../settings/app_settings_provider.dart';
@@ -273,10 +274,7 @@ class CatalogGrid extends ConsumerWidget {
                   child: SizedBox(
                     width: 28,
                     height: 28,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2.5,
-                      color: context.cs.primary,
-                    ),
+                    child: GlazeSpinner(color: context.cs.primary),
                   ),
                 ),
               ),

--- a/lib/features/catalog/widgets/import_url_dialog.dart
+++ b/lib/features/catalog/widgets/import_url_dialog.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import '../../../core/services/character_import_persistence_coordinator.dart';
 import '../../../core/state/db_provider.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../../character_list/character_import_persistence_provider.dart';
 import '../../settings/app_settings_provider.dart';
@@ -85,10 +86,7 @@ class _ImportUrlDialogState extends ConsumerState<ImportUrlDialog> {
                 SizedBox(
                   width: 20,
                   height: 20,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: context.cs.primary,
-                  ),
+                  child: GlazeSpinner(color: context.cs.primary),
                 ),
                 const SizedBox(width: 12),
                 Expanded(

--- a/lib/features/catalog/widgets/janitor_blocked_content_section.dart
+++ b/lib/features/catalog/widgets/janitor_blocked_content_section.dart
@@ -4,6 +4,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../catalog_models.dart';
 import '../services/janitor_provider.dart';
 
@@ -215,7 +216,7 @@ class _JanitorBlockedContentSectionState
                       child: SizedBox(
                         width: 16,
                         height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+                        child: GlazeSpinner(),
                       ),
                     )
                   : null,

--- a/lib/features/catalog/widgets/janitor_comments_section.dart
+++ b/lib/features/catalog/widgets/janitor_comments_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/utils/time_formatter.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../services/janitor_provider.dart';
 
 const _kSurface = Color(0x0DFFFFFF);
@@ -62,10 +63,7 @@ class JanitorCommentsView extends StatelessWidget {
           child: SizedBox(
             width: 22,
             height: 22,
-            child: CircularProgressIndicator(
-              strokeWidth: 2.4,
-              color: context.cs.primary,
-            ),
+            child: GlazeSpinner(color: context.cs.primary),
           ),
         ),
       );

--- a/lib/features/catalog/widgets/janitor_extract_sheet.dart
+++ b/lib/features/catalog/widgets/janitor_extract_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../../../core/llm/tokenizer.dart';
 import '../services/janitor_extractor.dart';
@@ -169,8 +170,7 @@ class _JanitorExtractSheetState extends ConsumerState<_JanitorExtractSheet> {
                     SizedBox(
                       width: 18,
                       height: 18,
-                      child: CircularProgressIndicator(
-                          strokeWidth: 2, color: cs.primary),
+                      child: GlazeSpinner(color: cs.primary),
                     ),
                     const SizedBox(width: 12),
                     Expanded(

--- a/lib/features/catalog/widgets/janitor_login_sheet.dart
+++ b/lib/features/catalog/widgets/janitor_login_sheet.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../chat/bridge/chat_webview_environment.dart';
 import '../catalog_provider.dart';
 import '../janitor_account_provider.dart';
@@ -225,7 +226,7 @@ class _Header extends StatelessWidget {
               child: SizedBox(
                 width: 18,
                 height: 18,
-                child: CircularProgressIndicator(strokeWidth: 2),
+                child: GlazeSpinner(),
               ),
             )
           else

--- a/lib/features/catalog/widgets/janitor_lorebooks_tab.dart
+++ b/lib/features/catalog/widgets/janitor_lorebooks_tab.dart
@@ -11,6 +11,7 @@ import '../../../core/services/file_export_service.dart';
 import '../../../core/state/lorebook_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../../settings/app_settings_provider.dart';
 import '../janitor_account_provider.dart';
@@ -503,10 +504,7 @@ class _JanitorLorebooksTabState extends ConsumerState<JanitorLorebooksTab> {
               SizedBox(
                 width: 14,
                 height: 14,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: cs.primary,
-                ),
+                child: GlazeSpinner(color: cs.primary),
               ),
               const SizedBox(width: 10),
               Expanded(
@@ -599,10 +597,7 @@ class _JanitorLorebooksTabState extends ConsumerState<JanitorLorebooksTab> {
                             const SizedBox(
                               width: 14,
                               height: 14,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: Colors.white,
-                              ),
+                              child: GlazeSpinner(color: Colors.white),
                             ),
                             const SizedBox(width: 8),
                             Text('Building… ${_elapsed}s'),
@@ -793,7 +788,7 @@ class _PublicSection extends StatelessWidget {
           SizedBox(
             width: 16,
             height: 16,
-            child: CircularProgressIndicator(strokeWidth: 2, color: cs.primary),
+            child: GlazeSpinner(color: cs.primary),
           ),
           const SizedBox(width: 12),
           Text(
@@ -918,10 +913,7 @@ class _PublicRow extends StatelessWidget {
               child: SizedBox(
                 width: 18,
                 height: 18,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: cs.primary,
-                ),
+                child: GlazeSpinner(color: cs.primary),
               ),
             )
           else
@@ -1027,10 +1019,7 @@ class _RebuildAllButton extends StatelessWidget {
             ? const SizedBox(
                 width: 16,
                 height: 16,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: Colors.white,
-                ),
+                child: GlazeSpinner(color: Colors.white),
               )
             : const Icon(Icons.auto_fix_high_rounded, size: 18),
         label: Text(

--- a/lib/features/catalog/widgets/saucepan_login_sheet.dart
+++ b/lib/features/catalog/widgets/saucepan_login_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../saucepan_account_provider.dart';
 
@@ -199,7 +200,7 @@ class _SaucepanLoginFormState extends ConsumerState<_SaucepanLoginForm> {
                 width: 18,
                 height: 18,
                 child:
-                    CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                    GlazeSpinner(color: Colors.white),
               )
             : Text(label,
                 style:

--- a/lib/features/character_gallery/gallery_image_picker.dart
+++ b/lib/features/character_gallery/gallery_image_picker.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/gallery_entry.dart';
 import '../../core/utils/platform_paths.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import 'gallery_provider.dart';
 
 Future<GalleryEntry?> showCharacterGalleryImagePicker(
@@ -52,7 +53,7 @@ class _GalleryImagePicker extends ConsumerWidget {
           ),
           Expanded(
             child: gallery.when(
-              loading: () => const Center(child: CircularProgressIndicator()),
+              loading: () => const Center(child: GlazeSpinner()),
               error: (error, _) => Center(child: Text(error.toString())),
               data: (entries) {
                 if (entries.isEmpty) {

--- a/lib/features/character_gallery/widgets/character_gallery_view.dart
+++ b/lib/features/character_gallery/widgets/character_gallery_view.dart
@@ -10,6 +10,7 @@ import '../../../core/state/character_provider.dart';
 import '../../../core/utils/platform_paths.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../../shared/widgets/glaze_error_dialog.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../gallery_provider.dart';
 
@@ -48,7 +49,7 @@ class CharacterGalleryView extends ConsumerWidget {
         .when(
           loading: () => const Padding(
             padding: EdgeInsets.all(32),
-            child: Center(child: CircularProgressIndicator()),
+            child: Center(child: GlazeSpinner()),
           ),
           error: (e, _) => Padding(
             padding: const EdgeInsets.all(32),

--- a/lib/features/character_list/character_detail_screen.dart
+++ b/lib/features/character_list/character_detail_screen.dart
@@ -15,6 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/models/character.dart';
 import '../../core/services/chat_import_export.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../catalog/services/janitor_provider.dart';
 import '../catalog/services/janitor_public_lorebook.dart';
 import '../catalog/widgets/janitor_comments_section.dart';
@@ -147,7 +148,7 @@ class _CharacterDetailSheetLauncherState
   Widget build(BuildContext context) {
     return const Scaffold(
       backgroundColor: Colors.transparent,
-      body: Center(child: CircularProgressIndicator()),
+      body: Center(child: GlazeSpinner()),
     );
   }
 }
@@ -734,7 +735,7 @@ class _CharacterDetailScreenState extends ConsumerState<CharacterDetailScreen> {
     Character? char,
   ) {
     if (!widget.isPreview && charactersAsync.isLoading && char == null) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: GlazeSpinner());
     }
     if (char == null) {
       return Center(
@@ -956,10 +957,7 @@ class _ImportFab extends StatelessWidget {
               const SizedBox(
                 width: 18,
                 height: 18,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2.5,
-                  color: Colors.white,
-                ),
+                child: GlazeSpinner(color: Colors.white),
               )
             else
               const Icon(Icons.download_rounded, color: Colors.white, size: 20),

--- a/lib/features/character_list/character_editor_screen.dart
+++ b/lib/features/character_list/character_editor_screen.dart
@@ -14,6 +14,7 @@ import '../../core/utils/id_generator.dart';
 import '../../core/utils/time_helpers.dart';
 import '../../core/state/lorebook_provider.dart';
 import '../../shared/theme/app_colors.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/sheet_view.dart';
 import '../../shared/widgets/glaze_error_dialog.dart';
 import '../../shared/widgets/glaze_toast.dart';
@@ -292,7 +293,7 @@ class _CharacterEditorScreenState extends ConsumerState<CharacterEditorScreen> {
     if (_loading) {
       return SheetView(
         title: "${'action_edit'.tr()} ${'sheet_title_char_options'.tr()}",
-        body: const Center(child: CircularProgressIndicator()),
+        body: const Center(child: GlazeSpinner()),
       );
     }
 

--- a/lib/features/character_list/character_list_screen.dart
+++ b/lib/features/character_list/character_list_screen.dart
@@ -24,6 +24,7 @@ import '../../shared/shell/shell_header_provider.dart';
 import '../../shared/theme/app_colors.dart';
 import '../../shared/widgets/glass_surface.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_tab_bar.dart';
 import '../../shared/widgets/swipe_tab_switcher.dart';
 import '../../shared/widgets/tab_slide_switcher.dart';
@@ -569,7 +570,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
 
     return infinite.when(
       loading: () =>
-          Center(child: CircularProgressIndicator(color: context.cs.primary)),
+          Center(child: GlazeSpinner(color: context.cs.primary)),
       error: (e, _) => Center(
         child: Text(
           '${'title_error'.tr()}: $e',
@@ -678,7 +679,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     final chars = ref.watch(charactersProvider);
     return chars.when(
       loading: () =>
-          Center(child: CircularProgressIndicator(color: context.cs.primary)),
+          Center(child: GlazeSpinner(color: context.cs.primary)),
       error: (e, _) => Center(
         child: Text(
           '${'title_error'.tr()}: $e',
@@ -763,7 +764,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     final chars = ref.watch(charactersProvider);
     return chars.when(
       loading: () =>
-          Center(child: CircularProgressIndicator(color: context.cs.primary)),
+          Center(child: GlazeSpinner(color: context.cs.primary)),
       error: (e, _) => Center(
         child: Text(
           '${'title_error'.tr()}: $e',

--- a/lib/features/character_list/widgets/character_grid.dart
+++ b/lib/features/character_list/widgets/character_grid.dart
@@ -8,6 +8,7 @@ import '../../../core/models/character.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../../shared/widgets/glass_surface.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../settings/app_settings_provider.dart';
 import '../character_detail_screen.dart';
 import '../character_sort.dart';
@@ -188,10 +189,7 @@ class CharacterGrid extends StatelessWidget {
                     child: SizedBox(
                       width: 22,
                       height: 22,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: context.cs.primary,
-                      ),
+                      child: GlazeSpinner(color: context.cs.primary),
                     ),
                   )
                 : null,

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -18,6 +18,7 @@ import 'package:share_plus/share_plus.dart';
 import '../../core/debug/perf_debug.dart';
 import '../../core/utils/image_src.dart';
 import '../../core/utils/platform_paths.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import 'editing_message_provider.dart';
 
 import '../../core/state/character_provider.dart';
@@ -393,7 +394,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
                 ),
               ],
         body: chatStateAsync.when(
-          loading: () => const Center(child: CircularProgressIndicator()),
+          loading: () => const Center(child: GlazeSpinner()),
           error: (e, _) => Center(child: Text('${'title_error'.tr()}: $e')),
           data: (state) {
             // The index comparison only gates the INITIAL navigation to a
@@ -418,7 +419,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
             // until restart. Keep the body mounted and overlay the spinner so
             // the WebView's own `_applySessionSwitch` handles the transition.
             if (awaitingTargetSession && !_everBuiltBody) {
-              return const Center(child: CircularProgressIndicator());
+              return const Center(child: GlazeSpinner());
             }
             _everBuiltBody = true;
             return Stack(
@@ -438,7 +439,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
                 if (awaitingTargetSession)
                   const Positioned.fill(
                     child: IgnorePointer(
-                      child: Center(child: CircularProgressIndicator()),
+                      child: Center(child: GlazeSpinner()),
                     ),
                   ),
               ],

--- a/lib/features/chat/widgets/agentic_last_turn_tab.dart
+++ b/lib/features/chat/widgets/agentic_last_turn_tab.dart
@@ -7,6 +7,7 @@ import '../../../core/models/chat_message.dart';
 import '../../../core/models/tracker.dart';
 import '../../../core/state/db_provider.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../services/manual_studio_ledger_service.dart';
 import '../state/agent_operations_log_provider.dart';
@@ -82,9 +83,7 @@ class _AgenticLastTurnTabState extends ConsumerState<AgenticLastTurnTab> {
                             ? const SizedBox(
                                 width: 14,
                                 height: 14,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
+                                child: GlazeSpinner(),
                               )
                             : const Icon(Icons.rule_folder_outlined, size: 16),
                         label: const Text('Run reconciliation'),
@@ -100,9 +99,7 @@ class _AgenticLastTurnTabState extends ConsumerState<AgenticLastTurnTab> {
                             ? const SizedBox(
                                 width: 14,
                                 height: 14,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
+                                child: GlazeSpinner(),
                               )
                             : const Icon(Icons.replay_outlined, size: 16),
                         label: const Text('Rerun Studio Ledger'),

--- a/lib/features/chat/widgets/agentic_snapshots_tab.dart
+++ b/lib/features/chat/widgets/agentic_snapshots_tab.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/models/tracker.dart';
 import '../../../core/models/tracker_snapshot.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../services/agentic_snapshots_service.dart';
 import 'agentic_operations_log_dialog.dart' show AgenticSessionScope;
 
@@ -55,7 +56,7 @@ class _AgenticSnapshotsTabState extends ConsumerState<AgenticSnapshotsTab> {
   @override
   Widget build(BuildContext context) {
     if (!_loaded) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: GlazeSpinner());
     }
     final snapshots = _snapshots ?? const <TrackerSnapshot>[];
     return Column(

--- a/lib/features/chat/widgets/agentic_tracker_values_tab.dart
+++ b/lib/features/chat/widgets/agentic_tracker_values_tab.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/models/tracker.dart';
 import '../../../core/state/memory_agent_providers.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../services/agentic_tracker_values_service.dart';
 import 'agentic_operations_log_dialog.dart' show AgenticSessionScope;
 
@@ -91,7 +92,7 @@ class _AgenticTrackerValuesTabState
   @override
   Widget build(BuildContext context) {
     if (!_loaded) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: GlazeSpinner());
     }
     final trackers = _trackers ?? const <Tracker>[];
     // Precompute lock/override key sets so tiles can show badges and decide

--- a/lib/features/chat/widgets/chat_status_card_shell.dart
+++ b/lib/features/chat/widgets/chat_status_card_shell.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../../shared/widgets/glaze_spinner.dart';
+
 class ChatStatusCardShell extends StatelessWidget {
   const ChatStatusCardShell({
     super.key,
@@ -42,7 +44,7 @@ class ChatStatusCardShell extends StatelessWidget {
               SizedBox(
                 width: 18,
                 height: 18,
-                child: CircularProgressIndicator(strokeWidth: 2, color: accent),
+                child: GlazeSpinner(color: accent),
               )
             else
               Icon(icon, size: 18, color: accent),

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -8,6 +8,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/debug/perf_debug.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../bridge/chat_bridge_controller.dart';
 import '../bridge/chat_bridge_registry.dart';
 import '../bridge/chat_webview_bridge_host.dart';
@@ -305,7 +306,7 @@ class ChatWebViewSurface extends ConsumerWidget {
         if (sessionSwitching)
           Positioned.fill(child: IgnorePointer(child: _background(context))),
         if (sessionSwitching)
-          const Center(child: CircularProgressIndicator(strokeWidth: 3)),
+          const Center(child: GlazeSpinner()),
         if (bottomInset > 0)
           Positioned.fill(
             child: IgnorePointer(

--- a/lib/features/chat/widgets/drawer_panel_scaffold.dart
+++ b/lib/features/chat/widgets/drawer_panel_scaffold.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/top_edge_blur.dart';
 
 /// Shared shell for bottom slide-up panels (Magic Drawer, Quick Replies).
@@ -61,7 +62,7 @@ class DrawerPanelScaffold extends StatelessWidget {
             const Positioned.fill(
               child: ColoredBox(
                 color: Color(0x22000000),
-                child: Center(child: CircularProgressIndicator()),
+                child: Center(child: GlazeSpinner()),
               ),
             ),
         ],

--- a/lib/features/chat/widgets/lorebook_coverage_sheet.dart
+++ b/lib/features/chat/widgets/lorebook_coverage_sheet.dart
@@ -11,6 +11,7 @@ import '../../../core/state/lorebook_embedding_provider.dart';
 import '../../../core/state/lorebook_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_filter_chip_bar.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/sheet_view.dart';
 import '../chat_provider.dart';
 
@@ -144,7 +145,7 @@ class _CoveragePanelState extends ConsumerState<CoveragePanel> {
   @override
   Widget build(BuildContext context) {
     final body = _loading
-        ? const Center(child: CircularProgressIndicator())
+        ? const Center(child: GlazeSpinner())
         : _result == null
         ? Center(
             child: Text(

--- a/lib/features/chat/widgets/memory_books_tab.dart
+++ b/lib/features/chat/widgets/memory_books_tab.dart
@@ -11,6 +11,7 @@ import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glass_surface.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../../shared/widgets/glaze_error_dialog.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_tab_bar.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../../../shared/widgets/swipe_tab_switcher.dart';
@@ -132,7 +133,7 @@ class _MemoryBooksTabState extends ConsumerState<MemoryBooksTab> {
   Widget build(BuildContext context) {
     final book = _ctrl.book;
     final loading = _ctrl.loading || book == null;
-    if (loading) return const Center(child: CircularProgressIndicator());
+    if (loading) return const Center(child: GlazeSpinner());
 
     // Studio Ledger entries (`source == 'studio_ledger'`) are legacy and
     // excluded from the UI — they were removed from the injection pipeline.

--- a/lib/features/chat/widgets/memory_generation_settings_sheet.dart
+++ b/lib/features/chat/widgets/memory_generation_settings_sheet.dart
@@ -11,6 +11,7 @@ import '../../../core/state/memory_settings_provider.dart';
 import '../../../core/state/pipeline_settings_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../../settings/api_list_provider.dart';
 import 'custom_prompt_manager_sheet.dart';
@@ -1106,7 +1107,7 @@ class _MemoryGenerationSettingsSheetState
                   ? const SizedBox(
                       width: 18,
                       height: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2),
+                      child: GlazeSpinner(),
                     )
                   : const Icon(Icons.refresh, size: 18),
             ),

--- a/lib/features/chat/widgets/memory_graph_panel.dart
+++ b/lib/features/chat/widgets/memory_graph_panel.dart
@@ -5,6 +5,7 @@ import '../../../core/models/memory_graph.dart';
 import '../../../core/state/db_provider.dart';
 import '../../../core/state/memory_agent_providers.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 
 class MemoryGraphPanel extends ConsumerStatefulWidget {
   final String sessionId;
@@ -55,7 +56,7 @@ class _MemoryGraphPanelState extends ConsumerState<MemoryGraphPanel>
                       child: SizedBox(
                         width: 16,
                         height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+                        child: GlazeSpinner(),
                       ),
                     ),
                   FilledButton.tonalIcon(
@@ -94,7 +95,7 @@ class _MemoryGraphPanelState extends ConsumerState<MemoryGraphPanel>
           .getBySessionId(widget.sessionId),
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
-          return const Center(child: CircularProgressIndicator());
+          return const Center(child: GlazeSpinner());
         }
         final entities = _mergeEntities(snapshot.data!);
         if (entities.isEmpty) {

--- a/lib/features/chat/widgets/memory_sheet.dart
+++ b/lib/features/chat/widgets/memory_sheet.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/state/summary_providers.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_tab_bar.dart';
 import '../../../shared/widgets/sheet_view.dart';
 import '../chat_provider.dart';
@@ -105,7 +106,7 @@ class _MemorySheetState extends ConsumerState<MemorySheet> {
           _summaryToggle(session.id),
       ],
       body: session == null || tab == null
-          ? const Center(child: CircularProgressIndicator())
+          ? const Center(child: GlazeSpinner())
           : IndexedStack(
               index: tab.index,
               sizing: StackFit.expand,

--- a/lib/features/chat/widgets/post_cleaner_diff_dialog.dart
+++ b/lib/features/chat/widgets/post_cleaner_diff_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/state/db_provider.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import 'post_cleaner_line_diff.dart';
 
 /// Side-by-side diff viewer for POST-cleaner results.
@@ -208,7 +209,7 @@ class _PostCleanerDiffDialogState extends ConsumerState<PostCleanerDiffDialog> {
 
   Widget _buildBody(BuildContext context) {
     if (_loading) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: GlazeSpinner());
     }
     if (_error != null) {
       return Center(

--- a/lib/features/chat/widgets/prompt_preview_screen.dart
+++ b/lib/features/chat/widgets/prompt_preview_screen.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 import '../../../core/llm/history_assembler.dart';
 import '../../../core/llm/prompt_builder.dart';
 import '../../../core/llm/prompt_isolate.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../providers/prompt_build_providers.dart';
 import '../../../core/llm/transport/anthropic_chat_transport.dart';
 import '../../../core/llm/transport/chat_transport_request.dart';
@@ -258,7 +259,7 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
 
             if (_dataTabIndex == 0) {
               if (_loading) {
-                return const Center(child: CircularProgressIndicator());
+                return const Center(child: GlazeSpinner());
               }
               if (_result == null) {
                 return Center(

--- a/lib/features/chat/widgets/session_picker_sheet.dart
+++ b/lib/features/chat/widgets/session_picker_sheet.dart
@@ -7,6 +7,7 @@ import '../../../core/state/chat_session_ops_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/utils/time_formatter.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../chat_history/chat_history_provider.dart';
 import '../chat_actions_service.dart';
 import '../chat_provider.dart';
@@ -162,7 +163,7 @@ class _SessionPickerListState extends ConsumerState<SessionPickerList> {
       return const Center(
         child: Padding(
           padding: EdgeInsets.all(32.0),
-          child: CircularProgressIndicator(),
+          child: GlazeSpinner(),
         ),
       );
     }

--- a/lib/features/chat/widgets/summary_tab.dart
+++ b/lib/features/chat/widgets/summary_tab.dart
@@ -8,6 +8,7 @@ import '../../../core/state/preset_resolution.dart';
 import '../../../core/state/summary_providers.dart';
 import '../../../shared/widgets/generic_editor.dart';
 import '../../../shared/widgets/glaze_error_block.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../presets/preset_list_provider.dart';
 import '../chat_provider.dart';
 import '../services/summary_generation_service.dart';
@@ -338,7 +339,7 @@ class _SummaryTabState extends ConsumerState<SummaryTab> {
                 ? const SizedBox(
                     width: 16,
                     height: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: GlazeSpinner(),
                   )
                 : const Icon(Icons.auto_awesome, size: 18),
             label: Text(

--- a/lib/features/chat/widgets/tokenizer_sheet.dart
+++ b/lib/features/chat/widgets/tokenizer_sheet.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/llm/context_calculator.dart';
 import '../../../core/llm/prompt_isolate.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../providers/prompt_build_providers.dart';
 import '../../../core/models/api_config.dart';
 import '../../../features/settings/api_list_provider.dart';
@@ -199,7 +200,7 @@ class _TokenizerSheetState extends ConsumerState<TokenizerSheet> {
     final nearLimit = historyFill >= _historyFillThreshold;
 
     final body = _loading
-        ? const Center(child: CircularProgressIndicator())
+        ? const Center(child: GlazeSpinner())
         : bd == null
         ? Center(
             child: Text(

--- a/lib/features/chat_history/chat_history_list.dart
+++ b/lib/features/chat_history/chat_history_list.dart
@@ -18,6 +18,7 @@ import '../../core/state/character_provider.dart'
         charactersProvider,
         revealHiddenCharactersProvider;
 import '../../shared/utils/variant_label.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/variation_chip.dart';
 import '../chat/chat_actions_service.dart';
 import '../chat/chat_provider.dart';
@@ -86,7 +87,7 @@ class _ChatHistoryListState extends ConsumerState<ChatHistoryList> {
 
     return sessionsAsync.when(
       loading: () =>
-          Center(child: CircularProgressIndicator(color: context.cs.primary)),
+          Center(child: GlazeSpinner(color: context.cs.primary)),
       error: (e, _) => Center(child: Text('${'title_error'.tr()}: $e')),
       data: (list) {
         _precacheAvatars(list);

--- a/lib/features/dev/spinner_demo_screen.dart
+++ b/lib/features/dev/spinner_demo_screen.dart
@@ -1,0 +1,340 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import '../../shared/theme/app_colors.dart';
+import '../../shared/widgets/glaze_scaffold.dart';
+import '../../shared/widgets/glaze_spinner.dart';
+import '../../shared/widgets/menu_group.dart';
+
+/// Dev-only gallery for [GlazeSpinner] — every size, color and mode the app
+/// uses, side by side with the Material indicator it replaced.
+class SpinnerDemoScreen extends StatefulWidget {
+  const SpinnerDemoScreen({super.key});
+
+  @override
+  State<SpinnerDemoScreen> createState() => _SpinnerDemoScreenState();
+}
+
+class _SpinnerDemoScreenState extends State<SpinnerDemoScreen> {
+  double _progress = 0.35;
+  bool _buttonBusy = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = context.cs;
+
+    return GlazeScaffold(
+      title: 'menu_spinner_demo'.tr(),
+      onBack: () => Navigator.of(context).pop(),
+      body: ListView(
+        padding: const EdgeInsets.only(top: 16, bottom: 32),
+        children: [
+          // ── Hero ──────────────────────────────────────────────────────────
+          const _Card(
+            child: Center(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: GlazeSpinner(size: 96),
+              ),
+            ),
+          ),
+
+          // ── Sizes ─────────────────────────────────────────────────────────
+          const _Label('Sizes — stroke scales with the diameter'),
+          const _Card(
+            child: _Wrap(
+              children: [
+                _Sample(label: '12', child: GlazeSpinner(size: 12)),
+                _Sample(label: '16', child: GlazeSpinner(size: 16)),
+                _Sample(label: '18', child: GlazeSpinner(size: 18)),
+                _Sample(label: '24', child: GlazeSpinner(size: 24)),
+                _Sample(label: '36', child: GlazeSpinner(size: 36)),
+                _Sample(label: '48', child: GlazeSpinner(size: 48)),
+                _Sample(label: '64', child: GlazeSpinner(size: 64)),
+              ],
+            ),
+          ),
+
+          // ── Inferred sizing ───────────────────────────────────────────────
+          const _Label('Sizing without an explicit size'),
+          const _Card(
+            child: _Wrap(
+              children: [
+                _Sample(
+                  label: 'default\n(36)',
+                  child: GlazeSpinner(),
+                ),
+                _Sample(
+                  label: 'SizedBox\n18',
+                  child: SizedBox(width: 18, height: 18, child: GlazeSpinner()),
+                ),
+                _Sample(
+                  label: 'SizedBox\n28',
+                  child: SizedBox(width: 28, height: 28, child: GlazeSpinner()),
+                ),
+              ],
+            ),
+          ),
+
+          // ── Colors ────────────────────────────────────────────────────────
+          const _Label('Colors'),
+          _Card(
+            child: _Wrap(
+              children: [
+                _Sample(
+                  label: 'primary',
+                  child: GlazeSpinner(size: 32, color: cs.primary),
+                ),
+                _Sample(
+                  label: 'accent',
+                  child: GlazeSpinner(size: 32, color: context.colors.accent),
+                ),
+                _Sample(
+                  label: 'error',
+                  child: GlazeSpinner(size: 32, color: cs.error),
+                ),
+                const _Sample(
+                  label: 'white',
+                  child: GlazeSpinner(size: 32, color: Colors.white),
+                ),
+                const _Sample(
+                  label: 'white70',
+                  child: GlazeSpinner(size: 32, color: Colors.white70),
+                ),
+              ],
+            ),
+          ),
+
+          // ── Glow / track ──────────────────────────────────────────────────
+          const _Label('Halo and track'),
+          const _Card(
+            child: _Wrap(
+              children: [
+                _Sample(label: 'default', child: GlazeSpinner(size: 40)),
+                _Sample(
+                  label: 'no halo',
+                  child: GlazeSpinner(size: 40, glow: false),
+                ),
+                _Sample(
+                  label: 'no track',
+                  child: GlazeSpinner(
+                    size: 40,
+                    trackColor: Colors.transparent,
+                  ),
+                ),
+                _Sample(
+                  label: 'bare',
+                  child: GlazeSpinner(
+                    size: 40,
+                    glow: false,
+                    trackColor: Colors.transparent,
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // ── Determinate ───────────────────────────────────────────────────
+          const _Label('Determinate — drag to animate the arc'),
+          _Card(
+            child: Column(
+              children: [
+                _Wrap(
+                  children: [
+                    _Sample(
+                      label: '${(_progress * 100).round()}%',
+                      child: GlazeSpinner(size: 56, value: _progress),
+                    ),
+                    _Sample(
+                      label: 'small',
+                      child: GlazeSpinner(size: 24, value: _progress),
+                    ),
+                    _Sample(
+                      label: 'no halo',
+                      child: GlazeSpinner(
+                        size: 56,
+                        value: _progress,
+                        glow: false,
+                      ),
+                    ),
+                  ],
+                ),
+                MenuGroup(
+                  compact: true,
+                  items: [
+                    MenuRangeItem(
+                      label: 'Progress',
+                      value: _progress,
+                      min: 0,
+                      max: 1,
+                      divisions: 100,
+                      onChanged: (v) => setState(() => _progress = v),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+
+          // ── Against the Material indicator ────────────────────────────────
+          const _Label('Next to the Material indicator it replaced'),
+          const _Card(
+            child: _Wrap(
+              children: [
+                _Sample(label: 'GlazeSpinner', child: GlazeSpinner(size: 36)),
+                _Sample(
+                  label: 'Material',
+                  child: SizedBox(
+                    width: 36,
+                    height: 36,
+                    child: CircularProgressIndicator(),
+                  ),
+                ),
+                _Sample(label: 'Glaze 18', child: GlazeSpinner(size: 18)),
+                _Sample(
+                  label: 'Material 18',
+                  child: SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          // ── In context ────────────────────────────────────────────────────
+          const _Label('In context'),
+          _Card(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                FilledButton.icon(
+                  onPressed: () => setState(() => _buttonBusy = !_buttonBusy),
+                  icon: _buttonBusy
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: GlazeSpinner(color: Colors.white),
+                        )
+                      : const Icon(Icons.play_arrow_rounded, size: 18),
+                  label: Text(_buttonBusy ? 'Working…' : 'Tap to toggle'),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    const SizedBox(width: 18, height: 18, child: GlazeSpinner()),
+                    const SizedBox(width: 12),
+                    Text(
+                      'Inline row label',
+                      style: TextStyle(color: cs.onSurfaceVariant),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Container(
+                  height: 120,
+                  decoration: BoxDecoration(
+                    color: cs.surfaceContainerHighest.withValues(alpha: 0.4),
+                    borderRadius: BorderRadius.circular(14),
+                  ),
+                  child: const Center(child: GlazeSpinner()),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── Layout helpers ──────────────────────────────────────────────────────────
+
+class _Label extends StatelessWidget {
+  const _Label(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 6),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: context.cs.primary.withValues(alpha: 0.7),
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}
+
+class _Card extends StatelessWidget {
+  const _Card({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: context.cs.surface.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: context.cs.outlineVariant),
+      ),
+      child: child,
+    );
+  }
+}
+
+class _Wrap extends StatelessWidget {
+  const _Wrap({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 20,
+      runSpacing: 16,
+      alignment: WrapAlignment.center,
+      crossAxisAlignment: WrapCrossAlignment.end,
+      children: children,
+    );
+  }
+}
+
+/// A spinner plus its caption, aligned on a common baseline so a row of mixed
+/// sizes reads as a scale rather than a jumble.
+class _Sample extends StatelessWidget {
+  const _Sample({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(height: 64, child: Center(child: child)),
+        const SizedBox(height: 6),
+        Text(
+          label,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 10,
+            height: 1.2,
+            color: context.cs.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/extensions/screens/preset_editor/widgets/model_field.dart
+++ b/lib/features/extensions/screens/preset_editor/widgets/model_field.dart
@@ -5,6 +5,7 @@ import '../../../../../core/llm/sse_client.dart';
 import '../../../../../core/models/api_config.dart';
 import '../../../../../shared/theme/app_colors.dart';
 import '../../../../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../../../../shared/widgets/glaze_spinner.dart';
 import '../../../../../shared/widgets/glaze_toast.dart';
 import '../../../../settings/api_list_provider.dart';
 
@@ -124,10 +125,7 @@ class ModelField extends ConsumerWidget {
               ? SizedBox(
                   width: 16,
                   height: 16,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: context.cs.primary,
-                  ),
+                  child: GlazeSpinner(color: context.cs.primary),
                 )
               : Icon(
                   Icons.download_rounded,

--- a/lib/features/glossary/glossary_sheet.dart
+++ b/lib/features/glossary/glossary_sheet.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../core/glossary/glossary_models.dart';
 import '../../core/glossary/glossary_provider.dart';
 import '../../shared/theme/app_colors.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/sheet_view.dart';
 import '../../shared/widgets/glass_surface.dart';
 import '../settings/app_settings_provider.dart';
@@ -211,7 +212,7 @@ class _GlossarySheetState extends ConsumerState<GlossarySheet> {
     return asyncCats.when(
       loading: () => SheetView(
         title: _safeTr('menu_glossary', fallback: 'Glossary'),
-        body: const Center(child: CircularProgressIndicator()),
+        body: const Center(child: GlazeSpinner()),
       ),
       error: (e, _) => SheetView(
         title: _safeTr('menu_glossary', fallback: 'Glossary'),

--- a/lib/features/image_gen/widgets/rows.dart
+++ b/lib/features/image_gen/widgets/rows.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/menu_group.dart';
 import '../image_gen_models.dart';
 
@@ -66,7 +67,7 @@ class ImageGenFetchButton extends StatelessWidget {
         child: SizedBox(
           width: 18,
           height: 18,
-          child: CircularProgressIndicator(strokeWidth: 2),
+          child: GlazeSpinner(),
         ),
       );
     }

--- a/lib/features/lorebooks/embedding_settings_screen.dart
+++ b/lib/features/lorebooks/embedding_settings_screen.dart
@@ -14,6 +14,7 @@ import '../../../shared/shell/shell_header_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_error_dialog.dart';
 import '../../../shared/widgets/glaze_toast.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 
 class EmbeddingSettingsScreen extends ConsumerStatefulWidget {
   const EmbeddingSettingsScreen({super.key});
@@ -246,7 +247,7 @@ class _EmbeddingSettingsScreenState
                         ? const SizedBox(
                             width: 16,
                             height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
+                            child: GlazeSpinner(),
                           )
                         : const Icon(Icons.wifi_tethering, size: 18),
                     label: Text(

--- a/lib/features/lorebooks/lorebook_editor_screen.dart
+++ b/lib/features/lorebooks/lorebook_editor_screen.dart
@@ -17,6 +17,7 @@ import '../../shared/theme/app_colors.dart';
 import '../../shared/widgets/glass_surface.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../shared/widgets/glaze_error_dialog.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import '../../shared/widgets/menu_group.dart';
 import '../../shared/widgets/sheet_view.dart';
@@ -1084,7 +1085,7 @@ class _LorebookEditorScreenState extends ConsumerState<LorebookEditorScreen> {
     if (!_loaded) {
       final list = ref.watch(lorebooksProvider).value;
       if (list == null) {
-        return const Scaffold(body: Center(child: CircularProgressIndicator()));
+        return const Scaffold(body: Center(child: GlazeSpinner()));
       }
       final lb = _findLorebook(list);
       if (lb == null) {

--- a/lib/features/lorebooks/lorebook_list_screen.dart
+++ b/lib/features/lorebooks/lorebook_list_screen.dart
@@ -17,6 +17,7 @@ import '../../shared/theme/app_colors.dart';
 import '../../shared/widgets/glass_surface.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../shared/widgets/glaze_error_dialog.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import '../../shared/widgets/help_tip.dart';
 import '../../shared/widgets/menu_group.dart';
@@ -126,7 +127,7 @@ class LorebookListScreen extends ConsumerWidget {
             ],
           ),
         ),
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(child: GlazeSpinner()),
         error: (e, _) => Center(child: Text('${'title_error'.tr()}: $e')),
       ),
     );

--- a/lib/features/menu/about_screen.dart
+++ b/lib/features/menu/about_screen.dart
@@ -12,6 +12,7 @@ import '../../core/services/update_check_coordinator.dart';
 import '../../core/state/dev_mode_provider.dart';
 import '../../shared/theme/app_colors.dart';
 import '../../shared/widgets/glaze_scaffold.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import '../../shared/widgets/menu_group.dart';
 import '../settings/app_settings_provider.dart';
@@ -270,10 +271,7 @@ class _UpdatesSectionState extends State<_UpdatesSection> {
                       ? SizedBox(
                           width: 18,
                           height: 18,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: cs.primary,
-                          ),
+                          child: GlazeSpinner(color: cs.primary),
                         )
                       : Icon(
                           Icons.refresh_rounded,

--- a/lib/features/menu/menu_screen.dart
+++ b/lib/features/menu/menu_screen.dart
@@ -20,6 +20,7 @@ import '../catalog/widgets/janitor_extract_sheet.dart';
 import '../catalog/widgets/third_party_providers_screen.dart';
 import '../cloud_sync/widgets/sync_sheet.dart';
 import '../dev/menu_group_demo_screen.dart';
+import '../dev/spinner_demo_screen.dart';
 import '../lorebooks/lorebook_connections_sheet.dart';
 import '../personas/persona_connections_sheet.dart';
 import '../personas/persona_list_provider.dart';
@@ -185,6 +186,13 @@ class _MenuScreenState extends ConsumerState<MenuScreen> with ShellHeaderMixin {
                         label: 'menu_menu_group_demo'.tr(),
                         onTap: () => Navigator.of(context).push(MaterialPageRoute<void>(
                           builder: (_) => const MenuGroupDemoScreen(),
+                        )),
+                      ),
+                      MenuItem(
+                        icon: Icons.refresh_rounded,
+                        label: 'menu_spinner_demo'.tr(),
+                        onTap: () => Navigator.of(context).push(MaterialPageRoute<void>(
+                          builder: (_) => const SpinnerDemoScreen(),
                         )),
                       ),
                       const MenuSubHeader('Connections sheets'),

--- a/lib/features/personas/persona_connections_sheet.dart
+++ b/lib/features/personas/persona_connections_sheet.dart
@@ -12,6 +12,7 @@ import '../../../shared/widgets/help_tip.dart';
 import '../../../shared/widgets/sheet_view.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../../shared/widgets/glaze_toast.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 
 class PersonaConnectionsSheet extends ConsumerStatefulWidget {
   final String personaId;
@@ -41,7 +42,7 @@ class _PersonaConnectionsSheetState
         .toList();
 
     return personaListAsync.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const Center(child: GlazeSpinner()),
       error: (error, stack) => Center(child: Text("${'title_error'.tr()}: $error")),
       data: (personas) {
         final persona = personas.where((p) => p.id == widget.personaId).firstOrNull ?? Persona(id: widget.personaId, name: 'tab_personas'.tr());

--- a/lib/features/personas/persona_list_screen.dart
+++ b/lib/features/personas/persona_list_screen.dart
@@ -12,6 +12,7 @@ import '../../core/utils/platform_paths.dart';
 import '../../core/state/active_selection_provider.dart';
 import '../../core/state/db_provider.dart';
 import '../../core/state/shared_prefs_provider.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import 'persona_connections_sheet.dart';
 import 'persona_list_provider.dart';
 import '../../core/utils/id_generator.dart';
@@ -63,7 +64,7 @@ class PersonaListScreen extends ConsumerWidget {
         ),
       ],
       body: personas.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(child: GlazeSpinner()),
         error: (e, _) => Center(child: Text("${'title_error'.tr()}: $e")),
         data: (list) => list.isEmpty
             ? Center(

--- a/lib/features/picks/widgets/picks_detail_launcher.dart
+++ b/lib/features/picks/widgets/picks_detail_launcher.dart
@@ -12,6 +12,7 @@ import '../../../core/state/db_provider.dart';
 import '../../../core/state/lorebook_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_error_dialog.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../../../shared/widgets/glaze_toast.dart';
 import '../../character_list/character_detail_screen.dart';
 import '../picks_models.dart';
@@ -248,7 +249,7 @@ class _LoadingView extends StatelessWidget {
         borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
       ),
       child: Center(
-        child: CircularProgressIndicator(color: context.cs.primary),
+        child: GlazeSpinner(color: context.cs.primary),
       ),
     );
   }

--- a/lib/features/picks/widgets/picks_grid.dart
+++ b/lib/features/picks/widgets/picks_grid.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/state/character_provider.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_spinner.dart';
 import '../picks_models.dart';
 import '../picks_provider.dart';
 import 'picks_detail_launcher.dart';
@@ -41,7 +42,7 @@ class PicksGrid extends ConsumerWidget {
             SliverToBoxAdapter(child: SizedBox(height: topPadding)),
           if (tabBar != null) SliverToBoxAdapter(child: tabBar!),
           const SliverFillRemaining(
-            child: Center(child: CircularProgressIndicator()),
+            child: Center(child: GlazeSpinner()),
           ),
         ],
       ),

--- a/lib/features/presets/preset_connections_sheet.dart
+++ b/lib/features/presets/preset_connections_sheet.dart
@@ -9,6 +9,7 @@ import '../../core/state/character_provider.dart';
 import '../../core/state/chat_session_ops_provider.dart';
 import '../../shared/widgets/connection_sheet_widgets.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/help_tip.dart';
 import '../../shared/widgets/sheet_view.dart';
 import '../../shared/widgets/glaze_toast.dart';
@@ -40,7 +41,7 @@ class _PresetConnectionsSheetState
         .toList();
 
     return presetsAsync.when(
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const Center(child: GlazeSpinner()),
       error: (error, stack) => Center(child: Text("${'title_error'.tr()}: $error")),
       data: (presets) {
         final preset = presets.where((p) => p.id == widget.presetId).firstOrNull

--- a/lib/features/presets/preset_list_screen.dart
+++ b/lib/features/presets/preset_list_screen.dart
@@ -19,6 +19,7 @@ import '../../core/state/db_provider.dart';
 import '../../core/state/active_studio_preset_provider.dart';
 import '../../core/state/preset_folder_provider.dart';
 import '../../core/utils/time_helpers.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../studio/studio_preset_stats.dart';
 import '../studio/studio_preset_workflow_provider.dart';
 import '../studio/widgets/studio_preset_options_sheet.dart';
@@ -240,7 +241,7 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
               // A save from the editor invalidates the list; keep the rows on
               // screen instead of flashing a spinner while it reloads.
               skipLoadingOnReload: true,
-              loading: () => const Center(child: CircularProgressIndicator()),
+              loading: () => const Center(child: GlazeSpinner()),
               error: (e, _) => Center(child: Text('${'title_error'.tr()}: $e')),
               // The inner Builder reads the MediaQuery padding SheetView
               // overrides for its body (header inset + nav bar), which the

--- a/lib/features/presets/studio_preset_editor_screen.dart
+++ b/lib/features/presets/studio_preset_editor_screen.dart
@@ -12,6 +12,7 @@ import '../../core/state/db_provider.dart';
 import '../../core/utils/id_generator.dart';
 import '../../shared/theme/app_colors.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_toast.dart';
 import '../../shared/widgets/folder_name_dialog.dart';
 import '../settings/app_settings_provider.dart';
@@ -509,7 +510,7 @@ class StudioPresetEditorBodyState
   @override
   Widget build(BuildContext context) {
     if (_loading) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: GlazeSpinner());
     }
     final preset = _preset;
     if (preset == null) {

--- a/lib/features/settings/api_settings_screen.dart
+++ b/lib/features/settings/api_settings_screen.dart
@@ -14,6 +14,7 @@ import '../../core/models/extra_request_parameter.dart';
 import '../../core/state/shared_prefs_provider.dart';
 import '../../shared/theme/app_colors.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_tab_bar.dart';
 import '../../shared/widgets/swipe_tab_switcher.dart';
 import '../../shared/widgets/tab_slide_switcher.dart';
@@ -409,7 +410,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
       // own pill animation while the content swipes beneath it.
       headerBottom: list.isEmpty ? null : _buildTabBar(),
       body: asyncList.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(child: GlazeSpinner()),
         error: (e, _) => Center(child: Text('${'title_error'.tr()}: $e')),
         data: (list) => list.isEmpty
             ? _buildEmptyState()
@@ -611,7 +612,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
                   child: SizedBox(
                     width: 18,
                     height: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: GlazeSpinner(),
                   ),
                 )
               : IconButton(
@@ -1020,7 +1021,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
                     ? const SizedBox(
                         width: 16,
                         height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
+                        child: GlazeSpinner(),
                       )
                     : const Icon(Icons.wifi_find_rounded),
                 label: Text(

--- a/lib/features/settings/app_settings_screen.dart
+++ b/lib/features/settings/app_settings_screen.dart
@@ -10,6 +10,7 @@ import '../../shared/theme/app_colors.dart';
 import '../../shared/theme/theme_provider.dart';
 import '../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../shared/widgets/glaze_scaffold.dart';
+import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/menu_group.dart';
 import '../chat/widgets/message_scripts_prompt_sheet.dart';
 import 'app_settings_provider.dart';
@@ -47,7 +48,7 @@ class _AppSettingsScreenState extends ConsumerState<AppSettingsScreen> {
       },
       showBackground: false,
       body: settingsAsync.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(child: GlazeSpinner()),
         error: (e, _) => Center(child: Text('${'title_error'.tr()}: $e')),
         data: (s) => AnimatedSwitcher(
           duration: const Duration(milliseconds: 200),

--- a/lib/shared/widgets/glaze_spinner.dart
+++ b/lib/shared/widgets/glaze_spinner.dart
@@ -1,0 +1,331 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Glaze's loading indicator — a rounded arc that tapers into the accent color
+/// and sweeps around a faint track under a soft halo. Used app-wide in place of
+/// [CircularProgressIndicator].
+///
+/// Sizing works like [CircularProgressIndicator]: the arc fills whatever box it
+/// is given, so an existing `SizedBox(width: 18, height: 18, child: ...)`
+/// wrapper keeps working, and [strokeWidth] scales with the diameter it ends up
+/// painting at. Pass [size] to size the spinner itself; with neither a size nor
+/// tight constraints it falls back to [defaultSize].
+///
+/// Pass [value] (0..1) for a determinate arc; leave it null to spin.
+class GlazeSpinner extends StatefulWidget {
+  const GlazeSpinner({
+    super.key,
+    this.size,
+    this.strokeWidth,
+    this.color,
+    this.trackColor,
+    this.value,
+    this.glow = true,
+    this.semanticsLabel,
+  }) : assert(value == null || (value >= 0.0 && value <= 1.0));
+
+  /// Diameter used when no [size] is given and the parent constraints are not
+  /// tight. Matches `CircularProgressIndicator`'s default so swapping the two
+  /// never shifts a layout.
+  static const double defaultSize = 36;
+
+  /// Outer diameter. Null fills the parent's constraints instead, falling back
+  /// to [defaultSize] when they are loose.
+  final double? size;
+
+  /// Arc thickness. Null scales with the diameter the arc paints at.
+  final double? strokeWidth;
+
+  /// Arc color. Defaults to the color scheme's primary.
+  final Color? color;
+
+  /// The ring behind the arc. Null derives a faint tint of [color]; pass
+  /// [Colors.transparent] to drop the track entirely.
+  final Color? trackColor;
+
+  /// Progress in 0..1 for a determinate arc, or null to spin indefinitely.
+  final double? value;
+
+  /// Whether to paint the soft halo around the arc. Turn it off for dense rows
+  /// of tiny spinners, where the glow only muddies the shape.
+  final bool glow;
+
+  final String? semanticsLabel;
+
+  @override
+  State<GlazeSpinner> createState() => _GlazeSpinnerState();
+}
+
+class _GlazeSpinnerState extends State<GlazeSpinner>
+    with SingleTickerProviderStateMixin {
+  /// One grow-and-shrink pass of the arc. The arc's tail travels exactly two
+  /// turns per cycle (one from the tail easing, one from the constant spin), so
+  /// the angle is continuous across the controller's wrap-around.
+  static const _cycle = Duration(milliseconds: 1600);
+
+  /// Arc length at its shortest and longest, in turns.
+  static const _minSweepTurns = 0.08;
+  static const _maxSweepTurns = 0.82;
+
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    // Created unconditionally: a lazy controller would have to spin up a ticker
+    // from dispose(), which the ticker provider rejects once unmounted.
+    _controller = AnimationController(vsync: this, duration: _cycle);
+    if (widget.value == null) _controller.repeat();
+  }
+
+  @override
+  void didUpdateWidget(covariant GlazeSpinner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final spinning = widget.value == null;
+    if (spinning && !_controller.isAnimating) {
+      _controller.repeat();
+    } else if (!spinning && _controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = widget.color ?? Theme.of(context).colorScheme.primary;
+    final track = widget.trackColor ?? color.withValues(alpha: 0.12 * color.a);
+    final stroke = widget.strokeWidth;
+
+    // The painter fills its box, so the box is what decides the diameter: an
+    // explicit size pins it, otherwise the parent's constraints do, floored at
+    // the default so a loose parent still gets a sensible spinner.
+    Widget spinner = ConstrainedBox(
+      constraints: widget.size == null
+          ? const BoxConstraints(
+              minWidth: GlazeSpinner.defaultSize,
+              minHeight: GlazeSpinner.defaultSize,
+            )
+          : BoxConstraints.tightFor(
+              width: widget.size,
+              height: widget.size,
+            ),
+      child: RepaintBoundary(
+        child: widget.value == null
+            ? _buildSpinning(color, track, stroke)
+            : _buildProgress(widget.value!, color, track, stroke),
+      ),
+    );
+
+    if (widget.semanticsLabel != null) {
+      spinner = Semantics(label: widget.semanticsLabel, child: spinner);
+    }
+    return spinner;
+  }
+
+  Widget _buildSpinning(Color color, Color track, double? stroke) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final t = _controller.value;
+        // The head runs its full travel over the first half of the cycle, the
+        // tail over the second, so the arc grows then shrinks; a constant turn
+        // on top keeps it moving while the two are level.
+        final head = Curves.easeInOutCubic.transform((t * 2).clamp(0.0, 1.0));
+        final tail = Curves.easeInOutCubic.transform(
+          (t * 2 - 1).clamp(0.0, 1.0),
+        );
+        final sweepTurns = _minSweepTurns +
+            (head - tail) * (_maxSweepTurns - _minSweepTurns);
+
+        return CustomPaint(
+          painter: _GlazeSpinnerPainter(
+            startAngle: -math.pi / 2 + (tail + t) * 2 * math.pi,
+            sweep: sweepTurns * 2 * math.pi,
+            color: color,
+            trackColor: track,
+            stroke: stroke,
+            glow: widget.glow,
+            tapered: true,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildProgress(
+    double value,
+    Color color,
+    Color track,
+    double? stroke,
+  ) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween<double>(begin: 0, end: value),
+      duration: const Duration(milliseconds: 260),
+      curve: Curves.easeOutCubic,
+      builder: (context, shown, _) => CustomPaint(
+        painter: _GlazeSpinnerPainter(
+          startAngle: -math.pi / 2,
+          // A hair of arc at zero keeps the rounded cap visible instead of
+          // blinking out of existence.
+          sweep: math.max(shown, 0.004) * 2 * math.pi,
+          color: color,
+          trackColor: track,
+          stroke: stroke,
+          glow: widget.glow,
+          tapered: false,
+        ),
+      ),
+    );
+  }
+}
+
+class _GlazeSpinnerPainter extends CustomPainter {
+  const _GlazeSpinnerPainter({
+    required this.startAngle,
+    required this.sweep,
+    required this.color,
+    required this.trackColor,
+    required this.stroke,
+    required this.glow,
+    required this.tapered,
+  });
+
+  final double startAngle;
+  final double sweep;
+  final Color color;
+  final Color trackColor;
+
+  /// Explicit arc thickness, or null to scale it with the painted diameter.
+  final double? stroke;
+
+  final bool glow;
+
+  /// Whether the arc fades out towards its tail. The indeterminate arc tapers
+  /// (it reads as motion); a progress arc stays solid so a full ring has no
+  /// seam where the transparent tail would meet the opaque head.
+  final bool tapered;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final width = stroke ?? _strokeFor(size.shortestSide);
+    // Room for the inner halo pass. Reserving space for the outer one too cost
+    // ~20% of the radius and left the spinner visibly smaller than the box it
+    // was given; the outer pass is faint enough to bleed a pixel past the
+    // bounds instead (nothing clips it).
+    final halo = glow ? width * 0.25 : 0.0;
+    final radius = (size.shortestSide - width) / 2 - halo;
+    if (radius <= 0) return;
+    final rect = Rect.fromCircle(center: center, radius: radius);
+
+    if (trackColor.a > 0) {
+      canvas.drawCircle(
+        center,
+        radius,
+        Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = width
+          ..color = trackColor,
+      );
+    }
+
+    if (glow) {
+      _paintArc(canvas, rect, radius, width: width * 2.2, alpha: 0.08);
+      _paintArc(canvas, rect, radius, width: width * 1.5, alpha: 0.14);
+    }
+    _paintArc(canvas, rect, radius, width: width, alpha: 1);
+
+    if (glow) _paintHeadGlow(canvas, center, radius, width);
+  }
+
+  /// Keeps the arc's weight proportional to its diameter, so a 16 px spinner in
+  /// a button and a 96 px one on a blank screen read as the same shape.
+  static double _strokeFor(double diameter) =>
+      (diameter * 0.115).clamp(1.8, 12.0).toDouble();
+
+  void _paintArc(
+    Canvas canvas,
+    Rect rect,
+    double radius, {
+    required double width,
+    required double alpha,
+  }) {
+    final peak = alpha * color.a;
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = width;
+
+    if (tapered) {
+      // The round cap at the tail sticks out behind the arc's start. Angles
+      // outside a sweep gradient's range clamp to its end colors, and behind
+      // the start means wrapping onto the *far* end — so without a pad of
+      // transparent gradient covering the cap it paints at full color, leaving
+      // a bright nub floating behind the tail.
+      final pad = width / 2 / radius;
+      final total = sweep + pad;
+      final capStop = pad / total;
+
+      paint.shader = SweepGradient(
+        startAngle: 0,
+        endAngle: total,
+        transform: GradientRotation(startAngle - pad),
+        // Fades in over the tail third only: a taper spread across the whole
+        // arc left it looking washed out at its longest.
+        colors: [
+          color.withValues(alpha: 0),
+          color.withValues(alpha: 0),
+          color.withValues(alpha: peak * 0.7),
+          color.withValues(alpha: peak),
+        ],
+        stops: [0, capStop, capStop + (1 - capStop) * 0.3, 1],
+      ).createShader(rect);
+    } else {
+      paint.color = color.withValues(alpha: peak);
+    }
+
+    canvas.drawArc(rect, startAngle, sweep, false, paint);
+  }
+
+  /// A soft bloom on the leading cap — the touch that makes the arc read as lit
+  /// rather than drawn.
+  void _paintHeadGlow(
+    Canvas canvas,
+    Offset center,
+    double radius,
+    double width,
+  ) {
+    final angle = startAngle + sweep;
+    final head = center + Offset(math.cos(angle), math.sin(angle)) * radius;
+    final bloom = width * 2;
+    final rect = Rect.fromCircle(center: head, radius: bloom);
+    canvas.drawCircle(
+      head,
+      bloom,
+      Paint()
+        ..shader = RadialGradient(
+          colors: [
+            color.withValues(alpha: 0.35 * color.a),
+            color.withValues(alpha: 0),
+          ],
+          stops: const [0.2, 1],
+        ).createShader(rect),
+    );
+  }
+
+  @override
+  bool shouldRepaint(_GlazeSpinnerPainter old) =>
+      old.startAngle != startAngle ||
+      old.sweep != sweep ||
+      old.color != color ||
+      old.trackColor != trackColor ||
+      old.stroke != stroke ||
+      old.glow != glow ||
+      old.tapered != tapered;
+}

--- a/lib/shared/widgets/image_viewer.dart
+++ b/lib/shared/widgets/image_viewer.dart
@@ -4,6 +4,8 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
+import 'glaze_spinner.dart';
+
 class ImageViewer extends StatefulWidget {
   final ImageProvider imageProvider;
   final String? description;
@@ -152,10 +154,7 @@ class _ImageViewerState extends State<ImageViewer> with SingleTickerProviderStat
                       child: SizedBox(
                         width: 32,
                         height: 32,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: Colors.white70,
-                        ),
+                        child: GlazeSpinner(color: Colors.white70),
                       ),
                     );
                   },

--- a/test/chat_status_card_shell_test.dart
+++ b/test/chat_status_card_shell_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/features/chat/widgets/chat_status_card_shell.dart';
+import 'package:glaze_flutter/shared/widgets/glaze_spinner.dart';
 
 void main() {
   testWidgets('renders the shared decoration and spinner/action slots', (
@@ -26,11 +27,11 @@ void main() {
     );
 
     expect(find.text('Working'), findsOneWidget);
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byType(GlazeSpinner), findsOneWidget);
     expect(find.byIcon(Icons.sync), findsNothing);
     expect(find.byTooltip('Stop work'), findsOneWidget);
     expect(
-      tester.getSize(find.byType(CircularProgressIndicator)),
+      tester.getSize(find.byType(GlazeSpinner)),
       const Size.square(18),
     );
 
@@ -68,7 +69,7 @@ void main() {
 
     expect(find.text('Complete'), findsOneWidget);
     expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
-    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.byType(GlazeSpinner), findsNothing);
 
     final text = tester.widget<Text>(find.text('Complete'));
     expect(text.maxLines, 1);

--- a/test/glaze_spinner_test.dart
+++ b/test/glaze_spinner_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/shared/widgets/glaze_spinner.dart';
+
+Widget _host(Widget child) =>
+    MaterialApp(home: Scaffold(body: Center(child: child)));
+
+void main() {
+  testWidgets('falls back to the default diameter without a size or tight '
+      'constraints', (tester) async {
+    await tester.pumpWidget(_host(const GlazeSpinner()));
+
+    expect(
+      tester.getSize(find.byType(GlazeSpinner)),
+      const Size.square(GlazeSpinner.defaultSize),
+    );
+  });
+
+  testWidgets('adopts tight parent constraints', (tester) async {
+    await tester.pumpWidget(
+      _host(const SizedBox(width: 18, height: 18, child: GlazeSpinner())),
+    );
+
+    expect(tester.getSize(find.byType(GlazeSpinner)), const Size.square(18));
+  });
+
+  testWidgets('an explicit size sets the diameter under loose constraints', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(const GlazeSpinner(size: 24)));
+
+    expect(tester.getSize(find.byType(GlazeSpinner)), const Size.square(24));
+  });
+
+  testWidgets('shrinks below the default when the parent is smaller', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(const SizedBox(width: 12, height: 12, child: GlazeSpinner())),
+    );
+
+    expect(tester.getSize(find.byType(GlazeSpinner)), const Size.square(12));
+  });
+
+  testWidgets('keeps animating while indeterminate', (tester) async {
+    await tester.pumpWidget(_host(const GlazeSpinner()));
+
+    // A live ticker means pumpAndSettle would never return; the spinner must
+    // still be scheduling frames.
+    expect(tester.binding.hasScheduledFrame, isTrue);
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(tester.binding.hasScheduledFrame, isTrue);
+  });
+
+  testWidgets('settles once a determinate value is given', (tester) async {
+    await tester.pumpWidget(_host(const GlazeSpinner(value: 0.4)));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('stops and restarts the ticker as value comes and goes', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(const GlazeSpinner()));
+    expect(tester.binding.hasScheduledFrame, isTrue);
+
+    await tester.pumpWidget(_host(const GlazeSpinner(value: 0.5)));
+    await tester.pumpAndSettle();
+    expect(tester.binding.hasScheduledFrame, isFalse);
+
+    await tester.pumpWidget(_host(const GlazeSpinner()));
+    expect(tester.binding.hasScheduledFrame, isTrue);
+  });
+
+  testWidgets('paints the extremes of both modes without error', (
+    tester,
+  ) async {
+    for (final child in const [
+      GlazeSpinner(size: 4),
+      GlazeSpinner(size: 200),
+      GlazeSpinner(value: 0),
+      GlazeSpinner(value: 1),
+      GlazeSpinner(glow: false, trackColor: Colors.transparent),
+      GlazeSpinner(color: Colors.white70, semanticsLabel: 'Loading'),
+    ]) {
+      await tester.pumpWidget(_host(child));
+      await tester.pump(const Duration(milliseconds: 800));
+      expect(tester.takeException(), isNull, reason: '$child');
+    }
+  });
+}

--- a/test/post_gen_status_card_test.dart
+++ b/test/post_gen_status_card_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/features/chat/state/post_gen_status_provider.dart';
 import 'package:glaze_flutter/features/chat/widgets/post_gen_status_card.dart';
+import 'package:glaze_flutter/shared/widgets/glaze_spinner.dart';
 
 void main() {
   testWidgets('shows a distinct Ledger reconciliation running badge', (
@@ -28,6 +29,6 @@ void main() {
     );
 
     expect(find.text('Ledger reconciliation running...'), findsOneWidget);
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byType(GlazeSpinner), findsOneWidget);
   });
 }


### PR DESCRIPTION
## The spinner

- Add `GlazeSpinner` (`lib/shared/widgets/glaze_spinner.dart`) — the app's loading indicator: a tapering arc with round caps sweeping a faint track ring, under a two-pass halo, with a radial bloom on the leading cap. Stroke weight is derived from the diameter the arc actually paints at (`_GlazeSpinnerPainter._strokeFor`), so the same shape reads correctly from a 14 px button spinner up to a 96 px one on a blank screen.
- Support a determinate mode: pass `value` (0..1) for a solid arc from 12 o'clock that tweens on change. The taper is switched off there (`_GlazeSpinnerPainter.tapered`) so a full ring has no seam where a transparent tail would meet the opaque head.
- Size it the way `CircularProgressIndicator` does — fill the box it is given, fall back to the same 36 px default under loose constraints (`GlazeSpinner.defaultSize`). That is what lets the existing `SizedBox(width: 18, height: 18, …)` wrappers at the call sites keep working untouched.
- Two bugs found while rendering the arc offscreen and fixed here, both called out in comments so they are not reintroduced:
  - the tail's round cap sits at angles *behind* the sweep gradient's start, which `TileMode.clamp` wraps onto the far end — it painted at full color, leaving a bright nub floating behind the arc. `_paintArc` now pads the gradient by the cap's angular half-width.
  - reserving bounds for the outer halo pass cost ~20% of the radius and made the spinner visibly smaller than its box; only the inner pass is reserved for now, and the faint outer one bleeds a pixel past the bounds instead (nothing clips a `CustomPaint`).

## Adoption

- Replace all 69 `CircularProgressIndicator` uses across `lib/` (56 files) with `GlazeSpinner`, dropping the now-redundant per-site `strokeWidth` overrides and mapping `valueColor: AlwaysStoppedAnimation<Color>(x)` onto `color: x`.
- `LinearProgressIndicator` bars are deliberately left alone — this change is about the spinner.
- `ChatStatusCardShell` and `PostGenStatusCard` are covered by existing widget tests that asserted on `CircularProgressIndicator`; those assertions now target `GlazeSpinner`.

## Dev menu

- Add `SpinnerDemoScreen` (`lib/features/dev/spinner_demo_screen.dart`) behind a new `menu_spinner_demo` entry in the dev-mode `MenuGroup` of `MenuScreen`: every size, color, halo/track variant, the determinate mode behind a `MenuRangeItem` slider, in-context samples (button, inline row, panel), and a side-by-side with the Material indicator it replaces.
- `menu_spinner_demo` added to `assets/translations/en.json` and `ru.json`.

## Verification

- `flutter analyze --no-fatal-infos --no-fatal-warnings` — clean, no new issues (the 24 remaining infos/warnings are pre-existing and in untouched files).
- `flutter test` — 2531 tests green, including a new `test/glaze_spinner_test.dart` covering the sizing rules, the ticker lifecycle as `value` comes and goes, and painting at both extremes (`size: 4`, `size: 200`, `value: 0`, `value: 1`).
- The rendering itself was checked by capturing the arc offscreen at several animation phases and at magnification, which is what surfaced the two bugs above. That harness was temporary and is not part of this PR.
- **Not run:** the app itself. `flutter run` is unavailable in this environment, so the live animation has not been watched on a device — only still frames. Worth a look before promoting past `nightly`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016FpMDERoWAjbNUwkkmoy84)_