### PR TITLE
feat(presets): animate row add/remove and cross-fade folder navigation

### DIFF
--- a/lib/features/presets/preset_list_screen.dart
+++ b/lib/features/presets/preset_list_screen.dart
@@ -45,6 +45,7 @@ import 'preset_list_provider.dart';
 import 'preset_selection_provider.dart';
 import 'preset_sort.dart';
 import 'widgets/add_presets_to_folder_sheet.dart';
+import 'widgets/animated_preset_row.dart';
 import 'widgets/preset_filter_sheet.dart';
 import 'widgets/preset_folders_section.dart';
 import 'widgets/preset_options_sheet.dart';
@@ -54,6 +55,10 @@ import 'widgets/preset_small_badge.dart';
 /// estimate the scroll offset of the active preset before its row is laid out;
 /// [Scrollable.ensureVisible] corrects the estimate on the following frame.
 const double _kRowExtent = 72;
+
+/// How long the list takes to cross-fade when the user steps into a folder or
+/// back out of it.
+const Duration _kFolderFade = Duration(milliseconds: 220);
 
 class PresetListScreen extends ConsumerStatefulWidget {
   final bool startExpanded;
@@ -87,7 +92,10 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
   /// Preset kind picked in the control-row dropdown; null = every kind.
   PresetKind? _typeFilter;
 
-  final ScrollController _scrollController = ScrollController();
+  /// Controller of the list that is currently on top. Each list owns its own
+  /// (see [_ScrollHost]) because the folder cross-fade keeps the outgoing one
+  /// mounted while the incoming one builds.
+  ScrollController? _scrollController;
 
   /// Key on the header sliver, used to measure what sits above the rows when
   /// estimating the active preset's scroll offset.
@@ -99,6 +107,16 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
   /// The list scrolls to the active preset once per screen open, not on every
   /// rebuild — otherwise the user could never scroll away from it.
   bool _didAutoScroll = false;
+
+  /// Set until that scroll has been made. [_activeRowKey] is only attached
+  /// while it holds, so the two lists that overlap during a folder cross-fade
+  /// can never claim the same [GlobalKey].
+  bool _revealPending = true;
+
+  /// Rows playing their collapse animation. The presets behind them still
+  /// exist — the delete is committed once the animation has run — so the list
+  /// keeps rendering them, shrinking and untappable, until then.
+  final Set<String> _exitingKeys = {};
 
   bool get _inEditor => _isCreating || _editingPreset != null;
   bool get _inStudioEditor => _editingStudioId != null;
@@ -115,11 +133,8 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
     });
   }
 
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
+  // No dispose override: the scroll controllers belong to the lists that use
+  // them and are disposed with them — see [_ScrollHost].
 
   void _openEditor(Preset? preset) {
     setState(() {
@@ -165,7 +180,7 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
       return;
     }
     if (_currentFolderId != null) {
-      setState(() => _currentFolderId = null);
+      _leaveFolder();
       return;
     }
     if (widget.startExpanded) {
@@ -173,6 +188,19 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
     } else {
       Navigator.of(context).maybePop();
     }
+  }
+
+  void _openFolder(String id) {
+    ref.read(presetSelectionProvider.notifier).clear();
+    // The auto-scroll is done with once the user navigates, and its key must be
+    // free before a second list is mounted alongside the current one.
+    _revealPending = false;
+    setState(() => _currentFolderId = id);
+  }
+
+  void _leaveFolder() {
+    _revealPending = false;
+    setState(() => _currentFolderId = null);
   }
 
   String? _folderName(String id) {
@@ -212,6 +240,12 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
       title: title,
       showBack: true,
       onBack: _handleBack,
+      // Opened as a modal sheet, a back gesture unwinds the same chain the
+      // header's back button walks — leave the editor, drop the selection, step
+      // out of the folder — and only closes the sheet once none of those is
+      // left. Without this every one of them would be skipped and the sheet
+      // would vanish on the first swipe.
+      canPop: !_inAnyEditor && !selection.active && folderId == null,
       // The type dropdown, the filter button and the sort chip belong to the
       // header, not to the scroll content: pinned there they stay reachable at
       // any scroll offset, in the modal sheet and as a fullscreen route alike.
@@ -277,6 +311,10 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
 
   // ─── list ──────────────────────────────────────────────────────────────
 
+  /// Identity of a row inside the list, so its element (and the animation state
+  /// riding on it) stays with its preset as the rows around it come and go.
+  static String _rowKey(PresetItem item) => 'row_${item.memberKey}';
+
   Widget _buildBody(
     BuildContext context,
     List<Preset> presets,
@@ -334,98 +372,144 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
     final topInset = MediaQuery.paddingOf(context).top;
     final bottomInset = MediaQuery.paddingOf(context).bottom;
 
+    final rowIndexByKey = <String, int>{
+      for (var i = 0; i < items.length; i++) _rowKey(items[i]): i,
+    };
+
     Widget row(int i) {
       final item = items[i];
       final active = isActive(item);
-      return Padding(
-        key: i == activeIndex ? _activeRowKey : null,
-        padding: const EdgeInsets.only(bottom: 10),
-        child: _PsCard(
-          item: item,
-          isActive: active,
-          selectionMode: selection.active,
-          isSelected: selection.contains(item.id, item.kind),
-          onTap: () => _onCardTap(item, active),
-          // While the list is manually ordered a long press starts the drag,
-          // so it can't also open multi-select — that moves to the row menu.
-          onLongPress: manual
-              ? null
-              : () => ref
-                    .read(presetSelectionProvider.notifier)
-                    .start(item.id, item.kind),
-          onConnections: item.isAgentic
-              ? null
-              : () => showPresetConnections(context, item.preset!.id),
-          onEdit: item.isAgentic
-              ? () => _openStudioEditor(item.studioPreset!.id)
-              : () => _openEditor(item.preset),
-          onMenu: () => _showItemMenu(item),
+      // Keyed by preset, so a row's state follows its preset when the list
+      // reorders and a row that just appeared gets a fresh state — which is
+      // what plays its entry animation.
+      return AnimatedPresetRow(
+        key: ValueKey(_rowKey(item)),
+        exiting: _exitingKeys.contains(item.memberKey),
+        child: Padding(
+          key: _revealPending && i == activeIndex ? _activeRowKey : null,
+          padding: const EdgeInsets.only(bottom: 10),
+          child: _PsCard(
+            item: item,
+            isActive: active,
+            selectionMode: selection.active,
+            isSelected: selection.contains(item.id, item.kind),
+            onTap: () => _onCardTap(item, active),
+            // While the list is manually ordered a long press starts the drag,
+            // so it can't also open multi-select — that moves to the row menu.
+            onLongPress: manual
+                ? null
+                : () => ref
+                      .read(presetSelectionProvider.notifier)
+                      .start(item.id, item.kind),
+            onConnections: item.isAgentic
+                ? null
+                : () => showPresetConnections(context, item.preset!.id),
+            onEdit: item.isAgentic
+                ? () => _openStudioEditor(item.studioPreset!.id)
+                : () => _openEditor(item.preset),
+            onMenu: () => _showItemMenu(item),
+          ),
         ),
       );
     }
 
-    return CustomScrollView(
-      controller: _scrollController,
-      slivers: [
-        SliverPadding(
-          padding: EdgeInsets.fromLTRB(16, 12 + topInset, 16, 0),
-          sliver: SliverToBoxAdapter(
-            child: KeyedSubtree(
-              key: _headerKey,
-              child: folderId == null
-                  ? PresetFoldersSection(
-                      onOpenFolder: (id) {
-                        ref.read(presetSelectionProvider.notifier).clear();
-                        setState(() => _currentFolderId = id);
-                      },
-                    )
-                  : const SizedBox.shrink(),
+    final list = _ScrollHost(
+      onCreated: (controller) => _scrollController = controller,
+      onDisposed: (controller) {
+        if (identical(_scrollController, controller)) _scrollController = null;
+      },
+      builder: (controller) => CustomScrollView(
+        controller: controller,
+        slivers: [
+          SliverPadding(
+            padding: EdgeInsets.fromLTRB(16, 12 + topInset, 16, 0),
+            sliver: SliverToBoxAdapter(
+              child: KeyedSubtree(
+                // Only while the auto-scroll still needs to measure this block:
+                // the two lists that overlap during the folder cross-fade must
+                // never both carry the same [GlobalKey].
+                key: _revealPending && folderId == null ? _headerKey : null,
+                child: folderId == null
+                    ? PresetFoldersSection(onOpenFolder: _openFolder)
+                    : const SizedBox.shrink(),
+              ),
             ),
           ),
-        ),
-        // "No presets" would be a lie at the top level while folders are
-        // listed above it — every preset simply lives in one of them.
-        if (items.isEmpty && !(folderId == null && hasFolders))
-          SliverPadding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 40),
-            sliver: SliverToBoxAdapter(
-              child: Center(
-                child: Text(
-                  folderId != null
-                      ? 'preset_folder_empty'.tr()
-                      : 'label_no_presets'.tr(),
-                  style: TextStyle(color: context.cs.onSurfaceVariant),
+          // "No presets" would be a lie at the top level while folders are
+          // listed above it — every preset simply lives in one of them.
+          if (items.isEmpty && !(folderId == null && hasFolders))
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 40),
+              sliver: SliverToBoxAdapter(
+                child: Center(
+                  child: Text(
+                    folderId != null
+                        ? 'preset_folder_empty'.tr()
+                        : 'label_no_presets'.tr(),
+                    style: TextStyle(color: context.cs.onSurfaceVariant),
+                  ),
                 ),
               ),
-            ),
-          )
-        else if (manual)
-          SliverPadding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            sliver: SliverReorderableList(
-              itemCount: items.length,
-              onReorderItem: (oldIndex, newIndex) =>
-                  _onManualReorder(items, all, oldIndex, newIndex),
-              itemBuilder: (_, i) => ReorderableDelayedDragStartListener(
-                key: ValueKey(items[i].memberKey),
-                index: i,
-                child: row(i),
+            )
+          else if (manual)
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              sliver: SliverReorderableList(
+                itemCount: items.length,
+                onReorderItem: (oldIndex, newIndex) =>
+                    _onManualReorder(items, all, oldIndex, newIndex),
+                itemBuilder: (_, i) => ReorderableDelayedDragStartListener(
+                  key: ValueKey(items[i].memberKey),
+                  index: i,
+                  child: row(i),
+                ),
+              ),
+            )
+          else
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              sliver: SliverList.builder(
+                itemCount: items.length,
+                itemBuilder: (_, i) => row(i),
+                // Without this the delegate matches rows by position, so
+                // deleting one rebuilds every row under it from scratch — and
+                // each of those would replay its entry animation instead of
+                // simply sliding up into the freed slot.
+                findChildIndexCallback: (key) =>
+                    key is ValueKey<String> ? rowIndexByKey[key.value] : null,
               ),
             ),
-          )
-        else
           SliverPadding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            sliver: SliverList.builder(
-              itemCount: items.length,
-              itemBuilder: (_, i) => row(i),
-            ),
+            padding: EdgeInsets.fromLTRB(16, 4, 16, 16 + bottomInset),
+            sliver: SliverToBoxAdapter(child: _buildAddButton(context)),
           ),
-        SliverPadding(
-          padding: EdgeInsets.fromLTRB(16, 4, 16, 16 + bottomInset),
-          sliver: SliverToBoxAdapter(child: _buildAddButton(context)),
-        ),
-      ],
+        ],
+      ),
+    );
+
+    // Stepping into a folder — and back out of it — swaps the whole list, so it
+    // cross-fades instead of cutting: the folder's rows appear over the ones
+    // they replace rather than snapping into their place.
+    return AnimatedSwitcher(
+      duration: _kFolderFade,
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      // Both lists are laid out at the viewport's full size while they overlap,
+      // so the incoming one is already scrolled and positioned exactly where it
+      // will stay once it is opaque.
+      layoutBuilder: (currentChild, previousChildren) => Stack(
+        fit: StackFit.expand,
+        children: [
+          // The list on its way out is still painted, but a tap during the
+          // fade belongs to the one arriving on top of it.
+          for (final child in previousChildren) IgnorePointer(child: child),
+          ?currentChild,
+        ],
+      ),
+      child: KeyedSubtree(
+        key: ValueKey(folderId ?? '#root'),
+        child: list,
+      ),
     );
   }
 
@@ -491,26 +575,33 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
   }
 
   void _revealIndex(int index) {
-    if (!mounted || !_scrollController.hasClients) return;
+    final controller = _scrollController;
+    if (!mounted || controller == null || !controller.hasClients) {
+      _revealPending = false;
+      return;
+    }
 
     final headerBox =
         _headerKey.currentContext?.findRenderObject() as RenderBox?;
     final double headerExtent = headerBox?.size.height ?? 0.0;
-    final viewport = _scrollController.position.viewportDimension;
+    final viewport = controller.position.viewportDimension;
     // Land the row a quarter of the way down the viewport rather than flush
     // against the top edge, so the presets around it stay in context. Cards
     // carrying a cover are taller than [_kRowExtent], so this is only a first
     // approximation.
     final double estimate =
         headerExtent + index * _kRowExtent - viewport * 0.25;
-    _scrollController.jumpTo(
-      estimate.clamp(0.0, _scrollController.position.maxScrollExtent),
+    controller.jumpTo(
+      estimate.clamp(0.0, controller.position.maxScrollExtent),
     );
 
     // Correct the estimate now that the row itself is built (it is, after that
     // jump — the error stays inside the viewport's cache extent).
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final ctx = _activeRowKey.currentContext;
+      // Done with the key from here on: the row drops it on the next rebuild,
+      // leaving it free for whichever list the folder cross-fade mounts next.
+      _revealPending = false;
       if (!mounted || ctx == null) return;
       Scrollable.ensureVisible(
         ctx,
@@ -713,10 +804,31 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
       ]),
       onClone: () => unawaited(_clonePreset(preset)),
       onExport: () => unawaited(exportPreset(context, preset)),
-      onDelete: () => unawaited(
-        deletePresetAndFolderMemberships(ref, preset.id, PresetKind.normal),
-      ),
+      onDelete: () => unawaited(_deleteItems([PresetItem(preset: preset)])),
     );
+  }
+
+  /// Collapses the rows of [targets] and only then deletes the presets behind
+  /// them, so the list closes the gap on an empty slot instead of yanking a
+  /// visible card out from under the ones below it.
+  Future<void> _deleteItems(List<PresetItem> targets) async {
+    if (targets.isEmpty) return;
+    final keys = [for (final item in targets) item.memberKey];
+    setState(() => _exitingKeys.addAll(keys));
+    await Future<void>.delayed(AnimatedPresetRow.exitDuration);
+
+    try {
+      for (final item in targets) {
+        // Each delete awaits a DB round-trip; bail out if the screen went away
+        // in the meantime rather than reading a disposed ref.
+        if (!mounted) return;
+        await deletePresetAndFolderMemberships(ref, item.id, item.kind);
+      }
+    } finally {
+      // The rows are gone by now, but a delete that failed would otherwise
+      // leave its preset collapsed to nothing and unreachable.
+      if (mounted) setState(() => _exitingKeys.removeAll(keys));
+    }
   }
 
   Future<void> _clonePreset(Preset preset) async {
@@ -799,7 +911,7 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
       description: 'studio_confirm_delete_preset'.tr(args: [preset.name]),
     );
     if (!ok || !mounted) return;
-    await deletePresetAndFolderMemberships(ref, preset.id, PresetKind.agentic);
+    await _deleteItems([PresetItem(studioPreset: preset)]);
   }
 
   // ─── add / import ──────────────────────────────────────────────────────
