### PR TITLE
fix(chat): make touchpad scrolling work in the chat WebView on Windows

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -6,6 +6,7 @@ import { MessageUpdateBatcher } from './message_update_batcher.js';
 import { SelectionManager } from './selection_manager.js';
 import { EditController } from './edit_controller.js';
 import { SwipeGestureHandler } from './swipe_gesture_handler.js';
+import { TrackpadScroll } from './trackpad_scroll.js';
 import { InteractionDispatch } from './interaction_dispatch.js';
 import { PanelHost } from './panel_host.js';
 import { sanitizeExtBlockHtml } from './html_sanitizer.js';
@@ -55,6 +56,9 @@ export class Bridge {
       () => this.isGenerating,
       () => this.disableSwipeRegeneration,
     );
+    // Windows-only fallback path: the embedder never delivers touchpad pans to
+    // WebView2 as wheel events, so Flutter replays them through here.
+    this._trackpadScroll = new TrackpadScroll(() => this.virtualList.container);
     // Bottom-inset reconciliation state — see setBottomPadding().
     // `_bottomInsetPx` is the inset Flutter measured from the bottom edge of the
     // full-size WebView box (input bar + keyboard/drawer + safe area);
@@ -230,6 +234,12 @@ export class Bridge {
   }
 
   /* ---------- Scroll / load-more ---------- */
+
+  // Windows touchpad pan replayed by Flutter as a wheel at the cursor. See
+  // ./trackpad_scroll.js for why the embedder can't deliver it itself.
+  trackpadScroll(dx, dy, x, y) {
+    this._trackpadScroll.scrollBy(dx, dy, x, y);
+  }
 
   // Re-shows the header and re-baselines the hide-on-scroll tracker. Flutter
   // calls this whenever a chat is opened or a session is switched.

--- a/assets/chat_webview/bridge/index.js
+++ b/assets/chat_webview/bridge/index.js
@@ -11,6 +11,7 @@ export { MessageUpdateBatcher } from './message_update_batcher.js';
 export { PanelHost } from './panel_host.js';
 export { SelectionManager } from './selection_manager.js';
 export { SwipeGestureHandler } from './swipe_gesture_handler.js';
+export { TrackpadScroll } from './trackpad_scroll.js';
 
 window.Bridge = Bridge;
 

