### PR TITLE
Fix Card Rewriter evidence confirmation semantics

### DIFF
--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -74,7 +74,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 112;
+  int get schemaVersion => 113;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2056,6 +2056,51 @@ class AppDatabase extends _$AppDatabase {
             'ALTER TABLE api_configs '
             'RENAME COLUMN gemini_use_system_instruction '
             'TO use_system_instruction',
+          );
+        }
+      }
+      if (from < 113) {
+        final columns = await customSelect(
+          "PRAGMA table_info('card_evolution_observations')",
+        ).get();
+        final columnNames = columns
+            .map((column) => column.read<String>('name'))
+            .toSet();
+        if (!columnNames.contains('evidence_clusters_json')) {
+          await m.addColumn(
+            cardEvolutionObservations,
+            cardEvolutionObservations.evidenceClustersJson,
+          );
+        }
+        final observations = await customSelect(
+          'SELECT id, evidence_message_ids FROM card_evolution_observations',
+        ).get();
+        for (final observation in observations) {
+          final legacy = observation.read<String>('evidence_message_ids');
+          final canonical = <String>[];
+          try {
+            final decoded = jsonDecode(legacy);
+            if (decoded is List) {
+              for (final value in decoded) {
+                if (value is String &&
+                    value.isNotEmpty &&
+                    !canonical.contains(value)) {
+                  canonical.add(value);
+                }
+              }
+            }
+          } catch (_) {
+            // Malformed legacy evidence is unverifiable and is discarded.
+          }
+          await customStatement(
+            'UPDATE card_evolution_observations '
+            'SET evidence_message_ids = ?, evidence_clusters_json = ?, '
+            'repeat_count = 1 WHERE id = ?',
+            [
+              jsonEncode(canonical),
+              jsonEncode(canonical.isEmpty ? const [] : [canonical]),
+              observation.read<String>('id'),
+            ],
           );
         }
       }

--- a/lib/core/db/repositories/card_evolution_observation_repo.dart
+++ b/lib/core/db/repositories/card_evolution_observation_repo.dart
@@ -47,6 +47,7 @@ class CardEvolutionObservationRepo {
           observedChange: observation.observedChange,
           canonicalClaim: Value(observation.canonicalClaim),
           evidenceMessageIds: jsonEncode(observation.evidenceMessageIds),
+          evidenceClustersJson: Value(jsonEncode(observation.evidenceClusters)),
           cardFieldPath: Value(observation.cardFieldPath),
           lorebookEntryId: Value(observation.lorebookEntryId),
           confidence: observation.confidence,
@@ -59,16 +60,39 @@ class CardEvolutionObservationRepo {
         ),
       );
 
-  Future<void> confirmObservation({
+  Future<ObservationConfirmationOutcome> confirmObservation({
     required String id,
     required int runOrdinal,
     required double confidence,
     required int now,
+    required List<String> evidenceMessageIds,
   }) => db.transaction(() async {
     final row = await (db.select(
       db.cardEvolutionObservations,
     )..where((r) => r.id.equals(id))).getSingleOrNull();
-    if (row == null) return;
+    if (row == null) return ObservationConfirmationOutcome.duplicate;
+    final incoming = _canonicalEvidence(evidenceMessageIds);
+    if (incoming.isEmpty) return ObservationConfirmationOutcome.noEvidence;
+    if (row.runOrdinal == runOrdinal || row.lastConfirmedRun == runOrdinal) {
+      return ObservationConfirmationOutcome.sameRun;
+    }
+    final clusters = _decodeClusters(row.evidenceClustersJson);
+    final incomingSet = incoming.toSet();
+    if (clusters.any(
+      (cluster) =>
+          cluster.length == incomingSet.length &&
+          incomingSet.containsAll(cluster),
+    )) {
+      return ObservationConfirmationOutcome.duplicate;
+    }
+    final existingIds = {for (final cluster in clusters) ...cluster};
+    if (incoming.any(existingIds.contains)) {
+      return ObservationConfirmationOutcome.overlap;
+    }
+    clusters.add(incoming);
+    final union = _canonicalEvidence([
+      for (final cluster in clusters) ...cluster,
+    ]);
     await (db.update(
       db.cardEvolutionObservations,
     )..where((r) => r.id.equals(id))).write(
@@ -76,9 +100,12 @@ class CardEvolutionObservationRepo {
         repeatCount: Value(row.repeatCount + 1),
         lastConfirmedRun: Value(runOrdinal),
         confidence: Value(confidence),
+        evidenceClustersJson: Value(jsonEncode(clusters)),
+        evidenceMessageIds: Value(jsonEncode(union)),
         updatedAt: Value(now),
       ),
     );
+    return ObservationConfirmationOutcome.confirmed;
   });
 
   Future<void> promoteObservation(String id, {required int now}) =>
@@ -92,7 +119,7 @@ class CardEvolutionObservationRepo {
             ),
           );
 
-  Future<void> expireObservation(String id, {required int now}) =>
+  Future<void> contradictObservation(String id, {required int now}) =>
       (db.update(db.cardEvolutionObservations)
             ..where((r) => r.id.equals(id))
             ..where((r) => r.status.equals('active')))
@@ -153,35 +180,8 @@ class CardEvolutionObservationRepo {
     return [for (final row in rows) _toModel(row)];
   });
 
