### PR TITLE
fix(studio): bind Agents tab API slots to the active preset

### DIFF
--- a/lib/core/state/active_studio_preset_provider.dart
+++ b/lib/core/state/active_studio_preset_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../models/studio_config.dart';
 import 'db_provider.dart';
 
 /// Global singleton for the active Studio preset.
@@ -32,3 +33,19 @@ class ActiveStudioPresetNotifier extends AsyncNotifier<String> {
     state = AsyncData(presetId);
   }
 }
+
+/// The Studio preset a turn actually runs: the one [activeStudioPresetProvider]
+/// names, falling back to the seeded `default` row when that id no longer
+/// resolves.
+///
+/// This must mirror `StudioTurnConfigResolver.resolve` exactly. Anything that
+/// reads or writes a preset's API slots (`cheapApiConfigId`,
+/// `expensiveApiConfigId`, `cleanerApiConfigId`, `ledgerApiConfigId`) has to go
+/// through the same preset generation reads — editing `default` while a turn
+/// runs a different preset silently drops the binding, leaving the global model
+/// override pointed at whatever connection the turn falls back to.
+final studioPresetProvider = FutureProvider<StudioPreset?>((ref) async {
+  final repo = ref.watch(studioPresetRepoProvider);
+  final activeId = await ref.watch(activeStudioPresetProvider.future);
+  return await repo.getById(activeId) ?? await repo.getDefault();
+});

--- a/lib/core/state/db_provider.dart
+++ b/lib/core/state/db_provider.dart
@@ -171,9 +171,9 @@ final studioPresetRepoProvider = Provider<StudioPresetRepo>((ref) {
   return StudioPresetRepo(ref.watch(appDbProvider));
 });
 
