### PR TITLE
fix(card-rewriter): allow repeated revision hashes

### DIFF
--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -79,7 +79,7 @@ All schema changes go in `AppDatabase.migration` in `app_db.dart`.
 Bump the schema version and add a `from → to` migration step.
 Never modify existing column types without a migration.
 
-Current version: **106**
+Current version: **114**
 
 Migration history:
 - v18: added `characters.picksHash`
@@ -194,6 +194,11 @@ Migration history:
   `use_system_instruction` — the toggle covers Anthropic's `system` as well as
   Gemini's `system_instruction`. Guarded: runs only on databases that still
   carry the prefixed name (v110/v111 builds of the branch that introduced it).
+- v113: added independent evidence clusters to card evolution observations and
+  migrated legacy evidence into one canonical cluster.
+- v114: rebuilt `character_revision_rows` so revision hashes are non-unique.
+  Returning to earlier card content now appends a valid lineage entry; a
+  non-unique `(character_id, revision_hash)` index retains lookup performance.
 
 ---
 

--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -74,7 +74,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 113;
+  int get schemaVersion => 114;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2103,6 +2103,42 @@ class AppDatabase extends _$AppDatabase {
             ],
           );
         }
+      }
+      if (from < 114) {
+        // A character can legitimately return to an earlier canonical state
+        // (A -> B -> A). Revision numbers identify lineage entries; hashes
+        // identify their content and therefore must not be unique. Rebuilding
+        // removes the old UNIQUE(character_id, revision_hash) auto-index while
+        // preserving rows and creates the non-unique lookup index declared on
+        // the table.
+        await customStatement(
+          'ALTER TABLE character_revision_rows '
+          'RENAME TO character_revision_rows_v113',
+        );
+        await customStatement(
+          'CREATE TABLE character_revision_rows ('
+          'character_id TEXT NOT NULL, '
+          'revision INTEGER NOT NULL, '
+          'revision_hash TEXT NOT NULL, '
+          "parent_revision_hash TEXT NOT NULL DEFAULT '', "
+          'snapshot_json TEXT NOT NULL, '
+          'created_at INTEGER NOT NULL DEFAULT 0, '
+          'PRIMARY KEY (character_id, revision)'
+          ')',
+        );
+        await customStatement(
+          'INSERT INTO character_revision_rows '
+          '(character_id, revision, revision_hash, parent_revision_hash, '
+          'snapshot_json, created_at) '
+          'SELECT character_id, revision, revision_hash, '
+          'parent_revision_hash, snapshot_json, created_at '
+          'FROM character_revision_rows_v113',
+        );
+        await customStatement('DROP TABLE character_revision_rows_v113');
+        await customStatement(
+          'CREATE INDEX idx_character_revision_hash '
+          'ON character_revision_rows (character_id, revision_hash)',
+        );
       }
     },
   );

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -435,6 +435,10 @@ class CharacterKnowledgeFactRows extends Table {
 }
 
 @DataClassName('CharacterRevisionRow')