--- a/assets/chat_webview/bridge/trackpad_scroll.js
+++ b/assets/chat_webview/bridge/trackpad_scroll.js
@@ -1,0 +1,99 @@
+/* Windows precision-touchpad scrolling for the chat WebView.
+ *
+ * Flutter's win32 embedder reports precision-touchpad scrolling as pan/zoom
+ * pointer events (PointerPanZoomStart/Update/End), not as PointerScrollEvent,
+ * and flutter_inappwebview_windows only forwards the latter to WebView2. The
+ * page therefore never sees a `wheel` event from a touchpad — only from a
+ * mouse wheel (flutter_inappwebview #2503 / #2511, both closed as not
+ * planned). ChatWebViewTrackpadScroll on the Flutter side captures the pan and
+ * calls bridge.trackpadScroll(), which lands here.
+ *
+ * The pan is replayed as a synthetic `wheel` event at the cursor so every
+ * existing wheel handler (the #chat-container handler in ./index.js, the edit
+ * textarea handler in ./edit_controller.js) reacts exactly as it does to a
+ * real mouse wheel — one scroll path, not two.
+ */
+
+/* Pixel-mode wheel scale used by the page's own wheel handlers: they scroll by
+ * `deltaY * 0.3`. Deltas arrive here already in CSS pixels, so they are
+ * divided by the same factor to survive the round trip and track the finger
+ * 1:1. Keep in sync with `e.deltaY * 0.3` in ./index.js and
+ * EditController._scaledWheelDelta in ./edit_controller.js. */
+export const WHEEL_PIXEL_SCALE = 0.3;
+
+const SCROLLABLE_OVERFLOW = /^(auto|scroll|overlay)$/;
+
+export class TrackpadScroll {
+  /** @param containerFn returns the chat scroll container (may be null early). */
+  constructor(containerFn) {
+    this._containerFn = containerFn;
+  }
+
+  /* Scroll by (dx, dy) CSS pixels, wheel sign convention: positive dy moves
+   * the content up (scrollTop grows), like a wheel scrolled towards the user.
+   * (x, y) are client coordinates of the cursor. */
+  scrollBy(dx, dy, x, y) {
+    dx = Number(dx) || 0;
+    dy = Number(dy) || 0;
+    if (dx === 0 && dy === 0) return;
+
+    const container = this._containerFn ? this._containerFn() : null;
+    const hasPoint = Number.isFinite(x) && Number.isFinite(y);
+    const target = (hasPoint ? document.elementFromPoint(x, y) : null) || container;
+    if (!target) return;
+
+    // dispatchEvent returns false when a listener called preventDefault(),
+    // which is how both page handlers signal "I scrolled this myself".
+    const consumed = !target.dispatchEvent(new WheelEvent('wheel', {
+      deltaX: dx / WHEEL_PIXEL_SCALE,
+      deltaY: dy / WHEEL_PIXEL_SCALE,
+      deltaMode: 0,
+      clientX: hasPoint ? x : 0,
+      clientY: hasPoint ? y : 0,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    }));
+    if (consumed) return;
+
+    // Synthetic events are untrusted, so the browser performs no default
+    // scrolling for them. Nothing claimed the event — do the default action
+    // ourselves on the nearest scrollable ancestor.
+    this._scrollNearest(target, dx, dy, container);
+  }
+
+  _scrollNearest(target, dx, dy, container) {
+    let el = target;
+    while (el && el !== document.body && el !== document.documentElement) {
+      if (this._canScroll(el, dx, dy)) {
+        el.scrollLeft += dx;
+        el.scrollTop += dy;
+        return;
+      }
+      el = el.parentElement;
+    }
+    if (container) {
+      container.scrollLeft += dx;
+      container.scrollTop += dy;
+    }
+  }
+
+  _canScroll(el, dx, dy) {
+    const style = window.getComputedStyle(el);
+    if (dy !== 0 && SCROLLABLE_OVERFLOW.test(style.overflowY)) {
+      const max = el.scrollHeight - el.clientHeight;
+      if (max > 1 && ((dy < 0 && el.scrollTop > 0) ||
+                      (dy > 0 && el.scrollTop < max - 1))) {
+        return true;
+      }
+    }
+    if (dx !== 0 && SCROLLABLE_OVERFLOW.test(style.overflowX)) {
+      const max = el.scrollWidth - el.clientWidth;
+      if (max > 1 && ((dx < 0 && el.scrollLeft > 0) ||
+                      (dx > 0 && el.scrollLeft < max - 1))) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/lib/features/chat/bridge/bridge_layout_commands.dart
+++ b/lib/features/chat/bridge/bridge_layout_commands.dart
@@ -84,4 +84,31 @@ class LayoutBridgeCommands {
       'window.bridge?.renderer?.toggleMessageSelection("${_host.escape(id)}")',
     );
   }
+
+  /// Replays a Windows precision-touchpad pan as a scroll inside the page.
+  ///
+  /// Flutter's win32 embedder reports precision-touchpad scrolling as
+  /// pan/zoom pointer events (`PointerPanZoom*`), not as `PointerScrollEvent`,
+  /// and `flutter_inappwebview_windows` only forwards the latter to WebView2 —
+  /// so a touchpad produces no `wheel` event in the page at all
+  /// (flutter_inappwebview #2503 / #2511, both closed as not planned). The
+  /// Flutter side captures the pan and hands it back here.
+  ///
+  /// [dx]/[dy] are scroll deltas in CSS pixels (already sign-flipped to
+  /// wheel semantics: positive [dy] scrolls the content down). [x]/[y] are
+  /// the pointer's client coordinates, used to pick the element under the
+  /// cursor so nested scrollers (edit textarea, panels) behave as they do
+  /// with a real wheel.
+  Future<void> trackpadScroll({
+    required double dx,
+    required double dy,
+    required double x,
+    required double y,
+  }) {
+    return _host.evalJs(
+      'window.bridge?.trackpadScroll('
+      '${dx.toStringAsFixed(2)}, ${dy.toStringAsFixed(2)}, '
+      '${x.toStringAsFixed(1)}, ${y.toStringAsFixed(1)})',
+    );
+  }
 }

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -695,6 +695,12 @@ class ChatBridgeController {
       layout.setSelectionMode(enabled);
   Future<void> toggleMessageSelection(String id) =>
       layout.toggleMessageSelection(id);
+  Future<void> trackpadScroll({
+    required double dx,
+    required double dy,
+    required double x,
+    required double y,
+  }) => layout.trackpadScroll(dx: dx, dy: dy, x: x, y: y);
 
   // Memory
   void updateMemoryBookData({

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -18,6 +18,7 @@ import '../bridge/chat_webview_settings.dart';
 import '../../settings/app_settings_provider.dart';
 import 'chat_webview_callbacks.dart';
 import 'chat_webview_ext_block_callbacks.dart';
+import 'chat_webview_trackpad_scroll.dart';
 import 'message_scripts_prompt_sheet.dart';
 import 'webview_callbacks.dart';
 
@@ -180,120 +181,127 @@ class ChatWebViewSurface extends ConsumerWidget {
         Positioned.fill(
           child: IgnorePointer(
             ignoring: sessionSwitching,
-            child: InAppWebView(
-              webViewEnvironment: webViewEnvironment,
-              keepAlive: chatWebViewKeepAliveForPlatform(),
-              initialFile: chatWebViewInitialFile(),
-              initialUrlRequest: chatWebViewInitialUrlRequest(),
-              initialSettings: chatWebViewInAppSettings(),
-              onWebViewCreated: (controller) async {
-                PerfDebug.chatWebViewSurfaceCreated();
-                final jsBridgeService = await bridgeHost.buildJsBridgeService();
-                if (!isMounted()) return;
-                final bridge = ChatBridgeController(
-                  controller,
-                  jsBridgeService,
-                );
-                final allowMessageScripts =
-                    ref.read(appSettingsProvider).value?.allowMessageScripts ??
-                    false;
-                await bridge.evalJs(
-                  'window.bridge?.setAllowMessageScripts('
-                  '$allowMessageScripts)',
-                );
-                // Register bridge in the registry so services can access it.
-                ref.read(chatBridgeRegistryProvider(charId).notifier).state =
-                    bridge;
-                onBridgeReady(bridge);
-                PerfDebug.chatWebViewBridgeReady();
-
-                // Do not call clearAll() here — it races with _initWebViewOnce
-                // (shows #loading-screen via JS) and broke UseVirtualScroll on
-                // keep-alive re-attach. Initializer.setMessages resets the DOM.
-
-                final callbacks = ChatWebViewCallbacks(
-                  ref: ref,
-                  charId: charId,
-                  messageActions: messageActions,
-                  editActions: editActions,
-                  imageGenActions: imageGenActions,
-                  scrollActions: scrollActions,
-                  miscActions: miscActions,
-                );
-                bridge.onMessageContext = callbacks.onMessageContext;
-                bridge.onSwipe = callbacks.onSwipe;
-                bridge.onChangeGreeting = callbacks.onChangeGreeting;
-                bridge.onHeaderScroll = callbacks.onHeaderScroll;
-                bridge.onScrollToBottomVisibility =
-                    callbacks.onScrollToBottomVisibility;
-                bridge.onRegenerate = callbacks.onRegenerate;
-                bridge.onSelectionAction = callbacks.onSelectionAction;
-                bridge.onSelectionChange = callbacks.onSelectionChange;
-                bridge.onEditSave = callbacks.onEditSave;
-                bridge.onEditCancel = callbacks.onEditCancel;
-                bridge.onEditFocusChange = callbacks.onEditFocusChange;
-                bridge.onImageClick = callbacks.onImageClick;
-                bridge.onImgDownload = callbacks.onImgDownload;
-                bridge.onGuidedSwipe = callbacks.onGuidedSwipe;
-                bridge.onMemoryClick = callbacks.onMemoryClick;
-                bridge.onToggleHidden = callbacks.onToggleHidden;
-                bridge.onToggleImageHidden = callbacks.onToggleImageHidden;
-                bridge.onInjectClick = callbacks.onInjectClick;
-                bridge.onImgRetry = callbacks.onImgRetry;
-                bridge.onImgEnableRetry = callbacks.onImgEnableRetry;
-                bridge.onImgFind = callbacks.onImgFind;
-                bridge.onImgRegen = callbacks.onImgRegen;
-                bridge.onImgOptions = callbacks.onImgOptions;
-                bridge.onImgCancel = callbacks.onImgCancel;
-                bridge.onStop = callbacks.onStop;
-                bridge.onLinkClick = callbacks.onLinkClick;
-                bridge.onLoadMore = callbacks.onLoadMore;
-                bridge.onMessageScriptBlocked = () {
+            // Windows touchpad panning never reaches WebView2 on its own —
+            // see ChatWebViewTrackpadScroll. Sits inside the IgnorePointer so
+            // a session switch freezes it along with the rest of the input.
+            child: ChatWebViewTrackpadScroll(
+              charId: charId,
+              child: InAppWebView(
+                webViewEnvironment: webViewEnvironment,
+                keepAlive: chatWebViewKeepAliveForPlatform(),
+                initialFile: chatWebViewInitialFile(),
+                initialUrlRequest: chatWebViewInitialUrlRequest(),
+                initialSettings: chatWebViewInAppSettings(),
+                onWebViewCreated: (controller) async {
+                  PerfDebug.chatWebViewSurfaceCreated();
+                  final jsBridgeService = await bridgeHost
+                      .buildJsBridgeService();
                   if (!isMounted()) return;
-                  // ignore: use_build_context_synchronously
-                  unawaited(maybeShowMessageScriptsPrompt(context, ref));
-                };
-                if (!isMounted()) return;
+                  final bridge = ChatBridgeController(
+                    controller,
+                    jsBridgeService,
+                  );
+                  final allowMessageScripts =
+                      ref.read(appSettingsProvider).value?.allowMessageScripts ??
+                      false;
+                  await bridge.evalJs(
+                    'window.bridge?.setAllowMessageScripts('
+                    '$allowMessageScripts)',
+                  );
+                  // Register bridge in the registry so services can access it.
+                  ref.read(chatBridgeRegistryProvider(charId).notifier).state =
+                      bridge;
+                  onBridgeReady(bridge);
+                  PerfDebug.chatWebViewBridgeReady();
 
-                // The ext-block callbacks run after `await` paths. The
-                // controller is created once per WebView lifetime so
-                // the context capture is safe.
-                final extBlocks = ChatWebViewExtBlockCallbacks(
-                  ref: ref,
-                  charId: charId,
-                  sessionId: sessionId,
-                  // ignore: use_build_context_synchronously
-                  context: context,
-                  isMounted: isMounted,
-                  refreshPanel: refreshPanel,
-                );
-                bridge.onExtBlocksRunAll = extBlocks.onRunAll();
-                bridge.onExtBlockStop = extBlocks.onStop();
-                bridge.onExtBlockRegen = extBlocks.onRegen();
-                bridge.onExtBlockRegenImage = extBlocks.onRegenImage();
-                bridge.onExtBlockEdit = extBlocks.onEdit();
-                bridge.onExtBlockDelete = extBlocks.onDelete();
+                  // Do not call clearAll() here — it races with _initWebViewOnce
+                  // (shows #loading-screen via JS) and broke UseVirtualScroll on
+                  // keep-alive re-attach. Initializer.setMessages resets the DOM.
 
-                final isAlive = await controller.isLoading() == false;
-                if (isAlive) {
+                  final callbacks = ChatWebViewCallbacks(
+                    ref: ref,
+                    charId: charId,
+                    messageActions: messageActions,
+                    editActions: editActions,
+                    imageGenActions: imageGenActions,
+                    scrollActions: scrollActions,
+                    miscActions: miscActions,
+                  );
+                  bridge.onMessageContext = callbacks.onMessageContext;
+                  bridge.onSwipe = callbacks.onSwipe;
+                  bridge.onChangeGreeting = callbacks.onChangeGreeting;
+                  bridge.onHeaderScroll = callbacks.onHeaderScroll;
+                  bridge.onScrollToBottomVisibility =
+                      callbacks.onScrollToBottomVisibility;
+                  bridge.onRegenerate = callbacks.onRegenerate;
+                  bridge.onSelectionAction = callbacks.onSelectionAction;
+                  bridge.onSelectionChange = callbacks.onSelectionChange;
+                  bridge.onEditSave = callbacks.onEditSave;
+                  bridge.onEditCancel = callbacks.onEditCancel;
+                  bridge.onEditFocusChange = callbacks.onEditFocusChange;
+                  bridge.onImageClick = callbacks.onImageClick;
+                  bridge.onImgDownload = callbacks.onImgDownload;
+                  bridge.onGuidedSwipe = callbacks.onGuidedSwipe;
+                  bridge.onMemoryClick = callbacks.onMemoryClick;
+                  bridge.onToggleHidden = callbacks.onToggleHidden;
+                  bridge.onToggleImageHidden = callbacks.onToggleImageHidden;
+                  bridge.onInjectClick = callbacks.onInjectClick;
+                  bridge.onImgRetry = callbacks.onImgRetry;
+                  bridge.onImgEnableRetry = callbacks.onImgEnableRetry;
+                  bridge.onImgFind = callbacks.onImgFind;
+                  bridge.onImgRegen = callbacks.onImgRegen;
+                  bridge.onImgOptions = callbacks.onImgOptions;
+                  bridge.onImgCancel = callbacks.onImgCancel;
+                  bridge.onStop = callbacks.onStop;
+                  bridge.onLinkClick = callbacks.onLinkClick;
+                  bridge.onLoadMore = callbacks.onLoadMore;
+                  bridge.onMessageScriptBlocked = () {
+                    if (!isMounted()) return;
+                    // ignore: use_build_context_synchronously
+                    unawaited(maybeShowMessageScriptsPrompt(context, ref));
+                  };
+                  if (!isMounted()) return;
+
+                  // The ext-block callbacks run after `await` paths. The
+                  // controller is created once per WebView lifetime so
+                  // the context capture is safe.
+                  final extBlocks = ChatWebViewExtBlockCallbacks(
+                    ref: ref,
+                    charId: charId,
+                    sessionId: sessionId,
+                    // ignore: use_build_context_synchronously
+                    context: context,
+                    isMounted: isMounted,
+                    refreshPanel: refreshPanel,
+                  );
+                  bridge.onExtBlocksRunAll = extBlocks.onRunAll();
+                  bridge.onExtBlockStop = extBlocks.onStop();
+                  bridge.onExtBlockRegen = extBlocks.onRegen();
+                  bridge.onExtBlockRegenImage = extBlocks.onRegenImage();
+                  bridge.onExtBlockEdit = extBlocks.onEdit();
+                  bridge.onExtBlockDelete = extBlocks.onDelete();
+
+                  final isAlive = await controller.isLoading() == false;
+                  if (isAlive) {
+                    await onInitWebView();
+                  }
+                },
+                onLoadStop: (controller, url) async {
+                  PerfDebug.chatWebViewLoadStopped();
+                  // The init path is also wired through onWebViewCreated. When
+                  // load stop wins the race, run init here.
+                  await ref
+                      .read(chatBridgeRegistryProvider(charId))
+                      ?.evalJs(
+                        'window.bridge?.setAllowMessageScripts('
+                        '${ref.read(appSettingsProvider).value?.allowMessageScripts ?? false})',
+                      );
                   await onInitWebView();
-                }
-              },
-              onLoadStop: (controller, url) async {
-                PerfDebug.chatWebViewLoadStopped();
-                // The init path is also wired through onWebViewCreated. When
-                // load stop wins the race, run init here.
-                await ref
-                    .read(chatBridgeRegistryProvider(charId))
-                    ?.evalJs(
-                      'window.bridge?.setAllowMessageScripts('
-                      '${ref.read(appSettingsProvider).value?.allowMessageScripts ?? false})',
-                    );
-                await onInitWebView();
-              },
-              shouldOverrideUrlLoading: (controller, request) async {
-                return chatWebViewNavigationPolicy(request.request.url);
-              },
+                },
+                shouldOverrideUrlLoading: (controller, request) async {
+                  return chatWebViewNavigationPolicy(request.request.url);
+                },
+              ),
             ),
           ),
         ),

--- a/lib/features/chat/widgets/chat_webview_trackpad_scroll.dart
+++ b/lib/features/chat/widgets/chat_webview_trackpad_scroll.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../bridge/chat_bridge_registry.dart';
+
+/// Turns Flutter trackpad pan events into wheel-convention scroll deltas,
+/// coalesced to at most one emission per frame.
+///
+/// Pan updates arrive faster than the display refreshes and every emission is
+/// a platform-channel round trip into the WebView, so the deltas are summed
+/// and flushed from a post-frame callback.
+class TrackpadScrollSink {
+  TrackpadScrollSink(this.onScroll);
+
+  /// Receives the accumulated delta in wheel sign convention (positive [dy]
+  /// scrolls the content down) and the cursor position of the latest event.
+  final void Function(double dx, double dy, Offset position) onScroll;
+
+  double _pendingDx = 0;
+  double _pendingDy = 0;
+  Offset _position = Offset.zero;
+  bool _flushScheduled = false;
+  bool _disposed = false;
+
+  @visibleForTesting
+  bool get hasPendingScroll => _pendingDx != 0 || _pendingDy != 0;
+
+  void start(PointerPanZoomStartEvent event) {
+    _position = event.localPosition;
+  }
+
+  void update(PointerPanZoomUpdateEvent event) {
+    _position = event.localPosition;
+    // `panDelta` is finger movement; a wheel delta points the other way
+    // (fingers moving up scroll the content down).
+    _pendingDx -= event.panDelta.dx;
+    _pendingDy -= event.panDelta.dy;
+    _scheduleFlush();
+  }
+
+  void end(PointerPanZoomEndEvent event) {
+    // Flush whatever the last frame did not carry so a short flick is not
+    // silently dropped.
+    _scheduleFlush();
+  }
+
+  void dispose() {
+    _disposed = true;
+  }
+
+  void _scheduleFlush() {
+    if (_disposed || _flushScheduled) return;
+    _flushScheduled = true;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _flushScheduled = false;
+      flush();
+    });
+    SchedulerBinding.instance.scheduleFrame();
+  }
+
+  @visibleForTesting
+  void flush() {
+    final dx = _pendingDx;
+    final dy = _pendingDy;
+    _pendingDx = 0;
+    _pendingDy = 0;
+    if (_disposed || (dx == 0 && dy == 0)) return;
+    onScroll(dx, dy, _position);
+  }
+}
+
+/// Makes precision-touchpad scrolling work over the chat WebView on Windows.
+///
+/// Since Flutter 3.3 the win32 embedder reports precision-touchpad scrolling
+/// as pan/zoom pointer events (`PointerPanZoomStart/Update/End`) rather than
+/// the `PointerScrollEvent` a mouse wheel produces.
+/// `flutter_inappwebview_windows` forwards only the latter to WebView2, so a
+/// touchpad generates no `wheel` event inside the page and the chat simply
+/// does not scroll — while a mouse wheel works fine (flutter_inappwebview
+/// #2503 / #2511, both closed as not planned upstream).
+///
+/// This wrapper captures the pan Flutter *does* deliver and replays it in the
+/// page through `bridge.trackpadScroll()`, which dispatches a synthetic wheel
+/// at the cursor so the page's existing wheel handlers do the scrolling.
+///
+/// On every other platform the child is returned untouched: Android/iOS scroll
+/// by touch, and macOS hosts a real native WKWebView that handles its own
+/// trackpad input.
+class ChatWebViewTrackpadScroll extends ConsumerStatefulWidget {
+  const ChatWebViewTrackpadScroll({
+    super.key,
+    required this.charId,
+    required this.child,
+  });
+
+  final String charId;
+  final Widget child;
+
+  /// Whether the pan-capture layer is needed on the current platform.
+  static bool get isSupported =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.windows;
+
+  @override
+  ConsumerState<ChatWebViewTrackpadScroll> createState() =>
+      _ChatWebViewTrackpadScrollState();
+}
+
+class _ChatWebViewTrackpadScrollState
+    extends ConsumerState<ChatWebViewTrackpadScroll> {
+  late final TrackpadScrollSink _sink = TrackpadScrollSink(_sendToWebView);
+
+  /// Local logical pixels map 1:1 to the page's CSS pixels because WebView2 is
+  /// sized to the widget's logical box, so the position needs no conversion.
+  void _sendToWebView(double dx, double dy, Offset position) {
+    if (!mounted) return;
+    final bridge = ref.read(chatBridgeRegistryProvider(widget.charId));
+    if (bridge == null) return;
+    // Fire-and-forget: the next frame's pan must not wait on this round trip.
+    unawaited(
+      bridge.trackpadScroll(dx: dx, dy: dy, x: position.dx, y: position.dy),
+    );
+  }
+
+  @override
+  void dispose() {
+    _sink.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!ChatWebViewTrackpadScroll.isSupported) return widget.child;
+    return Listener(
+      // Opaque rather than deferToChild: on Windows the WebView is composited
+      // from a Texture, which is not hit-testable by itself, so deferring
+      // would leave this Listener out of the hit-test path entirely. Opaque
+      // only *adds* this render object to the result — children are still hit
+      // first, so the WebView keeps receiving every event it does today.
+      behavior: HitTestBehavior.opaque,
+      onPointerPanZoomStart: _sink.start,
+      onPointerPanZoomUpdate: _sink.update,
+      onPointerPanZoomEnd: _sink.end,
+      child: widget.child,
+    );
+  }
+}

--- a/test/chat_webview_trackpad_scroll_test.dart
+++ b/test/chat_webview_trackpad_scroll_test.dart
@@ -120,6 +120,9 @@ void main() {
   });
 
   group('ChatWebViewTrackpadScroll', () {
+    // testWidgets bodies reset the override themselves: the binding asserts
+    // every foundation debug variable is unset when the body returns, which
+    // happens before tearDown gets a chance to run.
     tearDown(() => debugDefaultTargetPlatformOverride = null);
 
     test('is only needed on Windows', () {
@@ -158,6 +161,9 @@ void main() {
       expect(listener.onPointerPanZoomStart, isNotNull);
       expect(listener.onPointerPanZoomUpdate, isNotNull);
       expect(listener.onPointerPanZoomEnd, isNotNull);
+      expect(listener.behavior, HitTestBehavior.opaque);
+
+      debugDefaultTargetPlatformOverride = null;
     });
 
     testWidgets('adds no wrapper off Windows', (tester) async {
@@ -181,6 +187,8 @@ void main() {
         ),
         findsNothing,
       );
+
+      debugDefaultTargetPlatformOverride = null;
     });
   });
 

--- a/test/chat_webview_trackpad_scroll_test.dart
+++ b/test/chat_webview_trackpad_scroll_test.dart
@@ -1,0 +1,236 @@
+// Windows precision-touchpad scrolling for the chat WebView.
+//
+// Flutter's win32 embedder delivers touchpad scrolling as PointerPanZoom*
+// events, which flutter_inappwebview_windows never forwards to WebView2 — so
+// without this layer the chat only scrolls with a mouse wheel. These tests
+// guard the Flutter capture side and the JS replay side against regressions.
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/features/chat/widgets/chat_webview_trackpad_scroll.dart';
+
+String _bridgeAsset(String name) =>
+    File('assets/chat_webview/bridge/$name').readAsStringSync();
+
+PointerPanZoomUpdateEvent _panUpdate(Offset panDelta, {Offset? position}) {
+  return PointerPanZoomUpdateEvent(
+    position: position ?? Offset.zero,
+    pan: panDelta,
+    panDelta: panDelta,
+  );
+}
+
+void main() {
+  group('TrackpadScrollSink', () {
+    test('inverts pan into wheel sign convention', () {
+      final emitted = <List<double>>[];
+      final sink = TrackpadScrollSink(
+        (dx, dy, position) => emitted.add([dx, dy]),
+      );
+
+      // Fingers moving up (negative dy) must scroll the content down, which is
+      // a positive wheel delta — the same sign a mouse wheel produces.
+      sink.update(_panUpdate(const Offset(0, -20)));
+      sink.flush();
+
+      expect(emitted, [
+        [0.0, 20.0],
+      ]);
+    });
+
+    test('accumulates several pan updates into one emission', () {
+      final emitted = <List<double>>[];
+      final sink = TrackpadScrollSink(
+        (dx, dy, position) => emitted.add([dx, dy]),
+      );
+
+      sink.update(_panUpdate(const Offset(-3, -10)));
+      sink.update(_panUpdate(const Offset(-2, -5)));
+      sink.flush();
+
+      expect(emitted, [
+        [5.0, 15.0],
+      ]);
+    });
+
+    test('flush clears the accumulator and emits nothing when idle', () {
+      final emitted = <List<double>>[];
+      final sink = TrackpadScrollSink(
+        (dx, dy, position) => emitted.add([dx, dy]),
+      );
+
+      sink.update(_panUpdate(const Offset(0, -8)));
+      expect(sink.hasPendingScroll, isTrue);
+      sink.flush();
+      expect(sink.hasPendingScroll, isFalse);
+
+      sink.flush();
+      expect(emitted, hasLength(1), reason: 'an idle flush must not emit');
+    });
+
+    test('reports the cursor position of the latest event', () {
+      Offset? seen;
+      final sink = TrackpadScrollSink((dx, dy, position) => seen = position);
+
+      sink.start(
+        PointerPanZoomStartEvent(position: const Offset(10, 20)),
+      );
+      sink.update(
+        _panUpdate(const Offset(0, -4), position: const Offset(120, 340)),
+      );
+      sink.flush();
+
+      expect(seen, const Offset(120, 340));
+    });
+
+    test('emits nothing after dispose', () {
+      var calls = 0;
+      final sink = TrackpadScrollSink((dx, dy, position) => calls++);
+
+      sink.update(_panUpdate(const Offset(0, -8)));
+      sink.dispose();
+      sink.flush();
+
+      expect(calls, 0);
+    });
+
+    testWidgets('coalesces a burst of pan updates to one call per frame', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const SizedBox());
+
+      final emitted = <double>[];
+      final sink = TrackpadScrollSink((dx, dy, position) => emitted.add(dy));
+
+      sink.update(_panUpdate(const Offset(0, -5)));
+      sink.update(_panUpdate(const Offset(0, -5)));
+      sink.update(_panUpdate(const Offset(0, -5)));
+      expect(emitted, isEmpty, reason: 'flush is deferred to the next frame');
+
+      await tester.pump();
+
+      expect(emitted, [15.0]);
+    });
+  });
+
+  group('ChatWebViewTrackpadScroll', () {
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    test('is only needed on Windows', () {
+      for (final platform in TargetPlatform.values) {
+        debugDefaultTargetPlatformOverride = platform;
+        expect(
+          ChatWebViewTrackpadScroll.isSupported,
+          platform == TargetPlatform.windows,
+          reason: '$platform',
+        );
+      }
+    });
+
+    testWidgets('wraps the child in a pan-capturing Listener on Windows', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: ChatWebViewTrackpadScroll(
+              charId: 'char-1',
+              child: SizedBox(width: 100, height: 100),
+            ),
+          ),
+        ),
+      );
+
+      final listener = tester.widget<Listener>(
+        find.descendant(
+          of: find.byType(ChatWebViewTrackpadScroll),
+          matching: find.byType(Listener),
+        ),
+      );
+      expect(listener.onPointerPanZoomStart, isNotNull);
+      expect(listener.onPointerPanZoomUpdate, isNotNull);
+      expect(listener.onPointerPanZoomEnd, isNotNull);
+    });
+
+    testWidgets('adds no wrapper off Windows', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: ChatWebViewTrackpadScroll(
+              charId: 'char-1',
+              child: SizedBox(width: 100, height: 100),
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.descendant(
+          of: find.byType(ChatWebViewTrackpadScroll),
+          matching: find.byType(Listener),
+        ),
+        findsNothing,
+      );
+    });
+  });
+
+  group('trackpad_scroll.js', () {
+    late String trackpadJs;
+    late String bridgeIndexJs;
+    late String bridgeControllerJs;
+
+    setUpAll(() {
+      trackpadJs = _bridgeAsset('trackpad_scroll.js');
+      bridgeIndexJs = _bridgeAsset('index.js');
+      bridgeControllerJs = _bridgeAsset('chat_bridge_controller.js');
+    });
+
+    test('bridge exposes trackpadScroll to Flutter', () {
+      expect(bridgeControllerJs, contains('trackpadScroll(dx, dy, x, y)'));
+      expect(bridgeControllerJs, contains('new TrackpadScroll('));
+    });
+
+    test('undoes the page wheel scale so the pan tracks the finger 1:1', () {
+      // The page's own wheel handlers scroll by `deltaY * 0.3`, so a delta
+      // already expressed in CSS pixels has to be divided by the same factor
+      // before it is replayed as a wheel event.
+      expect(bridgeIndexJs, contains('container.scrollTop += e.deltaY * 0.3'));
+      expect(trackpadJs, contains('export const WHEEL_PIXEL_SCALE = 0.3;'));
+      expect(trackpadJs, contains('deltaX: dx / WHEEL_PIXEL_SCALE'));
+      expect(trackpadJs, contains('deltaY: dy / WHEEL_PIXEL_SCALE'));
+    });
+
+    test('replays the pan as a cancelable pixel-mode wheel at the cursor', () {
+      // Reusing the page's wheel handlers keeps one scroll path instead of a
+      // second, touchpad-only one that could drift out of sync.
+      expect(trackpadJs, contains("new WheelEvent('wheel'"));
+      expect(trackpadJs, contains('deltaMode: 0'));
+      expect(trackpadJs, contains('cancelable: true'));
+      expect(trackpadJs, contains('bubbles: true'));
+      expect(trackpadJs, contains('document.elementFromPoint(x, y)'));
+    });
+
+    test('performs the default scroll itself when nothing consumes it', () {
+      // Synthetic events are untrusted, so the browser runs no default action
+      // for them — an unhandled wheel has to be applied by hand.
+      expect(trackpadJs, contains('if (consumed) return;'));
+      expect(trackpadJs, contains('_scrollNearest'));
+      expect(trackpadJs, contains('el.scrollTop += dy'));
+      expect(trackpadJs, contains('el.scrollLeft += dx'));
+    });
+
+    test('falls back to the chat container when no scrollable is found', () {
+      expect(trackpadJs, contains('container.scrollTop += dy'));
+    });
+  });
+}


