### PR TITLE
feat(theme): darken the background instead of fading it out

### DIFF
--- a/assets/chat_webview/bridge.legacy.js
+++ b/assets/chat_webview/bridge.legacy.js
@@ -1494,7 +1494,7 @@ class Bridge {
     this._editController.stopEdit(messageId);
   }
 
-  setBackgroundImage(url, blur, opacity) {
+  setBackgroundImage(url, blur) {
     // Background is handled by Flutter layer behind the transparent WebView.
   }
 

--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -1173,7 +1173,7 @@ export class Bridge {
     this._editController.stopEdit(messageId);
   }
 
-  setBackgroundImage(url, blur, opacity) {
+  setBackgroundImage(url, blur) {
     // Duplicate the app background inside the WebView so its own
     // backdrop-filter blur regions have real pixels to sample — CSS
     // backdrop-filter can't see the natively-composited Flutter layer
@@ -1201,8 +1201,10 @@ export class Bridge {
       document.body.insertBefore(bg, document.body.firstChild);
     }
     bg.style.display = 'block';
-    const op = opacity == null ? 1 : Math.max(0, Math.min(1, Number(opacity)));
-    bg.style.opacity = op;
+    // The layer stays fully opaque: darkening is the `--bg-dim` overlay in
+    // #bg-layer::after. Fading the layer itself would let the transparent
+    // WebView show the Flutter background painted behind it.
+    bg.style.opacity = '';
 
     const b = Math.max(0, Number(blur) || 0);
     if (b <= 0) {

--- a/lib/core/services/backup/js_preset_importer.dart
+++ b/lib/core/services/backup/js_preset_importer.dart
@@ -147,7 +147,7 @@ class JsPresetImporter extends BackupHelpers {
     for (final p in presetsList) {
       if (p is! Map<String, dynamic>) continue;
       try {
-        final preset = ThemePreset.fromJson(p);
+        final preset = themePresetFromStoredJson(p);
         imported.add(preset);
       } catch (_) {
         continue;

--- a/lib/features/chat/bridge/bridge_theme_commands.dart
+++ b/lib/features/chat/bridge/bridge_theme_commands.dart
@@ -16,9 +16,12 @@ class ThemeBridgeCommands {
     );
   }
 
-  Future<void> setBackgroundImage(String? src, int blur, double opacity) {
+  /// Background darkening is not passed here — it rides on the `bg-dim`
+  /// theme variable ([applyTheme]), which paints a black overlay over the
+  /// in-WebView background copy instead of making it translucent.
+  Future<void> setBackgroundImage(String? src, int blur) {
     if (src == null || src.isEmpty) {
-      return _host.evalJs('window.bridge?.setBackgroundImage(null, 0, 1)');
+      return _host.evalJs('window.bridge?.setBackgroundImage(null, 0)');
     }
     String? url;
     if (src.startsWith('data:') ||
@@ -30,14 +33,14 @@ class ThemeBridgeCommands {
       url = _host.resolveLocalFileUrl(src);
     }
     if (url == null) {
-      return _host.evalJs('window.bridge?.setBackgroundImage(null, 0, 1)');
+      return _host.evalJs('window.bridge?.setBackgroundImage(null, 0)');
     }
     // Pass through JSON encoder — data URIs can be megabytes long and
     // may contain characters that the lightweight escape helper doesn't
     // handle.
     final encoded = jsonEncode(url);
     return _host.evalJs(
-      'window.bridge?.setBackgroundImage($encoded, $blur, $opacity)',
+      'window.bridge?.setBackgroundImage($encoded, $blur)',
     );
   }
 

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -629,8 +629,8 @@ class ChatBridgeController {
   // Theme
   Future<void> setBackgroundNoise(double opacity, double intensity) =>
       theme.setBackgroundNoise(opacity, intensity);
-  Future<void> setBackgroundImage(String? src, int blur, double opacity) =>
-      theme.setBackgroundImage(src, blur, opacity);
+  Future<void> setBackgroundImage(String? src, int blur) =>
+      theme.setBackgroundImage(src, blur);
   Future<void> setChatFont({
     String? fontName,
     String? fontDataUrl,

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -269,6 +269,36 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
     final batterySaver = appSettings?.batterySaver ?? false;
     _drawerCtrl.setBatterySaverMode(batterySaver);
 
+    // Does the chat body paint a background *image* of its own? When it does,
+    // the scaffold's [GlazeBackground] underneath is dead work: the WebView's
+    // #bg-layer holds the visible copy and `ChatWebViewSurface._background`
+    // already covers the whole body with an opaque base + the same image, so
+    // the scaffold's copy decodes and paints a full-screen image nobody sees.
+    //
+    // Only the image case is dropped. Without one the WebView paints no
+    // background at all (#bg-layer goes `display: none`), so the colour comes
+    // from Flutter alone and the cheap scaffold layer stays as the safety net
+    // — as it does for the loading/error branches below, which render instead
+    // of the chat body and would otherwise sit on nothing.
+    final chatBg = batteryAware(
+      ref,
+      batterySaver,
+      themeProvider.select(
+        (t) => (
+          mode: t.activePreset.chatBgMode,
+          hasGlobalImage: t.activePreset.hasBgImage,
+          hasCustomImage: t.activePreset.hasChatBgImage,
+        ),
+      ),
+    );
+    final avatarPath = character?.avatarPath;
+    final bodyPaintsBgImage = switch (chatBg.mode) {
+      'color' => false,
+      'custom' => chatBg.hasCustomImage,
+      'avatar' => avatarPath != null && avatarPath.isNotEmpty,
+      _ => chatBg.hasGlobalImage,
+    };
+
     final keyboardHeight = MediaQuery.viewInsetsOf(context).bottom;
     _drawerCtrl.handleKeyboardFrame(keyboardHeight);
 
@@ -297,6 +327,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
       // second `PopScope` would fire alongside `onBack` and still navigate away
       // even after we dismissed an overlay. All back handling lives in `onBack`.
       child: GlazeScaffold(
+        // `_everBuiltBody` / `hasError`: the spinner and error branches below
+        // render instead of the chat body, so they still need the scaffold's
+        // background to sit on.
+        showBackground:
+            !(bodyPaintsBgImage && _everBuiltBody && !chatStateAsync.hasError),
         extendBodyBehindHeader: true,
         resizeToAvoidBottomInset: false,
         // The body is a full-screen chat WebView; the header's glass blur is

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -1058,7 +1058,6 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
     _blurSafeTop = MediaQuery.paddingOf(context).top;
 
     final bgBlur = preset.bgBlur > 0 ? preset.bgBlur : 0.0;
-    final bgOpacity = preset.bgOpacity.clamp(0.0, 1.0);
     final fontStyle = batteryAware(
       ref,
       batterySaverMode,
@@ -1294,10 +1293,9 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                         personaAvatarPath: effectivePersona?.avatarPath,
                         bgImagePath: bgPath,
                         bgBlur: bgBlur,
-                        bgOpacity: bgOpacity,
                         bgNoiseOpacity: preset.bgNoiseOpacity,
                         bgNoiseIntensity: preset.bgNoiseIntensity,
-                        bgDim: preset.bgDim,
+                        bgDim: preset.bgDim.clamp(0.0, 1.0),
                         chatBgMode: preset.chatBgMode,
                         chatBgColor: preset.chatBgColorParsed,
                         chatFontName: fontStyle.fontFamily,

--- a/lib/features/chat/widgets/chat_webview_initializer.dart
+++ b/lib/features/chat/widgets/chat_webview_initializer.dart
@@ -28,7 +28,6 @@ class ChatWebViewInitInput {
     required this.greetingTotal,
     required this.bgImagePath,
     required this.bgBlur,
-    required this.bgOpacity,
     required this.bgNoiseOpacity,
     required this.bgNoiseIntensity,
     required this.chatFontName,
@@ -68,7 +67,6 @@ class ChatWebViewInitInput {
   final int greetingTotal;
   final String? bgImagePath;
   final double bgBlur;
-  final double bgOpacity;
   final double bgNoiseOpacity;
   final double bgNoiseIntensity;
   final String? chatFontName;
@@ -144,11 +142,7 @@ class ChatWebViewInitializer {
 
     await _setIdentity();
     await applyTheme();
-    await bridge.setBackgroundImage(
-      input.bgImagePath,
-      input.bgBlur.toInt(),
-      input.bgOpacity,
-    );
+    await bridge.setBackgroundImage(input.bgImagePath, input.bgBlur.toInt());
     await bridge.setBackgroundNoise(
       input.bgNoiseOpacity,
       input.bgNoiseIntensity,

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -49,7 +49,6 @@ class ChatWebViewSurface extends ConsumerWidget {
     required this.sessionSwitching,
     required this.refreshPanel,
     required this.bgImageBytes,
-    required this.bgOpacity,
     required this.bgBlur,
     required this.bgDim,
     required this.chatBgMode,
@@ -72,7 +71,6 @@ class ChatWebViewSurface extends ConsumerWidget {
   final bool sessionSwitching;
   final Future<void> Function(String sessionId, String messageId) refreshPanel;
   final Uint8List? bgImageBytes;
-  final double bgOpacity;
   final double bgBlur;
   final double bgDim;
 
@@ -135,19 +133,19 @@ class ChatWebViewSurface extends ConsumerWidget {
       children: [
         ColoredBox(color: base),
         if (image != null) ...[
-          Opacity(
-            opacity: bgOpacity,
-            child: bgBlur > 0
-                ? ImageFiltered(
-                    imageFilter: ui.ImageFilter.blur(
-                      sigmaX: bgBlur,
-                      sigmaY: bgBlur,
-                      tileMode: TileMode.clamp,
-                    ),
-                    child: image,
-                  )
-                : image,
-          ),
+          if (bgBlur > 0)
+            ImageFiltered(
+              imageFilter: ui.ImageFilter.blur(
+                sigmaX: bgBlur,
+                sigmaY: bgBlur,
+                tileMode: TileMode.clamp,
+              ),
+              child: image,
+            )
+          else
+            image,
+          // Darkening only — the image itself stays opaque so the theme
+          // surface under it never bleeds through.
           if (bgDim > 0)
             Container(color: Colors.black.withValues(alpha: bgDim)),
         ],

--- a/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
+++ b/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
@@ -248,13 +248,8 @@ class ChatWebViewSyncDispatcher {
   }) {
     if (current.bgImagePath != old.bgImagePath ||
         current.bgBlur != old.bgBlur ||
-        current.bgOpacity != old.bgOpacity ||
         current.bgDim != old.bgDim) {
-      bridge.setBackgroundImage(
-        current.bgImagePath,
-        current.bgBlur.toInt(),
-        current.bgOpacity,
-      );
+      bridge.setBackgroundImage(current.bgImagePath, current.bgBlur.toInt());
       bridge.applyTheme({'bg-dim': current.bgDim.toStringAsFixed(2)});
     }
   }
@@ -498,7 +493,6 @@ class ChatWebViewWidgetFields {
     required this.personaAvatarPath,
     required this.bgImagePath,
     required this.bgBlur,
-    required this.bgOpacity,
     required this.bgDim,
     required this.bgNoiseOpacity,
     required this.bgNoiseIntensity,
@@ -553,7 +547,6 @@ class ChatWebViewWidgetFields {
   final String? personaAvatarPath;
   final String? bgImagePath;
   final double bgBlur;
-  final double bgOpacity;
   final double bgDim;
   final double bgNoiseOpacity;
   final double bgNoiseIntensity;

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -46,7 +46,6 @@ class ChatWebViewWidget extends ConsumerStatefulWidget {
   final String? personaAvatarPath;
   final String? bgImagePath;
   final double bgBlur;
-  final double bgOpacity;
   final double bgNoiseOpacity;
   final double bgNoiseIntensity;
   final double bgDim;
@@ -135,7 +134,6 @@ class ChatWebViewWidget extends ConsumerStatefulWidget {
     this.personaAvatarPath,
     this.bgImagePath,
     this.bgBlur = 0.0,
-    this.bgOpacity = 1.0,
     this.bgNoiseOpacity = 0.0,
     this.bgNoiseIntensity = 1.0,
     this.bgDim = 0.0,
@@ -404,7 +402,6 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
           greetingTotal: widget.greetingTotal,
           bgImagePath: widget.bgImagePath,
           bgBlur: widget.bgBlur,
-          bgOpacity: widget.bgOpacity,
           bgNoiseOpacity: widget.bgNoiseOpacity,
           bgNoiseIntensity: widget.bgNoiseIntensity,
           chatFontName: widget.chatFontName,
@@ -828,7 +825,6 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       personaAvatarPath: w.personaAvatarPath,
       bgImagePath: w.bgImagePath,
       bgBlur: w.bgBlur,
-      bgOpacity: w.bgOpacity,
       bgDim: w.bgDim,
       bgNoiseOpacity: w.bgNoiseOpacity,
       bgNoiseIntensity: w.bgNoiseIntensity,
@@ -1080,7 +1076,6 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       sessionSwitching: _sessionSwitching,
       refreshPanel: _refreshExtBlocksPanel,
       bgImageBytes: bgImageBytes,
-      bgOpacity: widget.bgOpacity,
       bgBlur: widget.bgBlur,
       bgDim: widget.bgDim,
       chatBgMode: widget.chatBgMode,

--- a/lib/features/cloud_sync/services/sync_engine.dart
+++ b/lib/features/cloud_sync/services/sync_engine.dart
@@ -1174,7 +1174,7 @@ class SyncEngine {
     } else {
       items = [data];
     }
-    final presets = items.map((j) => ThemePreset.fromJson(j)).toList();
+    final presets = items.map((j) => themePresetFromStoredJson(j)).toList();
     await _themePresetRepo.putAll(presets);
   }
 

--- a/lib/features/settings/theme_editor_screen.dart
+++ b/lib/features/settings/theme_editor_screen.dart
@@ -472,16 +472,14 @@ class _GeneralTab extends StatelessWidget {
             if (preset.hasBgImage) ...[
               _SliderRow(
                 label: 'theme_dimming'.tr(),
-                // Slider reads as dimming amount (0 = no dim, 1 = full dim)
-                // but `bgOpacity` stores image visibility (1 - dimming).
-                value: 1.0 - preset.bgOpacity,
+                // 0 = untouched image, 1 = fully black overlay.
+                value: preset.bgDim,
                 min: 0,
                 max: 1,
                 divisions: 20,
                 unit: '%',
                 displayMultiplier: 100,
-                onChanged: (v) =>
-                    onUpdate((p) => p.copyWith(bgOpacity: 1.0 - v)),
+                onChanged: (v) => onUpdate((p) => p.copyWith(bgDim: v)),
               ),
               _SliderRow(
                 label: 'theme_bg_blur'.tr(),

--- a/lib/shared/theme/theme_preset.dart
+++ b/lib/shared/theme/theme_preset.dart
@@ -19,7 +19,6 @@ abstract class ThemePreset with _$ThemePreset {
     @Default('') String author,
     @Default('dark') String themeMode,
     @Default('#7996CE') String accentColor,
-    @Default(0.85) double bgOpacity,
     @Default(0) double bgBlur,
     @Default(0.8) double elementOpacity,
     @Default(12) double elementBlur,
@@ -72,7 +71,12 @@ abstract class ThemePreset with _$ThemePreset {
     @Default(0.8) double noiseIntensity,
     @Default(0.03) double bgNoiseOpacity,
     @Default(0.4) double bgNoiseIntensity,
-    @Default(0) double bgDim,
+    // Background darkening: a black overlay painted *over* the background
+    // image (0 = untouched image, 1 = solid black). Replaces the old
+    // `bgOpacity`, which faded the image itself and let whatever was painted
+    // behind it (the Flutter surface under the transparent WebView) show
+    // through instead of darkening it.
+    @Default(0.15) double bgDim,
     String? bgImage,
     // Chat-area background. Independent of the global UI background.
     //   'inherit' → reuse the global background (default)
@@ -90,6 +94,26 @@ abstract class ThemePreset with _$ThemePreset {
 
   factory ThemePreset.fromJson(Map<String, dynamic> json) =>
       _$ThemePresetFromJson(json);
+}
+
+/// Decode a preset stored/exported by an older build, migrating dropped
+/// fields to their current equivalents before handing the map to
+/// [ThemePreset.fromJson].
+///
+/// * `bgOpacity` (image visibility) → [ThemePreset.bgDim] (`1 - opacity`),
+///   since the background is now darkened by an overlay instead of being
+///   faded out. Presets written before the switch always carry `bgDim: 0`,
+///   so the migrated value wins.
+ThemePreset themePresetFromStoredJson(Map<String, dynamic> json) {
+  final legacyOpacity = json['bgOpacity'];
+  if (legacyOpacity is! num) return ThemePreset.fromJson(json);
+  final migrated = Map<String, dynamic>.from(json)..remove('bgOpacity');
+  final dim = (1.0 - legacyOpacity.toDouble()).clamp(0.0, 1.0);
+  final storedDim = migrated['bgDim'];
+  migrated['bgDim'] = storedDim is num && storedDim > dim
+      ? storedDim.toDouble()
+      : dim;
+  return ThemePreset.fromJson(migrated);
 }
 
 /// A parsed 2-stop bubble gradient. [angle] is in CSS degrees

--- a/lib/shared/theme/theme_preset_storage.dart
+++ b/lib/shared/theme/theme_preset_storage.dart
@@ -37,7 +37,7 @@ class ThemePresetStorage implements SyncThemePresetStore, ThemePresetStore {
     try {
       final list = jsonDecode(raw) as List;
       final presets = list
-          .map((e) => ThemePreset.fromJson(e as Map<String, dynamic>))
+          .map((e) => themePresetFromStoredJson(e as Map<String, dynamic>))
           .toList();
       return _withBuiltins(presets);
     } catch (_) {
@@ -122,7 +122,7 @@ class ThemePresetStorage implements SyncThemePresetStore, ThemePresetStore {
     stripped['id'] = id;
     stripped['name'] = name;
 
-    return ThemePreset.fromJson(stripped);
+    return themePresetFromStoredJson(stripped);
   }
 
   Archive? _tryDecodeArchive(Uint8List bytes) {
@@ -187,9 +187,11 @@ class ThemePresetStorage implements SyncThemePresetStore, ThemePresetStore {
         '#7996CE';
     final bgImage =
         _resolveBackgroundImage(background['image'] as String?, archive);
+    // Tavo stores image visibility; Glaze darkens the background instead.
     final bgOpacity = _asDouble(background['imageOpacity']) ??
         _opacityFromArgb(bgColorInt) ??
         0.85;
+    final bgDim = (1.0 - bgOpacity).clamp(0.0, 1.0).toDouble();
     final bgBlur = _asDouble(background['blur']) ?? 0;
     final elementBlur = _firstNonNullDouble([
           _asDouble(console['blur']),
@@ -241,7 +243,7 @@ class ThemePresetStorage implements SyncThemePresetStore, ThemePresetStore {
       author: 'Tavo',
       themeMode: themeMode,
       accentColor: accent,
-      bgOpacity: bgOpacity.clamp(0.0, 1.0).toDouble(),
+      bgDim: bgDim,
       bgBlur: bgBlur,
       elementOpacity: elementOpacity.clamp(0.0, 1.0).toDouble(),
       elementBlur: elementBlur,
@@ -453,7 +455,7 @@ final _defaultPreset = ThemePreset(
   id: 'default',
   name: 'Default',
   accentColor: '#7996CE',
-  bgOpacity: 0.85,
+  bgDim: 0.15,
   elementOpacity: 0.8,
   elementBlur: 12,
   chatLayout: 'default',
@@ -474,7 +476,7 @@ final _materialYouPreset = ThemePreset(
   id: kMaterialYouPresetId,
   name: 'Material You',
   accentColor: '#7996CE',
-  bgOpacity: 0.85,
+  bgDim: 0.15,
   elementOpacity: 0.8,
   elementBlur: 12,
   chatLayout: 'default',

--- a/lib/shared/widgets/glaze_background.dart
+++ b/lib/shared/widgets/glaze_background.dart
@@ -28,30 +28,41 @@ class GlazeBackground extends ConsumerWidget {
       child: Stack(
         fit: StackFit.expand,
         children: [
-          if (bytes != null)
+          if (bytes != null) ...[
             Positioned.fill(
-              child: Opacity(
-                opacity: preset.bgOpacity.clamp(0.0, 1.0),
-                child: !batterySaver && preset.bgBlur > 0
-                    ? ImageFiltered(
-                        imageFilter: ImageFilter.blur(
-                          sigmaX: preset.bgBlur,
-                          sigmaY: preset.bgBlur,
-                          tileMode: TileMode.clamp,
-                        ),
-                        child: Image.memory(
-                          bytes,
-                          fit: BoxFit.cover,
-                          gaplessPlayback: true,
-                        ),
-                      )
-                    : Image.memory(
+              child: !batterySaver && preset.bgBlur > 0
+                  ? ImageFiltered(
+                      imageFilter: ImageFilter.blur(
+                        sigmaX: preset.bgBlur,
+                        sigmaY: preset.bgBlur,
+                        tileMode: TileMode.clamp,
+                      ),
+                      child: Image.memory(
                         bytes,
                         fit: BoxFit.cover,
                         gaplessPlayback: true,
                       ),
-              ),
+                    )
+                  : Image.memory(
+                      bytes,
+                      fit: BoxFit.cover,
+                      gaplessPlayback: true,
+                    ),
             ),
+            // Darken the image with a black overlay instead of fading it out:
+            // a translucent image would let [base] (and, in the chat, the
+            // Flutter surface behind the transparent WebView) bleed through.
+            if (preset.bgDim > 0)
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: ColoredBox(
+                    color: Colors.black.withValues(
+                      alpha: preset.bgDim.clamp(0.0, 1.0),
+                    ),
+                  ),
+                ),
+              ),
+          ],
           if (!batterySaver && preset.bgNoiseOpacity > 0)
             Positioned.fill(
               child: IgnorePointer(

--- a/test/chat_webview_sync_dispatcher_test.dart
+++ b/test/chat_webview_sync_dispatcher_test.dart
@@ -448,7 +448,6 @@ ChatWebViewWidgetFields _fields({
   personaAvatarPath: null,
   bgImagePath: null,
   bgBlur: 0,
-  bgOpacity: 1,
   bgDim: 0,
   bgNoiseOpacity: 0,
   bgNoiseIntensity: 0,

--- a/test/theme_preset_migration_test.dart
+++ b/test/theme_preset_migration_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/shared/theme/theme_preset.dart';
+
+void main() {
+  Map<String, dynamic> presetJson(Map<String, dynamic> extra) => {
+    'id': 'custom',
+    'name': 'Custom',
+    ...extra,
+  };
+
+  test('legacy bgOpacity becomes its bgDim complement', () {
+    final preset = themePresetFromStoredJson(
+      presetJson({'bgOpacity': 0.85, 'bgDim': 0.0}),
+    );
+
+    expect(preset.bgDim, closeTo(0.15, 1e-9));
+  });
+
+  test('a fully opaque legacy background maps to no dimming', () {
+    final preset = themePresetFromStoredJson(presetJson({'bgOpacity': 1.0}));
+
+    expect(preset.bgDim, 0.0);
+  });
+
+  test('an already-dimmed legacy preset keeps the stronger value', () {
+    final preset = themePresetFromStoredJson(
+      presetJson({'bgOpacity': 0.9, 'bgDim': 0.5}),
+    );
+
+    expect(preset.bgDim, 0.5);
+  });
+
+  test('presets without bgOpacity decode unchanged', () {
+    final preset = themePresetFromStoredJson(presetJson({'bgDim': 0.4}));
+
+    expect(preset.bgDim, 0.4);
+  });
+}


### PR DESCRIPTION
The theme's "Background Dimming" slider stored image *visibility*
(`ThemePreset.bgOpacity`) and was rendered with `Opacity`, so dimming made the
image translucent instead of darker — whatever was painted behind it showed
through: the theme surface in the UI, and the Flutter background under the
transparent WebView in the chat.

## Background dimming

- Drop `ThemePreset.bgOpacity`. `bgDim` (0 = untouched image, 1 = solid black)
  is now the single darkening value, default `0.15` — the old `0.85` opacity —
  and the dimming slider in `theme_editor_screen.dart` writes it directly
  instead of storing `1 - v`.
- `GlazeBackground` paints the image opaque and lays a black overlay of
  `bgDim` on top of it.
- `ChatWebViewSurface._background` no longer takes an opacity: the image stays
  opaque (blur + the `bgDim` overlay only), so the theme surface beneath it
  can never bleed through.
- In the WebView, darkening is now solely the `--bg-dim` overlay on
  `#bg-layer::after`. `setBackgroundImage(url, blur)` lost its opacity
  argument and no longer fades `#bg-layer` — that layer was what exposed the
  Flutter background behind the transparent WebView. Plumbing for the dropped
  value is gone from `chat_screen.dart`, `ChatWebViewWidget`,
  `ChatWebViewInitInput`, `ChatWebViewWidgetFields` and `ThemeBridgeCommands`.
- Migrate stored, imported and synced presets: `themePresetFromStoredJson`
  decodes a legacy `bgOpacity` as `bgDim: 1 - bgOpacity`, and the Tavo import
  maps `background.imageOpacity` the same way. Applied on every decode path —
  `ThemePresetStorage.loadAll`, `_fromThemeJson`, `SyncEngine._applyUiThemes`
  and `JsPresetImporter.importTheme`.

## Redundant background paint in the chat

- `ChatWebViewSurface._background` already covers the whole chat body with an
  opaque base plus the same image the WebView's `#bg-layer` shows, so the
  `GlazeBackground` inside the chat's `GlazeScaffold` decoded and painted a
  full-screen image nothing ever revealed. It is now skipped via
  `showBackground` when the body paints an image of its own (per `chatBgMode`:
  global, chat-custom or character avatar).
- It stays on for a solid background colour — without an image the WebView
  paints no background at all (`#bg-layer` goes `display: none`), so the
  colour comes from the Flutter side alone.
- It also stays on for the loading and error branches, which render instead of
  the chat body and would otherwise sit on nothing.

## Verification

- Added `test/theme_preset_migration_test.dart` covering the legacy
  `bgOpacity` → `bgDim` migration, including a preset that already carried a
  stronger `bgDim`.
- `flutter analyze` and `flutter test` were **not** run — the agent's
  environment has no Flutter SDK — so this relies on the CI gate. Note that
  `ThemePreset` lost a field, so `dart run build_runner build` is required
  before building locally.
- The visual result (chat with an image background, chat with
  `chatBgMode: 'color'`, no black flash on the open spinner) has not been
  checked in a running app.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGvnnoxzWqqZD4vXkDV8Ud)_