### PR TITLE
fix(prompt): isolate lorebook timeout failures

### DIFF
--- a/lib/core/llm/glaze_matcher.dart
+++ b/lib/core/llm/glaze_matcher.dart
@@ -1,10 +1,15 @@
+import 'regex_validator.dart';
+
 const glazeBoundaries =
     r'[\s.,!?;:"\u201C\u201D\u2018\u2019\u00AB\u00BB(){}\[\]\u2014\u2013*]';
 
 enum WholeWordMode { no, yes, glaze }
 
 WholeWordMode resolveWholeWords(
-    bool? entryValue, bool globalValue, String keySearchMode) {
+  bool? entryValue,
+  bool globalValue,
+  String keySearchMode,
+) {
   if (entryValue == true) return WholeWordMode.yes;
   if (entryValue == false) return WholeWordMode.no;
   if (keySearchMode == 'glaze') return WholeWordMode.glaze;
@@ -13,7 +18,11 @@ WholeWordMode resolveWholeWords(
 }
 
 bool glazeCheckMatch(
-    String key, String text, bool caseSensitive, WholeWordMode wholeWords) {
+  String key,
+  String text,
+  bool caseSensitive,
+  WholeWordMode wholeWords,
+) {
   if (key.isEmpty) return false;
 
   if (wholeWords == WholeWordMode.glaze) {
@@ -38,7 +47,14 @@ bool glazeCheckMatch(
     pattern = '\\b$pattern\\b';
   }
 
-  final regex = _tryCreateRegex(pattern, caseSensitive);
+  // Tavern-compatible keys may be regular expressions. Dart's RegExp engine
+  // is synchronous and has no per-match timeout, so a single imported ReDoS
+  // pattern can otherwise block the prompt worker until its hard 60s kill.
+  // Keep regex compatibility for ordinary keys, but fall back to literal
+  // matching for patterns with known catastrophic-backtracking structure.
+  final regex = classifyRegexSafety(pattern) == RegexSafety.pathological
+      ? null
+      : _tryCreateRegex(pattern, caseSensitive);
   if (regex != null) return regex.hasMatch(text);
 
   final haystack = caseSensitive ? text : text.toLowerCase();
@@ -46,8 +62,10 @@ bool glazeCheckMatch(
   if (needle.isEmpty) return false;
 
   if (wholeWords == WholeWordMode.yes) {
-    final wordRegex =
-        _tryCreateRegex('\\b${RegExp.escape(needle)}\\b', caseSensitive);
+    final wordRegex = _tryCreateRegex(
+      '\\b${RegExp.escape(needle)}\\b',
+      caseSensitive,
+    );
     return wordRegex?.hasMatch(haystack) ?? false;
   }
 

--- a/lib/core/llm/lorebook_embedding_service.dart
+++ b/lib/core/llm/lorebook_embedding_service.dart
@@ -9,13 +9,7 @@ import 'retrieval_hints.dart';
 class LorebookEmbeddingService {
   final EmbeddingRepo _repo;
   final EmbeddingService _embeddingService;
-  final String _embeddingTarget;
-
-  LorebookEmbeddingService(
-    this._repo,
-    this._embeddingService, [
-    this._embeddingTarget = 'content',
-  ]);
+  LorebookEmbeddingService(this._repo, this._embeddingService);
 
   Future<void> clearLorebookEmbeddings(String lorebookId) {
     return _repo.deleteBySourceId(lorebookId);
@@ -73,7 +67,7 @@ class LorebookEmbeddingService {
         entry.comment.isNotEmpty ? entry.comment : entry.id,
       );
 
-      final text = _getEmbeddingText(entry, config);
+      final text = _getEmbeddingText(entry, embeddingTarget);
       final hints = extractRetrievalHints(entry);
       final fingerprint = buildEmbeddingFingerprint(entry, text);
       final textHash = computeHash(fingerprint);
@@ -144,7 +138,7 @@ class LorebookEmbeddingService {
 
         for (int j = i + 1; j < indexable.length; j++) {
           final laterEntry = indexable[j];
-          final laterText = _getEmbeddingText(laterEntry, config);
+          final laterText = _getEmbeddingText(laterEntry, embeddingTarget);
           final laterHash = computeHash(
             buildEmbeddingFingerprint(laterEntry, laterText),
           );
@@ -198,8 +192,8 @@ class LorebookEmbeddingService {
     );
   }
 
-  String _getEmbeddingText(LorebookEntry entry, EmbeddingConfig config) {
-    if (_embeddingTarget == 'keys') {
+  String _getEmbeddingText(LorebookEntry entry, String embeddingTarget) {
+    if (embeddingTarget == 'keys') {
       return entry.keys.join(', ');
     }
     return entry.content;

--- a/lib/core/llm/lorebook_scanner.dart
+++ b/lib/core/llm/lorebook_scanner.dart
@@ -79,7 +79,27 @@ List<ScannedEntry> scanLorebooks({
   if (activeLorebooks.isEmpty) return [];
 
   final allRelevantEntries = <ScannedEntry>[];
+  final relevantEntryKeys = <String>{};
   final candidateEntries = <_CandidateEntry>[];
+  final visibleHistory = history
+      .where((message) => !message.isHidden && !message.isTyping)
+      .toList(growable: false);
+  final historyByDepth = <int, String>{};
+  final lowerHistoryByDepth = <int, String>{};
+
+  String historyTextFor(int depth, {required bool caseSensitive}) {
+    final cache = caseSensitive ? historyByDepth : lowerHistoryByDepth;
+    return cache.putIfAbsent(depth, () {
+      final start = visibleHistory.length > depth
+          ? visibleHistory.length - depth
+          : 0;
+      final text = visibleHistory
+          .skip(start)
+          .map((message) => message.content)
+          .join('\n');
+      return caseSensitive ? text : text.toLowerCase();
+    });
+  }
 
   for (final lb in activeLorebooks) {
     final lbSettings = lb.settings;
@@ -121,9 +141,7 @@ List<ScannedEntry> scanLorebooks({
 
   for (final c in candidateEntries) {
     if (c.entry.constant) {
-      if (!allRelevantEntries.any(
-        (e) => e.id == c.entry.id && e.lorebookId == c.lorebookId,
-      )) {
+      if (relevantEntryKeys.add(_candidateKey(c))) {
         allRelevantEntries.add(_toScanned(c));
       }
     }
@@ -144,9 +162,7 @@ List<ScannedEntry> scanLorebooks({
 
     for (final c in candidateEntries) {
       final entry = c.entry;
-      if (allRelevantEntries.any(
-        (e) => e.id == entry.id && e.lorebookId == c.lorebookId,
-      )) {
+      if (relevantEntryKeys.contains(_candidateKey(c))) {
         continue;
       }
       if (entry.constant) continue;
@@ -178,22 +194,13 @@ List<ScannedEntry> scanLorebooks({
                 : temporalDepth
           : scanDepth;
 
-      final visibleHistory = history
-          .where((m) => !m.isHidden && !m.isTyping)
-          .toList();
-
-      final messagesToScan = visibleHistory
-          .skip(
-            visibleHistory.length > effectiveScanDepth
-                ? visibleHistory.length - effectiveScanDepth
-                : 0,
-          )
-          .map((m) => m.content)
-          .join('\n');
-
-      var scanSource = caseSensitive
+      final messagesToScan = historyTextFor(
+        effectiveScanDepth,
+        caseSensitive: caseSensitive,
+      );
+      final scanSource = caseSensitive
           ? '$messagesToScan$scanText'
-          : '${messagesToScan.toLowerCase()}${scanText.toLowerCase()}';
+          : '$messagesToScan${scanText.toLowerCase()}';
 
       bool isStickyActive = false;
       bool isOnCooldown = false;
@@ -260,6 +267,7 @@ List<ScannedEntry> scanLorebooks({
           }
 
           allRelevantEntries.add(_toScanned(c));
+          relevantEntryKeys.add(_candidateKey(c));
 
           if (!entry.preventRecursion && iteration < maxIterations) {
             scanText = '$scanText\n${entry.content.toLowerCase()}';
@@ -322,6 +330,9 @@ ScannedEntry _toScanned(_CandidateEntry c) => ScannedEntry(
   constant: c.entry.constant,
   maxInjectedEntries: c.maxInjectedEntries,
 );
+
+String _candidateKey(_CandidateEntry candidate) =>
+    '${candidate.lorebookId}_${candidate.entry.id}';
 
 class _CandidateEntry {
   final LorebookEntry entry;

--- a/lib/core/llm/prompt/lorebook_context_resolver.dart
+++ b/lib/core/llm/prompt/lorebook_context_resolver.dart
@@ -2,7 +2,6 @@ import '../../models/character.dart';
 import '../../models/chat_message.dart';
 import '../../models/lorebook.dart';
 import '../history_assembler.dart';
-import '../lorebook_coverage.dart';
 import '../lorebook_merger.dart';
 import '../lorebook_scanner.dart';
 import '../macro_engine.dart';
@@ -20,7 +19,6 @@ final class LorebookContextResolution {
   final List<TriggeredEntry> triggeredEntries;
   final int vectorLoreTokens;
   final Map<String, ScannedEntry> keywordEntries;
-  final Map<String, CoverageEntry> coverageKeywordEntries;
   final Map<String, LorebookEntry> vectorEntries;
 
   const LorebookContextResolution({
@@ -34,7 +32,6 @@ final class LorebookContextResolution {
     required this.triggeredEntries,
     required this.vectorLoreTokens,
     required this.keywordEntries,
-    required this.coverageKeywordEntries,
     required this.vectorEntries,
   });
 }
@@ -112,29 +109,6 @@ final class LorebookContextResolver {
       for (final entry in keywordEntries)
         '${entry.lorebookId}_${entry.id}': entry,
     };
-    final coverageKeywordEntriesByKey = <String, CoverageEntry>{};
-    if (settings.searchType != 'vector') {
-      final coverage = computeLorebookCoverage(
-        history: visibleHistory,
-        char: character,
-        textToScan: textToScan,
-        chatId: sessionId,
-        lorebooks: lorebooks,
-        globalSettings: settings,
-        activations: activations,
-      );
-      for (final entry in coverage.entries) {
-        final isKeywordLike =
-            entry.constant ||
-            (entry.activated &&
-                entry.matchedKeys.isNotEmpty &&
-                !entry.matchedKeys.contains('[vector]'));
-        if (isKeywordLike) {
-          coverageKeywordEntriesByKey['${entry.lorebookId}_${entry.id}'] =
-              entry;
-        }
-      }
-    }
     final vectorEntriesByKey = <String, LorebookEntry>{
       for (final entry in normalizedVectorEntries)
         '${entry.lorebookId}_${entry.id}': entry,
@@ -160,21 +134,6 @@ final class LorebookContextResolver {
             lorebookName: keyword.lorebookName,
             lorebookId: keyword.lorebookId,
             source: keyword.constant ? 'constant' : 'keyword',
-          ),
-        );
-        continue;
-      }
-      final coverageKeyword = coverageKeywordEntriesByKey[key];
-      if (coverageKeyword != null) {
-        triggeredEntries.add(
-          TriggeredEntry(
-            id: coverageKeyword.id,
-            name: coverageKeyword.comment.isNotEmpty
-                ? coverageKeyword.comment
-                : coverageKeyword.id,
-            lorebookName: coverageKeyword.lorebookName,
-            lorebookId: coverageKeyword.lorebookId,
-            source: coverageKeyword.constant ? 'constant' : 'keyword',
           ),
         );
         continue;
@@ -207,7 +166,6 @@ final class LorebookContextResolver {
           ? 0
           : estimateTokens(vectorLoreContent),
       keywordEntries: keywordEntriesByKey,
-      coverageKeywordEntries: coverageKeywordEntriesByKey,
       vectorEntries: vectorEntriesByKey,
     );
   }

--- a/lib/core/llm/prompt_builder.dart
+++ b/lib/core/llm/prompt_builder.dart
@@ -12,7 +12,6 @@ import '../models/lorebook.dart';
 import 'macro_engine.dart';
 import 'history_assembler.dart';
 import 'context_calculator.dart';
-import 'lorebook_coverage.dart';
 import 'lorebook_scanner.dart';
 import 'prompt_block_resolver.dart';
 import 'prompt_regex_applicator.dart';
@@ -224,7 +223,6 @@ PromptResult _buildPromptOnce(PromptPayload payload) {
     preset: preset,
     macroContext: currentMacroCtx,
     keywordEntries: loreContext.keywordEntries,
-    coverageKeywordEntries: loreContext.coverageKeywordEntries,
     vectorEntries: loreContext.vectorEntries,
   );
   // Capture attribution from the actual block assembly path.  This is an
@@ -455,7 +453,6 @@ ExactLorebookManifest _buildExactLorebookManifest({
   required Preset preset,
   required MacroContext macroContext,
   required Map<String, ScannedEntry> keywordEntries,
-  required Map<String, CoverageEntry> coverageKeywordEntries,
   required Map<String, LorebookEntry> vectorEntries,
 }) {
   final promptProvenance = ExactLorebookPromptProvenance(
@@ -478,12 +475,9 @@ ExactLorebookManifest _buildExactLorebookManifest({
   for (var index = 0; index < entries.length; index++) {
     final entry = entries[index];
     final key = '${entry.lorebookId}_${entry.id}';
-    final source =
-        keywordEntries[key]?.constant == true ||
-            coverageKeywordEntries[key]?.constant == true
+    final source = keywordEntries[key]?.constant == true
         ? 'constant'
-        : keywordEntries.containsKey(key) ||
-              coverageKeywordEntries.containsKey(key)
+        : keywordEntries.containsKey(key)
         ? 'keyword'
         : vectorEntries.containsKey(key)
         ? 'vector'

--- a/lib/core/llm/prompt_isolate.dart
+++ b/lib/core/llm/prompt_isolate.dart
@@ -6,15 +6,21 @@ import 'prompt_worker.dart';
 ///
 /// The isolate maintains its own o200k_base tokenizer and a persistent
 /// token cache, so repeated calls are fast (cached history tokens).
-Future<PromptResult> buildPromptInIsolate(PromptPayload payload) async {
+Future<PromptResult> buildPromptInIsolate(
+  PromptPayload payload, {
+  PromptWorkerPriority priority = PromptWorkerPriority.foreground,
+}) async {
   final worker = await PromptWorker.ensureInitialized();
-  return worker.buildPrompt(payload);
+  return worker.buildPrompt(payload, priority: priority);
 }
 
 /// Builds a complete prompt from raw inputs in the isolate.
 /// This runs memory injection, lorebook scanning, prompt assembly,
 /// and tokenization all off the main thread.
-Future<PromptResult> buildFromInputsInIsolate(PromptInputs inputs) async {
+Future<PromptResult> buildFromInputsInIsolate(
+  PromptInputs inputs, {
+  PromptWorkerPriority priority = PromptWorkerPriority.background,
+}) async {
   final worker = await PromptWorker.ensureInitialized();
-  return worker.buildFromInputs(inputs);
+  return worker.buildFromInputs(inputs, priority: priority);
 }

--- a/lib/core/llm/prompt_worker.dart
+++ b/lib/core/llm/prompt_worker.dart
@@ -17,27 +17,32 @@ import 'prompt_inputs.dart';
 import 'prompt_worker_codec.dart';
 import 'tokenizer.dart';
 
+enum PromptWorkerPriority { foreground, background }
+
 /// Long-lived isolate worker that runs buildPrompt off the main thread.
 ///
 /// The isolate loads its own o200k_base tokenizer once at startup and
 /// maintains a persistent token cache across requests.
 class PromptWorker {
+  /// Overridden by queue timeout tests.
+  static Duration requestTimeout = const Duration(seconds: 60);
+
   static PromptWorker? _instance;
   static Completer<PromptWorker>? _initGuard;
 
-  final Isolate _isolate;
-  final ReceivePort _commandPort;
-  final ReceivePort _responsePort;
-  final SendPort _sendPort;
-  final Map<int, Completer<dynamic>> _pending = {};
+  Isolate? _isolate;
+  ReceivePort? _commandPort;
+  ReceivePort? _responsePort;
+  StreamSubscription<dynamic>? _responseSubscription;
+  SendPort? _sendPort;
+  final List<_PromptWorkerRequest> _queue = [];
+  _PromptWorkerRequest? _active;
+  Timer? _activeTimer;
+  bool _restarting = false;
+  bool _disposed = false;
   int _requestId = 0;
 
-  PromptWorker._(
-    this._isolate,
-    this._commandPort,
-    this._responsePort,
-    this._sendPort,
-  );
+  PromptWorker._();
 
   static Future<PromptWorker> ensureInitialized() async {
     if (_instance != null) return _instance!;
@@ -57,6 +62,13 @@ class PromptWorker {
   }
 
   static Future<PromptWorker> _create() async {
+    final worker = PromptWorker._();
+    await worker._spawnIsolate();
+    await worker._send('init', null);
+    return worker;
+  }
+
+  Future<void> _spawnIsolate() async {
     final appSupportPath = await getAppDataDir();
 
     final commandPort = ReceivePort();
@@ -69,91 +81,207 @@ class PromptWorker {
     ]);
 
     final sendPort = await commandPort.first as SendPort;
-
-    final worker = PromptWorker._(isolate, commandPort, responsePort, sendPort);
-
-    responsePort.listen((message) {
+    _isolate = isolate;
+    _commandPort = commandPort;
+    _responsePort = responsePort;
+    _sendPort = sendPort;
+    _responseSubscription = responsePort.listen((message) {
       if (message is List && message.length == 2) {
         final id = message[0] as int;
         final data = message[1];
-        final completer = worker._pending.remove(id);
-        if (completer != null) {
-          if (data is Map && data.containsKey('error')) {
-            completer.completeError(Exception(data['error'] as String));
-          } else {
-            completer.complete(data);
-          }
-        }
+        _handleResponse(id, data);
       }
     });
-
-    await worker._send('init', null);
-
-    return worker;
   }
 
-  Future<dynamic> _send(String command, dynamic data) async {
-    final id = _requestId++;
+  Future<dynamic> _send(
+    String command,
+    dynamic data, {
+    bool addFirst = false,
+    PromptWorkerPriority priority = PromptWorkerPriority.foreground,
+    Duration? timeout,
+  }) {
+    if (_disposed) {
+      return Future<dynamic>.error(StateError('PromptWorker is disposed'));
+    }
     final completer = Completer<dynamic>();
-    _pending[id] = completer;
-
-    _sendPort.send([id, command, data]);
-    return completer.future.timeout(
-      const Duration(seconds: 60),
-      onTimeout: () {
-        _pending.remove(id);
-        // A synchronous regex (ReDoS) or other runaway computation can hang
-        // the isolate forever. Kill it so it stops burning CPU and so the
-        // next ensureInitialized() respawns a fresh worker — otherwise every
-        // subsequent prompt request would also time out.
-        _killAndInvalidate();
-        throw TimeoutException(
-          'PromptWorker request timed out after 60s',
-          const Duration(seconds: 60),
-        );
-      },
+    final request = _PromptWorkerRequest(
+      id: _requestId++,
+      command: command,
+      data: data,
+      completer: completer,
+      priority: priority,
+      timeout: timeout ?? requestTimeout,
     );
+    if (addFirst) {
+      _queue.insert(0, request);
+    } else if (priority == PromptWorkerPriority.foreground) {
+      final firstBackground = _queue.indexWhere(
+        (queued) => queued.priority == PromptWorkerPriority.background,
+      );
+      _queue.insert(
+        firstBackground < 0 ? _queue.length : firstBackground,
+        request,
+      );
+    } else {
+      _queue.add(request);
+    }
+    _dispatchNext();
+    return completer.future;
   }
 
-  /// Kills the isolate, closes ports, errors out all pending requests, and
-  /// clears the singleton so the next [ensureInitialized] recreates it.
-  void _killAndInvalidate() {
-    _isolate.kill(priority: Isolate.immediate);
-    _commandPort.close();
-    _responsePort.close();
-    for (final c in _pending.values) {
-      if (!c.isCompleted) {
-        c.completeError(
-          TimeoutException('PromptWorker isolate killed after timeout'),
+  void _dispatchNext() {
+    if (_disposed || _restarting || _active != null || _queue.isEmpty) return;
+    final sendPort = _sendPort;
+    if (sendPort == null) return;
+
+    final request = _queue.removeAt(0);
+    _active = request;
+    // Only the request actually executing in the isolate owns a timeout.
+    // Queued requests do not lose their budget while waiting for earlier work.
+    _activeTimer = Timer(request.timeout, () {
+      if (!identical(_active, request)) return;
+      _active = null;
+      if (!request.completer.isCompleted) {
+        request.completer.completeError(
+          TimeoutException(
+            'PromptWorker request timed out after ${request.timeout.inMilliseconds}ms',
+            request.timeout,
+          ),
         );
       }
+      // Synchronous regex/ReDoS cannot be interrupted. Replace the isolate,
+      // but retain requests which have not been dispatched yet.
+      unawaited(_restartAfterTimeout());
+    });
+    sendPort.send([request.id, request.command, request.data]);
+  }
+
+  void _handleResponse(int id, dynamic data) {
+    final request = _active;
+    if (request == null || request.id != id) return;
+    _activeTimer?.cancel();
+    _activeTimer = null;
+    _active = null;
+    if (!request.completer.isCompleted) {
+      if (data is Map && data.containsKey('error')) {
+        request.completer.completeError(Exception(data['error'] as String));
+      } else {
+        request.completer.complete(data);
+      }
     }
-    _pending.clear();
-    if (_instance == this) {
-      _instance = null;
+    _dispatchNext();
+  }
+
+  Future<void> _restartAfterTimeout() async {
+    if (_restarting || _disposed) return;
+    _restarting = true;
+    _closeIsolate();
+    try {
+      await _spawnIsolate();
+      _restarting = false;
+      // Preloading must complete before retained requests are dispatched.
+      await _send(
+        'init',
+        null,
+        addFirst: true,
+        timeout: const Duration(seconds: 60),
+      );
+    } catch (error, stackTrace) {
+      _restarting = false;
+      _failQueued(error, stackTrace);
+      if (_instance == this) _instance = null;
     }
   }
 
-  Future<PromptResult> buildPrompt(PromptPayload payload) async {
+  void _closeIsolate() {
+    _activeTimer?.cancel();
+    _activeTimer = null;
+    unawaited(_responseSubscription?.cancel());
+    _responseSubscription = null;
+    _commandPort?.close();
+    _responsePort?.close();
+    _isolate?.kill(priority: Isolate.immediate);
+    _commandPort = null;
+    _responsePort = null;
+    _isolate = null;
+    _sendPort = null;
+  }
+
+  void _failQueued(Object error, StackTrace stackTrace) {
+    for (final request in _queue) {
+      if (!request.completer.isCompleted) {
+        request.completer.completeError(error, stackTrace);
+      }
+    }
+    _queue.clear();
+  }
+
+  Future<PromptResult> buildPrompt(
+    PromptPayload payload, {
+    PromptWorkerPriority priority = PromptWorkerPriority.foreground,
+  }) async {
     final json = jsonEncode(serializePayload(payload));
-    final response = await _send('buildPrompt', json) as String;
+    final response =
+        await _send('buildPrompt', json, priority: priority) as String;
     return deserializeResult(jsonDecode(response) as Map<String, dynamic>);
   }
 
   /// Builds a complete prompt from raw inputs. This runs memory injection,
   /// lorebook scanning, prompt assembly, and tokenization all in the isolate.
-  Future<PromptResult> buildFromInputs(PromptInputs inputs) async {
+  Future<PromptResult> buildFromInputs(
+    PromptInputs inputs, {
+    PromptWorkerPriority priority = PromptWorkerPriority.background,
+  }) async {
     final json = jsonEncode(inputs.toJson());
-    final response = await _send('buildFromInputs', json) as String;
+    final response =
+        await _send('buildFromInputs', json, priority: priority) as String;
     return deserializeResult(jsonDecode(response) as Map<String, dynamic>);
   }
 
-  void dispose() {
-    _commandPort.close();
-    _responsePort.close();
-    _isolate.kill(priority: Isolate.immediate);
-    _instance = null;
+  /// Test-only command used to exercise queueing and restart semantics.
+  Future<String> debugBlock(
+    Duration duration,
+    String result, {
+    PromptWorkerPriority priority = PromptWorkerPriority.background,
+  }) async {
+    return await _send('debugBlock', {
+          'milliseconds': duration.inMilliseconds,
+          'result': result,
+        }, priority: priority)
+        as String;
   }
+
+  void dispose() {
+    _disposed = true;
+    _closeIsolate();
+    final error = StateError('PromptWorker disposed with pending requests');
+    final active = _active;
+    _active = null;
+    if (active != null && !active.completer.isCompleted) {
+      active.completer.completeError(error);
+    }
+    _failQueued(error, StackTrace.current);
+    if (_instance == this) _instance = null;
+  }
+}
+
+class _PromptWorkerRequest {
+  const _PromptWorkerRequest({
+    required this.id,
+    required this.command,
+    required this.data,
+    required this.completer,
+    required this.priority,
+    required this.timeout,
+  });
+
+  final int id;
+  final String command;
+  final dynamic data;
+  final Completer<dynamic> completer;
+  final PromptWorkerPriority priority;
+  final Duration timeout;
 }
 
 void _isolateEntryPoint(List<dynamic> args) {
@@ -190,6 +318,15 @@ void _isolateEntryPoint(List<dynamic> args) {
           );
           final result2 = _buildFromInputs(inputs);
           responseSendPort.send([id, jsonEncode(serializeResult(result2))]);
+
+        case 'debugBlock':
+          final options = data as Map;
+          final duration = Duration(
+            milliseconds: options['milliseconds'] as int,
+          );
+          final watch = Stopwatch()..start();
+          while (watch.elapsed < duration) {}
+          responseSendPort.send([id, options['result'] as String]);
 
         default:
           responseSendPort.send([

--- a/lib/features/chat/widgets/magic_drawer.dart
+++ b/lib/features/chat/widgets/magic_drawer.dart
@@ -14,7 +14,6 @@ import '../../../core/state/lorebook_provider.dart';
 import '../../../features/settings/app_settings_provider.dart';
 import '../../../core/state/active_selection_provider.dart';
 import '../../../core/state/active_studio_preset_provider.dart';
-import '../../../core/state/preset_resolution.dart';
 import '../../../core/state/studio_feature_provider.dart';
 import '../../../core/state/summary_providers.dart';
 import '../../../shared/theme/app_colors.dart';
@@ -184,10 +183,12 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
   int _statsRequest = 0;
   Timer? _debounceTimer;
   final _scrollController = ScrollController();
+  late final MagicDrawerStatsService _statsService;
 
   @override
   void initState() {
     super.initState();
+    _statsService = MagicDrawerStatsService(ref);
     // Stale-while-revalidate. The panel is destroyed on every drawer close, so
     // without a cache each open would sit behind the spinner until a full
     // layout read and stats recomputation finished. Paint the previous
@@ -255,9 +256,7 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
 
   Future<void> _loadStats() async {
     final request = ++_statsRequest;
-    final stats = await MagicDrawerStatsService(
-      ref,
-    ).computeStats(widget.charId);
+    final stats = await _statsService.computeStats(widget.charId);
     if (request != _statsRequest) return;
     _stats = stats;
     // The drawer can be closed mid-load, which disposes this state and with it
@@ -283,9 +282,7 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
     final request = _statsRequest;
     MagicDrawerStats updated;
     try {
-      updated = await MagicDrawerStatsService(
-        ref,
-      ).computeTokenStats(widget.charId, _stats);
+      updated = await _statsService.computeTokenStats(widget.charId, _stats);
     } catch (e) {
       debugPrint('[MagicDrawer] _loadTokenStats error: $e');
       return;
@@ -394,7 +391,7 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
       'presets' =>
         _stats.activePresetDisplayName == null
             ? 'label_default'.tr()
-        : _stats.presetTokens > 0
+            : _stats.presetTokens > 0
             ? '${_stats.activePresetDisplayName} • ${_stats.presetTokens} tokens'
             : _stats.activePresetDisplayName,
       'personas' => _stats.activePersona?.name ?? 'label_default'.tr(),
@@ -597,7 +594,7 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
     }
   }
 
-    Future<void> _showAgentOpsLog() async {
+  Future<void> _showAgentOpsLog() async {
     final session = ref.read(chatProvider(widget.charId)).value?.session;
     await AgenticOperationsLogDialog.show(context, sessionId: session?.id);
   }
@@ -625,8 +622,11 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
     switch (result.action) {
       case SessionPickerAction.open:
         final target = result.session!.sessionIndex;
-        final current =
-            ref.read(chatProvider(widget.charId)).value?.session?.sessionIndex;
+        final current = ref
+            .read(chatProvider(widget.charId))
+            .value
+            ?.session
+            ?.sessionIndex;
         if (target == current) return;
         await ref
             .read(chatProvider(widget.charId).notifier)

--- a/lib/features/chat/widgets/prompt_inspector_sheet.dart
+++ b/lib/features/chat/widgets/prompt_inspector_sheet.dart
@@ -31,6 +31,7 @@ class PromptInspectorSheet extends StatefulWidget {
 
 class _PromptInspectorSheetState extends State<PromptInspectorSheet> {
   late String _activeTabId = widget.initialTabId;
+  late final Set<String> _visitedTabs = {_activeTabId};
 
   static const _order = [
     PromptInspectorSheet._tabContext,
@@ -45,14 +46,20 @@ class _PromptInspectorSheetState extends State<PromptInspectorSheet> {
 
   @override
   Widget build(BuildContext context) {
-    // Keep every tab's state alive across switches (each runs its own async
-    // computation on first build) via an IndexedStack.
+    // Preserve visited tabs without eagerly starting every expensive prompt
+    // diagnostic when the inspector opens.
     final body = IndexedStack(
       index: _activeIndex,
       children: [
-        TokenizerSheet(charId: widget.charId, embedded: true),
-        PromptPreviewScreen(charId: widget.charId, embedded: true),
-        CoveragePanel(charId: widget.charId, embedded: true),
+        _visitedTabs.contains(PromptInspectorSheet._tabContext)
+            ? TokenizerSheet(charId: widget.charId, embedded: true)
+            : const SizedBox.shrink(),
+        _visitedTabs.contains(PromptInspectorSheet._tabPreview)
+            ? PromptPreviewScreen(charId: widget.charId, embedded: true)
+            : const SizedBox.shrink(),
+        _visitedTabs.contains(PromptInspectorSheet._tabCoverage)
+            ? CoveragePanel(charId: widget.charId, embedded: true)
+            : const SizedBox.shrink(),
       ],
     );
 
@@ -70,7 +77,10 @@ class _PromptInspectorSheetState extends State<PromptInspectorSheet> {
           GlazeTabItem(label: 'tab_coverage'.tr(), icon: Icons.search),
         ],
         activeIndex: _activeIndex,
-        onChanged: (i) => setState(() => _activeTabId = _order[i]),
+        onChanged: (i) => setState(() {
+          _activeTabId = _order[i];
+          _visitedTabs.add(_activeTabId);
+        }),
       ),
       body: body,
     );

--- a/lib/features/chat/widgets/prompt_preview_screen.dart
+++ b/lib/features/chat/widgets/prompt_preview_screen.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 import '../../../core/llm/history_assembler.dart';
 import '../../../core/llm/prompt_builder.dart';
 import '../../../core/llm/prompt_isolate.dart';
+import '../../../core/llm/prompt_worker.dart';
 import '../../../shared/widgets/glaze_spinner.dart';
 import '../providers/prompt_build_providers.dart';
 import '../../../core/llm/transport/anthropic_chat_transport.dart';
@@ -89,7 +90,10 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
       _apiConfig = payload.apiConfig;
       _sessionId = session.id;
 
-      final result = await buildPromptInIsolate(payload);
+      final result = await buildPromptInIsolate(
+        payload,
+        priority: PromptWorkerPriority.background,
+      );
 
       ref.read(cachedTokenBreakdownProvider(widget.charId).notifier).state =
           result.breakdown;

--- a/test/glaze_matcher_test.dart
+++ b/test/glaze_matcher_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/glaze_matcher.dart';
+
+void main() {
+  test('tavern matcher keeps regular expression compatibility', () {
+    expect(
+      glazeCheckMatch(r'cat|dog', 'a dog appears', false, WholeWordMode.no),
+      isTrue,
+    );
+  });
+
+  test('pathological regular expression falls back to literal matching', () {
+    const unsafeKey = r'(a+)+$';
+
+    expect(
+      glazeCheckMatch(
+        unsafeKey,
+        'the literal key is (a+)+\$',
+        false,
+        WholeWordMode.no,
+      ),
+      isTrue,
+    );
+    expect(
+      glazeCheckMatch(
+        unsafeKey,
+        '${List.filled(20000, 'a').join()}!',
+        false,
+        WholeWordMode.no,
+      ),
+      isFalse,
+    );
+  });
+}

--- a/test/lorebook_embedding_service_test.dart
+++ b/test/lorebook_embedding_service_test.dart
@@ -1,0 +1,66 @@
+import 'package:drift/native.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/embedding_repo.dart';
+import 'package:glaze_flutter/core/llm/embedding_service.dart';
+import 'package:glaze_flutter/core/llm/lorebook_embedding_service.dart';
+import 'package:glaze_flutter/core/models/lorebook.dart';
+import 'package:glaze_flutter/core/utils/cast_helpers.dart';
+
+class _FakeEmbeddingService extends EmbeddingService {
+  final List<String> requestedTexts = [];
+
+  @override
+  Future<List<EmbeddingChunk>> getEmbeddingsWithChunks(
+    List<String> texts,
+    EmbeddingConfig config, {
+    CancelToken? cancelToken,
+  }) async {
+    requestedTexts.addAll(texts);
+    return [
+      for (final text in texts)
+        EmbeddingChunk(text: text, vector: const [1, 0]),
+    ];
+  }
+}
+
+void main() {
+  test('keys embedding target indexes and fingerprints entry keys', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = EmbeddingRepo(db);
+    final embeddingService = _FakeEmbeddingService();
+    final service = LorebookEmbeddingService(repo, embeddingService);
+    const entry = LorebookEntry(
+      id: 'entry',
+      keys: ['alpha', 'beta'],
+      content: 'content must not be embedded',
+      vectorSearch: true,
+    );
+    const config = EmbeddingConfig(
+      endpoint: 'http://localhost/v1',
+      model: 'test',
+    );
+
+    final result = await service.indexLorebookEntries(
+      'book',
+      const [entry],
+      config,
+      embeddingTarget: 'keys',
+    );
+
+    expect(result.indexed, 1);
+    expect(embeddingService.requestedTexts, ['alpha, beta']);
+    final row = await repo.getByEntryId('book_entry');
+    expect(
+      row?.textHash,
+      computeHash(
+        LorebookEmbeddingService.buildEmbeddingFingerprint(
+          entry,
+          'alpha, beta',
+        ),
+      ),
+    );
+  });
+}

--- a/test/prompt_lorebook_baseline_test.dart
+++ b/test/prompt_lorebook_baseline_test.dart
@@ -11,62 +11,82 @@ import 'package:glaze_flutter/core/models/preset.dart';
 
 // Baseline command: flutter test test/prompt_lorebook_baseline_test.dart
 void main() {
-  test('baseline: isolate prompt build handles long history and large lorebook',
-      () async {
-    const historyCount = 160;
-    const lorebookEntryCount = 240;
-    const injectedLorebookEntries = 6;
-    final inputs = _baselineInputs();
+  test(
+    'baseline: isolate prompt build handles long history and large lorebook',
+    () async {
+      const historyCount = 160;
+      const lorebookEntryCount = 240;
+      const injectedLorebookEntries = 6;
+      final inputs = _baselineInputs();
 
-    // The first request includes worker/isolate initialization; the second
-    // measures the persistent worker path. Timings are diagnostic only.
-    final coldWatch = Stopwatch()..start();
-    final cold = await buildFromInputsInIsolate(inputs);
-    coldWatch.stop();
+      // The first request includes worker/isolate initialization; the second
+      // measures the persistent worker path. Timings are diagnostic only.
+      final coldWatch = Stopwatch()..start();
+      final cold = await buildFromInputsInIsolate(inputs);
+      coldWatch.stop();
 
-    final warmWatch = Stopwatch()..start();
-    final warm = await buildFromInputsInIsolate(inputs);
-    warmWatch.stop();
+      final warmWatch = Stopwatch()..start();
+      final warm = await buildFromInputsInIsolate(inputs);
+      warmWatch.stop();
+
+      addTearDown(() async {
+        final worker = await PromptWorker.ensureInitialized();
+        worker.dispose();
+      });
+
+      final outputChars = cold.messages.fold<int>(
+        0,
+        (total, message) => total + message.content.length,
+      );
+      // ignore: avoid_print
+      print(
+        'prompt/lorebook baseline: history=$historyCount '
+        'lorebookEntries=$lorebookEntryCount cold=${coldWatch.elapsedMilliseconds}ms '
+        'warm=${warmWatch.elapsedMilliseconds}ms outputChars=$outputChars '
+        'tokens=${cold.breakdown.totalTokens}',
+      );
+
+      final expectedLoreIds = [
+        for (var index = 0; index < injectedLorebookEntries; index++)
+          'lore-$index',
+      ];
+      expect(cold.triggeredLorebooks.map((entry) => entry.id), expectedLoreIds);
+      expect(
+        cold.messages.where((message) => message.isHistory).length,
+        historyCount,
+      );
+      expect(
+        cold.messages.map((message) => message.content).join('\n'),
+        allOf(contains('LOREBOOK_BASELINE_0'), contains('history-marker-159')),
+      );
+
+      // Assert output semantics, never a machine-dependent timing threshold.
+      expect(_signature(warm), _signature(cold));
+      expect(warm.breakdown.totalTokens, cold.breakdown.totalTokens);
+    },
+  );
+
+  test('regression: persistent worker handles a 690-entry lorebook', () async {
+    final inputs = _baselineInputs(lorebookEntryCount: 690);
+
+    final result = await buildFromInputsInIsolate(inputs);
 
     addTearDown(() async {
       final worker = await PromptWorker.ensureInitialized();
       worker.dispose();
     });
 
-    final outputChars = cold.messages.fold<int>(
-      0,
-      (total, message) => total + message.content.length,
-    );
-    // ignore: avoid_print
-    print(
-      'prompt/lorebook baseline: history=$historyCount '
-      'lorebookEntries=$lorebookEntryCount cold=${coldWatch.elapsedMilliseconds}ms '
-      'warm=${warmWatch.elapsedMilliseconds}ms outputChars=$outputChars '
-      'tokens=${cold.breakdown.totalTokens}',
-    );
-
-    final expectedLoreIds = [
-      for (var index = 0; index < injectedLorebookEntries; index++)
-        'lore-$index',
-    ];
-    expect(cold.triggeredLorebooks.map((entry) => entry.id), expectedLoreIds);
+    expect(result.triggeredLorebooks, hasLength(6));
     expect(
-      cold.messages.where((message) => message.isHistory).length,
-      historyCount,
+      result.messages.map((message) => message.content).join('\n'),
+      contains('LOREBOOK_BASELINE_0'),
     );
-    expect(
-      cold.messages.map((message) => message.content).join('\n'),
-      allOf(contains('LOREBOOK_BASELINE_0'), contains('history-marker-159')),
-    );
-
-    // Assert output semantics, never a machine-dependent timing threshold.
-    expect(_signature(warm), _signature(cold));
-    expect(warm.breakdown.totalTokens, cold.breakdown.totalTokens);
   });
 }
 
-PromptInputs _baselineInputs() {
-  const filler = 'synthetic history payload for deterministic prompt benchmarking ';
+PromptInputs _baselineInputs({int lorebookEntryCount = 240}) {
+  const filler =
+      'synthetic history payload for deterministic prompt benchmarking ';
   return PromptInputs(
     character: const Character(
       id: 'baseline-character',
@@ -110,7 +130,7 @@ PromptInputs _baselineInputs() {
         id: 'baseline-lorebook',
         name: 'Baseline lorebook',
         entries: [
-          for (var index = 0; index < 240; index++)
+          for (var index = 0; index < lorebookEntryCount; index++)
             LorebookEntry(
               id: 'lore-$index',
               comment: 'Benchmark lore $index',

--- a/test/prompt_worker_queue_test.dart
+++ b/test/prompt_worker_queue_test.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/prompt_worker.dart';
+
+void main() {
+  late PromptWorker worker;
+
+  setUp(() async {
+    worker = await PromptWorker.ensureInitialized();
+    PromptWorker.requestTimeout = const Duration(milliseconds: 150);
+  });
+
+  tearDown(() {
+    worker.dispose();
+    PromptWorker.requestTimeout = const Duration(seconds: 60);
+  });
+
+  test(
+    'queued request survives active request timeout and worker restart',
+    () async {
+      final timedOut = worker.debugBlock(
+        const Duration(milliseconds: 500),
+        'slow',
+      );
+      final retained = worker.debugBlock(Duration.zero, 'retained');
+
+      await expectLater(timedOut, throwsA(isA<TimeoutException>()));
+      await expectLater(retained, completion('retained'));
+    },
+  );
+
+  test(
+    'foreground requests are dispatched before queued diagnostics',
+    () async {
+      PromptWorker.requestTimeout = const Duration(seconds: 2);
+      final active = worker.debugBlock(
+        const Duration(milliseconds: 100),
+        'active',
+      );
+      final order = <String>[];
+      final background = worker
+          .debugBlock(Duration.zero, 'background')
+          .then(order.add);
+      final foreground = worker
+          .debugBlock(
+            Duration.zero,
+            'foreground',
+            priority: PromptWorkerPriority.foreground,
+          )
+          .then(order.add);
+
+      await active;
+      await Future.wait([background, foreground]);
+
+      expect(order, ['foreground', 'background']);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- serialize prompt isolate work and start the 60s timeout only when a request is dispatched
- retain queued requests across worker replacement, prioritize foreground generation, and prevent an older timed-out diagnostic from killing a newer generation after ~29s
- reduce duplicate/background prompt work by lazily mounting Prompt Inspector tabs and retaining the Magic Drawer stats service
- optimize large lorebook scans, guard pathological Tavern regex keys, and remove the duplicate coverage scan from normal prompt construction
- honor lorebook embeddingTarget: keys during vector indexing

## Root cause

Each request previously received a 60-second timer as soon as it was sent to the shared isolate. Prompt builds execute synchronously, so requests queued behind an older build consumed their timeout while waiting. When any request timed out, the worker killed the isolate and failed every pending request with PromptWorker isolate killed after timeout.

This explains the report where generation failed after about 29 seconds: an older background request had already used roughly 31 seconds of its own 60-second window. Its timeout killed the newer foreground generation. Immediate regenerate then succeeded on a fresh worker.

Large lorebooks amplified this through repeated history construction, duplicate keyword/coverage scans, and potentially pathological regex-like keys.

## Tests

- worker queue regression proving a queued request survives an active timeout/restart
- foreground-over-background priority coverage
- pathological lorebook regex coverage
- keys-target embedding indexing/fingerprint coverage
- 690-entry lorebook prompt regression

Validated with the targeted prompt/lorebook/vector suite: 33 tests passed. Targeted dart analyze reports no issues.