### PR TITLE
fix(memory): regenerate drafts and stabilize chat scroll

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -514,6 +514,22 @@ export class Bridge {
     this._updateBatcher.enqueue(msg.id, () => this._executeUpdateMessage(msg));
   }
 
+  // Patch only memory badges when the async memory providers settle. This
+  // deliberately avoids rebuilding message bodies/panels and works for both
+  // mounted and virtualized rows because itemMap retains every row element.
+  patchMemoryStatuses(statusesJson) {
+    const statuses = JSON.parse(statusesJson);
+    for (const [id, status] of Object.entries(statuses)) {
+      const item = this.virtualList.itemMap?.get(id);
+      const section = item?.el;
+      if (!section) continue;
+      const current = section.querySelector('.msg-memory-badge')?.textContent;
+      // REBUILD/STALE come from message-local coverage and outrank book state.
+      if (current === 'REBUILD' || current === 'STALE') continue;
+      this.renderer.updateMessageMeta(section, { id, memoryStatus: status });
+    }
+  }
+
   _executeUpdateMessage(msg) {
     const section = document.querySelector(`[data-message-id="${msg.id}"]`);
     if (!section) return;
@@ -758,10 +774,11 @@ export class Bridge {
   }
 
   scrollToBottom(behavior = 'auto') {
-    this.virtualList.scrollToBottom(behavior);
+    const settled = this.virtualList.scrollToBottom(behavior);
     requestAnimationFrame(() => {
       this._sendToFlutter('onScrollToBottomVisibility', [false]);
     });
+    return settled;
   }
 
   // Arm a one-shot "stick to bottom on the next append" so that sending a

--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -858,6 +858,8 @@ if (messageData.isEditing) classes.push('editing');
         badge.className = `msg-memory-badge ${cls}`;
         badge.textContent = msg.memoryStatus;
       }