@@ -1127,12 +1239,8 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
           onTap: () async {
             Navigator.of(context, rootNavigator: true).pop();
             ref.read(presetSelectionProvider.notifier).clear();
-            for (final item in deletable) {
-              // Each delete awaits a DB round-trip; bail out if the screen went
-              // away in the meantime rather than reading a disposed ref.
-              if (!mounted) return;
-              await deletePresetAndFolderMemberships(ref, item.id, item.kind);
-            }
+            // Every selected row collapses together, then the deletes land.
+            await _deleteItems(deletable);
           },
         ),
         BottomSheetItem(
@@ -1143,6 +1251,48 @@ class _PresetListScreenState extends ConsumerState<PresetListScreen> {
       ],
     );
   }
+}
+
+/// Gives the list it builds a [ScrollController] of its own.
+///
+/// The folder cross-fade keeps the outgoing list mounted while the incoming one
+/// builds, and one controller cannot be attached to two scroll views at the
+/// same time. Each host creates its controller with its list and disposes it
+/// with it; [onCreated] hands the screen the controller of the list that is
+/// currently on top, so the auto-scroll always talks to the live one.
+class _ScrollHost extends StatefulWidget {
+  final ValueChanged<ScrollController> onCreated;
+  final ValueChanged<ScrollController> onDisposed;
+  final Widget Function(ScrollController controller) builder;
+
+  const _ScrollHost({
+    required this.onCreated,
+    required this.onDisposed,
+    required this.builder,
+  });
+
+  @override
+  State<_ScrollHost> createState() => _ScrollHostState();
+}
+
+class _ScrollHostState extends State<_ScrollHost> {
+  final ScrollController _controller = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    widget.onCreated(_controller);
+  }
+
+  @override
+  void dispose() {
+    widget.onDisposed(_controller);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.builder(_controller);
 }
 
 // ─── ps-card ─────────────────────────────────────────────────────────────────

