### PR TITLE
feat(catalog): search JanitorAI custom tags from the tag filter

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1340,6 +1340,7 @@
   "catalog_blocked_add_keyword": "Block tag \"{keyword}\"",
   "catalog_clear_tags": "Clear ({count})",
   "catalog_search_tags": "Search tags...",
+  "catalog_add_custom_tag": "Search by tag \"{tag}\"",
   "catalog_searching_tags": "Searching tags...",
   "catalog_nsfl_warning_title": "NSFL Content Warning",
   "catalog_nsfl_warning_desc": "Trust me, you don't want to do this.",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -1351,6 +1351,7 @@
   "catalog_blocked_add_keyword": "Заблокировать тег «{keyword}»",
   "catalog_clear_tags": "Сбросить ({count})",
   "catalog_search_tags": "Поиск тегов...",
+  "catalog_add_custom_tag": "Искать по тегу «{tag}»",
   "catalog_searching_tags": "Поиск тегов...",
   "catalog_nsfl_warning_title": "NSFL-Контент",
   "catalog_nsfl_warning_desc": "Поверь мне, ты не хочешь этого видеть.",

--- a/lib/features/catalog/widgets/catalog_filter_sheet.dart
+++ b/lib/features/catalog/widgets/catalog_filter_sheet.dart
@@ -49,9 +49,10 @@ class _CatalogFilterSheetState extends ConsumerState<CatalogFilterSheet> {
   Set<int> _blockedTagIds = {};
   Set<String> _blockedKeywords = {};
 
+  bool get _isJanitor => widget.provider == CatalogProvider.janitor;
+
   bool get _janitorBlockTagsEnabled =>
-      widget.provider == CatalogProvider.janitor &&
-      ref.read(janitorAccountProvider).isLoggedIn;
+      _isJanitor && ref.read(janitorAccountProvider).isLoggedIn;
 
   @override
   void initState() {
@@ -266,6 +267,12 @@ class _CatalogFilterSheetState extends ConsumerState<CatalogFilterSheet> {
           selectedNames: _selectedTagNames,
           onToggle: _toggleTag,
           onClear: _clearTags,
+          // JanitorAI: `/hampter/tags` only covers the curated tags searched by
+          // id. Custom tags are free text (`custom_tags[]`), so they come from
+          // the same `/tags/suggest` autocomplete the block list uses, and the
+          // raw query can be searched verbatim.
+          fetchSuggestions: _isJanitor ? fetchJanitorTagSuggestions : null,
+          allowCustomTags: _isJanitor,
         ),
         if (_blockList != null)
           FilterCustomSection(

--- a/lib/shared/widgets/filter_sheet.dart
+++ b/lib/shared/widgets/filter_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:easy_localization/easy_localization.dart';
 import '../theme/app_colors.dart';
@@ -58,6 +60,11 @@ class FilterRangeSection extends FilterSection {
 }
 
 /// A titled, searchable, multi-select tag picker row.
+///
+/// [tags] is the curated list rendered as a chip grid and filtered locally.
+/// Sources that also accept free-text tags (JanitorAI custom tags, chub topics)
+/// can supply [fetchSuggestions] and/or [allowCustomTags] so the query can
+/// resolve to a name-based [FilterTag] that isn't in [tags].
 class FilterTagsSection extends FilterSection {
   final String title;
   final String searchHint;
@@ -67,6 +74,15 @@ class FilterTagsSection extends FilterSection {
   final ValueChanged<FilterTag> onToggle;
   final VoidCallback onClear;
 
+  /// Remote autocomplete for tags [tags] doesn't cover. Called with the trimmed
+  /// query after a short debounce; implementations must resolve to an empty
+  /// list on error rather than throwing.
+  final Future<List<String>> Function(String query)? fetchSuggestions;
+
+  /// When true the raw query can be selected verbatim as a name-based tag,
+  /// even when neither [tags] nor the suggestions contain it.
+  final bool allowCustomTags;
+
   const FilterTagsSection({
     required this.title,
     required this.searchHint,
@@ -75,6 +91,8 @@ class FilterTagsSection extends FilterSection {
     required this.selectedNames,
     required this.onToggle,
     required this.onClear,
+    this.fetchSuggestions,
+    this.allowCustomTags = false,
   });
 }
 
@@ -288,13 +306,71 @@ class _FilterTags extends StatefulWidget {
 }
 
 class _FilterTagsState extends State<_FilterTags> {
+  final _controller = TextEditingController();
+  Timer? _debounce;
+
+  /// Trimmed query. Doubles as the guard for [_fetch] so an out-of-order
+  /// response can't overwrite results for a newer query.
   String _search = '';
 
+  /// Free-text suggestions for [_search], from [FilterTagsSection.fetchSuggestions].
+  List<String> _suggestions = [];
+  bool _loading = false;
+
   FilterTagsSection get _s => widget.section;
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
 
   bool _isSelected(FilterTag tag) {
     if (tag.id != null) return _s.selectedIds.contains(tag.id);
     return _s.selectedNames.contains(tag.name);
+  }
+
+  void _onSearchChanged(String value) {
+    final q = value.trim();
+    setState(() => _search = q);
+    _debounce?.cancel();
+    if (_s.fetchSuggestions == null) return;
+    if (q.isEmpty) {
+      setState(() {
+        _suggestions = [];
+        _loading = false;
+      });
+      return;
+    }
+    setState(() => _loading = true);
+    _debounce = Timer(const Duration(milliseconds: 250), () => _fetch(q));
+  }
+
+  Future<void> _fetch(String q) async {
+    final results = await _s.fetchSuggestions!(q);
+    if (!mounted || q != _search) return;
+    setState(() {
+      _suggestions = results;
+      _loading = false;
+    });
+  }
+
+  /// Selects [name] as a name-based tag (no id) and clears the query.
+  void _addCustomTag(String name) {
+    final n = name.trim();
+    if (n.isEmpty || _s.selectedNames.contains(n)) return;
+    _s.onToggle(FilterTag(name: n));
+    _reset();
+  }
+
+  void _reset() {
+    _controller.clear();
+    setState(() {
+      _search = '';
+      _suggestions = [];
+      _loading = false;
+    });
   }
 
   List<FilterTag> get _filtered {
@@ -303,8 +379,53 @@ class _FilterTagsState extends State<_FilterTags> {
     return _s.tags.where((t) => t.name.toLowerCase().contains(q)).toList();
   }
 
-  List<FilterTag> get _selectedList =>
-      _s.tags.where(_isSelected).toList();
+  /// Names already offered by the curated grid — suggestions that duplicate one
+  /// would just be a second way to pick the same chip.
+  Set<String> get _knownNames =>
+      {for (final t in _s.tags) t.name.toLowerCase()};
+
+  /// Suggested custom tags for the current query, minus curated and already
+  /// selected ones.
+  List<String> get _customMatches {
+    if (_search.isEmpty || _suggestions.isEmpty) return const [];
+    final known = _knownNames;
+    final seen = <String>{};
+    final out = <String>[];
+    for (final s in _suggestions) {
+      final name = s.trim();
+      if (name.isEmpty) continue;
+      if (known.contains(name.toLowerCase())) continue;
+      if (_s.selectedNames.contains(name)) continue;
+      if (!seen.add(name.toLowerCase())) continue;
+      out.add(name);
+      if (out.length == 8) break;
+    }
+    return out;
+  }
+
+  /// Whether to offer the raw query as a custom tag — only when it isn't
+  /// already reachable as a curated chip, a suggestion or a selected tag.
+  bool get _canAddRaw {
+    if (!_s.allowCustomTags || _search.isEmpty) return false;
+    final q = _search.toLowerCase();
+    if (_knownNames.contains(q)) return false;
+    if (_s.selectedNames.any((n) => n.toLowerCase() == q)) return false;
+    return !_customMatches.any((s) => s.toLowerCase() == q);
+  }
+
+  /// Selected curated chips plus selected custom tags, which have no entry in
+  /// [FilterTagsSection.tags] and would otherwise be invisible.
+  List<FilterTag> get _selectedList {
+    final list = _s.tags.where(_isSelected).toList();
+    final shown = {
+      for (final t in _s.tags)
+        if (t.id == null) t.name,
+    };
+    for (final name in _s.selectedNames) {
+      if (!shown.contains(name)) list.add(FilterTag(name: name));
+    }
+    return list;
+  }
 
   int get _selectedCount => _s.selectedIds.length + _s.selectedNames.length;
 
@@ -368,7 +489,9 @@ class _FilterTagsState extends State<_FilterTags> {
             border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
           ),
           child: TextField(
+            controller: _controller,
             style: const TextStyle(fontSize: 14, color: Colors.white),
+            textInputAction: _s.allowCustomTags ? TextInputAction.done : null,
             decoration: InputDecoration(
               hintText: _s.searchHint,
               hintStyle: TextStyle(color: context.cs.onSurfaceVariant),
@@ -378,10 +501,41 @@ class _FilterTagsState extends State<_FilterTags> {
                 vertical: 10,
               ),
               isDense: true,
+              suffixIcon: _loading
+                  ? const Padding(
+                      padding: EdgeInsets.all(11),
+                      child: SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    )
+                  : null,
             ),
-            onChanged: (v) => setState(() => _search = v),
+            onChanged: _onSearchChanged,
+            onSubmitted: _s.allowCustomTags ? _addCustomTag : null,
           ),
         ),
+
+        // Custom (name-based) tag suggestions — sources without a curated id.
+        if (_customMatches.isNotEmpty || _canAddRaw) ...[
+          const SizedBox(height: 6),
+          ..._customMatches.map(
+            (name) => _suggestionRow(
+              icon: Icons.sell_outlined,
+              label: name,
+              onTap: () => _addCustomTag(name),
+            ),
+          ),
+          if (_canAddRaw)
+            _suggestionRow(
+              icon: Icons.add,
+              label: 'catalog_add_custom_tag'.tr(
+                namedArgs: {'tag': _search},
+              ),
+              onTap: () => _addCustomTag(_search),
+            ),
+        ],
         const SizedBox(height: 12),
 
         // Grid
@@ -393,6 +547,37 @@ class _FilterTagsState extends State<_FilterTags> {
               .toList(),
         ),
       ],
+    );
+  }
+
+  Widget _suggestionRow({
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+        child: Row(
+          children: [
+            Icon(icon, size: 16, color: context.cs.onSurfaceVariant),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: Colors.white.withValues(alpha: 0.85),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
The catalog tag filter only offered the curated JanitorAI tags from
`/hampter/tags`, which are searched by `tag_id[]`. `janitorSearch` already
writes free-text `custom_tags[]` from `CatalogFilters.tagNames`, but nothing in
the UI could produce a name-based tag for the JanitorAI provider (every curated
tag has an `id`), so that path was unreachable. Custom tags were only resolvable
in the account block list, via `/tags/suggest`.

## Changes

- `FilterTagsSection` takes an optional `fetchSuggestions` autocomplete callback
  and an `allowCustomTags` flag, so a source with free-text tags can resolve a
  query to a name-based `FilterTag` that is not in the curated list.
- `_FilterTags` debounces the query (250 ms) into that callback, guarding
  against out-of-order responses with the query itself, and shows a spinner in
  the search field while a fetch is in flight.
- Suggested custom tags render as rows under the search field, skipping names
  that already exist as curated chips or are already selected; when
  `allowCustomTags` is set, the raw query can also be picked verbatim (tap or
  submit).
- `_FilterTags._selectedList` now includes selected names with no entry in
  `tags` — previously a picked custom tag was invisible in the selected-chips
  row and could not be removed there.
- `CatalogFilterSheet` wires `fetchJanitorTagSuggestions` and `allowCustomTags`
  for the JanitorAI provider only; chub, datacat and the My Characters filter
  sheet keep the previous behaviour through the new defaults (`null` / `false`).
- New `catalog_add_custom_tag` string in `assets/translations/en.json` and
  `ru.json`.

Selected custom tags flow into `filters.tagNames` → `custom_tags[]` in
`janitorSearch`, and the existing `_ActiveTagsRow` in `catalog_grid.dart`
already renders and removes tags without an id, so they appear above the grid
and can be cleared from there.

## Verification

- Not run: `flutter analyze` and `flutter test`. The agent environment for this
  change had no Flutter/Dart SDK, so both are left to the CI gate — no local
  check was executed and none should be assumed to have passed.
- Reviewed by reading: the new section options default to the previous
  behaviour, so the two existing `FilterTagsSection` call sites (catalog filters
  for chub/datacat, My Characters filters) are unaffected.
- The branch was cut from `stable` and rebased onto `nightly` before pushing.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165rbq8asqbxgf2hqEpG3C6)_