+    } else {
+      sectionEl.querySelector('.msg-memory-badge')?.remove();
     }
 
     if (msg.isHidden !== undefined) {

--- a/assets/chat_webview/useVirtualScroll.js
+++ b/assets/chat_webview/useVirtualScroll.js
@@ -175,6 +175,7 @@ class UseVirtualScroll {
         
         this.observer = null;
         this.realObserver = null;
+        this.resizeObserver = null;
         
         this.cache = new VirtualScrollHeightCache(
             () => this.items.length,
@@ -336,9 +337,11 @@ class UseVirtualScroll {
         if (wasInDOM) {
             this.observer.unobserve(item.el);
             this.realObserver.unobserve(item.el);
+            this.resizeObserver?.unobserve(item.el);
             this.container.replaceChild(el, item.el);
             this.observer.observe(el);
             this.realObserver.observe(el);
+            this.resizeObserver?.observe(el);
         }
         item.el = el;
         this.cache.setHeight(item.index, 0); // trigger re-measure
@@ -352,6 +355,7 @@ class UseVirtualScroll {
         if (item.el.parentNode === this.container) {
             this.observer.unobserve(item.el);
             this.realObserver.unobserve(item.el);
+            this.resizeObserver?.unobserve(item.el);
             item.el.remove();
         }
         this.itemMap.delete(id);
@@ -391,7 +395,7 @@ class UseVirtualScroll {
 
     scrollToBottom(behavior = 'auto') {
         const count = this.items.length;
-        if (count === 0) return;
+        if (count === 0) return Promise.resolve();
 
         this._pinnedToBottom = true;
         let effectiveBehavior = behavior;
@@ -416,12 +420,18 @@ class UseVirtualScroll {
         // `setTimeout(…, 50)` left the new message rendered at the bottom while the
         // viewport stayed at the previous offset for ~50ms before snapping down,
         // which read as a janky, non-smooth jump when sending a message.
-        requestAnimationFrame(() => {
+        return new Promise((resolve) => requestAnimationFrame(() => {
             requestAnimationFrame(() => {
-                if (!this.mounted) return;
+                if (!this.mounted) {
+                    resolve();
+                    return;
+                }
                 if (effectiveBehavior === 'smooth') {
                     this.container.scrollTo({ top: this.container.scrollHeight, behavior: 'smooth' });
-                    setTimeout(() => { this.isProgrammaticScrolling = false; }, 500);
+                    setTimeout(() => {
+                        this.isProgrammaticScrolling = false;
+                        resolve();
+                    }, 500);
                 } else {
                     this.container.scrollTop = this.container.scrollHeight;
                     // Re-pin after layout settles (late image/height changes), matching
@@ -429,10 +439,11 @@ class UseVirtualScroll {
                     setTimeout(() => {
                         this.container.scrollTop = this.container.scrollHeight;
                         this.isProgrammaticScrolling = false;
+                        resolve();
                     }, 150);
                 }
             });
-        });
+        }));
     }
 
     scrollToTop() {
@@ -543,6 +554,7 @@ class UseVirtualScroll {
             if (item.el.parentNode === this.container) {
                 this.observer.unobserve(item.el);
                 this.realObserver.unobserve(item.el);
+                this.resizeObserver?.unobserve(item.el);
                 item.el.remove();
             }
         }
@@ -624,6 +636,7 @@ class UseVirtualScroll {
             if (!inRange && inDOM) {
                 this.observer.unobserve(item.el);
                 this.realObserver.unobserve(item.el);
+                this.resizeObserver?.unobserve(item.el);
                 item.el.remove();
             }
         }
@@ -636,6 +649,7 @@ class UseVirtualScroll {
                 this.container.insertBefore(item.el, insertBefore);
                 this.observer.observe(item.el);
                 this.realObserver.observe(item.el);
+                this.resizeObserver?.observe(item.el);
             }
             insertBefore = item.el;
         }
@@ -700,6 +714,34 @@ class UseVirtualScroll {
                 }
             });
         }, { root: this.container, threshold: [0, 0.1, 0.5, 1.0] });
+
+        // IntersectionObserver gives us an initial measurement but does not
+        // report later badge/image/font reflow. Keep cached heights current and
+        // follow that reflow only while the user is still bottom-pinned.
+        if (typeof ResizeObserver === 'function') {
+            this.resizeObserver = new ResizeObserver((entries) => {
+                if (!this.mounted) return;
+                const wasPinned = this._pinnedToBottom;
+                let changed = false;
+                for (const entry of entries) {
+                    const idx = parseInt(entry.target.dataset.index);
+                    const height = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+                    if (isNaN(idx) || height <= 0) continue;
+                    const previous = this.cache.itemHeights.get(idx);
+                    if (previous == null || Math.abs(previous - height) > 1) {
+                        this.cache.setHeight(idx, height);
+                        changed = true;
+                    }
+                }
+                if (!changed) return;
+                this.updateSpacers();
+                if (wasPinned) {
+                    requestAnimationFrame(() => {
+                        if (this.mounted && this._pinnedToBottom) this.smartScroll();
+                    });
+                }
+            });
+        }
     }
 
     _onContainerScroll() {
@@ -766,6 +808,7 @@ class UseVirtualScroll {
         this.mounted = false;
         if (this.observer) this.observer.disconnect();
         if (this.realObserver) this.realObserver.disconnect();
+        if (this.resizeObserver) this.resizeObserver.disconnect();
         this.container.removeEventListener('scroll', this._onContainerScroll);
     }
 }

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1400,6 +1400,7 @@
   "memory_books_badge_hybrid": "hybrid",
   "memory_books_btn_generate": "Generate",
   "memory_books_btn_regenerate": "Regenerate",
+  "memory_books_regeneration_failed": "Regeneration failed. Existing content was preserved",
   "memory_books_btn_generate_remaining": "Generate Remaining",
   "memory_books_btn_generate_batch": "Generate Batch",
   "memory_books_btn_approve": "Approve",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -1411,6 +1411,7 @@
   "memory_books_badge_hybrid": "гибридный",
   "memory_books_btn_generate": "Генерировать",
   "memory_books_btn_regenerate": "Перегенерировать",
+  "memory_books_regeneration_failed": "Не удалось перегенерировать. Предыдущее содержимое сохранено",
   "memory_books_btn_generate_remaining": "Генерировать оставшиеся",
   "memory_books_btn_generate_batch": "Генерировать пакет",
   "memory_books_btn_approve": "Принять",

--- a/lib/features/chat/bridge/bridge_memory_commands.dart
+++ b/lib/features/chat/bridge/bridge_memory_commands.dart
@@ -5,13 +5,20 @@ import 'chat_bridge_controller.dart';
 /// with the right memory state chip.
 class MemoryBridgeCommands {
   final ChatBridgeController _host;
+  Future<void>? _patchPending;
 
   MemoryBridgeCommands(this._host);
 
-  void updateMemoryBookData({
+  Future<void> updateMemoryBookData({
     required List<Map<String, dynamic>> entries,
     required List<Map<String, dynamic>> pendingDrafts,
-  }) {
+    bool patchMessages = true,
+  }) async {
+    final previousStatuses = <String, String?>{
+      for (final id in _host.coveredMemoryIds) id: 'MEM',
+      for (final id in _host.pendingMemoryIds) id: 'PENDING',
+      for (final id in _host.draftMemoryIds) id: 'DRAFT',
+    };
     _host.coveredMemoryIds.clear();
     _host.pendingMemoryIds.clear();
     _host.draftMemoryIds.clear();
@@ -37,6 +44,47 @@ class MemoryBridgeCommands {
           _host.draftMemoryIds.add(id.toString());
         }
       }
+    }
+
+    if (!patchMessages) return;
+
+    final changedIds = <String>{
+      ...previousStatuses.keys,
+      ..._host.coveredMemoryIds,
+      ..._host.pendingMemoryIds,
+      ..._host.draftMemoryIds,
+    };
+    if (changedIds.isEmpty) return;
+
+    final statuses = <String, String?>{};
+    for (final id in changedIds) {
+      final status = _host.coveredMemoryIds.contains(id)
+          ? 'MEM'
+          : _host.pendingMemoryIds.contains(id)
+          ? 'PENDING'
+          : _host.draftMemoryIds.contains(id)
+          ? 'DRAFT'
+          : null;
+      if (previousStatuses[id] != status) statuses[id] = status;
+    }
+    if (statuses.isEmpty) return;
+    final previous = _patchPending;
+    late final Future<void> operation;
+    operation = () async {
+      if (previous != null) {
+        try {
+          await previous;
+        } catch (_) {
+          // A failed/stale WebView call must not poison later status patches.
+        }
+      }
+      await _host.patchMemoryStatuses(statuses);
+    }();
+    _patchPending = operation;
+    try {
+      await operation;
+    } finally {
+      if (identical(_patchPending, operation)) _patchPending = null;
     }
   }
 }

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -257,6 +257,7 @@ class ChatBridgeController {
   void Function()? onLoadMore;
   void Function(bool hidden)? onHeaderScroll;
   void Function(bool visible)? onScrollToBottomVisibility;
+
   /// A rendered message carried a `<script>` while message script execution is
   /// off. Fired at most once per WebView load so the app can offer to enable
   /// execution.
@@ -703,13 +704,18 @@ class ChatBridgeController {
   }) => layout.trackpadScroll(dx: dx, dy: dy, x: x, y: y);
 
   // Memory
-  void updateMemoryBookData({
+  Future<void> updateMemoryBookData({
     required List<Map<String, dynamic>> entries,
     required List<Map<String, dynamic>> pendingDrafts,
+    bool patchMessages = true,
   }) => memory.updateMemoryBookData(
     entries: entries,
     pendingDrafts: pendingDrafts,
+    patchMessages: patchMessages,
   );
+
+  Future<void> patchMemoryStatuses(Map<String, String?> statuses) =>
+      callJs('patchMemoryStatuses', jsonEncode(statuses));
 
   // Ext Blocks
 

--- a/lib/features/chat/memory_draft_generator.dart
+++ b/lib/features/chat/memory_draft_generator.dart
@@ -137,6 +137,7 @@ class MemoryDraftGenerator {
       status: 'pending_approval',
       generatedAt: DateTime.now().millisecondsSinceEpoch,
       updatedAt: DateTime.now().millisecondsSinceEpoch,
+      error: null,
     );
   }
 }

--- a/lib/features/chat/widgets/chat_webview_initializer.dart
+++ b/lib/features/chat/widgets/chat_webview_initializer.dart
@@ -183,17 +183,21 @@ class ChatWebViewInitializer {
           ? input.searchCurrentIndex
           : -1,
     );
-    await bridge.setMessages(
-      input.messages,
-      visibleStartIndex: input.visibleStartIndex,
-    );
-    bridge.updateMemoryBookData(
+    // Memory membership is mapper input, not a post-render decoration. Seed it
+    // before mapping so the first layout already includes MEM/PENDING/DRAFT
+    // badges (whose height can otherwise invalidate the opening bottom jump).
+    await bridge.updateMemoryBookData(
       entries: input.memoryEntries
           .map((e) => {'status': e.status, 'messageIds': e.messageIds})
           .toList(),
       pendingDrafts: input.memoryDrafts
           .map((e) => {'messageIds': e.messageIds})
           .toList(),
+      patchMessages: false,
+    );
+    await bridge.setMessages(
+      input.messages,
+      visibleStartIndex: input.visibleStartIndex,
     );
     if (input.bottomInset > 0) {
       await bridge.setBottomPadding(

--- a/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
+++ b/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
@@ -216,13 +216,15 @@ class ChatWebViewSyncDispatcher {
   }) {
     if (current.memoryEntries != old.memoryEntries ||
         current.memoryDrafts != old.memoryDrafts) {
-      bridge.updateMemoryBookData(
-        entries: current.memoryEntries
-            .map((e) => {'status': e.status, 'messageIds': e.messageIds})
-            .toList(),
-        pendingDrafts: current.memoryDrafts
-            .map((e) => {'messageIds': e.messageIds})
-            .toList(),
+      unawaited(
+        bridge.updateMemoryBookData(
+          entries: current.memoryEntries
+              .map((e) => {'status': e.status, 'messageIds': e.messageIds})
+              .toList(),
+          pendingDrafts: current.memoryDrafts
+              .map((e) => {'messageIds': e.messageIds})
+              .toList(),
+        ),
       );
     }
   }

--- a/lib/features/chat/widgets/memory/memory_draft_card.dart
+++ b/lib/features/chat/widgets/memory/memory_draft_card.dart
@@ -19,6 +19,7 @@ class MemoryDraftCard extends StatelessWidget {
   final DateTime? generatingSince;
 
   final VoidCallback onGenerate;
+  final VoidCallback onRegenerate;
   final VoidCallback onCancel;
   final VoidCallback onApprove;
   final VoidCallback onEdit;
@@ -30,6 +31,7 @@ class MemoryDraftCard extends StatelessWidget {
     required this.isGenerating,
     required this.generatingSince,
     required this.onGenerate,
+    required this.onRegenerate,
     required this.onCancel,
     required this.onApprove,
     required this.onEdit,
@@ -130,6 +132,12 @@ class MemoryDraftCard extends StatelessWidget {
                   label: 'memory_books_btn_approve'.tr(),
                   color: _kGreen,
                   onTap: onApprove,
+                ),
+              if (hasContent && !isGenerating)
+                MemoryActionChip(
+                  label: 'memory_books_btn_regenerate'.tr(),
+                  color: _kAmber,
+                  onTap: onRegenerate,
                 ),
               if (hasContent && !isGenerating)
                 MemoryActionChip(

--- a/lib/features/chat/widgets/memory_books_tab.dart
+++ b/lib/features/chat/widgets/memory_books_tab.dart
@@ -271,6 +271,7 @@ class _MemoryBooksTabState extends ConsumerState<MemoryBooksTab> {
               isGenerating: _ctrl.generatingDrafts[draft.id] == true,
               generatingSince: _ctrl.genStartTimes[draft.id],
               onGenerate: () => _generateDraft(draft.id),
+              onRegenerate: () => _generateDraft(draft.id),
               onCancel: () => _cancelDraft(draft.id),
               onApprove: () => _approveDraft(draft.id),
               onEdit: () => _editDraft(draft),
@@ -318,6 +319,10 @@ class _MemoryBooksTabState extends ConsumerState<MemoryBooksTab> {
   }
 
   void _generateDraft(String draftId) {
+    final drafts = _ctrl.book?.pendingDrafts ?? const <MemoryDraft>[];
+    final draftIndex = drafts.indexWhere((draft) => draft.id == draftId);
+    final isRegeneration =
+        draftIndex >= 0 && drafts[draftIndex].content.isNotEmpty;
     _ctrl.generateDraft(
       draftId,
       onStart: () {
@@ -336,7 +341,10 @@ class _MemoryBooksTabState extends ConsumerState<MemoryBooksTab> {
         if (mounted) {
           setState(() {});
           _stopElapsedTimer();
-          GlazeToast.show(context, "${'error_generation'.tr()}: $error");
+          final label = isRegeneration
+              ? 'memory_books_regeneration_failed'.tr()
+              : 'error_generation'.tr();
+          GlazeToast.show(context, '$label: $error');
         }
       },
     );

--- a/lib/features/memory/controllers/memory_book_controller.dart
+++ b/lib/features/memory/controllers/memory_book_controller.dart
@@ -11,6 +11,7 @@ import '../../../core/state/memory_settings_provider.dart';
 import '../../../core/state/pipeline_settings_provider.dart';
 import '../../chat/chat_provider.dart';
 import '../../settings/api_list_provider.dart';
+import 'memory_book_write_queue.dart';
 import 'memory_draft_generation_controller.dart';
 import 'memory_settings_mapper.dart';
 
@@ -29,6 +30,11 @@ class MemoryBookController {
   bool _loading = true;
   bool _isReindexing = false;
   final MemorySettingsMapper _settingsMapper = const MemorySettingsMapper();
+  late final MemoryBookWriteQueue _bookWrites = MemoryBookWriteQueue(
+    readLatest: () => _book,
+    publish: (book) => _book = book,
+    persist: (book) => _ref.read(memoryBookOpsProvider).saveMemoryBook(book),
+  );
   late final MemoryDraftGenerationController _draftGen =
       MemoryDraftGenerationController(
         ref: _ref,
@@ -36,10 +42,7 @@ class MemoryBookController {
         sessionId: _sessionId,
         settingsMapper: _settingsMapper,
         bookGetter: () => _book,
-        persistAndSet: (book) async {
-          _book = book;
-          await save();
-        },
+        persistMutation: _bookWrites.mutate,
       );
 
   MemoryBookController(this._ref, this._sessionId, this._charId);
@@ -68,7 +71,7 @@ class MemoryBookController {
 
   Future<void> save() async {
     if (_book == null) return;
-    await _ref.read(memoryBookOpsProvider).saveMemoryBook(_book!);
+    await _bookWrites.saveLatest();
   }
 
   MemoryBookSettings globalSettingsAsBookSettings() =>
@@ -201,6 +204,9 @@ class MemoryBookController {
 
   Future<void> approveDraft(String draftId) async {
     if (_book == null) return;
+    // The card hides Approve while generating; keep the same invariant at the
+    // controller boundary for stale callbacks or programmatic callers.
+    if (_draftGen.isDraftGenerating(draftId)) return;
     final draftIndex = _book!.pendingDrafts.indexWhere((d) => d.id == draftId);
     if (draftIndex < 0) return;
     final draft = _book!.pendingDrafts[draftIndex];
@@ -233,6 +239,9 @@ class MemoryBookController {
 
   Future<void> deleteDraft(String draftId) async {
     if (_book == null) return;
+    // Invalidate an in-flight request before removing the draft so a late
+    // completion cannot publish it back into the book.
+    _draftGen.cancelDraftGeneration(draftId);
     _book = _book!.copyWith(
       pendingDrafts: _book!.pendingDrafts
           .where((d) => d.id != draftId)
@@ -243,6 +252,9 @@ class MemoryBookController {
 
   Future<void> deleteAllDrafts() async {
     if (_book == null) return;
+    for (final draft in _book!.pendingDrafts) {
+      _draftGen.cancelDraftGeneration(draft.id);
+    }
     _book = _book!.copyWith(pendingDrafts: []);
     await save();
   }
@@ -352,6 +364,9 @@ class MemoryBookController {
 
   Future<void> editDraft(MemoryDraft draft, MemoryEntry result) async {
     if (_book == null) return;
+    // Editing a draft that has an active generation would create ambiguous
+    // last-writer-wins semantics. Delete remains intentionally allowed.
+    if (_draftGen.isDraftGenerating(draft.id)) return;
     final drafts = [..._book!.pendingDrafts];
     final idx = drafts.indexWhere((d) => d.id == draft.id);
     if (idx >= 0) {

--- a/lib/features/memory/controllers/memory_book_write_queue.dart
+++ b/lib/features/memory/controllers/memory_book_write_queue.dart
@@ -1,0 +1,67 @@
+import '../../../core/models/memory_book.dart';
+
+typedef MemoryBookMutation = MemoryBook? Function(MemoryBook current);
+
+/// Serializes MemoryBook persistence while allowing generation to apply a
+/// narrow mutation to the freshest in-memory book.
+///
+/// Ordinary CRUD calls use [saveLatest], which deliberately reads the book
+/// only after earlier writes finish. Draft generation uses [mutate]: two
+/// completions therefore compose instead of saving competing full snapshots.
+class MemoryBookWriteQueue {
+  final MemoryBook? Function() readLatest;
+  final void Function(MemoryBook book) publish;
+  final Future<void> Function(MemoryBook book) persist;
+
+  Future<void> _tail = Future<void>.value();
+
+  MemoryBookWriteQueue({
+    required this.readLatest,
+    required this.publish,
+    required this.persist,
+  });
+
+  Future<void> saveLatest() => _enqueue(() async {
+    final latest = readLatest();
+    if (latest != null) await persist(latest);
+  });
+
+  /// Applies [mutation] inside the serialized operation and persists it.
+  ///
+  /// After persistence, the same narrow mutation is re-applied to the latest
+  /// in-memory book before publication. This preserves synchronous CRUD edits
+  /// made while persistence was awaiting I/O. Returning `null` from [mutation]
+  /// means the target no longer exists or the operation lost ownership.
+  Future<bool> mutate(MemoryBookMutation mutation) {
+    var applied = false;
+    return _enqueue(() async {
+      final latest = readLatest();
+      if (latest == null) return;
+      final candidate = mutation(latest);
+      if (candidate == null) return;
+
+      await persist(candidate);
+
+      final afterPersistence = readLatest();
+      if (afterPersistence == null) return;
+      final merged = mutation(afterPersistence);
+      if (merged == null) return;
+      publish(merged);
+      applied = true;
+    }).then((_) => applied);
+  }
+
+  Future<void> _enqueue(Future<void> Function() operation) {
+    final previous = _tail;
+    final next = () async {
+      try {
+        await previous;
+      } catch (_) {
+        // One failed write must not poison subsequent queued operations.
+      }
+      await operation();
+    }();
+    _tail = next.then<void>((_) {}, onError: (_, _) {});
+    return next;
+  }
+}

--- a/lib/features/memory/controllers/memory_draft_generation_controller.dart
+++ b/lib/features/memory/controllers/memory_draft_generation_controller.dart
@@ -11,6 +11,8 @@ import '../../../core/state/pipeline_settings_provider.dart';
 import '../../chat/chat_provider.dart';
 import '../../chat/memory_draft_generator.dart';
 import '../state/memory_active_drafts_provider.dart';
+import 'memory_book_write_queue.dart';
+import 'memory_draft_generation_update.dart';
 import 'memory_settings_mapper.dart';
 
 /// Owns the memory-draft generation lifecycle for a single chat session:
@@ -26,9 +28,9 @@ import 'memory_settings_mapper.dart';
 /// (which pins the shared provider, not this controller directly).
 ///
 /// The controller does not own the [MemoryBook] — the host does. It reads the
-/// book via [bookGetter] and atomically persists updates (book + save) via
-/// [persistAndSet], so there is a single owner of `_book` and a single
-/// `save()` code path.
+/// book via [bookGetter] and atomically applies targeted updates via
+/// [persistMutation], so there is a single owner of `_book` and parallel
+/// completions compose against the freshest state.
 class MemoryDraftGenerationController {
   final WidgetRef _ref;
   final String _charId;
@@ -38,10 +40,10 @@ class MemoryDraftGenerationController {
   /// Returns the host's current [MemoryBook] (or `null` if not loaded).
   final MemoryBook? Function() bookGetter;
 
-  /// Atomically sets the host's `_book` to [book] and persists it. The single
-  /// write path — keeps `_book` ownership in the host and avoids divergent
-  /// save code.
-  final Future<void> Function(MemoryBook book) persistAndSet;
+  /// Applies a targeted update to the freshest host book inside its serialized
+  /// write queue. This prevents parallel completions from competing via stale
+  /// full-book snapshots.
+  final Future<bool> Function(MemoryBookMutation mutation) persistMutation;
 
   final Map<String, bool> _generatingDrafts = {};
   final Set<String> _activeDraftIds = {};
@@ -55,7 +57,7 @@ class MemoryDraftGenerationController {
     required this._sessionId,
     required this._settingsMapper,
     required this.bookGetter,
-    required this.persistAndSet,
+    required this.persistMutation,
   });
   Map<String, bool> get generatingDrafts => Map.unmodifiable(_generatingDrafts);
   Map<String, DateTime> get genStartTimes => Map.unmodifiable(_genStartTimes);
@@ -63,8 +65,7 @@ class MemoryDraftGenerationController {
   /// The global memory settings (singleton, SharedPreferences-backed).
   MemoryGlobalSettings get _globalSettings =>
       _ref.read(memoryGlobalSettingsProvider);
-  PipelineSettings get _pipelineSettings =>
-      _ref.read(pipelineSettingsProvider);
+  PipelineSettings get _pipelineSettings => _ref.read(pipelineSettingsProvider);
 
   MemoryBookSettings get _bookSettings =>
       _settingsMapper.globalToBook(_globalSettings);
@@ -145,46 +146,63 @@ class MemoryDraftGenerationController {
         cancelToken: cancelToken,
       );
 
-      final currentBook = bookGetter();
-      if (currentBook == null) return;
-      final updatedDrafts = [...currentBook.pendingDrafts];
-      updatedDrafts[draftIndex] = result;
-      await persistAndSet(currentBook.copyWith(pendingDrafts: updatedDrafts));
-      _activeDraftIds.remove(draftId);
-      _generatingDrafts.remove(draftId);
-      _genStartTimes.remove(draftId);
-      _stopGenElapsedTimer();
-      if (_generatingDrafts.isEmpty) {
-        _ref.read(memoryActiveDraftsProvider.notifier).markInactive(_sessionId);
-      }
+      if (!_ownsOperation(draftId, cancelToken)) return;
+      await persistMutation((currentBook) {
+        if (!_ownsOperation(draftId, cancelToken)) return null;
+        return applyGeneratedMemoryDraft(
+          currentBook,
+          draftId: draftId,
+          generated: result,
+        );
+      });
+      if (!_ownsOperation(draftId, cancelToken)) return;
       onComplete();
     } catch (e) {
-      final currentBook = bookGetter();
-      if (currentBook == null) return;
-      final updatedDrafts = [...currentBook.pendingDrafts];
-      updatedDrafts[draftIndex] = updatedDrafts[draftIndex].copyWith(
-        status: 'needs_regeneration',
-        error: e.toString(),
-        updatedAt: DateTime.now().millisecondsSinceEpoch,
-      );
-      await persistAndSet(currentBook.copyWith(pendingDrafts: updatedDrafts));
-      _activeDraftIds.remove(draftId);
-      _generatingDrafts.remove(draftId);
-      _genStartTimes.remove(draftId);
-      _stopGenElapsedTimer();
-      if (_generatingDrafts.isEmpty) {
-        _ref.read(memoryActiveDraftsProvider.notifier).markInactive(_sessionId);
-      }
+      if (!_ownsOperation(draftId, cancelToken)) return;
+      // Keep the previous content and keys on failure. If even persisting the
+      // error state fails, still settle and report the generation error.
+      try {
+        await persistMutation((currentBook) {
+          if (!_ownsOperation(draftId, cancelToken)) return null;
+          return applyFailedMemoryDraftGeneration(
+            currentBook,
+            draftId: draftId,
+            error: e.toString(),
+            updatedAt: DateTime.now().millisecondsSinceEpoch,
+          );
+        });
+      } catch (_) {}
+      if (!_ownsOperation(draftId, cancelToken)) return;
       onError(e.toString());
     } finally {
-      _cancelTokens.remove(draftId);
+      if (identical(_cancelTokens[draftId], cancelToken)) {
+        _cancelTokens.remove(draftId);
+        _activeDraftIds.remove(draftId);
+        _generatingDrafts.remove(draftId);
+        _genStartTimes.remove(draftId);
+        _stopGenElapsedTimer();
+        if (_generatingDrafts.isEmpty) {
+          _ref
+              .read(memoryActiveDraftsProvider.notifier)
+              .markInactive(_sessionId);
+        }
+      }
     }
   }
+
+  bool _ownsOperation(String draftId, CancelToken token) =>
+      !token.isCancelled &&
+      _activeDraftIds.contains(draftId) &&
+      identical(_cancelTokens[draftId], token);
+
+  bool isDraftGenerating(String draftId) => _activeDraftIds.contains(draftId);
 
   void cancelDraftGeneration(String draftId) {
     _cancelTokens[draftId]?.cancel();
     _activeDraftIds.remove(draftId);
     _generatingDrafts.remove(draftId);
+    _genStartTimes.remove(draftId);
+    _stopGenElapsedTimer();
     if (_generatingDrafts.isEmpty) {
       _ref.read(memoryActiveDraftsProvider.notifier).markInactive(_sessionId);
     }

--- a/lib/features/memory/controllers/memory_draft_generation_update.dart
+++ b/lib/features/memory/controllers/memory_draft_generation_update.dart
@@ -1,0 +1,45 @@
+import '../../../core/models/memory_book.dart';
+
+/// Applies a completed request to the current draft with [draftId].
+///
+/// The ID lookup is intentionally performed on the post-await book. Returning
+/// `null` means the draft was deleted while generation was in flight.
+MemoryBook? applyGeneratedMemoryDraft(
+  MemoryBook currentBook, {
+  required String draftId,
+  required MemoryDraft generated,
+}) {
+  final index = currentBook.pendingDrafts.indexWhere((d) => d.id == draftId);
+  if (index < 0) return null;
+
+  final drafts = [...currentBook.pendingDrafts];
+  final current = drafts[index];
+  drafts[index] = current.copyWith(
+    content: generated.content,
+    keys: generated.keys,
+    status: 'pending_approval',
+    generatedAt: generated.generatedAt,
+    updatedAt: generated.updatedAt,
+    error: null,
+  );
+  return currentBook.copyWith(pendingDrafts: drafts);
+}
+
+/// Records a retryable generation error without discarding existing content.
+MemoryBook? applyFailedMemoryDraftGeneration(
+  MemoryBook currentBook, {
+  required String draftId,
+  required String error,
+  required int updatedAt,
+}) {
+  final index = currentBook.pendingDrafts.indexWhere((d) => d.id == draftId);
+  if (index < 0) return null;
+
+  final drafts = [...currentBook.pendingDrafts];
+  drafts[index] = drafts[index].copyWith(
+    status: 'needs_regeneration',
+    error: error,
+    updatedAt: updatedAt,
+  );
+  return currentBook.copyWith(pendingDrafts: drafts);
+}

--- a/test/chat_webview_memory_initialization_test.dart
+++ b/test/chat_webview_memory_initialization_test.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('initial memory membership is seeded before messages are mapped', () {
+    final source = File(
+      'lib/features/chat/widgets/chat_webview_initializer.dart',
+    ).readAsStringSync();
+    final runStart = source.indexOf('Future<void> run() async');
+    final memorySeed = source.indexOf(
+      'await bridge.updateMemoryBookData(',
+      runStart,
+    );
+    final messageSet = source.indexOf('await bridge.setMessages(', runStart);
+
+    expect(runStart, isNonNegative);
+    expect(memorySeed, isNonNegative);
+    expect(messageSet, isNonNegative);
+    expect(memorySeed, lessThan(messageSet));
+    expect(
+      source.substring(memorySeed, messageSet),
+      contains('patchMessages: false'),
+    );
+  });
+}

--- a/test/chat_webview_sync_dispatcher_test.dart
+++ b/test/chat_webview_sync_dispatcher_test.dart
@@ -420,6 +420,36 @@ void main() {
       expect(bridge.overlayBlurCalls, hasLength(1));
       expect(bridge.overlayBlurCalls.single, moved);
     });
+
+    test('patches memory status without requesting message-list sync', () {
+      final dispatcher = ChatWebViewSyncDispatcher(
+        state: ChatWebViewSyncState(),
+      );
+      final bridge = _FakeBridge();
+      final message = _assistant('a1');
+
+      final result = dispatcher.dispatch(
+        bridge: bridge,
+        old: _fields(isGenerating: false, messages: [message]),
+        current: _fields(
+          isGenerating: false,
+          messages: [message],
+          memoryDrafts: const [
+            _MemoryDraft(['a1']),
+          ],
+        ),
+        oldMessages: [message],
+        newMessages: [message],
+        streamingId: '__streaming__',
+        onSyncExtBlockPanels: () async {},
+        appendMessage: (_) async {},
+        buildStreamingPlaceholder: () => _assistant('__streaming__'),
+      );
+
+      expect(result.runMessageSync, isFalse);
+      expect(bridge.memoryUpdates, hasLength(1));
+      expect(bridge.memoryUpdates.single.$2, hasLength(1));
+    });
   });
 }
 
@@ -437,6 +467,7 @@ ChatWebViewWidgetFields _fields({
   bool isPostGenRunning = false,
   String? continuationTargetId,
   List<ChatOverlayBlurRegion> blurRegions = const [],
+  List<dynamic> memoryDrafts = const [],
 }) => ChatWebViewWidgetFields(
   continuationTargetId: continuationTargetId,
   blurRegions: blurRegions,
@@ -480,7 +511,7 @@ ChatWebViewWidgetFields _fields({
   disableSwipeRegeneration: false,
   studioEnabled: false,
   memoryEntries: const [],
-  memoryDrafts: const [],
+  memoryDrafts: memoryDrafts,
   sessionId: sessionId,
   isGenerating: isGenerating,
   isGeneratingImage: false,
@@ -507,6 +538,8 @@ class _FakeBridge implements ChatBridgeController {
   final List<ChatMessage> appendedMessages = [];
   final List<bool> updatedIsLast = [];
   final List<String?> lastMessageIds = [];
+  final List<(List<Map<String, dynamic>>, List<Map<String, dynamic>>, bool)>
+  memoryUpdates = [];
   Completer<void>? appendMessagesCompleter;
   Completer<void>? appendMessageCompleter;
 
@@ -556,6 +589,15 @@ class _FakeBridge implements ChatBridgeController {
   }
 
   @override
+  Future<void> updateMemoryBookData({
+    required List<Map<String, dynamic>> entries,
+    required List<Map<String, dynamic>> pendingDrafts,
+    bool patchMessages = true,
+  }) async {
+    memoryUpdates.add((entries, pendingDrafts, patchMessages));
+  }
+
+  @override
   Future<void> setIdentity({
     String? charName,
     String? charColor,
@@ -568,4 +610,10 @@ class _FakeBridge implements ChatBridgeController {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _MemoryDraft {
+  const _MemoryDraft(this.messageIds);
+
+  final List<String> messageIds;
 }

--- a/test/memory_draft_card_test.dart
+++ b/test/memory_draft_card_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/models/memory_book.dart';
+import 'package:glaze_flutter/features/chat/widgets/memory/memory_draft_card.dart';
+
+void main() {
+  testWidgets('content-bearing pending draft offers explicit regeneration', (
+    tester,
+  ) async {
+    var regenerations = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: Scaffold(
+          body: MemoryDraftCard(
+            draft: const MemoryDraft(
+              id: 'draft-1',
+              content: 'existing memory',
+              status: 'pending_approval',
+            ),
+            isGenerating: false,
+            generatingSince: null,
+            onGenerate: () {},
+            onRegenerate: () => regenerations++,
+            onCancel: () {},
+            onApprove: () {},
+            onEdit: () {},
+            onDelete: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('memory_books_btn_regenerate'), findsOneWidget);
+    expect(find.text('existing memory'), findsOneWidget);
+    await tester.tap(find.text('memory_books_btn_regenerate'));
+    expect(regenerations, 1);
+  });
+
+  testWidgets('failed regeneration keeps content, error, and retry action', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: Scaffold(
+          body: MemoryDraftCard(
+            draft: const MemoryDraft(
+              id: 'draft-1',
+              content: 'safe old content',
+              status: 'needs_regeneration',
+              error: 'request failed',
+            ),
+            isGenerating: false,
+            generatingSince: null,
+            onGenerate: () {},
+            onRegenerate: () {},
+            onCancel: () {},
+            onApprove: () {},
+            onEdit: () {},
+            onDelete: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('safe old content'), findsOneWidget);
+    expect(find.text('request failed'), findsOneWidget);
+    expect(find.text('memory_books_btn_regenerate'), findsOneWidget);
+  });
+
+  testWidgets(
+    'active generation hides approve and edit while keeping delete available',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: Scaffold(
+            body: MemoryDraftCard(
+              draft: const MemoryDraft(
+                id: 'draft-1',
+                content: 'existing content',
+                status: 'pending_approval',
+              ),
+              isGenerating: true,
+              generatingSince: null,
+              onGenerate: () {},
+              onRegenerate: () {},
+              onCancel: () {},
+              onApprove: () {},
+              onEdit: () {},
+              onDelete: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('memory_books_btn_approve'), findsNothing);
+      expect(find.text('memory_books_btn_regenerate'), findsNothing);
+      expect(find.text('action_edit'), findsNothing);
+      expect(find.text('memory_books_btn_stop'), findsOneWidget);
+      expect(find.text('btn_delete'), findsOneWidget);
+    },
+  );
+}

--- a/test/memory_draft_generation_update_test.dart
+++ b/test/memory_draft_generation_update_test.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/models/memory_book.dart';
+import 'package:glaze_flutter/features/memory/controllers/memory_book_write_queue.dart';
+import 'package:glaze_flutter/features/memory/controllers/memory_draft_generation_update.dart';
+
+void main() {
+  const original = MemoryDraft(
+    id: 'draft-1',
+    title: 'Current title',
+    content: 'old content',
+    keys: ['old'],
+    status: 'pending_approval',
+  );
+
+  MemoryBook bookWith(List<MemoryDraft> drafts) =>
+      MemoryBook(id: 'book-1', sessionId: 'session-1', pendingDrafts: drafts);
+
+  test('successful regeneration replaces content by ID and clears error', () {
+    final book = bookWith([
+      const MemoryDraft(id: 'other', content: 'untouched'),
+      original.copyWith(error: 'old error'),
+    ]);
+    const generated = MemoryDraft(
+      id: 'draft-1',
+      title: 'stale request title',
+      content: 'new content',
+      keys: ['new'],
+      status: 'pending_approval',
+      generatedAt: 20,
+      updatedAt: 21,
+    );
+
+    final updated = applyGeneratedMemoryDraft(
+      book,
+      draftId: 'draft-1',
+      generated: generated,
+    )!;
+
+    expect(updated.pendingDrafts.first.content, 'untouched');
+    final draft = updated.pendingDrafts.last;
+    expect(draft.content, 'new content');
+    expect(draft.keys, ['new']);
+    expect(draft.title, 'Current title');
+    expect(draft.status, 'pending_approval');
+    expect(draft.error, isNull);
+  });
+
+  test('failed regeneration preserves old content and remains retryable', () {
+    final updated = applyFailedMemoryDraftGeneration(
+      bookWith([original]),
+      draftId: 'draft-1',
+      error: 'network failed',
+      updatedAt: 30,
+    )!;
+
+    final draft = updated.pendingDrafts.single;
+    expect(draft.content, 'old content');
+    expect(draft.keys, ['old']);
+    expect(draft.status, 'needs_regeneration');
+    expect(draft.error, 'network failed');
+  });
+
+  test('completion after deletion is ignored without resurrecting draft', () {
+    final book = bookWith([const MemoryDraft(id: 'other')]);
+
+    expect(
+      applyGeneratedMemoryDraft(book, draftId: 'draft-1', generated: original),
+      isNull,
+    );
+    expect(
+      applyFailedMemoryDraftGeneration(
+        book,
+        draftId: 'draft-1',
+        error: 'late error',
+        updatedAt: 40,
+      ),
+      isNull,
+    );
+    expect(book.pendingDrafts, hasLength(1));
+  });
+
+  test(
+    'parallel completions from one initial snapshot preserve both results',
+    () async {
+      var current = bookWith([
+        const MemoryDraft(id: 'draft-1'),
+        const MemoryDraft(id: 'draft-2'),
+      ]);
+      final persisted = <MemoryBook>[];
+      final writes = MemoryBookWriteQueue(
+        readLatest: () => current,
+        publish: (book) => current = book,
+        persist: (book) async => persisted.add(book),
+      );
+      const firstResult = MemoryDraft(id: 'draft-1', content: 'first result');
+      const secondResult = MemoryDraft(id: 'draft-2', content: 'second result');
+
+      final first = writes.mutate(
+        (latest) => applyGeneratedMemoryDraft(
+          latest,
+          draftId: 'draft-1',
+          generated: firstResult,
+        ),
+      );
+      final second = writes.mutate(
+        (latest) => applyGeneratedMemoryDraft(
+          latest,
+          draftId: 'draft-2',
+          generated: secondResult,
+        ),
+      );
+      await Future.wait([first, second]);
+
+      expect(current.pendingDrafts[0].content, 'first result');
+      expect(current.pendingDrafts[1].content, 'second result');
+      expect(persisted.last.pendingDrafts[0].content, 'first result');
+      expect(persisted.last.pendingDrafts[1].content, 'second result');
+    },
+  );
+
+  test('delete during an in-flight generation write wins', () async {
+    var current = bookWith([original]);
+    final firstWriteStarted = Completer<void>();
+    final releaseFirstWrite = Completer<void>();
+    final persisted = <MemoryBook>[];
+    final writes = MemoryBookWriteQueue(
+      readLatest: () => current,
+      publish: (book) => current = book,
+      persist: (book) async {
+        persisted.add(book);
+        if (!firstWriteStarted.isCompleted) {
+          firstWriteStarted.complete();
+          await releaseFirstWrite.future;
+        }
+      },
+    );
+
+    final generation = writes.mutate(
+      (latest) => applyGeneratedMemoryDraft(
+        latest,
+        draftId: 'draft-1',
+        generated: original.copyWith(content: 'late result'),
+      ),
+    );
+    await firstWriteStarted.future;
+
+    current = current.copyWith(pendingDrafts: []);
+    final deletion = writes.saveLatest();
+    releaseFirstWrite.complete();
+    await Future.wait([generation, deletion]);
+
+    expect(current.pendingDrafts, isEmpty);
+    expect(persisted.last.pendingDrafts, isEmpty);
+  });
+}

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -32,6 +32,7 @@ void main() {
   late String formatterTextFormatJs;
   late String bridgeIndexJs;
   late String bridgeControllerJs;
+  late String virtualScrollJs;
   late String editControllerJs;
   late String genTimerJs;
   late String interactionDispatchJs;
@@ -59,6 +60,7 @@ void main() {
     ].join('\n');
     bridgeIndexJs = _bridgeAsset('index.js');
     bridgeControllerJs = _bridgeAsset('chat_bridge_controller.js');
+    virtualScrollJs = _asset('useVirtualScroll.js');
     editControllerJs = _bridgeAsset('edit_controller.js');
     genTimerJs = _bridgeAsset('gen_timer.js');
     interactionDispatchJs = _bridgeAsset('interaction_dispatch.js');
@@ -86,6 +88,53 @@ void main() {
         contains('selection.getRangeAt(i).cloneContents()'),
       );
       expect(selectionManagerJs, contains('content.innerText.trim()'));
+    });
+  });
+
+  group('memory badge and virtual-scroll settling', () {
+    test('late memory state patches metadata without a full render', () {
+      final body = _extractBlockBody(
+        bridgeControllerJs,
+        bridgeControllerJs.indexOf('patchMemoryStatuses(statusesJson)'),
+      );
+      expect(body, contains('this.virtualList.itemMap?.get(id)'));
+      expect(body, contains('this.renderer.updateMessageMeta(section'));
+      expect(body, isNot(contains('renderMessage(')));
+      expect(
+        rendererMessageJs,
+        contains("querySelector('.msg-memory-badge')?.remove()"),
+      );
+    });
+
+    test('late height changes re-pin only a still-pinned viewport', () {
+      expect(
+        virtualScrollJs,
+        contains('this.resizeObserver = new ResizeObserver'),
+      );
+      expect(
+        virtualScrollJs,
+        contains('const wasPinned = this._pinnedToBottom'),
+      );
+      expect(
+        virtualScrollJs,
+        contains(
+          'if (this.mounted && this._pinnedToBottom) this.smartScroll()',
+        ),
+      );
+      expect(virtualScrollJs, contains('if (!this._pinnedToBottom) return'));
+    });
+
+    test('scroll-to-bottom resolves after its correction pass', () {
+      final body = _extractBlockBody(
+        virtualScrollJs,
+        virtualScrollJs.indexOf("scrollToBottom(behavior = 'auto')"),
+      );
+      expect(body, contains('return new Promise'));
+      expect(
+        body,
+        contains('this.container.scrollTop = this.container.scrollHeight'),
+      );
+      expect(body, contains('resolve()'));
     });
   });
 
@@ -427,7 +476,9 @@ void main() {
     test('orphan emphasis markers cannot consume the next action segment', () {
       expect(
         formatterFormatterJs,
-        contains("html = html.replace(/\\*([ \\t]+)(?=\\x01S_\\d+\\x01)/g, '\$1');"),
+        contains(
+          "html = html.replace(/\\*([ \\t]+)(?=\\x01S_\\d+\\x01)/g, '\$1');",
+        ),
       );
     });
 
@@ -1100,7 +1151,9 @@ void main() {
 
     test('upward scroll restores a hidden header during generation', () {
       final marker = 'if (this.isGenerating) {';
-      final updateHeaderIdx = bridgeControllerJs.indexOf('const updateHeader = () => {');
+      final updateHeaderIdx = bridgeControllerJs.indexOf(
+        'const updateHeader = () => {',
+      );
       expect(updateHeaderIdx, isNot(-1));
       final idx = bridgeControllerJs.indexOf(marker, updateHeaderIdx);
       expect(idx, isNot(-1));
@@ -1138,7 +1191,9 @@ void main() {
 
     test('post-gen activity does not keep the generation timer running', () {
       expect(bridgeControllerJs, contains('setPostGenRunning(value)'));
-      final postGenIdx = bridgeControllerJs.indexOf('setPostGenRunning(value) {');
+      final postGenIdx = bridgeControllerJs.indexOf(
+        'setPostGenRunning(value) {',
+      );
       expect(postGenIdx, isNot(-1));
       final postGenBody = _extractBlockBody(bridgeControllerJs, postGenIdx);
       expect(postGenBody, isNot(contains('_syncGenerationTimer')));


### PR DESCRIPTION
## Summary
- add explicit regeneration for completed pending memory drafts while preserving previous content on failure
- serialize targeted memory-book updates so parallel completions compose and deleted drafts cannot be resurrected
- seed and patch memory badges without rebuilding the message list
- keep cold-open chats bottom-pinned through late virtual-row measurements without pulling users who scrolled up

## Testing
- flutter analyze on all changed Dart production and test files
- flutter test: memory draft generation/card/mutex, WebView memory initialization/sync, and WebView assets
- 143 tests passed
- git diff --check