--- a/lib/features/presets/widgets/animated_preset_row.dart
+++ b/lib/features/presets/widgets/animated_preset_row.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+/// Entry and exit animation for one row of the Presets list.
+///
+/// A freshly mounted row fades and slides into place, so a preset that was just
+/// created, cloned or imported glides in instead of popping. When [exiting]
+/// turns true the row fades out while its height collapses: the screen sets the
+/// flag *before* it commits the delete and waits [exitDuration], so the row has
+/// already left the screen by the time the store drops it and the list closes
+/// the gap without a jump.
+///
+/// Rows are keyed by their preset, so a state is only ever reused by the same
+/// preset — that is what makes "mounted" a reliable stand-in for "appeared".
+class AnimatedPresetRow extends StatefulWidget {
+  /// Whether the row is playing its removal animation.
+  final bool exiting;
+  final Widget child;
+
+  const AnimatedPresetRow({
+    super.key,
+    required this.exiting,
+    required this.child,
+  });
+
+  /// How long the collapse takes. The screen waits exactly this long between
+  /// marking a row as exiting and deleting the preset behind it.
+  static const Duration exitDuration = Duration(milliseconds: 240);
+
+  static const Duration entryDuration = Duration(milliseconds: 260);
+
+  @override
+  State<AnimatedPresetRow> createState() => _AnimatedPresetRowState();
+}
+
+class _AnimatedPresetRowState extends State<AnimatedPresetRow>
+    with TickerProviderStateMixin {
+  late final AnimationController _entry = AnimationController(
+    vsync: this,
+    duration: AnimatedPresetRow.entryDuration,
+  );
+  late final AnimationController _exit = AnimationController(
+    vsync: this,
+    duration: AnimatedPresetRow.exitDuration,
+  );
+
+  late final Animation<double> _entryFade = CurvedAnimation(
+    parent: _entry,
+    curve: Curves.easeOut,
+  );
+  late final Animation<Offset> _entrySlide =
+      Tween<Offset>(begin: const Offset(0, 0.12), end: Offset.zero).animate(
+        CurvedAnimation(parent: _entry, curve: Curves.easeOutCubic),
+      );
+
+  /// Drives both the fade and the height collapse on the way out: 1 → 0.
+  late final Animation<double> _exitFactor =
+      Tween<double>(begin: 1, end: 0).animate(
+        CurvedAnimation(parent: _exit, curve: Curves.easeIn),
+      );
+
+  @override
+  void initState() {
+    super.initState();
+    _entry.forward();
+    if (widget.exiting) _exit.value = 1;
+  }
+
+  @override
+  void didUpdateWidget(covariant AnimatedPresetRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.exiting == oldWidget.exiting) return;
+    if (widget.exiting) {
+      _exit.forward();
+    } else {
+      // A row that stops exiting is not arriving — the delete was abandoned, or
+      // this state was handed a different preset — so drop the collapse outright
+      // instead of playing it backwards.
+      _exit.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _entry.dispose();
+    _exit.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // SizeTransition clips for us, so a collapsing row never paints outside the
+    // shrinking slot.
+    return SizeTransition(
+      sizeFactor: _exitFactor,
+      // Pinned to the top edge, so the row shrinks upwards into the gap the
+      // rows below it are closing rather than towards its own centre.
+      alignment: AlignmentDirectional.topStart,
+      child: FadeTransition(
+        opacity: _exitFactor,
+        child: FadeTransition(
+          opacity: _entryFade,
+          child: SlideTransition(
+            position: _entrySlide,
+            // A row on its way out must not take taps meant for the row that
+            // slides up into its place.
+            child: IgnorePointer(
+              ignoring: widget.exiting,
+              child: widget.child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/sheet_view.dart
+++ b/lib/shared/widgets/sheet_view.dart
@@ -67,6 +67,18 @@ class SheetView extends ConsumerStatefulWidget {
   final int? shellBranchIndex;
   final bool enableHeaderBlur;
 
+  /// Whether a system/gesture back may dismiss the sheet outright.
+  ///
+  /// Set it to false while the body is showing an inner state of its own — a
+  /// folder, a multi-selection, an inline editor — and the back event is handed
+  /// to [onBack] instead, exactly like the header's back button, so the body
+  /// unwinds one level per press before the sheet closes. Only consulted when
+  /// the sheet is presented as a modal bottom sheet; as a fullscreen route back
+  /// already goes through [onBack].
+  ///
+  /// Dragging the sheet down stays an outright dismissal either way.
+  final bool canPop;
+
   const SheetView({
     super.key,
     this.title,
@@ -90,6 +102,7 @@ class SheetView extends ConsumerStatefulWidget {
     this.showRouteBackground = true,
     this.shellBranchIndex,
     this.enableHeaderBlur = true,
+    this.canPop = true,
   });
 
   @override
@@ -329,6 +342,12 @@ class _SheetViewState extends ConsumerState<SheetView>
     );
   }
 
+  /// Closes the sheet after a drag-down. pop(), not maybePop(): flinging the
+  /// sheet away is an explicit dismissal, so it closes the whole sheet even
+  /// when [SheetView.canPop] is false because the body has an inner state a
+  /// *back* press would step out of first.
+  void _dismiss() => Navigator.of(context).pop();
+
   void _onDragEnd(DragEndDetails d) {
     final vy = d.velocity.pixelsPerSecond.dy;
     final collapsed = _collapsed(context);
@@ -337,7 +356,7 @@ class _SheetViewState extends ConsumerState<SheetView>
 
     if (widget.fitContent) {
       if (vy > 600 || _currentHeight < collapsed * 0.6) {
-        Navigator.of(context).maybePop();
+        _dismiss();
       } else {
         _animateTo(collapsed, expanding: false);
       }
@@ -347,7 +366,7 @@ class _SheetViewState extends ConsumerState<SheetView>
     if (vy < -600 || (_currentHeight > mid && vy <= 600)) {
       _animateTo(full, expanding: true);
     } else if (vy > 600 || _currentHeight < collapsed * 0.6) {
-      Navigator.of(context).maybePop();
+      _dismiss();
     } else {
       _animateTo(
         _currentHeight >= mid ? full : collapsed,
@@ -569,28 +588,39 @@ class _SheetViewState extends ConsumerState<SheetView>
       opaque: true,
     );
 
-    return ConstrainedBox(
-      constraints: BoxConstraints(
-        maxHeight: widget.fitContent ? _full(context) * 0.95 : double.infinity,
-      ),
-      child: ValueListenableBuilder<double>(
-        valueListenable: _heightN,
-        child: content,
-        builder: (context, height, child) {
-          return SizedBox(
-            height: widget.fitContent ? null : height,
-            child: ClipRRect(
-              // Constant, so the sheet keeps its rounded top edge when expanded
-              // to full height. It used to taper to 0 on the way up, which made
-              // a sheet opened by tapping the handle end as a square-cornered
-              // slab flush against the status bar.
-              borderRadius: const BorderRadius.vertical(
-                top: Radius.circular(_kSheetCornerRadius),
+    // pop(), not maybePop(): a body that blocks the pop (canPop false) handles
+    // the back event in onBack, and maybePop() would re-enter this callback.
+    final sheetBackHandler = widget.onBack ?? () => Navigator.of(context).pop();
+
+    return PopScope(
+      canPop: widget.canPop,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        sheetBackHandler();
+      },
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: widget.fitContent ? _full(context) * 0.95 : double.infinity,
+        ),
+        child: ValueListenableBuilder<double>(
+          valueListenable: _heightN,
+          child: content,
+          builder: (context, height, child) {
+            return SizedBox(
+              height: widget.fitContent ? null : height,
+              child: ClipRRect(
+                // Constant, so the sheet keeps its rounded top edge when
+                // expanded to full height. It used to taper to 0 on the way up,
+                // which made a sheet opened by tapping the handle end as a
+                // square-cornered slab flush against the status bar.
+                borderRadius: const BorderRadius.vertical(
+                  top: Radius.circular(_kSheetCornerRadius),
+                ),
+                child: child,
               ),
-              child: child,
-            ),
-          );
-        },
+            );
+          },
+        ),
       ),
     );
   }

--- a/test/preset_row_animation_test.dart
+++ b/test/preset_row_animation_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/features/presets/widgets/animated_preset_row.dart';
+
+void main() {
+  const rowKey = ValueKey('row-child');
+
+  Widget host({required bool exiting}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: [
+            AnimatedPresetRow(
+              exiting: exiting,
+              child: const SizedBox(key: rowKey, height: 60, width: 100),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  double rowHeight(WidgetTester tester) =>
+      tester.getSize(find.byType(AnimatedPresetRow)).height;
+
+  /// The innermost fade — the one that plays when the row is mounted.
+  FadeTransition entryFade(WidgetTester tester) => tester.widget<FadeTransition>(
+    find
+        .descendant(
+          of: find.byType(AnimatedPresetRow),
+          matching: find.byType(FadeTransition),
+        )
+        .last,
+  );
+
+  testWidgets('a new row fades in at its full height', (tester) async {
+    await tester.pumpWidget(host(exiting: false));
+
+    expect(entryFade(tester).opacity.value, lessThan(1.0));
+    // The row must not grow into place: a list full of rows expanding at once
+    // would shove everything below them around on open.
+    expect(rowHeight(tester), 60);
+
+    await tester.pumpAndSettle();
+    expect(entryFade(tester).opacity.value, 1.0);
+    expect(rowHeight(tester), 60);
+  });
+
+  testWidgets('a deleted row collapses before it is gone', (tester) async {
+    await tester.pumpWidget(host(exiting: false));
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(host(exiting: true));
+    await tester.pump();
+    expect(rowHeight(tester), 60);
+
+    await tester.pump(AnimatedPresetRow.exitDuration ~/ 2);
+    expect(rowHeight(tester), lessThan(60));
+
+    // Fully collapsed by the time the screen commits the delete, so the list
+    // closes the gap on an empty slot.
+    await tester.pump(AnimatedPresetRow.exitDuration);
+    expect(rowHeight(tester), moreOrLessEquals(0, epsilon: 0.01));
+  });
+
+  testWidgets('a row that stops exiting is restored at once', (tester) async {
+    await tester.pumpWidget(host(exiting: false));
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(host(exiting: true));
+    await tester.pump(AnimatedPresetRow.exitDuration);
+
+    await tester.pumpWidget(host(exiting: false));
+    await tester.pump();
+    expect(rowHeight(tester), 60);
+  });
+}

--- a/test/sheet_view_back_gesture_test.dart
+++ b/test/sheet_view_back_gesture_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/shared/widgets/sheet_view.dart';
+
+/// A sheet whose body has inner state of its own — a folder, a selection, an
+/// inline editor — keeps the back gesture for itself until that state is gone.
+/// The Presets list relies on this to step out of a folder before it closes.
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('back goes to onBack while canPop is false, then closes', (
+    tester,
+  ) async {
+    final canPop = ValueNotifier<bool>(false);
+    addTearDown(canPop.dispose);
+    var backs = 0;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: ThemeData.dark(),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  backgroundColor: Colors.transparent,
+                  builder: (_) => ValueListenableBuilder<bool>(
+                    valueListenable: canPop,
+                    builder: (_, value, _) => SheetView(
+                      title: 'Presets',
+                      showBack: true,
+                      canPop: value,
+                      onBack: () => backs++,
+                      body: const Text('sheet body'),
+                    ),
+                  ),
+                ),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(find.text('sheet body'), findsOneWidget);
+
+    // Blocked: the body unwinds one level instead of the sheet vanishing.
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(backs, 1);
+    expect(find.text('sheet body'), findsOneWidget);
+
+    // Nothing left inside — now back closes the sheet itself.
+    canPop.value = true;
+    await tester.pumpAndSettle();
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    expect(backs, 1);
+    expect(find.text('sheet body'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Row add / remove animation

- Add `AnimatedPresetRow` (`lib/features/presets/widgets/animated_preset_row.dart`): a row fades and slides in when it is mounted — so a preset that was just created, cloned or imported glides into place — and fades out while collapsing its height when it leaves.
- Route every in-list delete through `_PresetListScreenState._deleteItems`: it marks the rows as exiting, waits `AnimatedPresetRow.exitDuration`, and only then calls `deletePresetAndFolderMemberships`. The list therefore closes the gap on an already-empty slot instead of yanking a visible card out from under the rows below it. Wired to the plain row menu, `_deleteAgentic` and the bulk delete (where every selected row collapses together).
- A failed delete is unwound in a `finally`, so a preset can never stay collapsed to nothing and unreachable.
- Key each row by its preset and give `SliverList.builder` a `findChildIndexCallback`. Without it the delegate matches rows by position, so deleting one row rebuilt every row under it from scratch and each of those replayed its entry animation instead of sliding up.

## Folder cross-fade

- Wrap the list in an `AnimatedSwitcher` keyed by the current folder, so stepping into a folder and back out of it cross-fades instead of cutting. The outgoing list is wrapped in `IgnorePointer` for the duration, so a tap during the fade belongs to the list arriving on top.
- Give each list its own `ScrollController` via the new `_ScrollHost`: both lists are mounted while they overlap, and one controller cannot be attached to two scroll views at once.
- Attach `_headerKey` / `_activeRowKey` only while the open-time auto-scroll is still pending (`_revealPending`). Both are `GlobalKey`s, and two overlapping lists must never claim the same one.

## Back gesture in the sheet

- Add `SheetView.canPop` (default `true`, so every other sheet is unchanged). When false, a system/gesture back is handed to `onBack` instead of dismissing the sheet.
- `PresetListScreen` sets it from its own inner state, so back now walks the same chain as the header's back button — leave the editor, drop the multi-selection, step out of the folder — and only closes the sheet once none of those is left. Previously the first back swipe skipped all of them and dismissed the sheet outright.
- Dragging the sheet down still dismisses it in one go: `_onDragEnd` goes through the new `_dismiss` (`pop`, not `maybePop`), because a fling is an explicit dismissal rather than a back press.

## Verification

- `flutter analyze --no-fatal-infos --no-fatal-warnings` — `No issues found!` on every changed file (Flutter 3.44.9, the same channel CI uses).
- `flutter test` — full suite green, 2572 tests passed.
- New tests: `test/preset_row_animation_test.dart` (row fades in at full height, collapses to zero before the delete lands, and is restored at once when it stops exiting) and `test/sheet_view_back_gesture_test.dart` (back reaches `onBack` while `canPop` is false, then closes the sheet once it is true).
- Not verified: runtime behaviour on a device — `flutter run` is unavailable to the agent, so the timing of the 220 ms cross-fade and the entry animation has only been checked in widget tests, not by eye.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBqF8ZHCFmcTgiWNwt7Pp9)_