+@TableIndex(
+  name: 'idx_character_revision_hash',
+  columns: {#characterId, #revisionHash},
+)
 class CharacterRevisionRows extends Table {
   @override
   String get tableName => 'character_revision_rows';
@@ -450,9 +454,6 @@ class CharacterRevisionRows extends Table {
 
   @override
   Set<Column> get primaryKey => {characterId, revision};
-
-  @override
-  List<String> get customConstraints => ['UNIQUE(character_id, revision_hash)'];
 }
 
 @DataClassName('AppliedCanonTransitionRow')

--- a/lib/core/services/card_rewriter/effective_canon_assembler.dart
+++ b/lib/core/services/card_rewriter/effective_canon_assembler.dart
@@ -100,7 +100,11 @@ class EffectiveCanonAssembler {
         'Baseline ${baseline.baselineHash} is not in ${input.sourceCharacter.id} lineage.',
       );
     }
-    final revision = mapped.single;
+    // Hashes identify content, not a unique lineage occurrence. A valid
+    // A -> B -> A history can contain the baseline hash more than once; the
+    // earliest occurrence is the one that originally established this
+    // hash-only legacy baseline.
+    final revision = mapped.first;
     final changed = current.revisionHash != baseline.sourceHashLastSeen;
     if (baseline.cardUpdatePolicy == CharacterCardUpdatePolicy.askOnChange &&
         !changed) {

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -78,7 +78,7 @@ void main() {
 
       // user_version matches the Drift schema version (app_db.dart schemaVersion).
       // Update this constant whenever a new migration step is added.
-      expect(version, 113);
+      expect(version, 114);
     });
 
     test(
@@ -232,7 +232,7 @@ void main() {
         final version = await upgraded
             .customSelect('PRAGMA user_version')
             .get();
-        expect(version.first.read<int>('user_version'), 113);
+        expect(version.first.read<int>('user_version'), 114);
         expect(names, contains('variant_group_id'));
         expect(names, contains('hidden'));
       },
@@ -262,7 +262,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
     });
 
     test(
@@ -611,7 +611,7 @@ void main() {
 
     test('current schema includes atomic character fact tables', () async {
       final version = await db.customSelect('PRAGMA user_version').getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
 
       final factColumns = await db
           .customSelect("PRAGMA table_info('character_knowledge_fact_rows')")
@@ -723,7 +723,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
     });
 
     test(
@@ -833,7 +833,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
     });
 
     test('v80 adds Responses API toggle defaulting to off', () async {
@@ -873,7 +873,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
     });
 
     test('v81 adds composite embedding source index', () async {
@@ -907,7 +907,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
     });
 
     test('v82 creates rewrite persistence schema and provenance columns', () async {
@@ -981,7 +981,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
     });
 
     test('v83 rebuilds interim text revision columns without losing rows', () async {
@@ -1139,9 +1139,24 @@ void main() {
         final revisionIndexes = await db
             .customSelect("PRAGMA index_list('character_revision_rows')")
             .get();
-        expect(
-          revisionIndexes.any((row) => row.read<int>('unique') == 1),
-          isTrue,
+        final hashIndex = revisionIndexes.singleWhere(
+          (row) => row.read<String>('name') == 'idx_character_revision_hash',
+        );
+        expect(hashIndex.read<int>('unique'), 0);
+
+        await db.customStatement(
+          'INSERT INTO character_revision_rows '
+          '(character_id, revision, revision_hash, snapshot_json) '
+          "VALUES ('repeatable', 1, 'same-hash', '{}'), "
+          "('repeatable', 2, 'same-hash', '{}')",
+        );
+        await expectLater(
+          db.customStatement(
+            'INSERT INTO character_revision_rows '
+            '(character_id, revision, revision_hash, snapshot_json) '
+            "VALUES ('repeatable', 2, 'another-hash', '{}')",
+          ),
+          throwsA(anything),
         );
       },
     );
@@ -1418,7 +1433,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
 
       // Rows and payloads survive; legacy statuses pass through or are
       // normalized fail-closed, and new columns carry neutral defaults.
@@ -1623,7 +1638,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
       final row = await upgraded
           .customSelect(
             'SELECT blocks_json FROM studio_preset_rows WHERE preset_id = ?',
@@ -1739,7 +1754,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
       final check = await upgraded.customSelect('PRAGMA integrity_check').get();
       expect(check.single.read<String>('integrity_check'), 'ok');
     });
@@ -2320,7 +2335,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
     });
 
     test(
@@ -2409,7 +2424,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 113);
+      expect(version.read<int>('user_version'), 114);
     });
 
     test('v111 resolves the retired session_id_mode default', () async {
@@ -2566,6 +2581,63 @@ void main() {
       expect(bad.read<String>('evidence_message_ids'), '[]');
       expect(bad.read<String>('evidence_clusters_json'), '[]');
       expect(bad.read<int>('repeat_count'), 1);
+    });
+
+    test('v114 allows a later revision to reuse an earlier hash', () async {
+      final file = File(
+        '${Directory.systemTemp.path}/glaze_mig_revision_hash_${DateTime.now().microsecondsSinceEpoch}.db',
+      );
+      addTearDown(() async {
+        if (file.existsSync()) await file.delete();
+      });
+      final seeded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      await seeded.customSelect('SELECT 1').get();
+      await seeded.customStatement('DROP INDEX idx_character_revision_hash');
+      await seeded.customStatement(
+        'CREATE UNIQUE INDEX character_revision_rows_character_id_revision_hash '
+        'ON character_revision_rows (character_id, revision_hash)',
+      );
+      await seeded.customStatement(
+        'INSERT INTO character_revision_rows '
+        '(character_id, revision, revision_hash, parent_revision_hash, snapshot_json) '
+        "VALUES ('c', 1, 'hash-a', '', '{\"description\":\"a\"}'), "
+        "('c', 2, 'hash-b', 'hash-a', '{\"description\":\"b\"}')",
+      );
+      await seeded.customStatement('PRAGMA user_version = 113');
+      await seeded.close();
+
+      final upgraded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      addTearDown(() async => upgraded.close());
+      await upgraded.customStatement(
+        'INSERT INTO character_revision_rows '
+        '(character_id, revision, revision_hash, parent_revision_hash, snapshot_json) '
+        "VALUES ('c', 3, 'hash-a', 'hash-b', '{\"description\":\"a\"}')",
+      );
+      final rows = await upgraded
+          .customSelect(
+            'SELECT revision, revision_hash, parent_revision_hash '
+            'FROM character_revision_rows ORDER BY revision',
+          )
+          .get();
+      expect(rows.map((row) => row.read<int>('revision')), [1, 2, 3]);
+      expect(rows.last.read<String>('revision_hash'), 'hash-a');
+      expect(rows.last.read<String>('parent_revision_hash'), 'hash-b');
+      final indexes = await upgraded
+          .customSelect("PRAGMA index_list('character_revision_rows')")
+          .get();
+      expect(
+        indexes
+            .singleWhere(
+              (row) =>
+                  row.read<String>('name') == 'idx_character_revision_hash',
+            )
+            .read<int>('unique'),
+        0,
+      );
     });
   });
 }