-  Future<List<CardEvolutionObservation>> getExpiryCandidates(
-    String sessionId, {
-    required int currentRunOrdinal,
-    required int expiryRuns,
-  }) => db.transaction(() async {
-    final rows =
-        await (db.select(db.cardEvolutionObservations)
-              ..where((r) => r.sessionId.equals(sessionId))
-              ..where((r) => r.status.equals('active'))
-              ..where((r) => r.lastConfirmedRun.isNotNull()))
-            .get();
-    return [
-      for (final row in rows)
-        if (currentRunOrdinal - (row.lastConfirmedRun ?? currentRunOrdinal) >=
-            expiryRuns)
-          _toModel(row),
-    ];
-  });
-
   static CardEvolutionObservation _toModel(CardEvolutionObservationRow row) {
-    List<String> evidence;
-    try {
-      final decoded = jsonDecode(row.evidenceMessageIds);
-      evidence = decoded is List
-          ? [for (final item in decoded) item.toString()]
-          : const [];
-    } catch (_) {
-      evidence = const [];
-    }
+    final evidenceClusters = _decodeClusters(row.evidenceClustersJson);
     return CardEvolutionObservation(
       id: row.id,
       sessionId: row.sessionId,
@@ -190,7 +190,7 @@ class CardEvolutionObservationRepo {
       semanticScopeKey: row.semanticScopeKey,
       observedChange: row.observedChange,
       canonicalClaim: row.canonicalClaim,
-      evidenceMessageIds: evidence,
+      evidenceClusters: evidenceClusters,
       cardFieldPath: row.cardFieldPath,
       lorebookEntryId: row.lorebookEntryId,
       confidence: row.confidence,
@@ -202,4 +202,36 @@ class CardEvolutionObservationRepo {
       updatedAt: row.updatedAt,
     );
   }
+
+  static List<String> _canonicalEvidence(Iterable<Object?> values) {
+    final result = <String>[];
+    for (final value in values) {
+      if (value is String && value.isNotEmpty && !result.contains(value)) {
+        result.add(value);
+      }
+    }
+    return result;
+  }
+
+  static List<List<String>> _decodeClusters(String encoded) {
+    try {
+      final decoded = jsonDecode(encoded);
+      if (decoded is! List) return [];
+      return [
+        for (final cluster in decoded)
+          if (cluster is List && _canonicalEvidence(cluster).isNotEmpty)
+            _canonicalEvidence(cluster),
+      ];
+    } catch (_) {
+      return [];
+    }
+  }
+}
+
+enum ObservationConfirmationOutcome {
+  confirmed,
+  duplicate,
+  noEvidence,
+  overlap,
+  sameRun,
 }

--- a/lib/core/db/repositories/card_evolution_repo.dart
+++ b/lib/core/db/repositories/card_evolution_repo.dart
@@ -541,7 +541,7 @@ class CardEvolutionRepo {
                 ..orderBy([(r) => OrderingTerm.asc(r.createdAt)]))
               .get();
       return _canonicalJson({
-        'contractVersion': 7,
+        'contractVersion': 8,
         'fields': [for (final field in writableFields) field.wireName],
         'chatHistoryHash': computeHash(historyJson),
         'effectiveCanonIdentity': assembled.$2.identity,
@@ -560,6 +560,7 @@ class CardEvolutionRepo {
               'observedChange': obs.observedChange,
               'canonicalClaim': obs.canonicalClaim,
               'evidenceMessageIds': _decodeJsonArray(obs.evidenceMessageIds),
+              'evidenceClusters': _decodeJsonClusters(obs.evidenceClustersJson),
               'cardFieldPath': obs.cardFieldPath,
               'lorebookEntryId': obs.lorebookEntryId,
               'confidence': obs.confidence,
@@ -775,6 +776,15 @@ Map<String, (String, String)>? _loreTargetsFromInput(String selectedInputJson) {
 }
 
 List<Object?> _decodeJsonArray(String encoded) {
+  try {
+    final decoded = jsonDecode(encoded);
+    return decoded is List ? decoded : const [];
+  } catch (_) {
+    return const [];
+  }
+}
+
+List<Object?> _decodeJsonClusters(String encoded) {
   try {
     final decoded = jsonDecode(encoded);
     return decoded is List ? decoded : const [];

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -1145,6 +1145,8 @@ class CardEvolutionObservations extends Table {
   TextColumn get observedChange => text()();
   TextColumn get canonicalClaim => text().nullable()();
   TextColumn get evidenceMessageIds => text()();
+  TextColumn get evidenceClustersJson =>
+      text().withDefault(const Constant('[]'))();
   TextColumn get cardFieldPath => text().nullable()();
   TextColumn get lorebookEntryId => text().nullable()();
   RealColumn get confidence => real()();

--- a/lib/core/models/card_evolution_observation.dart
+++ b/lib/core/models/card_evolution_observation.dart
@@ -10,6 +10,8 @@ part 'card_evolution_observation.g.dart';
 /// validated target. After a successful apply the status becomes `consumed`.
 @freezed
 abstract class CardEvolutionObservation with _$CardEvolutionObservation {
+  const CardEvolutionObservation._();
+
   const factory CardEvolutionObservation({
     required String id,
     required String sessionId,
@@ -18,7 +20,7 @@ abstract class CardEvolutionObservation with _$CardEvolutionObservation {
     required String semanticScopeKey,
     required String observedChange,
     String? canonicalClaim,
-    required List<String> evidenceMessageIds,
+    required List<List<String>> evidenceClusters,
     String? cardFieldPath,
     String? lorebookEntryId,
     required double confidence,
@@ -32,4 +34,9 @@ abstract class CardEvolutionObservation with _$CardEvolutionObservation {
 
   factory CardEvolutionObservation.fromJson(Map<String, dynamic> json) =>
       _$CardEvolutionObservationFromJson(json);
+
+  /// Compatibility/audit view. Independent clusters remain the source of truth.
+  List<String> get evidenceMessageIds => [
+    for (final cluster in evidenceClusters) ...cluster,
+  ];
 }

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -275,7 +275,7 @@ class AutomatedCardEvolutionService {
       final runOrdinal = count ~/ 2;
       onStage?.call(AutomatedCardEvolutionStage.observation);
       await _runObservationPass(sessionId, runOrdinal);
-      await _checkPromotionsAndExpiry(sessionId, runOrdinal);
+      await _checkPromotions(sessionId);
     } catch (_) {
       // Observation pass failures are intentionally non-blocking.
     }
@@ -296,6 +296,7 @@ class AutomatedCardEvolutionService {
             'firstSeenRun': o.firstSeenRun,
             'lastConfirmedRun': o.lastConfirmedRun,
             'confidence': o.confidence,
+            'evidenceClusters': o.evidenceClusters,
           },
         )
         .toList();
@@ -321,8 +322,11 @@ class AutomatedCardEvolutionService {
       }
       final actions = _parseObservationResponse(outcome.text!);
       if (actions == null) return;
+      final validEvidenceIds = _chatMessageIds(snapshot.selectedInputJson);
+      if (validEvidenceIds == null) return;
       final now = currentTimestampSeconds();
       for (final action in actions) {
+        if (!validEvidenceIds.containsAll(action.evidenceMessageIds)) continue;
         await _applyObservationAction(
           sessionId: sessionId,
           characterId: snapshot.character.id,
@@ -357,6 +361,7 @@ class AutomatedCardEvolutionService {
             runOrdinal: runOrdinal,
             confidence: action.confidence,
             now: now,
+            evidenceMessageIds: action.evidenceMessageIds,
           );
         }
         break;
@@ -375,38 +380,37 @@ class AutomatedCardEvolutionService {
               semanticScopeKey: action.scopeKey,
               observedChange: action.observedChange,
               canonicalClaim: action.canonicalClaim,
-              evidenceMessageIds: action.evidenceMessageIds,
+              evidenceClusters: [action.evidenceMessageIds],
               cardFieldPath: action.cardFieldPath,
               lorebookEntryId: action.lorebookEntryId,
               confidence: action.confidence,
               status: 'active',
               firstSeenRun: runOrdinal,
+              lastConfirmedRun: runOrdinal,
               createdAt: now,
               updatedAt: now,
             ),
           );
         }
         break;
-      case 'expire':
+      case 'no_evidence':
+        break;
+      case 'contradict':
         final existing = await observationRepo.findByScopeKey(
           sessionId,
           action.scopeKey,
         );
         if (existing != null && existing.status == 'active') {
-          await observationRepo.expireObservation(existing.id, now: now);
+          await observationRepo.contradictObservation(existing.id, now: now);
         }
         break;
     }
   }
 
-  Future<void> _checkPromotionsAndExpiry(
-    String sessionId,
-    int runOrdinal,
-  ) async {
+  Future<void> _checkPromotions(String sessionId) async {
     final now = currentTimestampSeconds();
     final threshold = observationPromotionThreshold?.call() ?? 3;
     final minConfidence = observationMinConfidence?.call() ?? 0.7;
-    final expiryRuns = observationExpiryRuns?.call() ?? 4;
     final promotable = await observationRepo.getPromotableObservations(
       sessionId,
       minRepeatCount: threshold,
@@ -415,13 +419,20 @@ class AutomatedCardEvolutionService {
     for (final obs in promotable) {
       await observationRepo.promoteObservation(obs.id, now: now);
     }
-    final expired = await observationRepo.getExpiryCandidates(
-      sessionId,
-      currentRunOrdinal: runOrdinal,
-      expiryRuns: expiryRuns,
-    );
-    for (final obs in expired) {
-      await observationRepo.expireObservation(obs.id, now: now);
+  }
+
+  static Set<String>? _chatMessageIds(String selectedInputJson) {
+    try {
+      final decoded = jsonDecode(selectedInputJson);
+      if (decoded is! Map || decoded['chatHistory'] is! List) return null;
+      final result = <String>{};
+      for (final message in decoded['chatHistory'] as List) {
+        if (message is! Map || message['messageId'] is! String) return null;
+        result.add(message['messageId'] as String);
+      }
+      return result;
+    } catch (_) {
+      return null;
     }
   }
 
@@ -454,6 +465,7 @@ class AutomatedCardEvolutionService {
       final observations = decoded['observations'];
       if (observations is! List) return null;
       final result = <_ParsedObservationAction>[];
+      final scopes = <String>{};
       for (final raw in observations) {
         if (raw is! Map) return null;
         final action = raw['action'];
@@ -461,11 +473,17 @@ class AutomatedCardEvolutionService {
         final observedChange = raw['observedChange'];
         final confidence = raw['confidence'];
         if (action is! String ||
-            !const {'confirm', 'new', 'expire'}.contains(action) ||
+            !const {
+              'confirm',
+              'new',
+              'no_evidence',
+              'contradict',
+            }.contains(action) ||
             scopeKey is! String ||
             scopeKey.isEmpty ||
-            observedChange is! String ||
-            observedChange.isEmpty) {
+            !scopes.add(scopeKey) ||
+            (action == 'new' &&
+                (observedChange is! String || observedChange.isEmpty))) {
           return null;
         }
         final conf = confidence is num ? confidence.toDouble() : 0.5;
@@ -475,14 +493,20 @@ class AutomatedCardEvolutionService {
             ? 1.0
             : conf;
         final evidenceRaw = raw['evidenceMessageIds'];
-        final evidence = evidenceRaw is List
-            ? [for (final item in evidenceRaw) item.toString()]
-            : const <String>[];
+        if (evidenceRaw is! List ||
+            evidenceRaw.any((item) => item is! String)) {
+          return null;
+        }
+        final evidence = <String>[];
+        for (final item in evidenceRaw.cast<String>()) {
+          if (item.isNotEmpty && !evidence.contains(item)) evidence.add(item);
+        }
+        if (action != 'no_evidence' && evidence.isEmpty) return null;
         result.add(
           _ParsedObservationAction(
             action: action,
             scopeKey: scopeKey,
-            observedChange: observedChange,
+            observedChange: observedChange is String ? observedChange : '',
             canonicalClaim: raw['canonicalClaim'] is String
                 ? raw['canonicalClaim'] as String
                 : null,

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -18,6 +18,8 @@ import 'manual_rewrite_service.dart';
 
 const _writerMaxTokens = 20000;
 
+enum AutomatedCardEvolutionStage { observation, cardRewriter }
+
 /// Dedicated review-only automation lane. Claim and final commit are repository
 /// operations; the only work between them is shared-context prompt assembly and
 /// two bounded, cancellable writer calls.
@@ -51,19 +53,26 @@ class AutomatedCardEvolutionService {
   final Map<String, CancelToken> _tokens = {};
   final Map<String, Future<CardEvolutionFinalizeOutcome>> _inFlight = {};
 
-  Future<CardEvolutionFinalizeOutcome> runOneBatch(String sessionId) {
+  Future<CardEvolutionFinalizeOutcome> runOneBatch(
+    String sessionId, {
+    void Function(AutomatedCardEvolutionStage stage)? onStage,
+  }) {
     if (isEnabled?.call() == false) {
       return Future.value(const CardEvolutionFinalizeOutcome('disabled'));
     }
     final active = _inFlight[sessionId];
     if (active != null) return active;
-    final future = _run(sessionId);
+    final future = _run(sessionId, onStage: onStage);
     _inFlight[sessionId] = future;
     return future.whenComplete(() => _inFlight.remove(sessionId));
   }
 
-  Future<CardEvolutionFinalizeOutcome> _run(String sessionId) async {
-    await _maybeRunObservationPass(sessionId);
+  Future<CardEvolutionFinalizeOutcome> _run(
+    String sessionId, {
+    void Function(AutomatedCardEvolutionStage stage)? onStage,
+  }) async {
+    await _maybeRunObservationPass(sessionId, onStage: onStage);
+    onStage?.call(AutomatedCardEvolutionStage.cardRewriter);
     final owner = 'evolution-owner-${generateId()}';
     final now = currentTimestampSeconds();
     final claimed = await repo.claim(
@@ -256,11 +265,15 @@ class AutomatedCardEvolutionService {
   /// Runs the observation pass when the cadence gate is active (every 2nd
   /// successful reconciliation). Failures are non-blocking: the card writer
   /// continues without validated targets.
-  Future<void> _maybeRunObservationPass(String sessionId) async {
+  Future<void> _maybeRunObservationPass(
+    String sessionId, {
+    void Function(AutomatedCardEvolutionStage stage)? onStage,
+  }) async {
     try {
       final count = await repo.countSuccessfulReconciliations(sessionId);
       if (count == 0 || count % 2 != 0) return;
       final runOrdinal = count ~/ 2;
+      onStage?.call(AutomatedCardEvolutionStage.observation);
       await _runObservationPass(sessionId, runOrdinal);
       await _checkPromotionsAndExpiry(sessionId, runOrdinal);
     } catch (_) {

--- a/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
+++ b/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
@@ -175,23 +175,39 @@ abstract final class CardRewriterPromptBuilder {
       ..writeln('# Actions')
       ..writeln('For each existing observation, choose:')
       ..writeln(
-        '- "confirm": the latest chat history still supports this change. '
-        'Update confidence.',
+        '- "confirm": a causally independent new opportunity in supplied chat '
+        'supports this change. Include its message IDs and update confidence.',
       )
       ..writeln(
-        '- "expire": the latest chat history contradicts or no longer supports '
-        'this change.',
+        '- "no_evidence": there is no new independent support. Absence of the '
+        'character or behavior is no_evidence and changes nothing.',
+      )
+      ..writeln(
+        '- "contradict": supplied chat contains explicit incompatible evidence. '
+        'Include its message IDs. Mere absence or lack of support is never a '
+        'contradiction.',
       )
       ..writeln('For new observations, choose:')
       ..writeln(
         '- "new": a new candidate durable change is evident from the chat '
-        'history.',
+        'history. Include the supporting supplied message IDs.',
+      )
+      ..writeln(
+        'Every new/confirm evidence set must be one causally independent cluster '
+        'or new opportunity, not a continuation of the same moment. Overlapping '
+        'windows or messages cannot reconfirm. One day may contain multiple '
+        'independent clusters, while 200 messages may remain one cluster when '
+        'they belong to the same causal moment.',
+      )
+      ..writeln(
+        'Use only message IDs present in the supplied immutable chat history. '
+        'Never fabricate IDs.',
       )
       ..writeln()
       ..writeln('# Response format')
       ..writeln(
         'Respond with exactly one JSON object and nothing else: '
-        '{"observations":[{"action":"confirm|new|expire","scopeKey":"...",'
+        '{"observations":[{"action":"new|confirm|no_evidence|contradict","scopeKey":"...",'
         '"observedChange":"...","canonicalClaim":"...",'
         '"evidenceMessageIds":[],"cardFieldPath":"personality"|null,'
         '"lorebookEntryId":"bookId:entryId"|null,"confidence":0.0-1.0}]}.',
@@ -199,7 +215,7 @@ abstract final class CardRewriterPromptBuilder {
       ..writeln(
         'Return an empty "observations" list ONLY when the chat history '
         'contains no new durable changes and no existing observation needs '
-        'confirmation or expiry.',
+        'confirmation or explicit contradiction.',
       )
       ..writeln()
       ..writeln('# Instruction')

--- a/lib/core/state/card_rewriter_providers.dart
+++ b/lib/core/state/card_rewriter_providers.dart
@@ -61,11 +61,23 @@ final automatedCardEvolutionServiceProvider =
         resolveModel: resolveModel,
         isEnabled: () =>
             ref.read(pipelineSettingsProvider).cardRewriter.enabled,
-        isLorebookEvolutionEnabled: () =>
-            ref.read(pipelineSettingsProvider)
-                .cardRewriter
-                .lorebookEvolutionEnabled,
+        isLorebookEvolutionEnabled: () => ref
+            .read(pipelineSettingsProvider)
+            .cardRewriter
+            .lorebookEvolutionEnabled,
         timeoutMs: settings.timeoutMs,
+        observationPromotionThreshold: () => ref
+            .read(pipelineSettingsProvider)
+            .cardRewriter
+            .observationPromotionThreshold,
+        observationMinConfidence: () => ref
+            .read(pipelineSettingsProvider)
+            .cardRewriter
+            .observationMinConfidence,
+        observationExpiryRuns: () => ref
+            .read(pipelineSettingsProvider)
+            .cardRewriter
+            .observationExpiryRuns,
         executor:
             ({
               required config,

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -11,6 +11,7 @@ import '../../../../core/llm/studio_turn_config_snapshot.dart';
 import '../../../../core/models/agent_operation_record.dart';
 import '../../../../core/models/chat_message.dart';
 import '../../../../core/models/pipeline_settings.dart';
+import '../../../../core/services/card_rewriter/automated_card_evolution_service.dart';
 import '../../../../core/state/db_provider.dart';
 import '../../../../core/state/memory_agent_providers.dart';
 import '../../../../core/state/character_provider.dart';
@@ -249,16 +250,57 @@ class LedgerStage {
             // (plan §Automated Card Evolution cadence). Counting via the run
             // repo head ordinal keeps the cadence durable across rerolls and
             // app restarts; the single-row checkpoint cannot do this.
-            final runHead = await ctx
-                .ref
+            final runHead = await ctx.ref
                 .read(ledgerReconciliationRunRepoProvider)
                 .getHead(sessionId);
-            if (runHead != null &&
-                runHead.ordinal % 2 == 0 &&
-                isCurrent()) {
-              await ctx.ref
+            if (runHead != null && runHead.ordinal % 2 == 0 && isCurrent()) {
+              final rewriteOutcome = await ctx.ref
                   .read(automatedCardEvolutionServiceProvider)
-                  .runOneBatch(sessionId);
+                  .runOneBatch(
+                    sessionId,
+                    onStage: (stage) {
+                      if (!ctx.ref.mounted || !isCurrent()) return;
+                      ctx.ref
+                          .read(postGenStatusProvider.notifier)
+                          .state = PostGenStatusState.running(
+                        sessionId: sessionId,
+                        task: stage == AutomatedCardEvolutionStage.observation
+                            ? PostGenTask.cardEvolutionObservation
+                            : PostGenTask.cardRewriter,
+                      );
+                    },
+                  );
+              if (ctx.ref.mounted && isCurrent()) {
+                final isFailure = const {
+                  'modelNotConfigured',
+                  'cardModelFailed',
+                  'lorebookModelFailed',
+                  'invalidCardOutput',
+                  'invalidLorebookOutput',
+                  'snapshotUnavailable',
+                  'staleEvidence',
+                  'canonUnavailable',
+                  'fieldMismatch',
+                  'unexpectedFailure',
+                }.contains(rewriteOutcome.kind);
+                final detail = rewriteOutcome.kind == 'persisted'
+                    ? 'Card Rewriter created a review proposal'
+                    : rewriteOutcome.kind == 'emptyModelProposal'
+                    ? 'Card Rewriter found no durable card changes'
+                    : 'Card Rewriter: ${rewriteOutcome.kind}'
+                          '${rewriteOutcome.detail == null ? '' : ' — ${rewriteOutcome.detail}'}';
+                ctx.ref.read(postGenStatusProvider.notifier).state = isFailure
+                    ? PostGenStatusState.error(
+                        sessionId: sessionId,
+                        task: PostGenTask.cardRewriter,
+                        detail: detail,
+                      )
+                    : PostGenStatusState.done(
+                        sessionId: sessionId,
+                        task: PostGenTask.cardRewriter,
+                        detail: detail,
+                      );
+              }
               if (!isCurrent()) return;
             }
           }

--- a/lib/features/chat/state/post_gen_status_provider.dart
+++ b/lib/features/chat/state/post_gen_status_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/legacy.dart';
 
-/// Live state for post-generation tasks (Ledger and extension blocks).
+/// Live state for post-generation tasks (Ledger, Card Rewriter, and extension
+/// blocks).
 /// Surfaced to the chat UI as a floating card so the user can see what's
 /// happening after the main generation + cleaner complete.
 class PostGenStatusState {
@@ -45,7 +46,14 @@ class PostGenStatusState {
   }) : phase = PostGenTaskPhase.error;
 }
 
-enum PostGenTask { none, ledgerReconciliation, ledger, extBlocks }
+enum PostGenTask {
+  none,
+  ledgerReconciliation,
+  cardEvolutionObservation,
+  cardRewriter,
+  ledger,
+  extBlocks,
+}
 
 enum PostGenTaskPhase { idle, running, done, error }
 

--- a/lib/features/chat/widgets/post_gen_status_card.dart
+++ b/lib/features/chat/widgets/post_gen_status_card.dart
@@ -5,7 +5,8 @@ import '../state/post_gen_status_provider.dart';
 import 'chat_status_card_shell.dart';
 
 /// Floating card shown at the top of the chat while post-generation tasks
-/// (Ledger and extension blocks) are running. Auto-dismisses 2.5s after
+/// (Ledger, Card Rewriter, and extension blocks) are running. Auto-dismisses
+/// 2.5s after
 /// the last task completes.
 class PostGenStatusCard extends ConsumerStatefulWidget {
   const PostGenStatusCard({super.key, required this.sessionId});
@@ -83,6 +84,40 @@ class _PostGenStatusCardState extends ConsumerState<PostGenStatusCard> {
           showSpinner = false;
         } else {
           label = state.detail ?? 'Ledger failed';
+          icon = Icons.error_outline;
+          accent = Colors.redAccent;
+          showSpinner = false;
+        }
+      case PostGenTask.cardEvolutionObservation:
+        if (state.phase == PostGenTaskPhase.running) {
+          label = 'Card evolution observations running...';
+          icon = Icons.manage_search_outlined;
+          accent = cs.primary;
+          showSpinner = true;
+        } else if (state.phase == PostGenTaskPhase.done) {
+          label = state.detail ?? 'Card evolution observations done';
+          icon = Icons.check_circle_outline;
+          accent = Colors.green;
+          showSpinner = false;
+        } else {
+          label = state.detail ?? 'Card evolution observations failed';
+          icon = Icons.error_outline;
+          accent = Colors.redAccent;
+          showSpinner = false;
+        }
+      case PostGenTask.cardRewriter:
+        if (state.phase == PostGenTaskPhase.running) {
+          label = 'Card Rewriter running...';
+          icon = Icons.auto_fix_high_outlined;
+          accent = cs.primary;
+          showSpinner = true;
+        } else if (state.phase == PostGenTaskPhase.done) {
+          label = state.detail ?? 'Card Rewriter done';
+          icon = Icons.check_circle_outline;
+          accent = Colors.green;
+          showSpinner = false;
+        } else {
+          label = state.detail ?? 'Card Rewriter failed';
           icon = Icons.error_outline;
           accent = Colors.redAccent;
           showSpinner = false;

--- a/test/card_evolution_observation_repo_test.dart
+++ b/test/card_evolution_observation_repo_test.dart
@@ -25,6 +25,9 @@ void main() {
     expect(found.repeatCount, 1);
     expect(found.lastConfirmedRun, isNull);
     expect(found.evidenceMessageIds, ['msg:1', 'msg:2']);
+    expect(found.evidenceClusters, [
+      ['msg:1', 'msg:2'],
+    ]);
   });
 
   test('confirm bumps repeat count and last confirmed run', () async {
@@ -34,6 +37,7 @@ void main() {
       runOrdinal: 2,
       confidence: 0.8,
       now: 20,
+      evidenceMessageIds: const ['msg:3', 'msg:4'],
     );
     final found = await repo.findByScopeKey(
       'session',
@@ -43,7 +47,59 @@ void main() {
     expect(found.lastConfirmedRun, 2);
     expect(found.confidence, 0.8);
     expect(found.updatedAt, 20);
+    expect(found.evidenceClusters, [
+      ['msg:1', 'msg:2'],
+      ['msg:3', 'msg:4'],
+    ]);
   });
+
+  test(
+    'confirm is idempotent for duplicate, overlap, empty, and same run',
+    () async {
+      await repo.insertObservation(_observation());
+      expect(
+        await repo.confirmObservation(
+          id: 'obs-1',
+          runOrdinal: 2,
+          confidence: 0.8,
+          now: 20,
+          evidenceMessageIds: const ['msg:2', 'msg:1'],
+        ),
+        ObservationConfirmationOutcome.duplicate,
+      );
+      expect(
+        await repo.confirmObservation(
+          id: 'obs-1',
+          runOrdinal: 2,
+          confidence: 0.8,
+          now: 20,
+          evidenceMessageIds: const ['msg:2', 'msg:3'],
+        ),
+        ObservationConfirmationOutcome.overlap,
+      );
+      expect(
+        await repo.confirmObservation(
+          id: 'obs-1',
+          runOrdinal: 2,
+          confidence: 0.8,
+          now: 20,
+          evidenceMessageIds: const [],
+        ),
+        ObservationConfirmationOutcome.noEvidence,
+      );
+      expect(
+        await repo.confirmObservation(
+          id: 'obs-1',
+          runOrdinal: 1,
+          confidence: 0.8,
+          now: 20,
+          evidenceMessageIds: const ['msg:3'],
+        ),
+        ObservationConfirmationOutcome.sameRun,
+      );
+      expect((await repo.findById('obs-1'))!.repeatCount, 1);
+    },
+  );
 
   test('promote flips status and excludes from active', () async {
     await repo.insertObservation(_observation());
@@ -54,9 +110,9 @@ void main() {
     expect(promoted.first.status, 'promoted');
   });
 
-  test('expire flips status and excludes from active', () async {
+  test('explicit contradiction expires and excludes from active', () async {
     await repo.insertObservation(_observation());
-    await repo.expireObservation('obs-1', now: 20);
+    await repo.contradictObservation('obs-1', now: 20);
     expect(await repo.getActiveObservations('session'), isEmpty);
   });
 
@@ -86,24 +142,6 @@ void main() {
     expect(promotable.first.id, 'obs-2');
   });
 
-  test('getExpiryCandidates filters by last confirmed run gap', () async {
-    await repo.insertObservation(_observation(lastConfirmedRun: 1));
-    await repo.insertObservation(
-      _observation(
-        id: 'obs-2',
-        scopeKey: 'character.attitude.Y',
-        lastConfirmedRun: 5,
-      ),
-    );
-    final expired = await repo.getExpiryCandidates(
-      'session',
-      currentRunOrdinal: 6,
-      expiryRuns: 4,
-    );
-    expect(expired, hasLength(1));
-    expect(expired.first.id, 'obs-1');
-  });
-
   test('unique key collision on insert throws', () async {
     await repo.insertObservation(_observation());
     await expectLater(
@@ -127,7 +165,9 @@ CardEvolutionObservation _observation({
   semanticScopeKey: scopeKey,
   observedChange: 'Alice is becoming more trusting',
   canonicalClaim: 'Alice has become more trusting over time',
-  evidenceMessageIds: const ['msg:1', 'msg:2'],
+  evidenceClusters: const [
+    ['msg:1', 'msg:2'],
+  ],
   cardFieldPath: 'personality',
   confidence: confidence,
   status: 'active',

--- a/test/card_evolution_observation_test.dart
+++ b/test/card_evolution_observation_test.dart
@@ -13,7 +13,10 @@ void main() {
       semanticScopeKey: 'character.preference.X',
       observedChange: 'Alice is becoming more trusting',
       canonicalClaim: 'Alice has become more trusting over time',
-      evidenceMessageIds: const ['msg:1', 'msg:2', 'msg:3'],
+      evidenceClusters: const [
+        ['msg:1', 'msg:2'],
+        ['msg:3'],
+      ],
       cardFieldPath: 'personality',
       lorebookEntryId: 'book:entry',
       confidence: 0.85,
@@ -39,7 +42,7 @@ void main() {
       runOrdinal: 1,
       semanticScopeKey: 'character.attitude.Y',
       observedChange: 'Bob is more reserved',
-      evidenceMessageIds: const [],
+      evidenceClusters: const [],
       confidence: 0.5,
       status: 'active',
       firstSeenRun: 1,
@@ -56,5 +59,6 @@ void main() {
     expect(restored.lorebookEntryId, isNull);
     expect(restored.lastConfirmedRun, isNull);
     expect(restored.repeatCount, 1);
+    expect(restored.evidenceMessageIds, isEmpty);
   });
 }

--- a/test/card_evolution_repo_test.dart
+++ b/test/card_evolution_repo_test.dart
@@ -79,12 +79,18 @@ void main() {
     );
 
     expect(claim.kind, 'claimed');
+    expect(
+      (jsonDecode(claim.claim!.selectedInputJson) as Map)['contractVersion'],
+      8,
+    );
     expect(claim.claim!.selectedInputJson, contains('assistant development'));
     expect(claim.claim!.selectedInputJson, contains('user response'));
     expect(claim.claim!.selectedInputJson, contains('"effectiveCanon"'));
-    expect(await db.select(db.ledgerReconciliationSuccessfulRuns).get(), isEmpty);
+    expect(
+      await db.select(db.ledgerReconciliationSuccessfulRuns).get(),
+      isEmpty,
+    );
   });
-
 
   test('a changed chat snapshot makes a claimed lease stale', () async {
     final claim = (await evolution.claim(
@@ -95,7 +101,10 @@ void main() {
     )).claim!;
     await db.customStatement(
       'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
-      [jsonEncode([..._messages, _nextAssistant, _nextUser]), 'session'],
+      [
+        jsonEncode([..._messages, _nextAssistant, _nextUser]),
+        'session',
+      ],
     );
 
     expect(
@@ -117,7 +126,10 @@ void main() {
     )).claim!;
     await db.customStatement(
       'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
-      [jsonEncode([..._messages, _nextAssistant, _nextUser]), 'session'],
+      [
+        jsonEncode([..._messages, _nextAssistant, _nextUser]),
+        'session',
+      ],
     );
 
     final recovered = await evolution.claim(
@@ -130,33 +142,45 @@ void main() {
     expect(recovered.kind, 'claimed');
     expect(recovered.claim!.row.id, isNot(first.row.id));
     expect(recovered.claim!.row.ownerId, 'new-app-owner');
-    expect(recovered.claim!.selectedInputJson, contains('new assistant development'));
     expect(
-      await (db.select(db.cardEvolutionClaims)
-            ..where((row) => row.id.equals(first.row.id)))
-          .getSingleOrNull(),
+      recovered.claim!.selectedInputJson,
+      contains('new assistant development'),
+    );
+    expect(
+      await (db.select(
+        db.cardEvolutionClaims,
+      )..where((row) => row.id.equals(first.row.id))).getSingleOrNull(),
       isNull,
     );
   });
 
-  test('excludes a trailing mutable user-assistant turn from evidence', () async {
-    await db.customStatement(
-      'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
-      [jsonEncode([..._messages, _nextAssistant]), 'session'],
-    );
+  test(
+    'excludes a trailing mutable user-assistant turn from evidence',
+    () async {
+      await db.customStatement(
+        'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
+        [
+          jsonEncode([..._messages, _nextAssistant]),
+          'session',
+        ],
+      );
 
-    final claim = await evolution.claim(
-      sessionId: 'session',
-      ownerId: 'owner',
-      now: 10,
-      leaseSeconds: 30,
-    );
+      final claim = await evolution.claim(
+        sessionId: 'session',
+        ownerId: 'owner',
+        now: 10,
+        leaseSeconds: 30,
+      );
 
-    expect(claim.kind, 'claimed');
-    expect(claim.claim!.selectedInputJson, isNot(contains('new assistant development')));
-    expect(claim.claim!.selectedInputJson, isNot(contains('user response')));
-    expect(claim.claim!.selectedInputJson, contains('assistant development'));
-  });
+      expect(claim.kind, 'claimed');
+      expect(
+        claim.claim!.selectedInputJson,
+        isNot(contains('new assistant development')),
+      );
+      expect(claim.claim!.selectedInputJson, isNot(contains('user response')));
+      expect(claim.claim!.selectedInputJson, contains('assistant development'));
+    },
+  );
 
   test('finalize atomically writes a three-field review proposal', () async {
     final claim = (await evolution.claim(
@@ -274,11 +298,7 @@ const _nextAssistant = {
   'content': 'new assistant development',
 };
 
-const _nextUser = {
-  'id': 'u3',
-  'role': 'user',
-  'content': 'next user response',
-};
+const _nextUser = {'id': 'u3', 'role': 'user', 'content': 'next user response'};
 
 List<CardRewriteOperationSnapshot> _operations() => [
   _operation(

--- a/test/card_rewrite_observation_pass_test.dart
+++ b/test/card_rewrite_observation_pass_test.dart
@@ -98,7 +98,9 @@ void main() {
           semanticScopeKey: 'character.preference.trust',
           observedChange: 'Alice is consistently more trusting',
           canonicalClaim: 'Alice has become more trusting',
-          evidenceMessageIds: const ['a1', 'u1'],
+          evidenceClusters: const [
+            ['a1', 'u1'],
+          ],
           cardFieldPath: 'personality',
           confidence: 0.9,
           status: 'promoted',
@@ -135,17 +137,20 @@ void main() {
         id: 'obs-1',
         sessionId: 'session',
         characterId: 'character',
-        runOrdinal: 1,
+        runOrdinal: 0,
         semanticScopeKey: 'character.preference.trust',
         observedChange: 'Alice is becoming more trusting',
         canonicalClaim: 'Alice has become more trusting',
-        evidenceMessageIds: const ['a1'],
+        evidenceClusters: const [
+          ['a1'],
+          ['u1'],
+        ],
         cardFieldPath: 'personality',
         confidence: 0.8,
         status: 'active',
         firstSeenRun: 1,
         repeatCount: 2,
-        lastConfirmedRun: 1,
+        lastConfirmedRun: 0,
         createdAt: 10,
         updatedAt: 10,
       ),
@@ -175,7 +180,9 @@ void main() {
         runOrdinal: 1,
         semanticScopeKey: 'character.preference.trust',
         observedChange: 'Alice is consistently more trusting',
-        evidenceMessageIds: const ['a1'],
+        evidenceClusters: const [
+          ['a1'],
+        ],
         confidence: 0.9,
         status: 'promoted',
         firstSeenRun: 1,
@@ -216,7 +223,7 @@ void main() {
     );
   });
 
-  test('expiry after runs without confirmation', () async {
+  test('no evidence does not expire or otherwise mutate observation', () async {
     await fixture.seedReconciliationRun(ordinal: 1);
     await fixture.seedReconciliationRun(ordinal: 2);
     await fixture.observationRepo.insertObservation(
@@ -227,7 +234,9 @@ void main() {
         runOrdinal: 1,
         semanticScopeKey: 'character.preference.trust',
         observedChange: 'Alice is becoming more trusting',
-        evidenceMessageIds: const ['a1'],
+        evidenceClusters: const [
+          ['a1'],
+        ],
         confidence: 0.6,
         status: 'active',
         firstSeenRun: 1,
@@ -239,16 +248,144 @@ void main() {
     );
     await fixture
         .service(
-          (_, _) async => _ok(fixture.cardBatchOutput),
-          observationExpiryRuns: () => 4,
+          (_, prompt) async => _ok(
+            prompt.contains('observation journal keeper')
+                ? jsonEncode({
+                    'observations': [
+                      {
+                        'action': 'no_evidence',
+                        'scopeKey': 'character.preference.trust',
+                        'evidenceMessageIds': <String>[],
+                        'confidence': 0.6,
+                      },
+                    ],
+                  })
+                : fixture.cardBatchOutput,
+          ),
         )
         .runOneBatch('session');
-    // runOrdinal = 2~/2 = 1. 1 - 1 = 0 < 4, so NOT expired yet.
     final active = await fixture.observationRepo.getActiveObservations(
       'session',
     );
     expect(active, hasLength(1));
+    expect(active.single.updatedAt, 10);
   });
+
+  test(
+    'explicit contradiction with valid evidence expires observation',
+    () async {
+      await fixture.seedReconciliationRun(ordinal: 1);
+      await fixture.seedReconciliationRun(ordinal: 2);
+      await fixture.observationRepo.insertObservation(
+        CardEvolutionObservation(
+          id: 'obs-contradicted',
+          sessionId: 'session',
+          characterId: 'character',
+          runOrdinal: 0,
+          semanticScopeKey: 'character.preference.trust',
+          observedChange: 'Alice is becoming more trusting',
+          evidenceClusters: const [
+            ['a1'],
+          ],
+          confidence: 0.7,
+          status: 'active',
+          firstSeenRun: 1,
+          createdAt: 10,
+          updatedAt: 10,
+        ),
+      );
+      await fixture
+          .service((_, prompt) async {
+            if (prompt.contains('observation journal keeper')) {
+              return _ok(
+                jsonEncode({
+                  'observations': [
+                    {
+                      'action': 'contradict',
+                      'scopeKey': 'character.preference.trust',
+                      'evidenceMessageIds': ['a2'],
+                      'confidence': 0.2,
+                    },
+                  ],
+                }),
+              );
+            }
+            return _ok(fixture.cardBatchOutput);
+          })
+          .runOneBatch('session');
+      expect(
+        (await fixture.observationRepo.findById('obs-contradicted'))!.status,
+        'expired',
+      );
+    },
+  );
+
+  test('fabricated evidence IDs cannot create observations', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
+    await fixture.seedReconciliationRun(ordinal: 2);
+    await fixture
+        .service((_, prompt) async {
+          if (prompt.contains('observation journal keeper')) {
+            return _ok(
+              jsonEncode({
+                'observations': [
+                  {
+                    'action': 'new',
+                    'scopeKey': 'character.preference.fabricated',
+                    'observedChange': 'Fabricated change',
+                    'evidenceMessageIds': ['not-in-chat'],
+                    'confidence': 0.9,
+                  },
+                ],
+              }),
+            );
+          }
+          return _ok(fixture.cardBatchOutput);
+        })
+        .runOneBatch('session');
+    expect(
+      await fixture.observationRepo.getActiveObservations('session'),
+      isEmpty,
+    );
+  });
+
+  test(
+    'duplicate scopes and non-string evidence reject the whole output',
+    () async {
+      await fixture.seedReconciliationRun(ordinal: 1);
+      await fixture.seedReconciliationRun(ordinal: 2);
+      await fixture
+          .service((_, prompt) async {
+            if (prompt.contains('observation journal keeper')) {
+              return _ok(
+                jsonEncode({
+                  'observations': [
+                    {
+                      'action': 'new',
+                      'scopeKey': 'character.preference.trust',
+                      'observedChange': 'First',
+                      'evidenceMessageIds': ['a1'],
+                      'confidence': 0.8,
+                    },
+                    {
+                      'action': 'confirm',
+                      'scopeKey': 'character.preference.trust',
+                      'evidenceMessageIds': [1],
+                      'confidence': 0.8,
+                    },
+                  ],
+                }),
+              );
+            }
+            return _ok(fixture.cardBatchOutput);
+          })
+          .runOneBatch('session');
+      expect(
+        await fixture.observationRepo.getActiveObservations('session'),
+        isEmpty,
+      );
+    },
+  );
 }
 
 AuxCallOutcome _ok(String text) =>
@@ -384,6 +521,7 @@ final class _Fixture {
         'scopeKey': 'character.preference.trust',
         'observedChange': 'Alice is becoming more trusting',
         'confidence': 0.85,
+        'evidenceMessageIds': ['a2', 'u2'],
       },
     ],
   });

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -78,7 +78,7 @@ void main() {
 
       // user_version matches the Drift schema version (app_db.dart schemaVersion).
       // Update this constant whenever a new migration step is added.
-      expect(version, 112);
+      expect(version, 113);
     });
 
     test(
@@ -232,7 +232,7 @@ void main() {
         final version = await upgraded
             .customSelect('PRAGMA user_version')
             .get();
-        expect(version.first.read<int>('user_version'), 112);
+        expect(version.first.read<int>('user_version'), 113);
         expect(names, contains('variant_group_id'));
         expect(names, contains('hidden'));
       },
@@ -262,7 +262,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
     });
 
     test(
@@ -611,7 +611,7 @@ void main() {
 
     test('current schema includes atomic character fact tables', () async {
       final version = await db.customSelect('PRAGMA user_version').getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
 
       final factColumns = await db
           .customSelect("PRAGMA table_info('character_knowledge_fact_rows')")
@@ -723,7 +723,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
     });
 
     test(
@@ -833,7 +833,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
     });
 
     test('v80 adds Responses API toggle defaulting to off', () async {
@@ -873,7 +873,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
     });
 
     test('v81 adds composite embedding source index', () async {
@@ -907,7 +907,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
     });
 
     test('v82 creates rewrite persistence schema and provenance columns', () async {
@@ -981,7 +981,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
     });
 
     test('v83 rebuilds interim text revision columns without losing rows', () async {
@@ -1418,7 +1418,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
 
       // Rows and payloads survive; legacy statuses pass through or are
       // normalized fail-closed, and new columns carry neutral defaults.
@@ -1623,7 +1623,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
       final row = await upgraded
           .customSelect(
             'SELECT blocks_json FROM studio_preset_rows WHERE preset_id = ?',
@@ -1739,7 +1739,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
       final check = await upgraded.customSelect('PRAGMA integrity_check').get();
       expect(check.single.read<String>('integrity_check'), 'ok');
     });
@@ -2320,7 +2320,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 112);
+      expect(version.read<int>('user_version'), 113);
     });
 
     test(
@@ -2348,72 +2348,69 @@ void main() {
       },
     );
 
-    test(
-      'v109 splits the Responses API opt-in into its own protocol and v110 '
-      'adds the system-instruction toggle',
-      () async {
-        final file = File(
-          '${Directory.systemTemp.path}/glaze_mig_sys_instruction_${DateTime.now().microsecondsSinceEpoch}.db',
-        );
-        addTearDown(() async {
-          if (file.existsSync()) await file.delete();
-        });
+    test('v109 splits the Responses API opt-in into its own protocol and v110 '
+        'adds the system-instruction toggle', () async {
+      final file = File(
+        '${Directory.systemTemp.path}/glaze_mig_sys_instruction_${DateTime.now().microsecondsSinceEpoch}.db',
+      );
+      addTearDown(() async {
+        if (file.existsSync()) await file.delete();
+      });
 
-        final seeded = AppDatabase.forTesting(
-          NativeDatabase.createInBackground(file),
-        );
-        await seeded.customSelect('SELECT 1').get();
-        await seeded.customStatement(
-          'INSERT INTO api_configs (config_id, name, protocol, '
-          'use_responses_api) VALUES (?, ?, ?, ?)',
-          ['chat', 'Chat Completions', 'openai', 0],
-        );
-        await seeded.customStatement(
-          'INSERT INTO api_configs (config_id, name, protocol, '
-          'use_responses_api) VALUES (?, ?, ?, ?)',
-          ['responses', 'Responses', 'openai', 1],
-        );
-        await seeded.customStatement(
-          'INSERT INTO api_configs (config_id, name, protocol, '
-          'use_responses_api) VALUES (?, ?, ?, ?)',
-          ['gemini', 'Gemini', 'gemini', 1],
-        );
-        await seeded.customStatement(
-          'ALTER TABLE api_configs DROP COLUMN use_system_instruction',
-        );
-        await seeded.customStatement('PRAGMA user_version = 108');
-        await seeded.close();
+      final seeded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      await seeded.customSelect('SELECT 1').get();
+      await seeded.customStatement(
+        'INSERT INTO api_configs (config_id, name, protocol, '
+        'use_responses_api) VALUES (?, ?, ?, ?)',
+        ['chat', 'Chat Completions', 'openai', 0],
+      );
+      await seeded.customStatement(
+        'INSERT INTO api_configs (config_id, name, protocol, '
+        'use_responses_api) VALUES (?, ?, ?, ?)',
+        ['responses', 'Responses', 'openai', 1],
+      );
+      await seeded.customStatement(
+        'INSERT INTO api_configs (config_id, name, protocol, '
+        'use_responses_api) VALUES (?, ?, ?, ?)',
+        ['gemini', 'Gemini', 'gemini', 1],
+      );
+      await seeded.customStatement(
+        'ALTER TABLE api_configs DROP COLUMN use_system_instruction',
+      );
+      await seeded.customStatement('PRAGMA user_version = 108');
+      await seeded.close();
 
-        final upgraded = AppDatabase.forTesting(
-          NativeDatabase.createInBackground(file),
-        );
-        addTearDown(() async => upgraded.close());
-        final rows = await upgraded
-            .customSelect(
-              'SELECT config_id, protocol, use_system_instruction '
-              'FROM api_configs ORDER BY config_id',
-            )
-            .get();
-        final byId = {
-          for (final row in rows)
-            row.read<String>('config_id'): row.read<String>('protocol'),
-        };
+      final upgraded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      addTearDown(() async => upgraded.close());
+      final rows = await upgraded
+          .customSelect(
+            'SELECT config_id, protocol, use_system_instruction '
+            'FROM api_configs ORDER BY config_id',
+          )
+          .get();
+      final byId = {
+        for (final row in rows)
+          row.read<String>('config_id'): row.read<String>('protocol'),
+      };
 
-        expect(byId['chat'], 'openai');
-        expect(byId['responses'], 'openai_responses');
-        // Only the OpenAI-compatible protocol carried the opt-in.
-        expect(byId['gemini'], 'gemini');
-        // Existing presets keep today's behaviour: the toggle defaults on.
-        for (final row in rows) {
-          expect(row.read<bool>('use_system_instruction'), isTrue);
-        }
+      expect(byId['chat'], 'openai');
+      expect(byId['responses'], 'openai_responses');
+      // Only the OpenAI-compatible protocol carried the opt-in.
+      expect(byId['gemini'], 'gemini');
+      // Existing presets keep today's behaviour: the toggle defaults on.
+      for (final row in rows) {
+        expect(row.read<bool>('use_system_instruction'), isTrue);
+      }
 
-        final version = await upgraded
-            .customSelect('PRAGMA user_version')
-            .getSingle();
-        expect(version.read<int>('user_version'), 112);
-      },
-    );
+      final version = await upgraded
+          .customSelect('PRAGMA user_version')
+          .getSingle();
+      expect(version.read<int>('user_version'), 113);
+    });
 
     test('v111 resolves the retired session_id_mode default', () async {
       final file = File(
@@ -2503,6 +2500,72 @@ void main() {
 
       // The stored choice survives the rename.
       expect(row.read<bool>('use_system_instruction'), isFalse);
+    });
+
+    test('v113 migrates legacy observation evidence into one cluster', () async {
+      final file = File(
+        '${Directory.systemTemp.path}/glaze_mig_observation_clusters_${DateTime.now().microsecondsSinceEpoch}.db',
+      );
+      addTearDown(() async {
+        if (file.existsSync()) await file.delete();
+      });
+      final seeded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      await seeded.customSelect('SELECT 1').get();
+      await seeded.customStatement(
+        'INSERT INTO card_evolution_observations '
+        '(id, session_id, character_id, run_ordinal, semantic_scope_key, '
+        'observed_change, evidence_message_ids, confidence, status, '
+        'first_seen_run, repeat_count, created_at, updated_at) '
+        'VALUES (?, ?, ?, 1, ?, ?, ?, 0.9, ?, 1, ?, 1, 1)',
+        [
+          'gilda',
+          'session',
+          'gilda-character',
+          'relationship:gilda',
+          'Gilda trusts the user',
+          '["m1","m2","m1",""]',
+          'active',
+          7,
+        ],
+      );
+      await seeded.customStatement(
+        'INSERT INTO card_evolution_observations '
+        '(id, session_id, character_id, run_ordinal, semantic_scope_key, '
+        'observed_change, evidence_message_ids, confidence, status, '
+        'first_seen_run, repeat_count, created_at, updated_at) '
+        "VALUES ('bad', 'session', 'gilda-character', 1, 'bad', 'Bad', "
+        "'not-json', 0.5, 'active', 1, 4, 1, 1)",
+      );
+      await seeded.customStatement(
+        'ALTER TABLE card_evolution_observations '
+        'DROP COLUMN evidence_clusters_json',
+      );
+      await seeded.customStatement('PRAGMA user_version = 112');
+      await seeded.close();
+
+      final upgraded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      addTearDown(() async => upgraded.close());
+      final rows = await upgraded
+          .customSelect(
+            'SELECT id, evidence_message_ids, evidence_clusters_json, repeat_count, '
+            'status FROM card_evolution_observations ORDER BY id',
+          )
+          .get();
+      final gilda = rows.singleWhere(
+        (row) => row.read<String>('id') == 'gilda',
+      );
+      expect(gilda.read<String>('evidence_message_ids'), '["m1","m2"]');
+      expect(gilda.read<String>('evidence_clusters_json'), '[["m1","m2"]]');
+      expect(gilda.read<int>('repeat_count'), 1);
+      expect(gilda.read<String>('status'), 'active');
+      final bad = rows.singleWhere((row) => row.read<String>('id') == 'bad');
+      expect(bad.read<String>('evidence_message_ids'), '[]');
+      expect(bad.read<String>('evidence_clusters_json'), '[]');
+      expect(bad.read<int>('repeat_count'), 1);
     });
   });
 }

--- a/test/post_gen_status_card_test.dart
+++ b/test/post_gen_status_card_test.dart
@@ -52,7 +52,7 @@ void main() {
     );
 
     expect(find.text('Card evolution observations running...'), findsOneWidget);
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byType(GlazeSpinner), findsOneWidget);
   });
 
   testWidgets('shows a distinct Card Rewriter running badge', (tester) async {
@@ -75,6 +75,6 @@ void main() {
     );
 
     expect(find.text('Card Rewriter running...'), findsOneWidget);
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byType(GlazeSpinner), findsOneWidget);
   });
 }

--- a/test/post_gen_status_card_test.dart
+++ b/test/post_gen_status_card_test.dart
@@ -31,4 +31,50 @@ void main() {
     expect(find.text('Ledger reconciliation running...'), findsOneWidget);
     expect(find.byType(GlazeSpinner), findsOneWidget);
   });
+
+  testWidgets('shows the Card evolution observation pass', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container
+        .read(postGenStatusProvider.notifier)
+        .state = const PostGenStatusState.running(
+      sessionId: 'session-1',
+      task: PostGenTask.cardEvolutionObservation,
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: PostGenStatusCard(sessionId: 'session-1')),
+        ),
+      ),
+    );
+
+    expect(find.text('Card evolution observations running...'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('shows a distinct Card Rewriter running badge', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container
+        .read(postGenStatusProvider.notifier)
+        .state = const PostGenStatusState.running(
+      sessionId: 'session-1',
+      task: PostGenTask.cardRewriter,
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: PostGenStatusCard(sessionId: 'session-1')),
+        ),
+      ),
+    );
+
+    expect(find.text('Card Rewriter running...'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- show Card Evolution observation and Card Rewriter post-generation status in chat
- track confirmations as independent, non-overlapping evidence clusters instead of repeated windows
- make missing evidence a no-op and require explicit evidence-backed contradiction to expire observations
- validate evidence IDs against immutable chat input and migrate legacy observations conservatively

## Behavior
- absent characters or unrelated scenes no longer confirm or expire a candidate
- duplicate, reordered, overlapping, empty, fabricated, or same-run evidence cannot increment promotion count
- promotion counts accepted independent causal clusters
- legacy flat evidence migrates into one cluster and unverifiable repeat counts reset to one

## Database
- schema version 112 -> 113
- adds evidence_clusters_json while retaining the flat evidence column for compatibility and audit
- selected-input contract version 7 -> 8

## Tests
- lutter test test/card_evolution_observation_test.dart test/card_evolution_observation_repo_test.dart test/card_rewrite_observation_pass_test.dart test/card_evolution_repo_test.dart (29 passed)
- lutter test test/db_migration_test.dart (43 passed)
- lutter test test/post_gen_status_card_test.dart (3 passed)
- targeted lutter analyze (no issues)
- git diff --check upstream/nightly...HEAD
