### PR TITLE
fix(transport): preserve whitespace in SSE data field parsing

### DIFF
--- a/lib/core/llm/transport/anthropic_chat_transport.dart
+++ b/lib/core/llm/transport/anthropic_chat_transport.dart
@@ -347,9 +347,8 @@ class AnthropicChatTransport implements ChatTransport {
         buffer = lines.removeLast();
 
         for (final line in lines) {
-          final trimmed = line.trim();
-          if (!trimmed.startsWith('data:')) continue;
-          final payload = trimmed.substring(5).trim();
+          final payload = _sseData(line);
+          if (payload == null) continue;
           if (payload.isEmpty) continue;
           lastRawJsonPayload = payload;
 
@@ -446,6 +445,15 @@ class AnthropicChatTransport implements ChatTransport {
         type: DioExceptionType.connectionError,
       );
     }
+  }
+
+  String? _sseData(String line) {
+    final normalized = line.endsWith('\r')
+        ? line.substring(0, line.length - 1)
+        : line;
+    if (!normalized.startsWith('data:')) return null;
+    final value = normalized.substring(5);
+    return value.startsWith(' ') ? value.substring(1) : value;
   }
 
   Future<void> _oneShotResponse(

--- a/lib/core/llm/transport/gemini_chat_transport.dart
+++ b/lib/core/llm/transport/gemini_chat_transport.dart
@@ -294,9 +294,8 @@ class GeminiChatTransport implements ChatTransport {
         buffer = lines.removeLast();
 
         for (final line in lines) {
-          final trimmed = line.trim();
-          if (!trimmed.startsWith('data:')) continue;
-          final payload = trimmed.substring(5).trim();
+          final payload = _sseData(line);
+          if (payload == null) continue;
           if (payload.isEmpty) continue;
           lastRawPayload = payload;
 
@@ -369,6 +368,15 @@ class GeminiChatTransport implements ChatTransport {
         lastPayload: lastRawPayload,
       ),
     );
+  }
+
+  String? _sseData(String line) {
+    final normalized = line.endsWith('\r')
+        ? line.substring(0, line.length - 1)
+        : line;
+    if (!normalized.startsWith('data:')) return null;
+    final value = normalized.substring(5);
+    return value.startsWith(' ') ? value.substring(1) : value;
   }
 
   Future<void> _oneShotResponse(

--- a/lib/core/llm/transport/openai_chat_transport.dart
+++ b/lib/core/llm/transport/openai_chat_transport.dart
@@ -262,9 +262,8 @@ class OpenAiChatTransport implements ChatTransport {
             unawaited(finishAfterCancel());
             return;
           }
-          final trimmed = line.trim();
-          if (!trimmed.startsWith('data: ')) continue;
-          final data = trimmed.substring(6).trim();
+          final data = _sseData(line);
+          if (data == null) continue;
           if (data == '[DONE]') {
             if (cancelToken != null && cancelToken.isCancelled) {
               debugPrint(
@@ -455,9 +454,8 @@ class OpenAiChatTransport implements ChatTransport {
     var fullText = '';
     var fullReasoning = '';
     for (final line in body.split('\n')) {
-      final trimmed = line.trim();
-      if (!trimmed.startsWith('data: ')) continue;
-      final payload = trimmed.substring(6).trim();
+      final payload = _sseData(line);
+      if (payload == null) continue;
       if (payload == '[DONE]') break;
       try {
         final json = jsonDecode(payload) as Map<String, dynamic>;
@@ -532,6 +530,17 @@ class OpenAiChatTransport implements ChatTransport {
         {'index': 0, 'message': message, 'finish_reason': 'stop'},
       ],
     });
+  }
+
+  /// Extract an SSE data field without trimming its JSON payload. The optional
+  /// single space after `data:` is framing, not content.
+  String? _sseData(String line) {
+    final normalized = line.endsWith('\r')
+        ? line.substring(0, line.length - 1)
+        : line;
+    if (!normalized.startsWith('data:')) return null;
+    final value = normalized.substring(5);
+    return value.startsWith(' ') ? value.substring(1) : value;
   }
 
   @override

--- a/lib/core/llm/transport/openai_responses_transport.dart
+++ b/lib/core/llm/transport/openai_responses_transport.dart
@@ -203,9 +203,8 @@ class OpenAiResponsesTransport implements ChatTransport {
       final lines = buffer.split('\n');
       buffer = lines.removeLast();
       for (final line in lines) {
-        final trimmed = line.trim();
-        if (!trimmed.startsWith('data:')) continue;
-        final payload = trimmed.substring(5).trim();
+        final payload = _sseData(line);
+        if (payload == null) continue;
         if (payload.isEmpty || payload == '[DONE]') continue;
         try {
           final event = jsonDecode(payload) as Map<String, dynamic>;
@@ -243,6 +242,15 @@ class OpenAiResponsesTransport implements ChatTransport {
       rawResponseJson:
           rawResponseJson ?? jsonEncode(_aggregatedResponse(text, reasoning)),
     );
+  }
+
+  String? _sseData(String line) {
+    final normalized = line.endsWith('\r')
+        ? line.substring(0, line.length - 1)
+        : line;
+    if (!normalized.startsWith('data:')) return null;
+    final value = normalized.substring(5);
+    return value.startsWith(' ') ? value.substring(1) : value;
   }
 
   Future<void> _oneShotResponse(

--- a/test/llm/transport/_sse_adapter.dart
+++ b/test/llm/transport/_sse_adapter.dart
@@ -7,8 +7,9 @@ import 'package:dio/dio.dart';
 /// request. Used to exercise the streaming parse path of transports without a
 /// real network round-trip.
 class SseAdapter implements HttpClientAdapter {
-  SseAdapter(this.body);
+  SseAdapter(this.body, {this.chunkSizes = const []});
   final String body;
+  final List<int> chunkSizes;
 
   @override
   Future<ResponseBody> fetch(
@@ -17,8 +18,19 @@ class SseAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     final bytes = Uint8List.fromList(utf8.encode(body));
-    return ResponseBody.fromBytes(
-      bytes,
+    final chunks = <Uint8List>[];
+    var offset = 0;
+    for (final size in chunkSizes) {
+      if (offset >= bytes.length) break;
+      final end = (offset + size).clamp(offset, bytes.length);
+      chunks.add(Uint8List.fromList(bytes.sublist(offset, end)));
+      offset = end;
+    }
+    if (offset < bytes.length) {
+      chunks.add(Uint8List.fromList(bytes.sublist(offset)));
+    }
+    return ResponseBody(
+      Stream<Uint8List>.fromIterable(chunks),
       200,
       headers: {
         Headers.contentTypeHeader: ['text/event-stream'],

--- a/test/llm/transport/openai_chat_transport_test.dart
+++ b/test/llm/transport/openai_chat_transport_test.dart
@@ -8,6 +8,8 @@ import 'package:glaze_flutter/core/llm/transport/llm_protocol.dart';
 import 'package:glaze_flutter/core/llm/transport/openai_chat_transport.dart';
 import 'package:glaze_flutter/core/models/extra_request_parameter.dart';
 
+import '_sse_adapter.dart';
+
 ChatTransportRequest _req({
   String endpoint = 'https://api.openai.com',
   String sessionIdMode = 'openrouter',
@@ -210,5 +212,33 @@ void main() {
       expect(body['stream'], isTrue);
       expect(body['messages'], isNotEmpty);
     });
+  });
+
+  test('preserves newlines split across SSE network chunks', () async {
+    const body = '''data:{"choices":[{"delta":{"content":"first\\n"}}]}
+
+data: {"choices":[{"delta":{"content":"\\nsecond"}}]}
+
+data: [DONE]
+
+''';
+    final bodyBytes = utf8.encode(body);
+    final firstNewline = bodyBytes.indexOf(0x0a);
+    final dio = Dio()
+      ..httpClientAdapter = SseAdapter(
+        body,
+        chunkSizes: [firstNewline + 1, 1, 2],
+      );
+    final updates = <String>[];
+    String? completed;
+
+    await OpenAiChatTransport(dio: dio).stream(
+      request: _req(),
+      onUpdate: (delta, _) => updates.add(delta),
+      onComplete: (text, _, {rawResponseJson}) => completed = text,
+    );
+
+    expect(updates, ['first\n', '\nsecond']);
+    expect(completed, 'first\n\nsecond');
   });
 }


### PR DESCRIPTION
## Problem

Streaming responses sometimes lost line breaks (paragraph breaks) during reception. The SSE `data:` field parser in all four chat transports trimmed the entire line before extracting the payload, then trimmed the payload again — stripping leading/trailing whitespace that is part of the JSON content, including newlines in text deltas.

## Root cause

Each transport did:

`dart
final trimmed = line.trim();
if (!trimmed.startsWith('data:')) continue;
final payload = trimmed.substring(5).trim();
`

The first `.trim()` removed leading whitespace before `data:` but also stripped the trailing `\n`/`\r` and any whitespace at the end of the payload. The second `.trim()` on the extracted payload removed whitespace that is legitimately part of the JSON value (e.g. a newline at the start/end of a `content` delta).

Additionally, the OpenAI Chat transport used `startsWith('data: ')` (with a mandatory space), which rejected `data:` without a trailing space — a valid SSE framing.

## Fix

Replace the double-trim with a `_sseData` helper in all four transports (OpenAI Chat, Anthropic, Gemini, OpenAI Responses) that:

- strips only a trailing `\r` (CRLF line ending)
- accepts both `data:` and `data: ` (the single optional space after `data:` is framing, not content)
- does **not** trim the extracted JSON payload

## Test

Added `preserves newlines split across SSE network chunks` — splits an SSE body containing newlines in `content` across multiple network byte chunks and verifies the deltas and final text retain the newlines intact. The `SseAdapter` test helper gained a `chunkSizes` parameter to simulate chunked delivery.