-final studioPresetProvider = FutureProvider<StudioPreset?>((ref) async {
-  return ref.watch(studioPresetRepoProvider).getDefault();
-});
+// `studioPresetProvider` — the preset a turn actually runs — lives in
+// `active_studio_preset_provider.dart`: it needs the active-preset id, and that
+// provider already imports this file.
 
 final studioPresetListProvider = FutureProvider<List<StudioPreset>>((
   ref,

--- a/lib/features/studio/widgets/studio_slots_tab.dart
+++ b/lib/features/studio/widgets/studio_slots_tab.dart
@@ -7,6 +7,7 @@ import '../../../core/llm/transport/llm_protocol.dart';
 import '../../../core/models/api_config.dart';
 import '../../../core/models/pipeline_settings.dart';
 import '../../../core/models/studio_config.dart';
+import '../../../core/state/active_studio_preset_provider.dart';
 import '../../../core/state/db_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
@@ -162,14 +163,22 @@ class _StudioSlotsTabState extends ConsumerState<StudioSlotsTab> {
 
   // ── Persistence ────────────────────────────────────────────────────────────
 
-  /// Slot API bindings live on the default Studio preset new sessions inherit;
-  /// the preset row is seeded on the first edit, never just by opening the tab.
+  /// Slot API bindings live on the **active** Studio preset — the one a turn
+  /// resolves through `StudioTurnConfigResolver`. Writing to `default` instead
+  /// would drop the binding for anyone running a different preset, while the
+  /// global model override still applied, sending that model to whatever
+  /// connection the turn fell back to.
+  ///
+  /// The `default` row is seeded on the first edit only when the active id no
+  /// longer resolves, never just by opening the tab.
   Future<void> _saveProfile(
     StudioPreset Function(StudioPreset) mutate, {
     required String slotName,
   }) async {
     final repo = ref.read(studioPresetRepoProvider);
-    final preset = await repo.ensureDefaultSeeded();
+    final activeId = await ref.read(activeStudioPresetProvider.future);
+    final preset =
+        await repo.getById(activeId) ?? await repo.ensureDefaultSeeded();
     await repo.upsert(
       mutate(
         preset,

--- a/test/studio_active_preset_slots_test.dart
+++ b/test/studio_active_preset_slots_test.dart
@@ -1,0 +1,84 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/models/studio_config.dart';
+import 'package:glaze_flutter/core/state/active_studio_preset_provider.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// `studioPresetProvider` feeds the Agents tab, which reads and writes the API
+/// slot bindings (`cheapApiConfigId` and friends). Generation resolves those
+/// slots from the ACTIVE preset via `StudioTurnConfigResolver`, so the provider
+/// has to resolve the same row.
+///
+/// Regression: it used to return `getDefault()` unconditionally. With any
+/// non-default preset selected, the tab then edited `default`'s slots while the
+/// turn read the active preset's empty ones and fell back to the chat's own
+/// connection — and because the model override is global, that override was
+/// still applied, sending a model from one provider to another provider's
+/// endpoint ("model not found"). Only "Automatic" survived, because it takes
+/// the model from whatever connection the turn ended up on.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late ProviderContainer container;
+
+  Future<void> boot({required String activePresetId}) async {
+    SharedPreferences.setMockInitialValues(
+      activePresetId.isEmpty
+          ? <String, Object>{}
+          : <String, Object>{activeStudioPresetKey: activePresetId},
+    );
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    addTearDown(container.dispose);
+    addTearDown(db.close);
+
+    final repo = container.read(studioPresetRepoProvider);
+    await repo.upsert(
+      const StudioPreset(
+        id: 'default',
+        name: 'Default Studio Preset',
+        cheapApiConfigId: 'connection-default',
+      ),
+    );
+    await repo.upsert(
+      const StudioPreset(
+        id: 'custom',
+        name: 'Custom Studio Preset',
+        cheapApiConfigId: 'connection-custom',
+      ),
+    );
+  }
+
+  test('resolves the active preset, not the default one', () async {
+    await boot(activePresetId: 'custom');
+
+    final preset = await container.read(studioPresetProvider.future);
+
+    expect(preset?.id, 'custom');
+    expect(preset?.cheapApiConfigId, 'connection-custom');
+  });
+
+  test('falls back to the default preset when no active id is stored', () async {
+    await boot(activePresetId: '');
+
+    final preset = await container.read(studioPresetProvider.future);
+
+    expect(preset?.id, 'default');
+    expect(preset?.cheapApiConfigId, 'connection-default');
+  });
+
+  test('falls back to the default preset when the active id is stale', () async {
+    await boot(activePresetId: 'deleted-preset');
+
+    final preset = await container.read(studioPresetProvider.future);
+
+    expect(preset?.id, 'default');
+    expect(preset?.cheapApiConfigId, 'connection-default');
+  });
+}


### PR DESCRIPTION
Fixes the "model not found" reported on the pre-gen slot, where only "Automatic" worked.

## The bug

The Agents tab read the slot bindings from `studioPresetProvider`, which returned `getDefault()` — the preset row with id `default` — and wrote them back through `ensureDefaultSeeded()`, the same row. Generation resolves them from a different row: `StudioTurnConfigResolver.resolve` loads the preset named by `activeStudioPresetProvider` and only falls back to `default` when that id does not resolve.

With any non-default Studio preset selected the two diverge. The tab edits `default.cheapApiConfigId`; the turn reads the active preset's `cheapApiConfigId`, finds it empty, and falls back to the chat's own connection.

The model override does not diverge — it lives in global `PipelineSettings`, so it applies to whatever connection the turn landed on. The result is a model id picked from one provider's list sent to another provider's endpoint, which comes back as "model not found". "Automatic" keeps working because it leaves the override empty and takes `config.model` from the connection the turn actually uses.

## Changes

- Resolve `studioPresetProvider` through `activeStudioPresetProvider`, falling back to the seeded `default` row — mirroring `StudioTurnConfigResolver.resolve`
- Move it next to `activeStudioPresetProvider`: `db_provider` cannot import that file back without an import cycle, and the provider was only consumed by the Agents tab plus one `invalidate` in the sync controller, which already imports both
- Write slot changes to that same active preset, seeding `default` only when the stored active id no longer resolves
- Add `test/studio_active_preset_slots_test.dart` covering all three resolutions: active preset selected, no active id stored, and a stale active id

## Verification

- No Flutter SDK in the environment these changes were written in, so `flutter analyze` and `flutter test` were **not** run locally — CI is the first execution
- Traced both sides in code before changing anything: `studio_preset_repo.dart` (`getDefault` → `getById('default')`, `ensureDefaultSeeded` → same row) against `studio_turn_config_resolver.dart` (`loadPreset(activeId) ?? loadDefaultPreset()`)
- Confirmed the Agents tab is the only writer of `cheapApiConfigId` / `expensiveApiConfigId` / `cleanerApiConfigId` / `ledgerApiConfigId`, so no other screen depended on the old routing
- Checked the new test against `StudioPresetRepo.upsert`'s empty-block guard: it only substitutes stored blocks when a row already exists, so the fresh rows the test inserts are written verbatim

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2xhQJE11JYZxqkdLsyWyL)_