### PR TITLE
fix: preserve SSE UTF-8 and action styling

### DIFF
--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -205,23 +205,42 @@ export class Formatter {
 
     // 7. Extract Glaze custom markers BEFORE quotes
     const styledSegments = [];
-    const styledRegex = /(==hc:#[0-9a-fA-F]{3,8}==.+?==|==glow:#[0-9a-fA-F]{3,8},\d+==.+?==|==cg:#[0-9a-fA-F]{3,8},#[0-9a-fA-F]{3,8},\d+==.+?==|==grad:#[0-9a-fA-F]{3,8}(?:,#[0-9a-fA-F]{3,8})+==.+?==|==bg:#[0-9a-fA-F]{3,8}==.+?==|==mark==.+?==|==active==.+?==|\*\*[^*\n]+?\*\*|(?<!\*)\*[^*\n]+?\*(?!\*)|__[^_\n]+?__|(?<!\w)_[^_\n]+?_(?!\w)|~~[^~\n]+?~~)/gs;
+    const styledRegex = /(==hc:#[0-9a-fA-F]{3,8}==.+?==|==glow:#[0-9a-fA-F]{3,8},\d+==.+?==|==cg:#[0-9a-fA-F]{3,8},#[0-9a-fA-F]{3,8},\d+==.+?==|==grad:#[0-9a-fA-F]{3,8}(?:,#[0-9a-fA-F]{3,8})+==.+?==|==bg:#[0-9a-fA-F]{3,8}==.+?==|==mark==.+?==|==active==.+?==|\*\*[^*\n]+?\*\*|(?<!\*)\*(?=[^*\n]*[^ \t*\n])[^*\n]+?\*(?!\*)|__[^_\n]+?__|(?<!\w)_[^_\n]+?_(?!\w)|~~[^~\n]+?~~)/gs;
 
     html = html.replace(styledRegex, (match) => {
       const id = this._ph('S_', styledSegments.length);
       styledSegments.push(match);
       return id;
     });
+    // Models occasionally emit `».* *action*`: the first `*` is an orphan
+    // marker, not an empty italic segment. Drop it once the real action is
+    // safely stashed, otherwise it steals that action's opening marker.
+    html = html.replace(/\*([ \t]+)(?=\x01S_\d+\x01)/g, '$1');
 
     // 8. Quote formatting — with unclosed quote handling for streaming
     if (!skipQuotes) {
       const phGroup = '\x01[A-Z_]+\\d+\x01';
-      const quoteRegex = new RegExp(`(${phGroup})|(=[ \\t]*"(?:[^"]|\\\\")*?")|(")((?:[^"]|\\\\")*?)(")|(«)((?:[^»])*?)(»)|(")((?:[^"]*)$)`, 'gm');
+      // Never let a malformed outer « quote consume a styled-segment
+      // placeholder while looking for its closing ». Each placeholder is
+      // restored independently in step 9.
+      const quoteRegex = new RegExp(`(${phGroup})|(=[ \\t]*"(?:[^"]|\\\\")*?")|(")((?:[^"]|\\\\")*?)(")|(«)([^»\x01]*?(?:«[^»\x01]*?»[^»\x01]*?)*?)(»)|(")((?:[^"]*)$)`, 'gm');
       html = html.replace(quoteRegex, (match, placeholder, skipQuote, openQ, closedContent, closeQ, openG, guillemetContent, closeG, openU, unclosedContent) => {
         if (placeholder) return placeholder;
         if (skipQuote) return skipQuote;
         if (openQ !== undefined) return `<span class="chat-quote">${openQ}</span><span class="chat-quote-text">${closedContent}</span><span class="chat-quote">${closeQ}</span>`;
-        if (openG !== undefined) return `<span class="chat-quote">${openG}</span><span class="chat-quote-text">${guillemetContent}</span><span class="chat-quote">${closeG}</span>`;
+        if (openG !== undefined) {
+          // Nested «outer «inner» more outer» — split at inner «» so the
+          // inner quote renders with default (narration) color, while the
+          // outer text keeps the quote color. Inner «» are literal chars,
+          // not separately colored.
+          const parts = guillemetContent.split(/(«[^»]*?»)/);
+          const rendered = parts.map(p => {
+            if (!p) return '';
+            if (/^«[^»]*?»$/.test(p)) return p;
+            return `<span class="chat-quote-text">${p}</span>`;
+          }).join('');
+          return `<span class="chat-quote">${openG}</span>${rendered}<span class="chat-quote">${closeG}</span>`;
+        }
         if (openU !== undefined) return `<span class="chat-quote">${openU}</span><span class="chat-quote-text">${unclosedContent}</span>`;
         return match;
       });

--- a/lib/core/llm/transport/openai_chat_transport.dart
+++ b/lib/core/llm/transport/openai_chat_transport.dart
@@ -223,7 +223,7 @@ class OpenAiChatTransport implements ChatTransport {
     }
     final responseStream = responseBody.stream;
     final completer = Completer<void>();
-    StreamSubscription<List<int>>? subscription;
+    StreamSubscription<String>? subscription;
     var buffer = '';
     var fullText = '';
     var fullReasoning = '';
@@ -240,86 +240,88 @@ class OpenAiChatTransport implements ChatTransport {
       }
     }
 
-    subscription = (responseStream as Stream<List<int>>).listen(
-      (chunk) {
-        if (cancelToken?.isCancelled == true) {
-          debugPrint(
-            '[SSE] cancel detected in listen callback, stopping stream',
-          );
-          unawaited(finishAfterCancel());
-          return;
-        }
-        buffer += utf8.decode(chunk, allowMalformed: true);
-        final lines = buffer.split('\n');
-        buffer = lines.removeLast();
-
-        for (final line in lines) {
-          if (cancelToken?.isCancelled == true) {
-            debugPrint(
-              '[SSE] cancel detected while parsing lines, stopping immediately',
-            );
-            buffer = '';
-            unawaited(finishAfterCancel());
-            return;
-          }
-          final data = _sseData(line);
-          if (data == null) continue;
-          if (data == '[DONE]') {
-            if (cancelToken != null && cancelToken.isCancelled) {
+    subscription = utf8.decoder
+        .bind(responseStream)
+        .listen(
+          (chunk) {
+            if (cancelToken?.isCancelled == true) {
               debugPrint(
-                '[SSE] cancel detected at [DONE], suppressing onComplete',
+                '[SSE] cancel detected in listen callback, stopping stream',
               );
-            } else {
-              onComplete?.call(
-                fullText,
-                fullReasoning.isNotEmpty ? fullReasoning : null,
-                rawResponseJson: _buildAggregatedRawResponse(
-                  fullText: fullText,
-                  fullReasoning: fullReasoning,
-                  fallbackRawJsonPayload: lastRawJsonPayload,
-                ),
-              );
-              doneReceived = true;
+              unawaited(finishAfterCancel());
+              return;
             }
-            unawaited(finishAfterCancel());
-            return;
-          }
+            buffer += chunk;
+            final lines = buffer.split('\n');
+            buffer = lines.removeLast();
 
-          lastRawJsonPayload = data;
+            for (final line in lines) {
+              if (cancelToken?.isCancelled == true) {
+                debugPrint(
+                  '[SSE] cancel detected while parsing lines, stopping immediately',
+                );
+                buffer = '';
+                unawaited(finishAfterCancel());
+                return;
+              }
+              final data = _sseData(line);
+              if (data == null) continue;
+              if (data == '[DONE]') {
+                if (cancelToken != null && cancelToken.isCancelled) {
+                  debugPrint(
+                    '[SSE] cancel detected at [DONE], suppressing onComplete',
+                  );
+                } else {
+                  onComplete?.call(
+                    fullText,
+                    fullReasoning.isNotEmpty ? fullReasoning : null,
+                    rawResponseJson: _buildAggregatedRawResponse(
+                      fullText: fullText,
+                      fullReasoning: fullReasoning,
+                      fallbackRawJsonPayload: lastRawJsonPayload,
+                    ),
+                  );
+                  doneReceived = true;
+                }
+                unawaited(finishAfterCancel());
+                return;
+              }
 
-          try {
-            final json = jsonDecode(data) as Map<String, dynamic>;
-            final choice = json['choices']?[0];
-            final delta = choice?['delta'];
+              lastRawJsonPayload = data;
 
-            final contentDelta = delta?['content'] as String? ?? '';
-            // When omitReasoning is set, skip native reasoning_content so
-            // inline <think> parsing in StreamAccumulator is not suppressed
-            // by _hasExternalReasoning. The provider may still emit the
-            // field, but we discard it on the response side.
-            final reasoningDelta = omitReasoning
-                ? null
-                : (delta?['reasoning_content'] as String? ??
-                      delta?['reasoning'] as String?);
+              try {
+                final json = jsonDecode(data) as Map<String, dynamic>;
+                final choice = json['choices']?[0];
+                final delta = choice?['delta'];
 
-            if (contentDelta.isNotEmpty) {
-              fullText += contentDelta;
+                final contentDelta = delta?['content'] as String? ?? '';
+                // When omitReasoning is set, skip native reasoning_content so
+                // inline <think> parsing in StreamAccumulator is not suppressed
+                // by _hasExternalReasoning. The provider may still emit the
+                // field, but we discard it on the response side.
+                final reasoningDelta = omitReasoning
+                    ? null
+                    : (delta?['reasoning_content'] as String? ??
+                          delta?['reasoning'] as String?);
+
+                if (contentDelta.isNotEmpty) {
+                  fullText += contentDelta;
+                }
+                if (reasoningDelta != null && reasoningDelta.isNotEmpty) {
+                  fullReasoning += reasoningDelta;
+                }
+
+                if (contentDelta.isNotEmpty || reasoningDelta != null) {
+                  onUpdate?.call(contentDelta, reasoningDelta);
+                }
+              } catch (_) {}
             }
-            if (reasoningDelta != null && reasoningDelta.isNotEmpty) {
-              fullReasoning += reasoningDelta;
-            }
-
-            if (contentDelta.isNotEmpty || reasoningDelta != null) {
-              onUpdate?.call(contentDelta, reasoningDelta);
-            }
-          } catch (_) {}
-        }
-      },
-      onDone: () => unawaited(finishAfterCancel()),
-      onError: (Object e, StackTrace stack) =>
-          unawaited(finishAfterCancel(e, stack)),
-      cancelOnError: true,
-    );
+          },
+          onDone: () => unawaited(finishAfterCancel()),
+          onError: (Object e, StackTrace stack) =>
+              unawaited(finishAfterCancel(e, stack)),
+          cancelOnError: true,
+        );
 
     if (cancelToken != null) {
       unawaited(

--- a/test/llm/transport/openai_chat_transport_test.dart
+++ b/test/llm/transport/openai_chat_transport_test.dart
@@ -241,4 +241,33 @@ data: [DONE]
     expect(updates, ['first\n', '\nsecond']);
     expect(completed, 'first\n\nsecond');
   });
+
+  test(
+    'preserves UTF-8 text and newlines split across network chunks',
+    () async {
+      const body = '''data: {"choices":[{"delta":{"content":"Привет\\n"}}]}
+
+data: {"choices":[{"delta":{"content":"\\nмир"}}]}
+
+data: [DONE]
+
+''';
+      final bytes = utf8.encode(body);
+      final splitInsideFirstRussianCharacter =
+          bytes.indexOf(utf8.encode('П').first) + 1;
+      final dio = Dio()
+        ..httpClientAdapter = SseAdapter(
+          body,
+          chunkSizes: [splitInsideFirstRussianCharacter, 1, 2, 3],
+        );
+      String? completed;
+
+      await OpenAiChatTransport(dio: dio).stream(
+        request: _req(),
+        onComplete: (text, _, {rawResponseJson}) => completed = text,
+      );
+
+      expect(completed, 'Привет\n\nмир');
+    },
+  );
 }

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -416,11 +416,28 @@ void main() {
     test('unmatched emphasis markers cannot consume a later line', () {
       expect(
         formatterFormatterJs,
-        contains(r'(?<!\*)\*[^*\n]+?\*(?!\*)'),
+        contains(r'(?<!\*)\*(?=[^*\n]*[^ \t*\n])[^*\n]+?\*(?!\*)'),
       );
       expect(
         formatterFormatterJs,
         contains(r'html = html.replace(/\*([^*\n]+?)\*/g'),
+      );
+    });
+
+    test('orphan emphasis markers cannot consume the next action segment', () {
+      expect(
+        formatterFormatterJs,
+        contains("html = html.replace(/\\*([ \\t]+)(?=\\x01S_\\d+\\x01)/g, '\$1');"),
+      );
+    });
+
+    test('nested guillemets cannot consume styled-segment placeholders', () {
+      expect(
+        formatterFormatterJs,
+        contains(r'(«)([^»\x01]*?(?:«[^»\x01]*?»[^»\x01]*?)*?)(»)'),
+        reason:
+            'a malformed outer quote must not cross a styled segment while '
+            'searching for its closing guillemet',
       );
     });
   });


### PR DESCRIPTION
## Summary\n- decode OpenAI SSE streams incrementally so split UTF-8 characters and newlines remain intact\n- keep a malformed orphan asterisk from consuming the opening marker of the following action segment\n- keep malformed nested guillemets from crossing styled segment placeholders\n\n## Verification\n- flutter test test/llm/transport/openai_chat_transport_test.dart\n- flutter test test/webview_assets_test.dart