### PR DESCRIPTION
On Windows the chat only scrolled with a mouse wheel — a precision touchpad did nothing at all.

Since Flutter 3.3 the win32 embedder reports precision-touchpad scrolling as `PointerPanZoomStart/Update/End` events rather than the `PointerScrollEvent` a mouse wheel produces. `flutter_inappwebview_windows` forwards only the latter to WebView2, so the page never saw a `wheel` event from a touchpad and the handler on `#chat-container` (`assets/chat_webview/bridge/index.js`) never ran. Upstream tracks this as [#2503](https://github.com/pichillilorenzo/flutter_inappwebview/issues/2503) and [#2511](https://github.com/pichillilorenzo/flutter_inappwebview/issues/2511), both closed as *not planned*, so the fix lives here.

## Changes

- Add `ChatWebViewTrackpadScroll` (`lib/features/chat/widgets/chat_webview_trackpad_scroll.dart`) — a Windows-only `Listener` wrapping the chat `InAppWebView` that captures the pan events Flutter *does* deliver. On every other platform the child is returned untouched: Android/iOS scroll by touch and macOS hosts a real native `WKWebView`.
- Extract `TrackpadScrollSink` in the same file: it inverts `panDelta` into wheel sign convention and coalesces a burst of pan updates into one emission per frame, so a fast two-finger swipe costs one platform-channel round trip per frame instead of one per pan event.
- The `Listener` uses `HitTestBehavior.opaque`, not the default `deferToChild` — on Windows the WebView is composited from a `Texture`, which is not hit-testable on its own, so deferring would leave the `Listener` out of the hit-test path. Opaque only *adds* the render object to the result, so the WebView still receives every event it does today.
- Add `assets/chat_webview/bridge/trackpad_scroll.js` with `TrackpadScroll.scrollBy()`, exposed as `bridge.trackpadScroll()`. It replays the pan as a synthetic pixel-mode `WheelEvent` at the cursor (`document.elementFromPoint`) so the page's existing wheel handlers — `#chat-container` in `bridge/index.js` and the edit textarea in `EditController` — do the scrolling. One scroll path, not a second touchpad-only one that could drift out of sync.
- Divide the delta by the same `0.3` pixel-wheel factor those handlers apply (`WHEEL_PIXEL_SCALE`), so the chat tracks the finger 1:1 instead of at a third of its speed.
- Synthetic events are untrusted and get no default action from the browser, so an unconsumed wheel is applied by hand to the nearest scrollable ancestor, falling back to the chat container. This is what lets a pan over a nested scroller hand the scroll back to the chat once that scroller is exhausted.
- Wire `trackpadScroll` through `LayoutBridgeCommands` and `ChatBridgeController`.
- Wrap the `InAppWebView` inside the existing `IgnorePointer` in `ChatWebViewSurface`, so a session switch freezes trackpad panning along with the rest of the input. Most of that file's diff is re-indentation from the added nesting level.

## Known gaps

- Panels rendered in a sandboxed cross-origin `<iframe>` still do not scroll by touchpad — a synthetic wheel cannot cross that boundary, and forwarding would need a `postMessage` hop through `PanelHost`.
- The catalog WebView (`catalog_grid.dart`) and the Janitor login sheet have the same embedder limitation. They have no chat bridge, so they need a different fix and are left alone here.

## Verification

- Added `test/chat_webview_trackpad_scroll_test.dart`: sign inversion, multi-update accumulation, per-frame coalescing, idle flush, disposal, cursor position, the Windows-only platform gate, `Listener` wiring on/off Windows, and the JS contract (scale factor agreeing with `bridge/index.js`, cancelable pixel-mode wheel at the cursor, manual fallback scroll).
- Exercised the JS end-to-end against a DOM stub carrying a copy of the real `#chat-container` wheel handler: a `+120` CSS px pan produces exactly `scrollTop += 120`, signs are correct in both directions, a zero delta is a no-op, and an exhausted nested scroller correctly passes the scroll to the chat container.
- **`flutter analyze` and `flutter test` were not run** — the agent environment has no Flutter SDK. Relying on the CI gate and on a manual check that touchpad scrolling now works in a Windows build. Note that `assets/chat_webview/` changed, so verifying locally needs a **hot restart** (`R`), not a hot reload.

---
_Generated by [Claude Code](https://claude.ai/code/session_0141BPyAr8e3AkXiGUrXuLgF)_