### PR TITLE
fix(reasoning-stripper): stop collapsing paragraph newlines in chat history

### DIFF
--- a/lib/core/llm/reasoning_stripper.dart
+++ b/lib/core/llm/reasoning_stripper.dart
@@ -55,7 +55,6 @@ class ReasoningStripper {
     }
     result = result.replaceAll('<think>', 'hidden reasoning');
     result = result.replaceAll('</think>', 'hidden reasoning');
-    result = result.replaceAll(RegExp(r'\s{2,}'), ' ');
     return result.trim();
   }
 

--- a/test/llm/reasoning_stripper_test.dart
+++ b/test/llm/reasoning_stripper_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/reasoning_stripper.dart';
+
+void main() {
+  group('ReasoningStripper.stripMessageReasoning', () {
+    test('preserves paragraph newlines in history content', () {
+      final messages = [
+        {
+          'role': 'assistant',
+          'content':
+              '*First action paragraph.*\n\n*Second action paragraph.*\n\n«Dialogue.»',
+        },
+      ];
+      final result = ReasoningStripper.stripMessageReasoning(messages);
+      expect(result[0]['content'], contains('\n\n'));
+      expect(
+        result[0]['content'],
+        '*First action paragraph.*\n\n*Second action paragraph.*\n\n«Dialogue.»',
+      );
+    });
+
+    test('preserves single newlines inside content', () {
+      final messages = [
+        {
+          'role': 'assistant',
+          'content': 'Line one\nLine two\nLine three',
+        },
+      ];
+      final result = ReasoningStripper.stripMessageReasoning(messages);
+      expect(result[0]['content'], 'Line one\nLine two\nLine three');
+    });
+
+    test('rewrites literal think tags to hidden reasoning', () {
+      final messages = [
+        {
+          'role': 'system',
+          'content': 'Use <think>reasoning</think> for planning.',
+        },
+      ];
+      final result = ReasoningStripper.stripMessageReasoning(messages);
+      expect(result[0]['content'], contains('hidden reasoning'));
+      expect(result[0]['content'], isNot(contains('<think>')));
+      expect(result[0]['content'], isNot(contains('</think>')));
+    });
+
+    test('strips Plan internally directive and preserves surrounding newlines', () {
+      final messages = [
+        {
+          'role': 'system',
+          'content':
+              'Introduction.\n\nPlan internally before responding <think>secret</think> after.\n\nConclusion.',
+        },
+      ];
+      final result = ReasoningStripper.stripMessageReasoning(messages);
+      final content = result[0]['content'] as String;
+      expect(content, isNot(contains('Plan internally')));
+      expect(content, isNot(contains('secret')));
+      expect(content, contains('Introduction.'));
+      expect(content, contains('Conclusion.'));
+    });
+
+    test('does not collapse non-directive whitespace in roleplay content', () {
+      final rp =
+          '*action one* "dialogue" *action two*\n\n*action three*\n\n«quote»';
+      final messages = [
+        {'role': 'assistant', 'content': rp},
+      ];
+      final result = ReasoningStripper.stripMessageReasoning(messages);
+      expect(result[0]['content'], rp);
+    });
+
+    test('preserves lumiaooc blocks with internal newlines', () {
+      final content =
+          '*Action.*\n\n<lumiaooc>\nOOC note here\nmore notes\n</lumiaooc>';
+      final messages = [
+        {'role': 'assistant', 'content': content},
+      ];
+      final result = ReasoningStripper.stripMessageReasoning(messages);
+      expect(result[0]['content'], content);
+    });
+
+    test('passes through non-string content unchanged', () {
+      final messages = [
+        {
+          'role': 'user',
+          'content': [
+            {'type': 'text', 'text': 'hello'},
+          ],
+        },
+      ];
+      final result = ReasoningStripper.stripMessageReasoning(messages);
+      expect(result[0]['content'], same(messages[0]['content']));
+    });
+  });
+}


### PR DESCRIPTION
## Root cause

ReasoningStripper._stripThinkDirective applied a global \s{2,} → ' ' whitespace collapse to **every** message in the request — including chat history — which destroyed all \n\n paragraph breaks.

The collapse was meant to clean up residual whitespace after removing \<think>\ directive patterns, but those patterns already include their own \s* boundaries, making the global pass unnecessary.

## Impact

The stripper runs on the final agent's messages when reasoning is not requested (\isFinalResponse && (!requestReasoning || omitReasoning)\). Every history message had its \n\n flattened to a single space. The model then saw the entire conversation as one unbroken line and mirrored that style in its output — producing replies with no paragraph breaks.

The effect was **intermittent** because the stripper only runs under certain reasoning-config combinations, which matched user reports of 'one message has breaks, another doesn't'.

## Evidence

Diagnostic logging confirmed:
- DB stores assistant messages with \lf=6, lf=8\ (newlines present)
- Outgoing request had the same messages with \lf=0\ (newlines stripped)
- Only single \\\n\ inside \<lumiaooc>\ blocks survived (not matched by \\\s{2,}\)

## Fix

Removed the global \eplaceAll(RegExp(r'\\s{2,}'), ' ')\ line. The directive patterns already handle their own whitespace cleanup.

## Tests

7 regression tests covering: paragraph newlines, single newlines, lumiaooc blocks, roleplay content, think-tag rewrite, directive stripping, and non-string content pass-through.