--- a/test/effective_canon_context_loader_test.dart
+++ b/test/effective_canon_context_loader_test.dart
@@ -78,6 +78,16 @@ void main() {
         (await revisions.getForCharacter('c')).last.parentRevisionHash,
         CardCanonicalizer.sha256(first),
       );
+
+      final reverted = await loader.load(
+        sessionId: 's',
+        sourceCharacter: first,
+      );
+      final lineage = await revisions.getForCharacter('c');
+      expect(reverted.effectiveRevision.number, 3);
+      expect(lineage.map((item) => item.revision), [1, 2, 3]);
+      expect(lineage[2].revisionHash, lineage[0].revisionHash);
+      expect(lineage[2].parentRevisionHash, lineage[1].revisionHash);
     },
   );
 
@@ -120,6 +130,10 @@ void main() {
       );
       var context = await loader.load(sessionId: 's', sourceCharacter: second);
       expect(context.character.description, 'one');
+      await loader.load(sessionId: 's', sourceCharacter: first);
+      context = await loader.load(sessionId: 's', sourceCharacter: first);
+      expect(context.character.description, 'one');
+      expect(context.effectiveRevision.number, 1);
       await baselines.updatePolicy(
         sessionId: 's',
         policy: CharacterCardUpdatePolicy.askOnChange,


### PR DESCRIPTION
## Summary
- allow character revision lineages to return to earlier card content without violating a hash uniqueness constraint
- migrate existing databases to schema v114 while preserving revision history and retaining a non-unique hash lookup index
- resolve legacy hash-only pinned baselines deterministically when a lineage contains repeated content

## Tests
- flutter test test/effective_canon_context_loader_test.dart test/db_migration_test.dart
- flutter test test/effective_canon_context_loader_test.dart test/manual_rewrite_apply_repo_test.dart
- flutter analyze lib/core/db/app_db.dart lib/core/db/tables.dart lib/core/services/card_rewriter/effective_canon_assembler.dart test/effective_canon_context_loader_test.dart test/db_migration_test.dart