### PR TITLE
fix(card-rewriter): correct cadence and bound observation retrieval

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:glaze_flutter/core/llm/prompt_worker.dart';
 import 'package:glaze_flutter/core/llm/tokenizer.dart';
 import 'core/navigation/router.dart';
+import 'core/navigation/rewrite_review_navigation.dart';
 import 'core/services/deep_link_service.dart';
 import 'core/services/generation_notification_service.dart';
 import 'features/chat/bridge/chat_webview_environment.dart';
@@ -95,9 +96,11 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
   /// that the UI already renders empty — so a failure is logged and dropped
   /// rather than escalated.
   void _initInBackground(Future<void> work, String what) {
-    unawaited(work.catchError((Object e) {
-      debugPrint('Glaze init: $what failed — $e');
-    }));
+    unawaited(
+      work.catchError((Object e) {
+        debugPrint('Glaze init: $what failed — $e');
+      }),
+    );
   }
 
   /// Starts the DB-backed providers behind the initial routes now, concurrently
@@ -243,6 +246,21 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
       }
     });
 
+    ref.listen<RewriteReviewNavigationIntent?>(
+      rewriteReviewNavigationIntentProvider,
+      (previous, next) {
+        if (next == null || next.sequence == previous?.sequence) return;
+        final authority =
+            GenerationNotificationService.instance.activeChatContext;
+        if (authority?.charId != next.charId ||
+            authority?.sessionId != next.sessionId ||
+            authority?.revision != next.authorityRevision) {
+          return;
+        }
+        ref.read(routerProvider).push(next.location);
+      },
+    );
+
     final router = ref.watch(routerProvider);
     final themeSettings = ref.watch(themeProvider);
     final uiFont = ref.watch(uiFontFamilyProvider).value;
@@ -290,8 +308,16 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
       // Stretch overscroll without an offscreen layer, so glass surfaces
       // inside scroll views keep their backdrop blur during the stretch.
       scrollBehavior: const GlazeScrollBehavior(),
-      theme: AppTheme.light(preset, fontFamily: uiFont, dynamicScheme: lightScheme),
-      darkTheme: AppTheme.dark(preset, fontFamily: uiFont, dynamicScheme: darkScheme),
+      theme: AppTheme.light(
+        preset,
+        fontFamily: uiFont,
+        dynamicScheme: lightScheme,
+      ),
+      darkTheme: AppTheme.dark(
+        preset,
+        fontFamily: uiFont,
+        dynamicScheme: darkScheme,
+      ),
       themeMode: mode,
       routerConfig: router,
       debugShowCheckedModeBanner: false,

--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -55,6 +55,7 @@ part 'app_db.g.dart';
     CardEvolutionProposalRuns,
     CardEvolutionDebugRuns,
     CardEvolutionObservations,
+    CardEvolutionCollectorRuns,
     CharacterKnowledgeFactRows,
     CharacterSessionBaselineRows,
     CharacterRevisionRows,
@@ -74,7 +75,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 115;
+  int get schemaVersion => 116;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2150,6 +2151,20 @@ class AppDatabase extends _$AppDatabase {
           "provider_id = 'custom_chat_completion' "
           "WHERE protocol IN ('openai', 'openai_responses', "
           "'openai_compatible') OR provider_id = 'openai_compatible'",
+        );
+      }
+      if (from < 116) {
+        await m.createTable(cardEvolutionCollectorRuns);
+        // Legacy automatic proposals were produced at reconciliation 2/4/6.
+        // Treat each completed proposal as delivery of the latest three-run
+        // boundary already reached, so upgrading never immediately repeats a
+        // proposal the user has reviewed or cancelled.
+        await customStatement(
+          'UPDATE card_evolution_claims '
+          'SET predecessor_run_ordinal = ('
+          'SELECT (COUNT(*) / 3) * 3 FROM reconciliation_successful_runs r '
+          'WHERE r.session_id = card_evolution_claims.session_id) '
+          "WHERE status = 'completed' AND predecessor_run_ordinal = 0",
         );
       }
     },

--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -75,7 +75,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 116;
+  int get schemaVersion => 117;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2165,6 +2165,43 @@ class AppDatabase extends _$AppDatabase {
           'SELECT (COUNT(*) / 3) * 3 FROM reconciliation_successful_runs r '
           'WHERE r.session_id = card_evolution_claims.session_id) '
           "WHERE status = 'completed' AND predecessor_run_ordinal = 0",
+        );
+      }
+      if (from < 117) {
+        final columns = await customSelect(
+          "PRAGMA table_info('card_evolution_observations')",
+        ).get();
+        final names = columns
+            .map((column) => column.read<String>('name'))
+            .toSet();
+        if (!names.contains('retrieval_keys_json')) {
+          await m.addColumn(
+            cardEvolutionObservations,
+            cardEvolutionObservations.retrievalKeysJson,
+          );
+        }
+        if (!names.contains('target_kind')) {
+          await m.addColumn(
+            cardEvolutionObservations,
+            cardEvolutionObservations.targetKind,
+          );
+        }
+        // Safe structural backfill only. Rows without an exact target remain
+        // unkeyed and are matched against a snapshot at read time, never
+        // globally injected.
+        await customStatement(
+          "UPDATE card_evolution_observations SET target_kind = "
+          "CASE WHEN lorebook_entry_id IS NOT NULL AND lorebook_entry_id <> '' "
+          "THEN 'injected_lorebook_entry' "
+          "WHEN card_field_path IS NOT NULL AND card_field_path <> '' "
+          "THEN 'main_character_card' ELSE NULL END "
+          'WHERE target_kind IS NULL',
+        );
+        await customStatement(
+          "UPDATE card_evolution_observations "
+          "SET retrieval_keys_json = json_array(lorebook_entry_id) "
+          "WHERE lorebook_entry_id IS NOT NULL AND lorebook_entry_id <> '' "
+          "AND retrieval_keys_json = '[]'",
         );
       }
     },

--- a/lib/core/db/repositories/card_evolution_collector_run_repo.dart
+++ b/lib/core/db/repositories/card_evolution_collector_run_repo.dart
@@ -64,6 +64,14 @@ class CardEvolutionCollectorRunRepo {
       return CardEvolutionCollectorClaimOutcome('existing', row);
     }
 
+    final nextOrdinalRow = await db
+        .customSelect(
+          'SELECT COALESCE(MAX(collector_ordinal), 0) + 1 AS ordinal '
+          'FROM card_evolution_collector_runs WHERE session_id = ?',
+          variables: [Variable.withString(reconciliationRun.sessionId)],
+        )
+        .getSingle();
+    final collectorOrdinal = nextOrdinalRow.read<int>('ordinal');
     final id = 'evolution-collector-${generateId()}';
     try {
       await db
@@ -73,7 +81,7 @@ class CardEvolutionCollectorRunRepo {
               id: id,
               sessionId: reconciliationRun.sessionId,
               characterId: characterId,
-              collectorOrdinal: reconciliationRun.ordinal,
+              collectorOrdinal: collectorOrdinal,
               reconciliationRunId: reconciliationRun.id,
               reconciliationRunOrdinal: reconciliationRun.ordinal,
               reconciliationChainHash: reconciliationRun.chainHash,
@@ -149,5 +157,33 @@ class CardEvolutionCollectorRunRepo {
         )
         .getSingle();
     return row.read<int>('ordinal');
+  }
+
+  /// Exact three completed collectors ending at [boundary]. Gaps or claimed
+  /// rows fail closed, so a writer never substitutes newer reconciliation data.
+  Future<List<CardEvolutionCollectorRunRow>> completedBoundary(
+    String sessionId,
+    int boundary,
+  ) async {
+    if (boundary < 3) return const [];
+    final rows =
+        await (db.select(db.cardEvolutionCollectorRuns)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..where(
+                (row) => row.collectorOrdinal.isBetweenValues(
+                  boundary - 2,
+                  boundary,
+                ),
+              )
+              ..where((row) => row.status.equals('completed'))
+              ..orderBy([(row) => OrderingTerm.asc(row.collectorOrdinal)]))
+            .get();
+    if (rows.length != 3 ||
+        rows.indexed.any(
+          (entry) => entry.$2.collectorOrdinal != boundary - 2 + entry.$1,
+        )) {
+      return const [];
+    }
+    return rows;
   }
 }

--- a/lib/core/db/repositories/card_evolution_collector_run_repo.dart
+++ b/lib/core/db/repositories/card_evolution_collector_run_repo.dart
@@ -1,0 +1,153 @@
+import 'package:drift/drift.dart';
+
+import '../../utils/id_generator.dart';
+import '../app_db.dart';
+
+final class CardEvolutionCollectorClaimOutcome {
+  const CardEvolutionCollectorClaimOutcome(this.kind, [this.row]);
+
+  final String kind;
+  final CardEvolutionCollectorRunRow? row;
+
+  bool get canRun => kind == 'claimed' || kind == 'existing';
+}
+
+/// Durable collector lease and completion journal. A valid empty observation
+/// response is a completed run, so cadence remains stable across restarts.
+class CardEvolutionCollectorRunRepo {
+  CardEvolutionCollectorRunRepo(this.db);
+
+  final AppDatabase db;
+
+  Future<CardEvolutionCollectorClaimOutcome> claim({
+    required LedgerReconciliationSuccessfulRunRow reconciliationRun,
+    required String characterId,
+    required String inputHash,
+    required String ownerId,
+    required int now,
+    required int leaseSeconds,
+  }) => db.transaction(() async {
+    final existing =
+        await (db.select(db.cardEvolutionCollectorRuns)..where(
+              (row) =>
+                  row.sessionId.equals(reconciliationRun.sessionId) &
+                  row.reconciliationRunId.equals(reconciliationRun.id),
+            ))
+            .getSingleOrNull();
+    if (existing != null) {
+      if (existing.status == 'completed') {
+        return CardEvolutionCollectorClaimOutcome('completed', existing);
+      }
+      if (existing.inputHash != inputHash) {
+        return const CardEvolutionCollectorClaimOutcome('staleInput');
+      }
+      if (existing.leaseExpiresAt > now && existing.ownerId != ownerId) {
+        return const CardEvolutionCollectorClaimOutcome('busy');
+      }
+      final changed =
+          await (db.update(db.cardEvolutionCollectorRuns)..where(
+                (row) =>
+                    row.id.equals(existing.id) & row.status.equals('claimed'),
+              ))
+              .write(
+                CardEvolutionCollectorRunsCompanion(
+                  ownerId: Value(ownerId),
+                  leaseExpiresAt: Value(now + leaseSeconds),
+                ),
+              );
+      if (changed != 1) {
+        return const CardEvolutionCollectorClaimOutcome('busy');
+      }
+      final row = await (db.select(
+        db.cardEvolutionCollectorRuns,
+      )..where((row) => row.id.equals(existing.id))).getSingle();
+      return CardEvolutionCollectorClaimOutcome('existing', row);
+    }
+
+    final id = 'evolution-collector-${generateId()}';
+    try {
+      await db
+          .into(db.cardEvolutionCollectorRuns)
+          .insert(
+            CardEvolutionCollectorRunsCompanion.insert(
+              id: id,
+              sessionId: reconciliationRun.sessionId,
+              characterId: characterId,
+              collectorOrdinal: reconciliationRun.ordinal,
+              reconciliationRunId: reconciliationRun.id,
+              reconciliationRunOrdinal: reconciliationRun.ordinal,
+              reconciliationChainHash: reconciliationRun.chainHash,
+              rangeHash: reconciliationRun.rangeHash,
+              inputHash: inputHash,
+              ownerId: ownerId,
+              status: 'claimed',
+              leaseExpiresAt: now + leaseSeconds,
+              createdAt: now,
+            ),
+          );
+    } catch (_) {
+      return const CardEvolutionCollectorClaimOutcome('busy');
+    }
+    final row = await (db.select(
+      db.cardEvolutionCollectorRuns,
+    )..where((item) => item.id.equals(id))).getSingle();
+    return CardEvolutionCollectorClaimOutcome('claimed', row);
+  });
+
+  Future<bool> complete({
+    required String id,
+    required String ownerId,
+    required String modelOutputHash,
+    required int now,
+  }) async {
+    final changed =
+        await (db.update(db.cardEvolutionCollectorRuns)..where(
+              (row) =>
+                  row.id.equals(id) &
+                  row.ownerId.equals(ownerId) &
+                  row.status.equals('claimed') &
+                  row.leaseExpiresAt.isBiggerThanValue(now),
+            ))
+            .write(
+              CardEvolutionCollectorRunsCompanion(
+                status: const Value('completed'),
+                modelOutputHash: Value(modelOutputHash),
+                completedAt: Value(now),
+              ),
+            );
+    return changed == 1;
+  }
+
+  Future<void> abandon({required String id, required String ownerId}) =>
+      (db.delete(db.cardEvolutionCollectorRuns)..where(
+            (row) =>
+                row.id.equals(id) &
+                row.ownerId.equals(ownerId) &
+                row.status.equals('claimed'),
+          ))
+          .go();
+
+  Future<int> latestCompletedOrdinal(String sessionId) async {
+    final row = await db
+        .customSelect(
+          'SELECT COALESCE(MAX(collector_ordinal), 0) AS ordinal '
+          'FROM card_evolution_collector_runs '
+          "WHERE session_id = ? AND status = 'completed'",
+          variables: [Variable.withString(sessionId)],
+        )
+        .getSingle();
+    return row.read<int>('ordinal');
+  }
+
+  Future<int> latestDeliveredWriterBoundary(String sessionId) async {
+    final row = await db
+        .customSelect(
+          'SELECT COALESCE(MAX(predecessor_run_ordinal), 0) AS ordinal '
+          'FROM card_evolution_claims '
+          "WHERE session_id = ? AND status = 'completed'",
+          variables: [Variable.withString(sessionId)],
+        )
+        .getSingle();
+    return row.read<int>('ordinal');
+  }
+}

--- a/lib/core/db/repositories/card_evolution_observation_repo.dart
+++ b/lib/core/db/repositories/card_evolution_observation_repo.dart
@@ -48,6 +48,8 @@ class CardEvolutionObservationRepo {
           canonicalClaim: Value(observation.canonicalClaim),
           evidenceMessageIds: jsonEncode(observation.evidenceMessageIds),
           evidenceClustersJson: Value(jsonEncode(observation.evidenceClusters)),
+          retrievalKeysJson: Value(jsonEncode(observation.retrievalKeys)),
+          targetKind: Value(observation.targetKind),
           cardFieldPath: Value(observation.cardFieldPath),
           lorebookEntryId: Value(observation.lorebookEntryId),
           confidence: observation.confidence,
@@ -66,6 +68,8 @@ class CardEvolutionObservationRepo {
     required double confidence,
     required int now,
     required List<String> evidenceMessageIds,
+    List<String>? retrievalKeys,
+    String? targetKind,
   }) => db.transaction(() async {
     final row = await (db.select(
       db.cardEvolutionObservations,
@@ -102,6 +106,12 @@ class CardEvolutionObservationRepo {
         confidence: Value(confidence),
         evidenceClustersJson: Value(jsonEncode(clusters)),
         evidenceMessageIds: Value(jsonEncode(union)),
+        retrievalKeysJson: retrievalKeys == null
+            ? const Value.absent()
+            : Value(jsonEncode(_canonicalEvidence(retrievalKeys))),
+        targetKind: targetKind == null
+            ? const Value.absent()
+            : Value(targetKind),
         updatedAt: Value(now),
       ),
     );
@@ -191,6 +201,8 @@ class CardEvolutionObservationRepo {
       observedChange: row.observedChange,
       canonicalClaim: row.canonicalClaim,
       evidenceClusters: evidenceClusters,
+      retrievalKeys: _decodeStringList(row.retrievalKeysJson),
+      targetKind: row.targetKind,
       cardFieldPath: row.cardFieldPath,
       lorebookEntryId: row.lorebookEntryId,
       confidence: row.confidence,
@@ -224,6 +236,15 @@ class CardEvolutionObservationRepo {
       ];
     } catch (_) {
       return [];
+    }
+  }
+
+  static List<String> _decodeStringList(String encoded) {
+    try {
+      final decoded = jsonDecode(encoded);
+      return decoded is List ? _canonicalEvidence(decoded) : const [];
+    } catch (_) {
+      return const [];
     }
   }
 }

--- a/lib/core/db/repositories/card_evolution_repo.dart
+++ b/lib/core/db/repositories/card_evolution_repo.dart
@@ -15,6 +15,10 @@ import 'manual_rewrite_job_repo.dart';
 import 'session_lorebook_evolution_repo.dart';
 
 const _maxChatHistoryMessages = 40;
+const _maxEvolutionSnapshotCharacters = 120000;
+const _maxCanonValueCharacters = 2000;
+const _maxLorebookEntryCharacters = 20000;
+const _maxLorebookTotalCharacters = 40000;
 
 final class CardEvolutionClaim {
   const CardEvolutionClaim({
@@ -96,6 +100,7 @@ class CardEvolutionRepo {
     required int leaseSeconds,
     int throughCollectorOrdinal = 0,
     String collectorBoundaryHash = '',
+    List<String> reconciliationRunIds = const [],
   }) => db.transaction(() async {
     if (ownerId.isEmpty || leaseSeconds <= 0) {
       return const CardEvolutionClaimOutcome('invalidRequest');
@@ -131,7 +136,10 @@ class CardEvolutionRepo {
         return const CardEvolutionClaimOutcome('busy');
       }
     }
-    final selected = await _selectInput(sessionId);
+    final selected = await _selectInput(
+      sessionId,
+      reconciliationRunIds: reconciliationRunIds,
+    );
     if (selected == null) {
       return const CardEvolutionClaimOutcome('notEligible');
     }
@@ -270,6 +278,16 @@ class CardEvolutionRepo {
               target.$2 != operation.expectedContentHash;
         })) {
       return const CardEvolutionFinalizeOutcome('invalidLorebookOperation');
+    }
+    final loreOnlyObservationKeys = _loreOnlyObservationKeys(selected);
+    if (cardOperations.any(
+      (operation) => {
+        operation.transition.scopeKey,
+        ...operation.transition.affectedTrackerKeys,
+        ...operation.patches.map((patch) => patch.scopeKey),
+      }.any((key) => loreOnlyObservationKeys.contains(_ledgerGroupKey(key))),
+    )) {
+      return const CardEvolutionFinalizeOutcome('invalidCardObservationTarget');
     }
     final values = {
       for (final field in CardRewriteField.values)
@@ -536,7 +554,12 @@ class CardEvolutionRepo {
           );
 
   Future<String?> _selectedInputForClaim(CardEvolutionClaimRow claim) async {
-    final selected = await _selectInput(claim.sessionId);
+    final runIds = await _reconciliationRunIdsForClaim(claim);
+    if (claim.predecessorRunOrdinal > 0 && runIds.length != 3) return null;
+    final selected = await _selectInput(
+      claim.sessionId,
+      reconciliationRunIds: runIds,
+    );
     if (selected == null || computeHash(selected) != claim.inputHash) {
       return null;
     }
@@ -550,6 +573,7 @@ class CardEvolutionRepo {
   Future<String?> _selectInput(
     String sessionId, {
     LedgerReconciliationSuccessfulRunRow? reconciliationRun,
+    List<String> reconciliationRunIds = const [],
   }) async {
     try {
       final session = await (db.select(
@@ -562,12 +586,28 @@ class CardEvolutionRepo {
       if (assembled == null || assembled.$2.requiresBaselineDecision) {
         return null;
       }
-      final history = reconciliationRun == null
-          ? _selectChatHistory(messages: messages)
-          : _selectReconciliationHistory(
+      final boundaryRuns = reconciliationRunIds.isEmpty
+          ? <LedgerReconciliationSuccessfulRunRow>[]
+          : await (db.select(
+              db.ledgerReconciliationSuccessfulRuns,
+            )..where((row) => row.id.isIn(reconciliationRunIds))).get();
+      if (boundaryRuns.length != reconciliationRunIds.length) return null;
+      boundaryRuns.sort(
+        (a, b) => reconciliationRunIds
+            .indexOf(a.id)
+            .compareTo(reconciliationRunIds.indexOf(b.id)),
+      );
+      final history = reconciliationRun != null
+          ? _selectReconciliationHistory(
               messages: messages,
               run: reconciliationRun,
-            );
+            )
+          : boundaryRuns.isNotEmpty
+          ? _selectReconciliationHistories(
+              messages: messages,
+              runs: boundaryRuns,
+            )
+          : _selectChatHistory(messages: messages);
       if (history == null || history.length < 2) {
         return null;
       }
@@ -586,7 +626,7 @@ class CardEvolutionRepo {
       );
       if (lorebookEntries == null) return null;
       final historyJson = _canonicalJson(history);
-      final canonEvidence = _canonEvidence(assembled.$1, assembled.$2);
+      final canonEvidence = _canonEvidence(assembled.$1, assembled.$2, history);
       final writableFields = CardRewritePolicy.nonEmptyEvolutionFields(
         assembled.$2.character,
       );
@@ -594,9 +634,42 @@ class CardEvolutionRepo {
           await (db.select(db.cardEvolutionObservations)
                 ..where((r) => r.sessionId.equals(sessionId))
                 ..where((r) => r.status.isIn(const ['active', 'promoted']))
-                ..orderBy([(r) => OrderingTerm.asc(r.createdAt)]))
+                ..orderBy([(r) => OrderingTerm.desc(r.updatedAt)]))
               .get();
-      return _canonicalJson({
+      final rangeTrackerKeys = await _rangeTrackerKeys(
+        sessionId: sessionId,
+        reconciliationRun: reconciliationRun,
+        reconciliationRuns: boundaryRuns,
+        history: history,
+        candidateObservationKeys: {
+          for (final observation in accumulatedObservations)
+            ..._decodeJsonArray(
+              observation.retrievalKeysJson,
+            ).whereType<String>(),
+        },
+      );
+      final availableRetrievalTargets = _retrievalTargets(
+        input: assembled.$1,
+        history: history,
+        lorebookEntries: lorebookEntries,
+        rangeTrackerKeys: rangeTrackerKeys,
+      );
+      final availableKeys = availableRetrievalTargets
+          .map((target) => target['key'])
+          .whereType<String>()
+          .toSet();
+      final relevantObservations = accumulatedObservations.where(
+        (observation) => _observationMatches(
+          observation: observation,
+          availableKeys: availableKeys,
+          input: assembled.$1,
+        ),
+      );
+      final compactObservations = _compactObservations(
+        relevantObservations,
+        availableKeys: availableKeys,
+      );
+      final selected = _canonicalJson({
         'contractVersion': 8,
         'fields': [for (final field in writableFields) field.wireName],
         'chatHistoryHash': computeHash(historyJson),
@@ -606,34 +679,346 @@ class CardEvolutionRepo {
           'excludesTrailingUserAssistantPair': reconciliationRun == null,
           'reconciliationRunId': reconciliationRun?.id,
           'reconciliationRunOrdinal': reconciliationRun?.ordinal,
+          'reconciliationRunIds': reconciliationRunIds,
           'reconciliationRangeHash': reconciliationRun?.rangeHash,
         },
         'chatHistory': history,
         'card': _evolutionCardSnapshot(assembled.$2.character),
         'effectiveCanon': jsonDecode(canonEvidence),
         'injectedLorebookEntries': lorebookEntries,
-        'accumulatedObservations': [
-          for (final obs in accumulatedObservations)
-            {
-              'id': obs.id,
-              'status': obs.status,
-              'scopeKey': obs.semanticScopeKey,
-              'observedChange': obs.observedChange,
-              'canonicalClaim': obs.canonicalClaim,
-              'evidenceMessageIds': _decodeJsonArray(obs.evidenceMessageIds),
-              'evidenceClusters': _decodeJsonClusters(obs.evidenceClustersJson),
-              'cardFieldPath': obs.cardFieldPath,
-              'lorebookEntryId': obs.lorebookEntryId,
-              'confidence': obs.confidence,
-              'repeatCount': obs.repeatCount,
-              'firstSeenRun': obs.firstSeenRun,
-              'lastConfirmedRun': obs.lastConfirmedRun,
-            },
-        ],
+        'availableObservationRetrievalTargets': availableRetrievalTargets,
+        'accumulatedObservations': compactObservations,
       });
+      return selected.length <= _maxEvolutionSnapshotCharacters
+          ? selected
+          : null;
     } catch (_) {
       return null;
     }
+  }
+
+  List<Map<String, Object?>> _retrievalTargets({
+    required EffectiveCanonAssemblyInput input,
+    required List<Object?> history,
+    required List<Object?> lorebookEntries,
+    required Set<String> rangeTrackerKeys,
+  }) {
+    const maxTargets = 80;
+    final primaryTargets = <String, Map<String, Object?>>{};
+    final extraTargets = <String, Map<String, Object?>>{};
+    final rangeMessages = {
+      for (final message in history)
+        if (message is Map)
+          '${message['messageId']}\u0000${message['swipeId']}\u0000${message['agentSwipeId']}',
+    };
+    for (final key in rangeTrackerKeys) {
+      primaryTargets['ledger_tracker\u0000$key'] = {
+        'kind': 'ledger_tracker',
+        'key': key,
+      };
+    }
+    for (final fact in input.facts) {
+      final sourceIdentity =
+          '${fact.sourceMessageId}\u0000${fact.sourceSwipeId}\u0000${fact.sourceAgentSwipeId}';
+      if (!rangeMessages.contains(sourceIdentity)) {
+        continue;
+      }
+      final factGroup = _ledgerGroupKey(fact.scopeKey);
+      if (factGroup == null) continue;
+      extraTargets['knowledge_fact\u0000${fact.id}'] = {
+        'kind': 'knowledge_fact',
+        'key': factGroup,
+        'factId': fact.id,
+        'scopeKey': fact.scopeKey,
+        'subjectKey': fact.subjectKey,
+        'subjectName': fact.subjectName,
+        'predicate': fact.predicate,
+        'object': _boundedText(fact.object),
+      };
+    }
+    for (final raw in lorebookEntries) {
+      if (raw is! Map ||
+          raw['lorebookId'] is! String ||
+          raw['entryId'] is! String) {
+        continue;
+      }
+      final identity = '${raw['lorebookId']}:${raw['entryId']}';
+      extraTargets['injected_lorebook_entry\u0000$identity'] = {
+        'kind': 'injected_lorebook_entry',
+        'key': identity,
+      };
+    }
+    int compare(Map<String, Object?> a, Map<String, Object?> b) {
+      final kind = (a['kind']! as String).compareTo(b['kind']! as String);
+      return kind != 0
+          ? kind
+          : (a['key']! as String).compareTo(b['key']! as String);
+    }
+
+    final primary = primaryTargets.values.toList()..sort(compare);
+    final extras = extraTargets.values.toList()..sort(compare);
+    // Exact groups from this range are never displaced by fact/lorebook
+    // metadata. Reconciliation itself bounds the primary set.
+    return [
+      ...primary,
+      ...extras.take((maxTargets - primary.length).clamp(0, maxTargets)),
+    ];
+  }
+
+  bool _observationMatches({
+    required CardEvolutionObservationRow observation,
+    required Set<String> availableKeys,
+    required EffectiveCanonAssemblyInput input,
+  }) {
+    final keys = _decodeJsonArray(
+      observation.retrievalKeysJson,
+    ).whereType<String>().map((key) => _ledgerGroupKey(key) ?? key);
+    if (keys.any(availableKeys.contains)) return true;
+    // Legacy best effort is exact and local to identities in this snapshot.
+    // It never treats an unkeyed row as globally relevant.
+    final legacyScope = _ledgerGroupKey(observation.semanticScopeKey);
+    if (legacyScope != null && availableKeys.contains(legacyScope)) return true;
+    if (observation.lorebookEntryId case final String loreId
+        when loreId.isNotEmpty && availableKeys.contains(loreId)) {
+      return true;
+    }
+    return input.facts.any(
+      (fact) =>
+          fact.scopeKey.isNotEmpty &&
+          (_ledgerGroupKey(fact.scopeKey) == legacyScope) &&
+          availableKeys.contains(legacyScope),
+    );
+  }
+
+  Future<Set<String>> _rangeTrackerKeys({
+    required String sessionId,
+    required LedgerReconciliationSuccessfulRunRow? reconciliationRun,
+    List<LedgerReconciliationSuccessfulRunRow> reconciliationRuns = const [],
+    required List<Object?> history,
+    required Set<String> candidateObservationKeys,
+  }) async {
+    final runs = reconciliationRun != null
+        ? [reconciliationRun]
+        : reconciliationRuns.isNotEmpty
+        ? reconciliationRuns
+        : await (db.select(db.ledgerReconciliationSuccessfulRuns)
+                ..where((row) => row.sessionId.equals(sessionId))
+                ..orderBy([(row) => OrderingTerm.desc(row.ordinal)])
+                ..limit(3))
+              .get();
+    final groups = <String>{};
+    for (final run in runs) {
+      try {
+        final result = jsonDecode(run.canonicalResultJson);
+        if (result is! Map || result['export'] is! Map) continue;
+        final ops = (result['export'] as Map)['ops'];
+        if (ops is! List) continue;
+        for (final op in ops) {
+          if (op is! Map || op['key'] is! String) continue;
+          final key = op['key'] as String;
+          final group = _ledgerGroupKey(key);
+          if (group != null) groups.add(group);
+          if (key == 'scene.present_entities' && op['value'] is String) {
+            groups.addAll(_presentEntityGroups(op['value'] as String));
+          }
+        }
+        final sceneState = (result['export'] as Map)['sceneState'];
+        if (sceneState is Map && sceneState['presentEntities'] is List) {
+          for (final raw in sceneState['presentEntities'] as List) {
+            if (raw is Map && raw['name'] is String) {
+              final group = _npcGroup(raw['name'] as String);
+              if (group != null) groups.add(group);
+            }
+          }
+        }
+      } catch (_) {
+        // Fail closed for legacy/malformed ranges.
+      }
+    }
+    final chatText = history
+        .whereType<Map<Object?, Object?>>()
+        .map((message) => message['content'])
+        .whereType<String>()
+        .join('\n');
+    for (final key in candidateObservationKeys) {
+      final group = _ledgerGroupKey(key);
+      if (group == null) continue;
+      final subjects = _groupSearchSubjects(group);
+      if (subjects.any((subject) => _containsExactToken(chatText, subject))) {
+        groups.add(group);
+      }
+    }
+    return groups;
+  }
+
+  static String? _ledgerGroupKey(String key) {
+    if (key.startsWith('npc:') || key.startsWith('arc:')) {
+      final dot = key.lastIndexOf('.');
+      final group = dot > key.indexOf(':') + 1 ? key.substring(0, dot) : key;
+      return CardRewriteScope.tryParse(group)?.key;
+    }
+    if (key.startsWith('relationship:')) {
+      final dot = key.lastIndexOf('.');
+      final group = dot > 'relationship:'.length ? key.substring(0, dot) : key;
+      return CardRewriteScope.tryParse(group)?.key;
+    }
+    return CardRewriteScope.tryParse(key)?.key;
+  }
+
+  static Iterable<String> _presentEntityGroups(String value) sync* {
+    for (final raw in value.split(RegExp(r'[;,\n]+'))) {
+      final group = _npcGroup(raw);
+      if (group != null) yield group;
+    }
+  }
+
+  static String? _npcGroup(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return null;
+    final group = 'npc:$trimmed';
+    return CardRewriteScope.tryParse(group)?.key;
+  }
+
+  static Iterable<String> _groupSearchSubjects(String group) sync* {
+    if (group.startsWith('npc:') || group.startsWith('arc:')) {
+      yield group.substring(group.indexOf(':') + 1);
+      return;
+    }
+    if (group.startsWith('relationship:')) {
+      final identities = group.substring('relationship:'.length).split(':');
+      if (identities.length == 2) yield* identities;
+    }
+  }
+
+  static bool _containsExactToken(String text, String subject) {
+    final foldedText = text.toLowerCase();
+    final foldedSubject = subject.toLowerCase();
+    if (foldedSubject.isEmpty) return false;
+    var start = 0;
+    while (true) {
+      final index = foldedText.indexOf(foldedSubject, start);
+      if (index < 0) return false;
+      final before = index == 0
+          ? null
+          : foldedText.substring(0, index).runes.last;
+      final end = index + foldedSubject.length;
+      final after = end == foldedText.length
+          ? null
+          : foldedText.substring(end).runes.first;
+      if (!_isWordRune(before) && !_isWordRune(after)) return true;
+      start = index + 1;
+    }
+  }
+
+  static bool _isWordRune(int? rune) {
+    if (rune == null) return false;
+    final character = String.fromCharCode(rune);
+    return RegExp(r'^[\p{L}\p{N}_]$', unicode: true).hasMatch(character);
+  }
+
+  Future<List<String>> _reconciliationRunIdsForClaim(
+    CardEvolutionClaimRow claim,
+  ) async {
+    if (claim.predecessorRunOrdinal <= 0) return const [];
+    final rows =
+        await (db.select(db.cardEvolutionCollectorRuns)
+              ..where((row) => row.sessionId.equals(claim.sessionId))
+              ..where(
+                (row) => row.collectorOrdinal.isBetweenValues(
+                  claim.predecessorRunOrdinal - 2,
+                  claim.predecessorRunOrdinal,
+                ),
+              )
+              ..where((row) => row.status.equals('completed'))
+              ..orderBy([(row) => OrderingTerm.asc(row.collectorOrdinal)]))
+            .get();
+    if (rows.length != 3 ||
+        rows.last.reconciliationChainHash != claim.predecessorCursorHash) {
+      return const [];
+    }
+    return [for (final row in rows) row.reconciliationRunId];
+  }
+
+  List<Object?>? _selectReconciliationHistories({
+    required List<dynamic> messages,
+    required List<LedgerReconciliationSuccessfulRunRow> runs,
+  }) {
+    final byIdentity = <String, Object?>{};
+    for (final run in runs) {
+      final history = _selectReconciliationHistory(
+        messages: messages,
+        run: run,
+      );
+      if (history == null) return null;
+      for (final item in history) {
+        if (item is Map) {
+          byIdentity['${item['messageId']}\u0000${item['swipeId']}\u0000${item['agentSwipeId']}'] =
+              item;
+        }
+      }
+    }
+    return byIdentity.values.toList();
+  }
+
+  List<Map<String, Object?>> _compactObservations(
+    Iterable<CardEvolutionObservationRow> observations, {
+    required Set<String> availableKeys,
+  }) {
+    const maxCount = 12;
+    const maxCharacters = 8000;
+    final sorted = observations.toList()
+      ..sort((a, b) {
+        final updated = b.updatedAt.compareTo(a.updatedAt);
+        return updated != 0 ? updated : a.id.compareTo(b.id);
+      });
+    final result = <Map<String, Object?>>[];
+    var characters = 0;
+    for (final obs in sorted) {
+      if (result.length == maxCount) break;
+      final clusters = _decodeJsonClusters(obs.evidenceClustersJson);
+      final recentClusters = clusters.length <= 3
+          ? clusters
+          : clusters.sublist(clusters.length - 3);
+      final value = <String, Object?>{
+        'id': obs.id,
+        'status': obs.status,
+        'scopeKey': obs.semanticScopeKey,
+        'observedChange': obs.observedChange,
+        'canonicalClaim': obs.canonicalClaim,
+        'evidenceClusters': recentClusters,
+        'retrievalKeys':
+            _decodeJsonArray(obs.retrievalKeysJson)
+                .whereType<String>()
+                .map((key) => _ledgerGroupKey(key) ?? key)
+                .toSet()
+                .toList()
+              ..sort(),
+        'targetKind': obs.targetKind,
+        'cardFieldPath': obs.cardFieldPath,
+        'lorebookEntryId': obs.lorebookEntryId,
+        'confidence': obs.confidence,
+        'repeatCount': obs.repeatCount,
+        'firstSeenRun': obs.firstSeenRun,
+        'lastConfirmedRun': obs.lastConfirmedRun,
+      };
+      if (_decodeJsonArray(obs.retrievalKeysJson).isEmpty) {
+        final legacyKeys = <String>{};
+        final legacyScope = _ledgerGroupKey(obs.semanticScopeKey);
+        if (legacyScope != null && availableKeys.contains(legacyScope)) {
+          legacyKeys.add(legacyScope);
+        }
+        if (obs.lorebookEntryId != null &&
+            availableKeys.contains(obs.lorebookEntryId)) {
+          legacyKeys.add(obs.lorebookEntryId!);
+        }
+        value['retrievalKeys'] = legacyKeys.toList()..sort();
+      }
+      final size = jsonEncode(value).length;
+      if (characters + size > maxCharacters) continue;
+      result.add(value);
+      characters += size;
+    }
+    return result;
   }
 
   Future<List<Object?>?> _selectInjectedLorebookEntries({
@@ -675,20 +1060,30 @@ class CardEvolutionRepo {
         for (final entry in selected.values) (entry.lorebookId, entry.entryId),
       ],
     );
-    return [
-      for (final entry in selected.values)
-        () {
-          final overlay = overlays['${entry.lorebookId}\u0000${entry.entryId}'];
-          final content = overlay?.content ?? entry.rawContent;
-          return <String, Object?>{
-            'lorebookId': entry.lorebookId,
-            'entryId': entry.entryId,
-            'baseContent': overlay?.baseContent ?? entry.rawContent,
-            'content': content,
-            'expectedContentHash': CardCanonicalizer.scalarSha256(content),
-          };
-        }(),
-    ];
+    final result = <Object?>[];
+    var totalCharacters = 0;
+    for (final entry in selected.values) {
+      final overlay = overlays['${entry.lorebookId}\u0000${entry.entryId}'];
+      final baseContent = overlay?.baseContent ?? entry.rawContent;
+      final content = overlay?.content ?? entry.rawContent;
+      final size = baseContent.length + content.length;
+      // Exact content is required for safe anchored lorebook patching. Omit an
+      // oversized target rather than truncating and weakening CAS validation.
+      if (baseContent.length > _maxLorebookEntryCharacters ||
+          content.length > _maxLorebookEntryCharacters ||
+          totalCharacters + size > _maxLorebookTotalCharacters) {
+        continue;
+      }
+      result.add(<String, Object?>{
+        'lorebookId': entry.lorebookId,
+        'entryId': entry.entryId,
+        'baseContent': baseContent,
+        'content': content,
+        'expectedContentHash': CardCanonicalizer.scalarSha256(content),
+      });
+      totalCharacters += size;
+    }
+    return result;
   }
 
   Future<(EffectiveCanonAssemblyInput, EffectiveCanonAssembly)?> _assemble(
@@ -808,6 +1203,7 @@ class CardEvolutionRepo {
   String _canonEvidence(
     EffectiveCanonAssemblyInput input,
     EffectiveCanonAssembly assembly,
+    List<Object?> history,
   ) => _canonicalJson({
     'identity': assembly.identity,
     'revision': {
@@ -815,35 +1211,50 @@ class CardEvolutionRepo {
       'hash': assembly.effectiveRevision.hash,
     },
     'trackers': [
-      for (final tracker in input.committedTrackers)
+      for (final tracker in input.committedTrackers.take(80))
         {
           'name': tracker.name,
-          'value': tracker.value,
+          'value': _boundedText(tracker.value),
           'scope': tracker.scope,
           'provenance': tracker.provenance,
         },
     ],
     'facts': [
-      for (final fact in input.facts)
+      for (final fact
+          in input.facts
+              .where((fact) {
+                return history.any(
+                  (message) =>
+                      message is Map &&
+                      message['messageId'] == fact.sourceMessageId &&
+                      message['swipeId'] == fact.sourceSwipeId &&
+                      message['agentSwipeId'] == fact.sourceAgentSwipeId,
+                );
+              })
+              .take(40))
         {
           'scopeKey': fact.scopeKey,
           'predicate': fact.predicate,
-          'object': fact.object,
+          'object': _boundedText(fact.object),
           'epistemicState': fact.epistemicState.wireName,
           'confidence': fact.confidence,
           'importance': fact.importance,
         },
     ],
     'transitions': [
-      for (final transition in input.transitions)
+      for (final transition in input.transitions.take(40))
         {
           'scopeKey': transition.semanticScopeKey,
-          'canonicalClaim': transition.canonicalClaim,
-          'promotionDestination': transition.promotionDestination,
+          'canonicalClaim': _boundedText(transition.canonicalClaim),
+          'promotionDestination': _boundedText(transition.promotionDestination),
         },
     ],
   });
 }
+
+String _boundedText(String value) => value.length <= _maxCanonValueCharacters
+    ? value
+    : value.substring(0, _maxCanonValueCharacters);
 
 bool _hasEvolutionOperations(
   List<RewriteOperationSnapshot> operations, {
@@ -885,6 +1296,24 @@ Map<String, (String, String)>? _loreTargetsFromInput(String selectedInputJson) {
     return result;
   } catch (_) {
     return null;
+  }
+}
+
+Set<String> _loreOnlyObservationKeys(String selectedInputJson) {
+  try {
+    final input = jsonDecode(selectedInputJson) as Map;
+    final observations = input['accumulatedObservations'];
+    if (observations is! List) return const {};
+    return {
+      for (final observation in observations)
+        if (observation is Map &&
+            observation['targetKind'] == 'injected_lorebook_entry' &&
+            observation['retrievalKeys'] is List)
+          for (final key in observation['retrievalKeys'] as List)
+            if (key is String) key,
+    };
+  } catch (_) {
+    return const {};
   }
 }
 

--- a/lib/core/db/repositories/card_evolution_repo.dart
+++ b/lib/core/db/repositories/card_evolution_repo.dart
@@ -94,6 +94,8 @@ class CardEvolutionRepo {
     required String ownerId,
     required int now,
     required int leaseSeconds,
+    int throughCollectorOrdinal = 0,
+    String collectorBoundaryHash = '',
   }) => db.transaction(() async {
     if (ownerId.isEmpty || leaseSeconds <= 0) {
       return const CardEvolutionClaimOutcome('invalidRequest');
@@ -157,8 +159,8 @@ class CardEvolutionRepo {
               chatHistoryHash: snapshot['chatHistoryHash'] as String,
               effectiveCanonIdentity:
                   snapshot['effectiveCanonIdentity'] as String,
-              predecessorCursorHash: '',
-              predecessorRunOrdinal: 0,
+              predecessorCursorHash: collectorBoundaryHash,
+              predecessorRunOrdinal: throughCollectorOrdinal,
               inputHash: inputHash,
               createdAt: now,
             ),
@@ -397,6 +399,32 @@ class CardEvolutionRepo {
     return CardEvolutionFinalizeOutcome('persisted', job);
   });
 
+  /// Records a successful automatic writer cycle that correctly produced no
+  /// operations. This prevents the same three-collector boundary from being
+  /// retried after every subsequent collector while retaining no review job.
+  Future<bool> completeEmptyClaim({
+    required String claimId,
+    required String ownerId,
+    required int now,
+  }) async {
+    final changed =
+        await (db.update(db.cardEvolutionClaims)..where(
+              (row) =>
+                  row.id.equals(claimId) &
+                  row.ownerId.equals(ownerId) &
+                  row.status.equals('claimed') &
+                  row.predecessorRunOrdinal.isBiggerThanValue(0) &
+                  row.leaseExpiresAt.isBiggerThanValue(now),
+            ))
+            .write(
+              CardEvolutionClaimsCompanion(
+                status: const Value('completed'),
+                completedAt: Value(now),
+              ),
+            );
+    return changed == 1;
+  }
+
   /// Releases an uncompleted lease after work outside the transaction fails.
   /// Claims are otherwise retained only for successful idempotency records.
   Future<void> abandonClaim({
@@ -457,6 +485,26 @@ class CardEvolutionRepo {
     );
   });
 
+  /// Builds collector evidence from the exact immutable anchors committed by
+  /// one successful reconciliation. It deliberately does not re-run the
+  /// generic mutable-tail heuristic.
+  Future<CardEvolutionObservationSnapshot?> buildObservationSnapshotForRun(
+    LedgerReconciliationSuccessfulRunRow run,
+  ) => db.transaction(() async {
+    final selected = await _selectInput(run.sessionId, reconciliationRun: run);
+    if (selected == null) return null;
+    final session = await (db.select(
+      db.chatSessions,
+    )..where((row) => row.sessionId.equals(run.sessionId))).getSingleOrNull();
+    if (session == null) return null;
+    final assembled = await _assemble(run.sessionId, session.characterId);
+    if (assembled == null || assembled.$2.requiresBaselineDecision) return null;
+    return CardEvolutionObservationSnapshot(
+      character: assembled.$2.character,
+      selectedInputJson: selected,
+    );
+  });
+
   /// Counts successful Ledger reconciliations for the session. The observation
   /// pass runs on every even count (every 2nd reconciliation cadence).
   Future<int> countSuccessfulReconciliations(String sessionId) async {
@@ -499,7 +547,10 @@ class CardEvolutionRepo {
         : null;
   }
 
-  Future<String?> _selectInput(String sessionId) async {
+  Future<String?> _selectInput(
+    String sessionId, {
+    LedgerReconciliationSuccessfulRunRow? reconciliationRun,
+  }) async {
     try {
       final session = await (db.select(
         db.chatSessions,
@@ -511,7 +562,12 @@ class CardEvolutionRepo {
       if (assembled == null || assembled.$2.requiresBaselineDecision) {
         return null;
       }
-      final history = _selectChatHistory(messages: messages);
+      final history = reconciliationRun == null
+          ? _selectChatHistory(messages: messages)
+          : _selectReconciliationHistory(
+              messages: messages,
+              run: reconciliationRun,
+            );
       if (history == null || history.length < 2) {
         return null;
       }
@@ -534,10 +590,10 @@ class CardEvolutionRepo {
       final writableFields = CardRewritePolicy.nonEmptyEvolutionFields(
         assembled.$2.character,
       );
-      final promotedObservations =
+      final accumulatedObservations =
           await (db.select(db.cardEvolutionObservations)
                 ..where((r) => r.sessionId.equals(sessionId))
-                ..where((r) => r.status.equals('promoted'))
+                ..where((r) => r.status.isIn(const ['active', 'promoted']))
                 ..orderBy([(r) => OrderingTerm.asc(r.createdAt)]))
               .get();
       return _canonicalJson({
@@ -547,15 +603,20 @@ class CardEvolutionRepo {
         'effectiveCanonIdentity': assembled.$2.identity,
         'limits': {
           'maxChatHistoryMessages': _maxChatHistoryMessages,
-          'excludesTrailingUserAssistantPair': true,
+          'excludesTrailingUserAssistantPair': reconciliationRun == null,
+          'reconciliationRunId': reconciliationRun?.id,
+          'reconciliationRunOrdinal': reconciliationRun?.ordinal,
+          'reconciliationRangeHash': reconciliationRun?.rangeHash,
         },
         'chatHistory': history,
         'card': _evolutionCardSnapshot(assembled.$2.character),
         'effectiveCanon': jsonDecode(canonEvidence),
         'injectedLorebookEntries': lorebookEntries,
-        'validatedTargets': [
-          for (final obs in promotedObservations)
+        'accumulatedObservations': [
+          for (final obs in accumulatedObservations)
             {
+              'id': obs.id,
+              'status': obs.status,
               'scopeKey': obs.semanticScopeKey,
               'observedChange': obs.observedChange,
               'canonicalClaim': obs.canonicalClaim,
@@ -566,6 +627,7 @@ class CardEvolutionRepo {
               'confidence': obs.confidence,
               'repeatCount': obs.repeatCount,
               'firstSeenRun': obs.firstSeenRun,
+              'lastConfirmedRun': obs.lastConfirmedRun,
             },
         ],
       });
@@ -690,6 +752,57 @@ class CardEvolutionRepo {
         : 0;
     final result = stableCandidates.sublist(start, stableCandidates.length);
     return result.isEmpty ? null : result;
+  }
+
+  List<Object?>? _selectReconciliationHistory({
+    required List<dynamic> messages,
+    required LedgerReconciliationSuccessfulRunRow run,
+  }) {
+    try {
+      final decoded = jsonDecode(run.anchorsJson);
+      if (decoded is! List || decoded.isEmpty) return null;
+      final byId = <String, Map<Object?, Object?>>{};
+      for (final message in messages) {
+        if (message is Map && message['id'] is String) {
+          byId[message['id'] as String] = message;
+        }
+      }
+      final result = <Map<String, Object?>>[];
+      for (final raw in decoded) {
+        if (raw is! Map ||
+            raw['messageId'] is! String ||
+            raw['swipeId'] is! int ||
+            raw['agentSwipeId'] is! int ||
+            raw['role'] is! String ||
+            raw['contentHash'] is! String) {
+          return null;
+        }
+        final message = byId[raw['messageId'] as String];
+        if (message == null || message['role'] != raw['role']) return null;
+        final content = _anchoredContent(
+          message,
+          raw['swipeId'] as int,
+          raw['agentSwipeId'] as int,
+        );
+        if (content == null || computeHash(content) != raw['contentHash']) {
+          return null;
+        }
+        result.add({
+          'messageId': raw['messageId'],
+          'role': raw['role'],
+          'swipeId': raw['swipeId'],
+          'agentSwipeId': raw['agentSwipeId'],
+          'content': content,
+          'contentHash': raw['contentHash'],
+        });
+      }
+      final start = result.length > _maxChatHistoryMessages
+          ? result.length - _maxChatHistoryMessages
+          : 0;
+      return result.sublist(start);
+    } catch (_) {
+      return null;
+    }
   }
 
   String _canonEvidence(

--- a/lib/core/db/repositories/manual_rewrite_apply_repo.dart
+++ b/lib/core/db/repositories/manual_rewrite_apply_repo.dart
@@ -356,6 +356,40 @@ class ManualRewriteApplyRepo {
     if (jobChanged != 1) {
       throw StateError('Job CAS changed inside apply transaction.');
     }
+    final proposal = await (_db.select(
+      _db.cardEvolutionProposalRuns,
+    )..where((row) => row.rewriteJobId.equals(jobId))).getSingleOrNull();
+    if (proposal != null) {
+      final observationIds = <String>{};
+      try {
+        final selected = jsonDecode(proposal.selectedInputJson);
+        final rawObservations = selected is Map
+            ? selected['accumulatedObservations']
+            : null;
+        if (rawObservations is List) {
+          for (final raw in rawObservations) {
+            if (raw is Map && raw['id'] is String) {
+              observationIds.add(raw['id'] as String);
+            }
+          }
+        }
+      } catch (_) {
+        // Legacy/malformed provenance must not block an otherwise valid apply.
+      }
+      if (observationIds.isNotEmpty) {
+        await (_db.update(_db.cardEvolutionObservations)
+              ..where((row) => row.id.isIn(observationIds))
+              ..where(
+                (row) => row.status.isIn(const ['active', 'promoted']),
+              ))
+            .write(
+              CardEvolutionObservationsCompanion(
+                status: const Value('consumed'),
+                updatedAt: Value(currentTimestampSeconds()),
+              ),
+            );
+      }
+    }
         return const ManualRewriteApplyOutcome.applied();
       });
     } on _ApplyBlocked catch (blocked) {

--- a/lib/core/db/repositories/session_deletion_queries.dart
+++ b/lib/core/db/repositories/session_deletion_queries.dart
@@ -62,6 +62,9 @@ class SessionDeletionQueries {
     await (_db.delete(
       _db.ledgerReconciliationCursors,
     )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.cardEvolutionCollectorRuns,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
     await (_db.delete(_db.cardEvolutionClaims)..where((row) {
           final session = row.sessionId.equals(sessionId);
           return preserveMemoryBookSettings

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -1147,6 +1147,14 @@ class CardEvolutionObservations extends Table {
   TextColumn get evidenceMessageIds => text()();
   TextColumn get evidenceClustersJson =>
       text().withDefault(const Constant('[]'))();
+
+  /// Exact, case-preserving Unicode Ledger keys (or exact injected lorebook
+  /// identities) used to retrieve this row for a later bounded snapshot.
+  TextColumn get retrievalKeysJson =>
+      text().withDefault(const Constant('[]'))();
+
+  /// `main_character_card` or `injected_lorebook_entry`.
+  TextColumn get targetKind => text().nullable()();
   TextColumn get cardFieldPath => text().nullable()();
   TextColumn get lorebookEntryId => text().nullable()();
   RealColumn get confidence => real()();

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -1172,6 +1172,56 @@ class CardEvolutionObservations extends Table {
   ];
 }
 
+/// Durable completion/lease journal for the observation collector. A collector
+/// run is tied to one immutable Ledger reconciliation range; valid empty model
+/// responses are still recorded as completed so they are not replayed after a
+/// restart.
+@DataClassName('CardEvolutionCollectorRunRow')
+@TableIndex(
+  name: 'idx_card_evolution_collector_session_ordinal',
+  columns: {#sessionId, #collectorOrdinal},
+  unique: true,
+)
+@TableIndex(
+  name: 'idx_card_evolution_collector_reconciliation',
+  columns: {#sessionId, #reconciliationRunId},
+  unique: true,
+)
+class CardEvolutionCollectorRuns extends Table {
+  @override
+  String get tableName => 'card_evolution_collector_runs';
+  TextColumn get id => text()();
+  TextColumn get sessionId => text()();
+  TextColumn get characterId => text()();
+  IntColumn get collectorOrdinal => integer()();
+  TextColumn get reconciliationRunId => text()();
+  IntColumn get reconciliationRunOrdinal => integer()();
+  TextColumn get reconciliationChainHash => text()();
+  TextColumn get rangeHash => text()();
+  TextColumn get inputHash => text()();
+  TextColumn get ownerId => text()();
+  TextColumn get status => text()();
+  IntColumn get leaseExpiresAt => integer()();
+  TextColumn get modelOutputHash => text().nullable()();
+  IntColumn get createdAt => integer()();
+  IntColumn get completedAt => integer().nullable()();
+  @override
+  Set<Column> get primaryKey => {id};
+  @override
+  List<Set<Column>> get uniqueKeys => [
+    {sessionId, collectorOrdinal},
+    {sessionId, reconciliationRunId},
+  ];
+  @override
+  List<String> get customConstraints => [
+    "CHECK (status IN ('claimed', 'completed'))",
+    "CHECK (id <> '' AND session_id <> '' AND character_id <> '' "
+        "AND collector_ordinal > 0 AND reconciliation_run_id <> '' "
+        "AND reconciliation_run_ordinal > 0 AND reconciliation_chain_hash <> '' "
+        "AND range_hash <> '' AND input_hash <> '' AND owner_id <> '')",
+  ];
+}
+
 /// Immutable canonical lorebook-use manifest at one message variation anchor.
 @DataClassName('LorebookUseManifestRow')
 @TableIndex(

--- a/lib/core/models/card_evolution_observation.dart
+++ b/lib/core/models/card_evolution_observation.dart
@@ -21,6 +21,8 @@ abstract class CardEvolutionObservation with _$CardEvolutionObservation {
     required String observedChange,
     String? canonicalClaim,
     required List<List<String>> evidenceClusters,
+    @Default([]) List<String> retrievalKeys,
+    String? targetKind,
     String? cardFieldPath,
     String? lorebookEntryId,
     required double confidence,

--- a/lib/core/navigation/rewrite_review_navigation.dart
+++ b/lib/core/navigation/rewrite_review_navigation.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../db/repositories/card_evolution_repo.dart';
+import '../services/generation_notification_service.dart';
+
+/// A one-shot request for the app shell to open an automatically-created
+/// rewrite proposal. [sequence] makes repeated requests monotonic even when
+/// they happen to target the same job.
+@immutable
+class RewriteReviewNavigationIntent {
+  const RewriteReviewNavigationIntent({
+    required this.sequence,
+    required this.charId,
+    required this.sessionId,
+    required this.jobId,
+    required this.authorityRevision,
+  });
+
+  final int sequence;
+  final String charId;
+  final String sessionId;
+  final String jobId;
+  final int authorityRevision;
+
+  String get location =>
+      '/${Uri(pathSegments: ['character', charId, 'rewrite', jobId])}';
+}
+
+class RewriteReviewNavigationIntentNotifier
+    extends Notifier<RewriteReviewNavigationIntent?> {
+  int _sequence = 0;
+
+  @override
+  RewriteReviewNavigationIntent? build() => null;
+
+  void emit({
+    required String charId,
+    required String sessionId,
+    required String jobId,
+    required int authorityRevision,
+  }) {
+    state = RewriteReviewNavigationIntent(
+      sequence: ++_sequence,
+      charId: charId,
+      sessionId: sessionId,
+      jobId: jobId,
+      authorityRevision: authorityRevision,
+    );
+  }
+}
+
+final rewriteReviewNavigationIntentProvider =
+    NotifierProvider<
+      RewriteReviewNavigationIntentNotifier,
+      RewriteReviewNavigationIntent?
+    >(RewriteReviewNavigationIntentNotifier.new);
+
+/// Pure authorization policy for automatic review navigation.
+///
+/// Navigation is allowed only for the job returned by the exact `persisted`
+/// finalize result, and only while the same foreground chat authority
+/// (including its revision) remains current.
+class AutomaticRewriteReviewNavigationPolicy {
+  const AutomaticRewriteReviewNavigationPolicy();
+
+  RewriteReviewNavigationTarget? resolve({
+    required CardEvolutionFinalizeOutcome outcome,
+    required ActiveChatContext? capturedAuthority,
+    required ActiveChatContext? currentAuthority,
+  }) {
+    if (outcome.kind != 'persisted') return null;
+    final job = outcome.job;
+    if (job == null ||
+        job.id.isEmpty ||
+        job.characterId.isEmpty ||
+        capturedAuthority == null ||
+        currentAuthority == null) {
+      return null;
+    }
+    if (capturedAuthority.charId != job.characterId ||
+        capturedAuthority.sessionId != job.chatSessionId ||
+        currentAuthority.charId != capturedAuthority.charId ||
+        currentAuthority.sessionId != capturedAuthority.sessionId ||
+        currentAuthority.revision != capturedAuthority.revision) {
+      return null;
+    }
+    return RewriteReviewNavigationTarget(
+      charId: job.characterId,
+      sessionId: job.chatSessionId,
+      jobId: job.id,
+      authorityRevision: capturedAuthority.revision,
+    );
+  }
+}
+
+@immutable
+class RewriteReviewNavigationTarget {
+  const RewriteReviewNavigationTarget({
+    required this.charId,
+    required this.sessionId,
+    required this.jobId,
+    required this.authorityRevision,
+  });
+
+  final String charId;
+  final String sessionId;
+  final String jobId;
+  final int authorityRevision;
+}
+
+/// Captures authority immediately before automatic rewrite work starts.
+/// Returns null unless the requested session is the focused foreground chat.
+ActiveChatContext? captureAutomaticRewriteReviewAuthority({
+  required String charId,
+  required String sessionId,
+  GenerationNotificationService? notificationService,
+}) {
+  final authority =
+      (notificationService ?? GenerationNotificationService.instance)
+          .activeChatContext;
+  if (authority?.charId != charId || authority?.sessionId != sessionId) {
+    return null;
+  }
+  return authority;
+}
+
+/// Emits the app-level navigation intent after an automatic rewrite finishes.
+///
+/// The caller must pass the authority captured before starting the async work.
+/// A changed lifecycle, character, session, or revision suppresses navigation.
+bool emitAutomaticRewriteReviewIntent(
+  Ref ref, {
+  required CardEvolutionFinalizeOutcome outcome,
+  required ActiveChatContext? capturedAuthority,
+  GenerationNotificationService? notificationService,
+}) {
+  if (!ref.mounted) return false;
+  final service = notificationService ?? GenerationNotificationService.instance;
+  final target = const AutomaticRewriteReviewNavigationPolicy().resolve(
+    outcome: outcome,
+    capturedAuthority: capturedAuthority,
+    currentAuthority: service.activeChatContext,
+  );
+  if (target == null) return false;
+  ref
+      .read(rewriteReviewNavigationIntentProvider.notifier)
+      .emit(
+        charId: target.charId,
+        sessionId: target.sessionId,
+        jobId: target.jobId,
+        authorityRevision: target.authorityRevision,
+      );
+  return true;
+}

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -4,12 +4,15 @@ import 'dart:convert';
 import 'package:dio/dio.dart';
 
 import '../../db/repositories/card_evolution_observation_repo.dart';
+import '../../db/repositories/card_evolution_collector_run_repo.dart';
 import '../../db/repositories/card_evolution_repo.dart';
+import '../../db/app_db.dart';
 import '../../llm/card_rewrite_slot_resolver.dart';
 import '../../llm/aux_retry_runner.dart';
 import '../../models/agent_operation_record.dart';
 import '../../models/card_evolution_observation.dart';
 import '../../utils/id_generator.dart';
+import '../../utils/cast_helpers.dart';
 import '../../utils/time_helpers.dart';
 import 'card_rewrite_operation_parser.dart';
 import 'card_rewrite_prompt_builder.dart';
@@ -33,14 +36,18 @@ class AutomatedCardEvolutionService {
     this.timeoutMs = 180000,
     this.leaseSeconds = 300,
     CardEvolutionObservationRepo? observationRepo,
+    CardEvolutionCollectorRunRepo? collectorRunRepo,
     this.observationPromotionThreshold,
     this.observationMinConfidence,
     this.observationExpiryRuns,
   }) : observationRepo =
-           observationRepo ?? CardEvolutionObservationRepo(repo.db);
+           observationRepo ?? CardEvolutionObservationRepo(repo.db),
+       collectorRunRepo =
+           collectorRunRepo ?? CardEvolutionCollectorRunRepo(repo.db);
 
   final CardEvolutionRepo repo;
   final CardEvolutionObservationRepo observationRepo;
+  final CardEvolutionCollectorRunRepo collectorRunRepo;
   final CardRewriteModelResolver resolveModel;
   final CardRewriteLlmExecutor _executor;
   final bool Function()? isEnabled;
@@ -62,16 +69,83 @@ class AutomatedCardEvolutionService {
     }
     final active = _inFlight[sessionId];
     if (active != null) return active;
-    final future = _run(sessionId, onStage: onStage);
+    final future = _runManual(sessionId, onStage: onStage);
     _inFlight[sessionId] = future;
     return future.whenComplete(() => _inFlight.remove(sessionId));
   }
 
-  Future<CardEvolutionFinalizeOutcome> _run(
+  Future<CardEvolutionFinalizeOutcome> _runManual(
     String sessionId, {
     void Function(AutomatedCardEvolutionStage stage)? onStage,
   }) async {
-    await _maybeRunObservationPass(sessionId, onStage: onStage);
+    // Explicit "Run now" retains its historical convenience: when the current
+    // reconciliation count is even it also refreshes observations. Automatic
+    // cadence never uses this path.
+    try {
+      final count = await repo.countSuccessfulReconciliations(sessionId);
+      if (count > 0 && count.isEven) {
+        onStage?.call(AutomatedCardEvolutionStage.observation);
+        final snapshot = await repo.buildObservationSnapshot(sessionId);
+        if (snapshot != null) {
+          await _runObservationPass(sessionId, snapshot, count ~/ 2);
+          await _checkPromotions(sessionId);
+        }
+      }
+    } catch (_) {
+      // Manual observation refresh is best effort; writer remains available.
+    }
+    return _runWriter(sessionId, onStage: onStage);
+  }
+
+  /// Automatic lane: collect once for this immutable reconciliation, then run
+  /// at most one overdue writer cycle for each completed group of three.
+  Future<CardEvolutionFinalizeOutcome> runAfterReconciliation(
+    LedgerReconciliationSuccessfulRunRow reconciliationRun, {
+    void Function(AutomatedCardEvolutionStage stage)? onStage,
+  }) {
+    if (isEnabled?.call() == false) {
+      return Future.value(const CardEvolutionFinalizeOutcome('disabled'));
+    }
+    final sessionId = reconciliationRun.sessionId;
+    final active = _inFlight[sessionId];
+    if (active != null) return active;
+    final future = _runAutomatic(reconciliationRun, onStage: onStage);
+    _inFlight[sessionId] = future;
+    return future.whenComplete(() => _inFlight.remove(sessionId));
+  }
+
+  Future<CardEvolutionFinalizeOutcome> _runAutomatic(
+    LedgerReconciliationSuccessfulRunRow reconciliationRun, {
+    void Function(AutomatedCardEvolutionStage stage)? onStage,
+  }) async {
+    final collector = await _runCollector(reconciliationRun, onStage: onStage);
+    if (!collector) {
+      return const CardEvolutionFinalizeOutcome('collectorUnavailable');
+    }
+    final latest = await collectorRunRepo.latestCompletedOrdinal(
+      reconciliationRun.sessionId,
+    );
+    final dueBoundary = (latest ~/ 3) * 3;
+    final delivered = await collectorRunRepo.latestDeliveredWriterBoundary(
+      reconciliationRun.sessionId,
+    );
+    if (dueBoundary == 0 || dueBoundary <= delivered) {
+      return const CardEvolutionFinalizeOutcome('collectorCompleted');
+    }
+    return _runWriter(
+      reconciliationRun.sessionId,
+      onStage: onStage,
+      throughCollectorOrdinal: dueBoundary,
+      collectorBoundaryHash: reconciliationRun.chainHash,
+    );
+  }
+
+  Future<CardEvolutionFinalizeOutcome> _runWriter(
+    String sessionId, {
+    void Function(AutomatedCardEvolutionStage stage)? onStage,
+    int throughCollectorOrdinal = 0,
+    String collectorBoundaryHash = '',
+  }) async {
     onStage?.call(AutomatedCardEvolutionStage.cardRewriter);
     final owner = 'evolution-owner-${generateId()}';
     final now = currentTimestampSeconds();
@@ -80,6 +154,8 @@ class AutomatedCardEvolutionService {
       ownerId: owner,
       now: now,
       leaseSeconds: leaseSeconds,
+      throughCollectorOrdinal: throughCollectorOrdinal,
+      collectorBoundaryHash: collectorBoundaryHash,
     );
     final claim = claimed.claim;
     if (claim == null) return CardEvolutionFinalizeOutcome(claimed.kind);
@@ -105,11 +181,11 @@ class AutomatedCardEvolutionService {
       final cardOperations = <CardRewriteOperationSnapshot>[];
       String? cardOutput;
       if (allowedCardFields.isNotEmpty) {
-        final validatedTargets = _extractValidatedTargets(
+        final accumulatedObservations = _extractAccumulatedObservations(
           snapshot.selectedInputJson,
         );
         final cardPrompt =
-            '${CardRewriterPromptBuilder.buildEvolution(character: snapshot.character, instruction: 'Use the available non-empty card fields, the 40 latest immutable chat messages, and the current Ledger-backed factual context below to infer durable character evolution. Ledger supports the chat evidence; it does not replace it. Return patches only for fields with a durable, supported change. Change the smallest exact fragments possible; do not rewrite a whole field or card. Do not invent canon.', validatedTargets: validatedTargets)}\n\n# Immutable chat history and effective canon\n${snapshot.selectedInputJson}';
+            '${CardRewriterPromptBuilder.buildEvolution(character: snapshot.character, instruction: 'Independently evaluate the accumulated observation candidates, the available non-empty card fields, the 40 latest immutable chat messages, and the current Ledger-backed factual context. Active observations are unconfirmed candidates; promoted observations are stronger evidence. Return an empty operations list when no candidate is durable enough. Change only the smallest exact fragments and do not invent canon.', accumulatedObservations: accumulatedObservations)}\n\n# Immutable chat history and effective canon\n${snapshot.selectedInputJson}';
         final cardOutcome = await _executor(
           config: config,
           prompt: cardPrompt,
@@ -201,6 +277,13 @@ class AutomatedCardEvolutionService {
         lorebookOutput = lorebookOutcome.text;
       }
       if (operations.isEmpty) {
+        if (throughCollectorOrdinal > 0) {
+          finalized = await repo.completeEmptyClaim(
+            claimId: claim.row.id,
+            ownerId: owner,
+            now: currentTimestampSeconds(),
+          );
+        }
         return const CardEvolutionFinalizeOutcome(
           'emptyModelProposal',
           null,
@@ -219,12 +302,6 @@ class AutomatedCardEvolutionService {
         operations: operations,
       );
       finalized = result.isPersisted;
-      if (finalized) {
-        await repo.consumePromotedObservations(
-          sessionId,
-          now: currentTimestampSeconds(),
-        );
-      }
       return result;
     } on CardRewriteModelNotConfigured {
       return const CardEvolutionFinalizeOutcome('modelNotConfigured');
@@ -262,28 +339,61 @@ class AutomatedCardEvolutionService {
     }
   }
 
-  /// Runs the observation pass when the cadence gate is active (every 2nd
-  /// successful reconciliation). Failures are non-blocking: the card writer
-  /// continues without validated targets.
-  Future<void> _maybeRunObservationPass(
-    String sessionId, {
+  Future<bool> _runCollector(
+    LedgerReconciliationSuccessfulRunRow reconciliationRun, {
     void Function(AutomatedCardEvolutionStage stage)? onStage,
   }) async {
+    final sessionId = reconciliationRun.sessionId;
+    String? claimId;
+    String? ownerId;
     try {
-      final count = await repo.countSuccessfulReconciliations(sessionId);
-      if (count == 0 || count % 2 != 0) return;
-      final runOrdinal = count ~/ 2;
+      final snapshot = await repo.buildObservationSnapshotForRun(
+        reconciliationRun,
+      );
+      if (snapshot == null) return false;
+      ownerId = 'collector-owner-${generateId()}';
+      final now = currentTimestampSeconds();
+      final claim = await collectorRunRepo.claim(
+        reconciliationRun: reconciliationRun,
+        characterId: snapshot.character.id,
+        inputHash: computeHash(snapshot.selectedInputJson),
+        ownerId: ownerId,
+        now: now,
+        leaseSeconds: leaseSeconds,
+      );
+      if (claim.kind == 'completed') return true;
+      if (!claim.canRun || claim.row == null) return false;
+      claimId = claim.row!.id;
       onStage?.call(AutomatedCardEvolutionStage.observation);
-      await _runObservationPass(sessionId, runOrdinal);
+      final output = await _runObservationPass(
+        sessionId,
+        snapshot,
+        reconciliationRun.ordinal,
+      );
+      if (output == null) return false;
       await _checkPromotions(sessionId);
+      final completed = await collectorRunRepo.complete(
+        id: claimId,
+        ownerId: ownerId,
+        modelOutputHash: computeHash(output),
+        now: currentTimestampSeconds(),
+      );
+      if (completed) claimId = null;
+      return completed;
     } catch (_) {
-      // Observation pass failures are intentionally non-blocking.
+      return false;
+    } finally {
+      if (claimId != null && ownerId != null) {
+        await collectorRunRepo.abandon(id: claimId, ownerId: ownerId);
+      }
     }
   }
 
-  Future<void> _runObservationPass(String sessionId, int runOrdinal) async {
-    final snapshot = await repo.buildObservationSnapshot(sessionId);
-    if (snapshot == null) return;
+  Future<String?> _runObservationPass(
+    String sessionId,
+    CardEvolutionObservationSnapshot snapshot,
+    int runOrdinal,
+  ) async {
     final config = await resolveModel();
     final active = await observationRepo.getActiveObservations(sessionId);
     final activeMaps = active
@@ -305,7 +415,7 @@ class AutomatedCardEvolutionService {
     final token = CancelToken();
     _tokens['observation-$sessionId'] = token;
     try {
-      if (token.isCancelled) return;
+      if (token.isCancelled) return null;
       final outcome = await _executor(
         config: config,
         prompt: prompt,
@@ -318,12 +428,12 @@ class AutomatedCardEvolutionService {
           outcome.status == AgentOperationStatus.aborted ||
           !outcome.isOk ||
           outcome.text == null) {
-        return;
+        return null;
       }
       final actions = _parseObservationResponse(outcome.text!);
-      if (actions == null) return;
+      if (actions == null) return null;
       final validEvidenceIds = _chatMessageIds(snapshot.selectedInputJson);
-      if (validEvidenceIds == null) return;
+      if (validEvidenceIds == null) return null;
       final now = currentTimestampSeconds();
       for (final action in actions) {
         if (!validEvidenceIds.containsAll(action.evidenceMessageIds)) continue;
@@ -335,6 +445,7 @@ class AutomatedCardEvolutionService {
           action: action,
         );
       }
+      return outcome.text;
     } finally {
       if (identical(_tokens['observation-$sessionId'], token)) {
         _tokens.remove('observation-$sessionId');
@@ -436,12 +547,12 @@ class AutomatedCardEvolutionService {
     }
   }
 
-  static List<Map<String, Object?>> _extractValidatedTargets(
+  static List<Map<String, Object?>> _extractAccumulatedObservations(
     String selectedInputJson,
   ) {
     try {
       final input = jsonDecode(selectedInputJson) as Map;
-      final targets = input['validatedTargets'];
+      final targets = input['accumulatedObservations'];
       if (targets is! List) return const [];
       return [
         for (final target in targets)

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -122,21 +122,29 @@ class AutomatedCardEvolutionService {
     if (!collector) {
       return const CardEvolutionFinalizeOutcome('collectorUnavailable');
     }
-    final latest = await collectorRunRepo.latestCompletedOrdinal(
-      reconciliationRun.sessionId,
-    );
-    final dueBoundary = (latest ~/ 3) * 3;
     final delivered = await collectorRunRepo.latestDeliveredWriterBoundary(
       reconciliationRun.sessionId,
     );
-    if (dueBoundary == 0 || dueBoundary <= delivered) {
+    final dueBoundary = delivered + 3;
+    final latest = await collectorRunRepo.latestCompletedOrdinal(
+      reconciliationRun.sessionId,
+    );
+    if (latest < dueBoundary) {
       return const CardEvolutionFinalizeOutcome('collectorCompleted');
+    }
+    final boundaryRuns = await collectorRunRepo.completedBoundary(
+      reconciliationRun.sessionId,
+      dueBoundary,
+    );
+    if (boundaryRuns.length != 3) {
+      return const CardEvolutionFinalizeOutcome('collectorUnavailable');
     }
     return _runWriter(
       reconciliationRun.sessionId,
       onStage: onStage,
       throughCollectorOrdinal: dueBoundary,
-      collectorBoundaryHash: reconciliationRun.chainHash,
+      collectorBoundaryHash: boundaryRuns.last.reconciliationChainHash,
+      collectorBoundaryRuns: boundaryRuns,
     );
   }
 
@@ -145,6 +153,7 @@ class AutomatedCardEvolutionService {
     void Function(AutomatedCardEvolutionStage stage)? onStage,
     int throughCollectorOrdinal = 0,
     String collectorBoundaryHash = '',
+    List<CardEvolutionCollectorRunRow> collectorBoundaryRuns = const [],
   }) async {
     onStage?.call(AutomatedCardEvolutionStage.cardRewriter);
     final owner = 'evolution-owner-${generateId()}';
@@ -156,6 +165,9 @@ class AutomatedCardEvolutionService {
       leaseSeconds: leaseSeconds,
       throughCollectorOrdinal: throughCollectorOrdinal,
       collectorBoundaryHash: collectorBoundaryHash,
+      reconciliationRunIds: [
+        for (final run in collectorBoundaryRuns) run.reconciliationRunId,
+      ],
     );
     final claim = claimed.claim;
     if (claim == null) return CardEvolutionFinalizeOutcome(claimed.kind);
@@ -174,6 +186,7 @@ class AutomatedCardEvolutionService {
       token = CancelToken();
       _tokens[sessionId] = token;
       final sharedContext = snapshot.selectedInputJson;
+      final cardContext = _cardWriterContext(sharedContext);
       final allowedCardFields = CardRewritePolicy.nonEmptyEvolutionFields(
         snapshot.character,
       );
@@ -182,10 +195,10 @@ class AutomatedCardEvolutionService {
       String? cardOutput;
       if (allowedCardFields.isNotEmpty) {
         final accumulatedObservations = _extractAccumulatedObservations(
-          snapshot.selectedInputJson,
+          cardContext,
         );
         final cardPrompt =
-            '${CardRewriterPromptBuilder.buildEvolution(character: snapshot.character, instruction: 'Independently evaluate the accumulated observation candidates, the available non-empty card fields, the 40 latest immutable chat messages, and the current Ledger-backed factual context. Active observations are unconfirmed candidates; promoted observations are stronger evidence. Return an empty operations list when no candidate is durable enough. Change only the smallest exact fragments and do not invent canon.', accumulatedObservations: accumulatedObservations)}\n\n# Immutable chat history and effective canon\n${snapshot.selectedInputJson}';
+            '${CardRewriterPromptBuilder.buildEvolution(character: snapshot.character, instruction: 'Independently evaluate the accumulated observation candidates, the available non-empty card fields, the 40 latest immutable chat messages, and the current Ledger-backed factual context. Russian evidence may support an English card patch; preserve exact Ledger identities without translation. Active observations are unconfirmed candidates; promoted observations are stronger evidence. Return an empty operations list when no candidate is durable enough. Change only the smallest exact fragments and do not invent canon.', accumulatedObservations: accumulatedObservations)}\n\n# Immutable chat history and effective canon\n$cardContext';
         final cardOutcome = await _executor(
           config: config,
           prompt: cardPrompt,
@@ -368,7 +381,7 @@ class AutomatedCardEvolutionService {
       final output = await _runObservationPass(
         sessionId,
         snapshot,
-        reconciliationRun.ordinal,
+        claim.row!.collectorOrdinal,
       );
       if (output == null) return false;
       await _checkPromotions(sessionId);
@@ -395,23 +408,11 @@ class AutomatedCardEvolutionService {
     int runOrdinal,
   ) async {
     final config = await resolveModel();
-    final active = await observationRepo.getActiveObservations(sessionId);
-    final activeMaps = active
-        .map(
-          (o) => <String, Object?>{
-            'scopeKey': o.semanticScopeKey,
-            'observedChange': o.observedChange,
-            'canonicalClaim': o.canonicalClaim,
-            'repeatCount': o.repeatCount,
-            'firstSeenRun': o.firstSeenRun,
-            'lastConfirmedRun': o.lastConfirmedRun,
-            'confidence': o.confidence,
-            'evidenceClusters': o.evidenceClusters,
-          },
-        )
-        .toList();
+    final activeMaps = _extractAccumulatedObservations(
+      snapshot.selectedInputJson,
+    ).where((observation) => observation['status'] == 'active').toList();
     final prompt =
-        '${CardRewriterPromptBuilder.buildObservationPass(character: snapshot.character, activeObservations: activeMaps, instruction: 'Review the last 40 immutable chat messages and the current Ledger-backed canon below. For each active observation, decide whether the chat history still supports it. Identify any new repeatedly demonstrated shift in preference, attitude, relationship dynamics, or lasting character development. Do not record one-off events or temporary state. Be conservative.')}\n\n# Immutable chat history and effective canon\n${snapshot.selectedInputJson}';
+        '${CardRewriterPromptBuilder.buildObservationPass(character: snapshot.character, activeObservations: activeMaps, instruction: 'Review the last 40 immutable chat messages and the current Ledger-backed canon below. For each active observation, decide whether the chat history still supports it. Identify any new repeatedly demonstrated shift in preference, attitude, relationship dynamics, or lasting character development. Do not record one-off events or temporary state. Be conservative.')}\n\n# Immutable chat history and effective canon\n${_collectorContext(snapshot.selectedInputJson)}';
     final token = CancelToken();
     _tokens['observation-$sessionId'] = token;
     try {
@@ -434,9 +435,29 @@ class AutomatedCardEvolutionService {
       if (actions == null) return null;
       final validEvidenceIds = _chatMessageIds(snapshot.selectedInputJson);
       if (validEvidenceIds == null) return null;
+      final retrievalTargets = _retrievalTargets(snapshot.selectedInputJson);
+      if (retrievalTargets == null) return null;
       final now = currentTimestampSeconds();
       for (final action in actions) {
         if (!validEvidenceIds.containsAll(action.evidenceMessageIds)) continue;
+        if (!retrievalTargets.keys.toSet().containsAll(action.retrievalKeys)) {
+          continue;
+        }
+        final loreIdentity = action.lorebookEntryId;
+        final hasExactLoreTarget =
+            loreIdentity != null &&
+            action.retrievalKeys.contains(loreIdentity) &&
+            retrievalTargets[loreIdentity] == 'injected_lorebook_entry';
+        if ((action.targetKind == 'injected_lorebook_entry' &&
+                !hasExactLoreTarget) ||
+            (action.targetKind == 'main_character_card' &&
+                (loreIdentity != null ||
+                    action.retrievalKeys.any(
+                      (key) =>
+                          retrievalTargets[key] == 'injected_lorebook_entry',
+                    )))) {
+          continue;
+        }
         await _applyObservationAction(
           sessionId: sessionId,
           characterId: snapshot.character.id,
@@ -466,13 +487,19 @@ class AutomatedCardEvolutionService {
           sessionId,
           action.scopeKey,
         );
-        if (existing != null && existing.status == 'active') {
+        if (existing != null &&
+            existing.status == 'active' &&
+            (existing.targetKind == null ||
+                existing.targetKind == action.targetKind) &&
+            existing.lorebookEntryId == action.lorebookEntryId) {
           await observationRepo.confirmObservation(
             id: existing.id,
             runOrdinal: runOrdinal,
             confidence: action.confidence,
             now: now,
             evidenceMessageIds: action.evidenceMessageIds,
+            retrievalKeys: action.retrievalKeys,
+            targetKind: action.targetKind,
           );
         }
         break;
@@ -492,6 +519,8 @@ class AutomatedCardEvolutionService {
               observedChange: action.observedChange,
               canonicalClaim: action.canonicalClaim,
               evidenceClusters: [action.evidenceMessageIds],
+              retrievalKeys: action.retrievalKeys,
+              targetKind: action.targetKind,
               cardFieldPath: action.cardFieldPath,
               lorebookEntryId: action.lorebookEntryId,
               confidence: action.confidence,
@@ -547,6 +576,29 @@ class AutomatedCardEvolutionService {
     }
   }
 
+  static Map<String, String>? _retrievalTargets(String selectedInputJson) {
+    try {
+      final decoded = jsonDecode(selectedInputJson);
+      if (decoded is! Map ||
+          decoded['availableObservationRetrievalTargets'] is! List) {
+        return null;
+      }
+      final result = <String, String>{};
+      for (final target
+          in decoded['availableObservationRetrievalTargets'] as List) {
+        if (target is! Map ||
+            target['key'] is! String ||
+            target['kind'] is! String) {
+          return null;
+        }
+        result[target['key'] as String] = target['kind'] as String;
+      }
+      return result;
+    } catch (_) {
+      return null;
+    }
+  }
+
   static List<Map<String, Object?>> _extractAccumulatedObservations(
     String selectedInputJson,
   ) {
@@ -560,6 +612,37 @@ class AutomatedCardEvolutionService {
       ];
     } catch (_) {
       return const [];
+    }
+  }
+
+  static String _cardWriterContext(String selectedInputJson) {
+    try {
+      final input = Map<String, Object?>.from(
+        jsonDecode(selectedInputJson) as Map,
+      );
+      final observations = input['accumulatedObservations'];
+      input['accumulatedObservations'] = observations is List
+          ? [
+              for (final value in observations)
+                if (value is Map &&
+                    value['targetKind'] != 'injected_lorebook_entry')
+                  value,
+            ]
+          : const [];
+      return jsonEncode(input);
+    } catch (_) {
+      return selectedInputJson;
+    }
+  }
+
+  static String _collectorContext(String selectedInputJson) {
+    try {
+      final decoded = Map<String, Object?>.from(
+        jsonDecode(selectedInputJson) as Map,
+      )..remove('card');
+      return jsonEncode(decoded);
+    } catch (_) {
+      return selectedInputJson;
     }
   }
 
@@ -583,6 +666,8 @@ class AutomatedCardEvolutionService {
         final scopeKey = raw['scopeKey'];
         final observedChange = raw['observedChange'];
         final confidence = raw['confidence'];
+        final retrievalKeysRaw = raw['retrievalKeys'];
+        final targetKind = raw['targetKind'];
         if (action is! String ||
             !const {
               'confirm',
@@ -594,7 +679,18 @@ class AutomatedCardEvolutionService {
             scopeKey.isEmpty ||
             !scopes.add(scopeKey) ||
             (action == 'new' &&
-                (observedChange is! String || observedChange.isEmpty))) {
+                (observedChange is! String || observedChange.isEmpty)) ||
+            (action != 'no_evidence' &&
+                (retrievalKeysRaw is! List ||
+                    retrievalKeysRaw.isEmpty ||
+                    retrievalKeysRaw.any(
+                      (value) => value is! String || value.isEmpty,
+                    ))) ||
+            (action != 'no_evidence' &&
+                !const {
+                  'main_character_card',
+                  'injected_lorebook_entry',
+                }.contains(targetKind))) {
           return null;
         }
         final conf = confidence is num ? confidence.toDouble() : 0.5;
@@ -604,12 +700,16 @@ class AutomatedCardEvolutionService {
             ? 1.0
             : conf;
         final evidenceRaw = raw['evidenceMessageIds'];
-        if (evidenceRaw is! List ||
-            evidenceRaw.any((item) => item is! String)) {
+        if (action != 'no_evidence' &&
+            (evidenceRaw is! List ||
+                evidenceRaw.any((item) => item is! String))) {
           return null;
         }
         final evidence = <String>[];
-        for (final item in evidenceRaw.cast<String>()) {
+        for (final item
+            in (evidenceRaw is List
+                ? evidenceRaw.cast<String>()
+                : const <String>[])) {
           if (item.isNotEmpty && !evidence.contains(item)) evidence.add(item);
         }
         if (action != 'no_evidence' && evidence.isEmpty) return null;
@@ -622,6 +722,10 @@ class AutomatedCardEvolutionService {
                 ? raw['canonicalClaim'] as String
                 : null,
             evidenceMessageIds: evidence,
+            retrievalKeys: retrievalKeysRaw is List
+                ? retrievalKeysRaw.cast<String>().toSet().toList()
+                : const [],
+            targetKind: targetKind is String ? targetKind : null,
             cardFieldPath: raw['cardFieldPath'] is String
                 ? raw['cardFieldPath'] as String
                 : null,
@@ -690,6 +794,8 @@ final class _ParsedObservationAction {
     required this.observedChange,
     required this.canonicalClaim,
     required this.evidenceMessageIds,
+    required this.retrievalKeys,
+    required this.targetKind,
     required this.cardFieldPath,
     required this.lorebookEntryId,
     required this.confidence,
@@ -700,6 +806,8 @@ final class _ParsedObservationAction {
   final String observedChange;
   final String? canonicalClaim;
   final List<String> evidenceMessageIds;
+  final List<String> retrievalKeys;
+  final String? targetKind;
   final String? cardFieldPath;
   final String? lorebookEntryId;
   final double confidence;

--- a/lib/core/services/card_rewriter/card_rewrite_operation_parser.dart
+++ b/lib/core/services/card_rewriter/card_rewrite_operation_parser.dart
@@ -112,7 +112,7 @@ final class CardRewriteOperationParseResult {
 /// - `field` is a writable [CardRewriteField] equal to [expectedField];
 /// - `patches` is a non-empty list of single-field, non-empty-anchor patches
 ///   whose `scopeKey` parses per [CardRewriteScope], whose `anchorSha256`
-  ///   matches the RECOMPUTED [CardCanonicalizer.scalarSha256] of the anchor;
+///   matches the RECOMPUTED [CardCanonicalizer.scalarSha256] of the anchor;
 /// - the transition is global (`chatSessionId` absent or null) with
 ///   non-empty `id`/`canonicalClaim`/`promotionDestination`, a valid scope
 ///   shared by every patch, and a present `affectedTrackerKeys` list whose
@@ -142,7 +142,10 @@ abstract final class CardRewriteOperationParser {
     String output, {
     Set<CardRewriteField> allowedFields = CardRewritePolicy.evolutionFields,
   }) {
-    return _parseEvolutionBatch(output, allowedFields: allowedFields).operations;
+    return _parseEvolutionBatch(
+      output,
+      allowedFields: allowedFields,
+    ).operations;
   }
 
   /// Describes why a one-call card evolution response could not be screened.
@@ -184,7 +187,9 @@ abstract final class CardRewriteOperationParser {
         );
       }
       final field = _fieldFromWireName(rawOperation['field'] as String);
-      if (field == null || !allowedFields.contains(field) || !fields.add(field)) {
+      if (field == null ||
+          !allowedFields.contains(field) ||
+          !fields.add(field)) {
         return const _EvolutionBatchParse.failure(
           'field is unsupported or repeated',
         );
@@ -367,9 +372,7 @@ abstract final class CardRewriteOperationParser {
           anchor: anchor,
           // The automated batch is still bounded by exact live-anchor checks,
           // but an LLM cannot reliably produce a cryptographic digest.
-          anchorSha256: recomputeAnchorHash
-              ? computedAnchorHash
-              : anchorSha256,
+          anchorSha256: recomputeAnchorHash ? computedAnchorHash : anchorSha256,
           value: value,
         ),
       );
@@ -556,12 +559,10 @@ abstract final class CardRewriteOperationParser {
     return null;
   }
 
-  /// Model-facing subjects are often title-cased display names. Persist scope
-  /// identities canonically so `relationship:Danvi` and
-  /// `relationship:danvi` address the same permitted tracker family.
+  /// Scope identities are exact RP-language Ledger keys. Case folding or
+  /// transliteration would silently retarget a different identity.
   static String? _canonicalScopeKey(String value) {
-    final canonical = value.toLowerCase();
-    return CardRewriteScope.tryParse(canonical)?.key;
+    return CardRewriteScope.tryParse(value)?.key;
   }
 }
 

--- a/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
+++ b/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
@@ -86,8 +86,9 @@ abstract final class CardRewriterPromptBuilder {
       ..writeln(
         '- scopeKey supports npc:<subject>, relationship:<subject>, '
         'arc:<subject>, world:<subject>, or scene.<subject>. Every patch and '
-        'its transition must use the same scopeKey. Use ASCII lowercase IDs '
-        'only: for example relationship:danvi, never relationship:Danvi.',
+        'its transition must use the same scopeKey. Preserve exact RP-language '
+        'Unicode identities from supplied Ledger keys; never translate, '
+        'transliterate, case-fold, or invent an identity.',
       )
       ..writeln(
         '- Each anchor must occur exactly once in its current field and its '
@@ -161,6 +162,20 @@ abstract final class CardRewriterPromptBuilder {
         'dynamics, or lasting character development ARE observations.',
       )
       ..writeln(
+        '- retrievalKeys must contain exact, stable, case-preserving Unicode '
+        'Ledger GROUP keys (for example npc:Квинн, '
+        'relationship:Гильда:Квинн, arc:Спонсорство) from '
+        'availableObservationRetrievalTargets in the supplied snapshot. Never '
+        'return volatile field suffixes such as .location or .trust. Never '
+        'translate, transliterate, or invent a key.',
+      )
+      ..writeln(
+        '- targetKind is main_character_card for the main character\'s enduring '
+        'traits or relationships, or injected_lorebook_entry for NPC-owned '
+        'facts. NPC-owned facts may target only an existing injected lorebook '
+        'entry; they must never target the main character card.',
+      )
+      ..writeln(
         '- Each observation has a narrow semantic scope key '
         '(e.g. character.preference.X).',
       )
@@ -209,6 +224,8 @@ abstract final class CardRewriterPromptBuilder {
         'Respond with exactly one JSON object and nothing else: '
         '{"observations":[{"action":"new|confirm|no_evidence|contradict","scopeKey":"...",'
         '"observedChange":"...","canonicalClaim":"...",'
+        '"retrievalKeys":["exact Ledger key"],'
+        '"targetKind":"main_character_card|injected_lorebook_entry",'
         '"evidenceMessageIds":[],"cardFieldPath":"personality"|null,'
         '"lorebookEntryId":"bookId:entryId"|null,"confidence":0.0-1.0}]}.',
       )
@@ -231,6 +248,7 @@ abstract final class CardRewriterPromptBuilder {
 
 # Writable targets
 Only the supplied lorebookId/entryId pairs are writable. Do not create, delete, move, rename, or change keys/settings. Do not output card patches. The shared context includes the current card and the card writer's proposed operations. Avoid only card-lorebook duplication: do not patch an entry with a fact already represented in the current card or proposed card operations. Chat history and Ledger are evidence, not alternate durable targets; do not omit a supported lorebook patch merely because Ledger already records the fact.
+NPC-owned facts may patch only an existing supplied injected lorebook entry. Main-character relationships may patch the card instead. Preserve exact RP-language Unicode Ledger identities; never translate or transliterate them.
 
 # Response format
 Respond with exactly one JSON object and nothing else:

--- a/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
+++ b/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
@@ -15,7 +15,7 @@ abstract final class CardRewriterPromptBuilder {
   static String buildEvolution({
     required Character character,
     required String instruction,
-    List<Map<String, Object?>> validatedTargets = const [],
+    List<Map<String, Object?>> accumulatedObservations = const [],
   }) {
     final writableFields = CardRewritePolicy.nonEmptyEvolutionFields(character);
     final snapshot = Map<String, Object?>.from(
@@ -116,18 +116,18 @@ abstract final class CardRewriterPromptBuilder {
       ..writeln()
       ..writeln('# Canonical character card snapshot (read-only)')
       ..write(jsonEncode(snapshot));
-    if (validatedTargets.isNotEmpty) {
+    if (accumulatedObservations.isNotEmpty) {
       buffer
         ..writeln()
-        ..writeln('# Validated targets from observation journal')
+        ..writeln('# Accumulated candidates from observation journal')
         ..writeln(
-          'These changes have been confirmed durable across multiple '
-          'observation passes. Produce patches for them with priority. You '
-          'may also propose additional changes from the current chat window, '
-          'but validated targets take precedence. A validated target may be '
-          'omitted only when the current chat window clearly contradicts it.',
+          'Evaluate these candidates independently. Status "active" means the '
+          'candidate is not yet confirmed; status "promoted" is a stronger '
+          'signal, but neither status requires a patch. Use repeatCount, '
+          'confidence, evidence clusters, chat, card, and Ledger together. '
+          'Return no patch when evidence is insufficient or already canonical.',
         )
-        ..write(jsonEncode(validatedTargets));
+        ..write(jsonEncode(accumulatedObservations));
     }
     return buffer.toString();
   }

--- a/lib/core/services/card_rewriter/card_rewriter_contracts.dart
+++ b/lib/core/services/card_rewriter/card_rewriter_contracts.dart
@@ -112,7 +112,8 @@ abstract final class CardRewritePolicy {
     CardRewriteField.creatorNotes,
   };
 
-  static bool isWritable(CardRewriteField field) => writableFields.contains(field);
+  static bool isWritable(CardRewriteField field) =>
+      writableFields.contains(field);
 
   static Set<CardRewriteField> nonEmptyEvolutionFields(Character character) => {
     if (character.description?.isNotEmpty == true) CardRewriteField.description,
@@ -133,11 +134,6 @@ final class CardRewriteScope {
   final String subject;
   final String key;
 
-  static final RegExp _colonKey = RegExp(r'^[a-z0-9][a-z0-9_-]*$');
-  static final RegExp _sceneKey = RegExp(
-    r'^[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*)*$',
-  );
-
   static CardRewriteScope? tryParse(String key) {
     for (final entry in const <String, CardRewriteScopeKind>{
       'npc:': CardRewriteScopeKind.npc,
@@ -147,16 +143,64 @@ final class CardRewriteScope {
     }.entries) {
       if (key.startsWith(entry.key)) {
         final subject = key.substring(entry.key.length);
-        return _colonKey.hasMatch(subject)
+        return _safeIdentity(
+              subject,
+              allowDots: false,
+              allowColons: entry.value == CardRewriteScopeKind.relationship,
+            )
             ? CardRewriteScope._(entry.value, subject, key)
             : null;
       }
     }
     if (!key.startsWith('scene.')) return null;
     final subject = key.substring('scene.'.length);
-    return _sceneKey.hasMatch(subject)
+    return _safeIdentity(
+          subject,
+          allowDots: true,
+          requireNonEmptySegments: true,
+        )
         ? CardRewriteScope._(CardRewriteScopeKind.scene, subject, key)
         : null;
+  }
+
+  static bool _safeIdentity(
+    String value, {
+    required bool allowDots,
+    bool allowColons = false,
+    bool requireNonEmptySegments = false,
+  }) {
+    if (value.isEmpty ||
+        value.trim() != value ||
+        value.contains(RegExp(r'\s'))) {
+      return false;
+    }
+    if (!allowColons && value.contains(':')) return false;
+    if (allowColons &&
+        (value.split(':').length != 2 ||
+            value.split(':').any((part) => part.isEmpty))) {
+      return false;
+    }
+    if (requireNonEmptySegments &&
+        value.split('.').any((part) => part.isEmpty)) {
+      return false;
+    }
+    for (var index = 0; index < value.codeUnits.length; index++) {
+      final unit = value.codeUnitAt(index);
+      if (unit < 0x20 ||
+          unit == 0x7f ||
+          (unit >= 0x202a && unit <= 0x202e) ||
+          (unit >= 0x2066 && unit <= 0x2069)) {
+        return false;
+      }
+      if (unit >= 0xd800 && unit <= 0xdbff) {
+        if (++index >= value.codeUnits.length) return false;
+        final low = value.codeUnitAt(index);
+        if (low < 0xdc00 || low > 0xdfff) return false;
+      } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+        return false;
+      }
+    }
+    return allowDots || !value.contains('.');
   }
 }
 

--- a/lib/features/chat/bridge/chat_webview_bridge_host.dart
+++ b/lib/features/chat/bridge/chat_webview_bridge_host.dart
@@ -46,12 +46,31 @@ class ChatWebViewBridgeHost {
     required this.overlayContextResolver,
     required this.currentSessionId,
     required this.currentCharacterId,
+    required this.isActive,
   });
 
   final WidgetRef ref;
   final BuildContext? Function() overlayContextResolver;
   final String? Function() currentSessionId;
   final String? Function() currentCharacterId;
+  final bool Function() isActive;
+  bool _disposed = false;
+
+  bool get active => !_disposed && isActive();
+
+  void _ensureActive() {
+    if (!active) throw StateError('ChatWebViewBridgeHost is inactive');
+  }
+
+  String? _activeSessionId() {
+    _ensureActive();
+    return currentSessionId();
+  }
+
+  String? _activeCharacterId() {
+    _ensureActive();
+    return currentCharacterId();
+  }
 
   static const ConnectionProfileResolver _profileResolver =
       ConnectionProfileResolver();
@@ -64,6 +83,7 @@ class ChatWebViewBridgeHost {
   /// `false` (default-deny) if the lookup fails. Mirrors the previous
   /// in-widget `_bridgePermissionCheck`.
   bool _bridgePermissionCheck(String capabilityId) {
+    if (!active) return false;
     try {
       final permissions = ref.read(activePresetPermissionsProvider);
       return permissions.isGrantedById(capabilityId);
@@ -75,8 +95,10 @@ class ChatWebViewBridgeHost {
   /// Build a fresh [JsBridgeService] wired to the current widget state.
   /// Called from `onWebViewCreated`; its command registry re-enters this same
   /// bridge so dedicated capabilities and context resolution remain canonical.
-  Future<JsBridgeService> buildJsBridgeService() async {
+  Future<JsBridgeService?> buildJsBridgeService() async {
+    if (!active) return null;
     final globalRepo = await ref.read(globalVariablesRepoProvider.future);
+    if (!active) return null;
     late final JsBridgeService bridge;
     final commandRegistry = buildWiredCommandRegistry(
       WiredCommandDeps(bridgeDispatch: (request) => bridge.dispatch(request)),
@@ -85,9 +107,12 @@ class ChatWebViewBridgeHost {
       chatRepo: ref.read(chatRepoProvider),
       characterRepo: ref.read(characterRepoProvider),
       globalVariablesRepo: globalRepo,
-      messageVariables: () => ref.read(messageVariablesProvider.notifier),
-      currentSessionId: currentSessionId,
-      currentCharacterId: currentCharacterId,
+      messageVariables: () {
+        _ensureActive();
+        return ref.read(messageVariablesProvider.notifier);
+      },
+      currentSessionId: _activeSessionId,
+      currentCharacterId: _activeCharacterId,
       generateText: _generateBridgeText,
       injectPrompt: _injectBridgePrompt,
       uninjectPrompt: _uninjectBridgePrompt,
@@ -98,6 +123,7 @@ class ChatWebViewBridgeHost {
           _executeBridgeCommand(commandRegistry, command, args, context),
       showToast: _showBridgeToast,
     );
+    if (!active) return null;
     return bridge;
   }
 
@@ -106,7 +132,9 @@ class ChatWebViewBridgeHost {
     Map<String, dynamic> options,
     Map<String, dynamic> bridgeContext,
   ) async {
+    _ensureActive();
     await ref.read(apiListProvider.future);
+    _ensureActive();
     final configs = ref.read(apiListProvider).value ?? const [];
     final activeApiConfig = ref.read(activeApiConfigProvider);
     final profile =
@@ -144,7 +172,7 @@ class ChatWebViewBridgeHost {
             {'role': 'user', 'content': prompt},
           ],
           stream: false,
-          sessionId: currentSessionId(),
+          sessionId: _activeSessionId(),
         ),
         cancelToken: cancelToken,
         onComplete: (text, _, {rawResponseJson}) {
@@ -170,8 +198,9 @@ class ChatWebViewBridgeHost {
     Map<String, dynamic> options,
     Map<String, dynamic> bridgeContext,
   ) {
+    _ensureActive();
     final sessionId =
-        (bridgeContext['sessionId'] as String?) ?? currentSessionId();
+        (bridgeContext['sessionId'] as String?) ?? _activeSessionId();
     if (sessionId == null || sessionId.isEmpty) {
       throw StateError('Chat session context is not available');
     }
@@ -202,8 +231,9 @@ class ChatWebViewBridgeHost {
     String id,
     Map<String, dynamic> bridgeContext,
   ) {
+    _ensureActive();
     final sessionId =
-        (bridgeContext['sessionId'] as String?) ?? currentSessionId();
+        (bridgeContext['sessionId'] as String?) ?? _activeSessionId();
     if (sessionId == null || sessionId.isEmpty) {
       throw StateError('Chat session context is not available');
     }
@@ -217,8 +247,9 @@ class ChatWebViewBridgeHost {
     String? charId,
     Map<String, dynamic> params,
   ) async {
+    if (!active) return TriggerNoSession(mode: TriggerMode.auto).toMap();
     final resolvedCharId =
-        (params['characterId'] as String?) ?? (charId) ?? currentCharacterId();
+        (params['characterId'] as String?) ?? (charId) ?? _activeCharacterId();
     if (resolvedCharId == null || resolvedCharId.isEmpty) {
       return TriggerNoSession(mode: TriggerMode.auto).toMap();
     }
@@ -227,14 +258,18 @@ class ChatWebViewBridgeHost {
       dispatcher: dispatcher,
       log: (line) => debugPrint(line),
     );
-    return handler.handle(charId: resolvedCharId, params: params);
+    final result = await handler.handle(charId: resolvedCharId, params: params);
+    _ensureActive();
+    return result;
   }
 
   Future<void> _playBridgeAudio(String? source, Map<String, dynamic> options) {
+    if (!active) return Future.value();
     return _audioBridge.play(source, options);
   }
 
   void _showBridgeToast(String? message, Map<String, dynamic> options) {
+    if (!active) return;
     final severity = GlazeToastSeverity.parse(options['severity'] as String?);
     // Re-resolve the BuildContext on every call so the toast surfaces
     // from the currently mounted screen, not the snapshot at bridge init.
@@ -252,8 +287,9 @@ class ChatWebViewBridgeHost {
     Map<String, dynamic> args,
     Map<String, dynamic> context,
   ) async {
+    _ensureActive();
     final characterId =
-        (context['characterId'] as String?) ?? currentCharacterId();
+        (context['characterId'] as String?) ?? _activeCharacterId();
     final result = await commandRegistry.run(
       command,
       args,
@@ -263,11 +299,12 @@ class ChatWebViewBridgeHost {
         bridgeContext: {
           ...context,
           if (!context.containsKey('sessionId'))
-            'sessionId': currentSessionId(),
+            'sessionId': _activeSessionId(),
           if (!context.containsKey('characterId')) 'characterId': characterId,
         },
       ),
     );
+    _ensureActive();
     return result.toMap();
   }
 
@@ -275,6 +312,8 @@ class ChatWebViewBridgeHost {
   /// widget's [State.dispose]. Mirrors the previous in-widget disposal
   /// path: drop the audio player.
   Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
     await _audioBridge.dispose();
   }
 }

--- a/lib/features/chat/services/magic_drawer_stats_service.dart
+++ b/lib/features/chat/services/magic_drawer_stats_service.dart
@@ -14,9 +14,7 @@ import '../../../core/state/lorebook_provider.dart';
 import '../../../core/state/active_studio_preset_provider.dart';
 import '../../../core/state/active_selection_provider.dart';
 import '../../../core/state/db_provider.dart';
-import '../../../core/state/preset_resolution.dart';
 import '../../../core/state/summary_providers.dart';
-import '../../../core/state/studio_feature_provider.dart';
 import '../../extensions/providers/extension_presets_provider.dart';
 import '../../extensions/providers/extensions_settings_provider.dart';
 import '../../image_gen/image_gen_provider.dart';
@@ -35,6 +33,22 @@ class MagicDrawerStatsService {
   bool _pendingRecalc = false;
   String? _pendingCharId;
   MagicDrawerStats? _pendingBase;
+  bool _disposed = false;
+
+  bool get isActive => !_disposed;
+
+  void _ensureActive() {
+    if (_disposed) {
+      throw StateError('MagicDrawerStatsService has been disposed');
+    }
+  }
+
+  void dispose() {
+    _disposed = true;
+    _pendingRecalc = false;
+    _pendingCharId = null;
+    _pendingBase = null;
+  }
 
   /// Awaits [future], swallowing failures into `null` so one broken read
   /// cannot take down the whole parallel batch in [computeStats].
@@ -48,13 +62,18 @@ class MagicDrawerStatsService {
   }
 
   Future<String?> _resolveStudioPresetName() async {
-    final studioPreset = await _ref
-        .read(studioPresetRepoProvider)
-        .getById(await _ref.read(activeStudioPresetProvider.future));
+    _ensureActive();
+    final studioPresetRepo = _ref.read(studioPresetRepoProvider);
+    final activeStudioPresetId = await _ref.read(
+      activeStudioPresetProvider.future,
+    );
+    _ensureActive();
+    final studioPreset = await studioPresetRepo.getById(activeStudioPresetId);
     return studioPreset?.name;
   }
 
   Future<MagicDrawerStats> computeStats(String charId) async {
+    _ensureActive();
     final chatState = _ref.read(chatProvider(charId)).value;
     final session = chatState?.session;
     final sessionId = session?.id;
@@ -106,11 +125,17 @@ class MagicDrawerStatsService {
         : _guarded(chatRepo.countByCharacterId(charId), 'session count');
 
     await apiListFuture;
+    _ensureActive();
     final character = await characterFuture;
+    _ensureActive();
     final presets = await presetsFuture ?? const <Preset>[];
+    _ensureActive();
     final personas = await personasFuture ?? const <Persona>[];
+    _ensureActive();
     final lorebooks = await lorebooksFuture ?? const <Lorebook>[];
+    _ensureActive();
     final regexes = await regexesFuture ?? const <PresetRegex>[];
+    _ensureActive();
 
     final activePreset = getEffectivePreset(
       presets,
@@ -119,9 +144,8 @@ class MagicDrawerStatsService {
       _ref.read(activePresetIdProvider),
       _ref.read(presetConnectionsProvider),
     );
-    final studioName = studioNameFuture == null
-        ? null
-        : await studioNameFuture;
+    final studioName = studioNameFuture == null ? null : await studioNameFuture;
+    _ensureActive();
     final activePresetDisplayName = studioName ?? activePreset?.name;
 
     final activePersona = activePersonaId != null
@@ -129,12 +153,15 @@ class MagicDrawerStatsService {
         : personas.firstOrNull;
 
     final summaryContent = summaryFuture == null ? null : await summaryFuture;
+    _ensureActive();
     final summaryChars = summaryContent?.length ?? 0;
     final memoryBook = memoryFuture == null ? null : await memoryFuture;
+    _ensureActive();
     final memoryEntries = memoryBook?.entries.length ?? 0;
     final sessionCount = sessionCountFuture == null
         ? 0
         : await sessionCountFuture ?? 0;
+    _ensureActive();
     final messageCount = session?.messages.length ?? 0;
 
     final extActivePresetName = extSettings.activePresetId == null
@@ -203,6 +230,7 @@ class MagicDrawerStatsService {
     String charId,
     MagicDrawerStats base,
   ) async {
+    _ensureActive();
     final session = base.session;
     final character = base.character;
     final chatApi = base.apiConfig;
@@ -256,7 +284,9 @@ class MagicDrawerStatsService {
         charId: charId,
         session: session,
       );
+      _ensureActive();
       final result = await buildFromInputsInIsolate(inputs);
+      _ensureActive();
       var breakdown = result.breakdown;
 
       final lastVectorTokens = _ref.read(lastVectorLoreTokensProvider(charId));
@@ -308,7 +338,7 @@ class MagicDrawerStatsService {
       return base;
     } finally {
       _isCalculating = false;
-      if (_pendingRecalc) {
+      if (!_disposed && _pendingRecalc) {
         _pendingRecalc = false;
         final cId = _pendingCharId;
         final b = _pendingBase;
@@ -317,6 +347,10 @@ class MagicDrawerStatsService {
         if (cId != null && b != null) {
           unawaited(computeTokenStats(cId, b));
         }
+      } else if (_disposed) {
+        _pendingRecalc = false;
+        _pendingCharId = null;
+        _pendingBase = null;
       }
     }
   }

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -12,6 +12,7 @@ import '../../../../core/models/agent_operation_record.dart';
 import '../../../../core/models/chat_message.dart';
 import '../../../../core/models/pipeline_settings.dart';
 import '../../../../core/models/studio_config.dart';
+import '../../../../core/navigation/rewrite_review_navigation.dart';
 import '../../../../core/services/card_rewriter/automated_card_evolution_service.dart';
 import '../../../../core/state/db_provider.dart';
 import '../../../../core/state/memory_agent_providers.dart';
@@ -290,18 +291,19 @@ class LedgerStage {
           if (reconciliationResult.status == 'ok' &&
               pipeline.cardRewriter.enabled &&
               isCurrent()) {
-            // Card-rewriter runs on every 2nd successful reconciliation
-            // (plan §Automated Card Evolution cadence). Counting via the run
-            // repo head ordinal keeps the cadence durable across rerolls and
-            // app restarts; the single-row checkpoint cannot do this.
             final runHead = await ctx.ref
                 .read(ledgerReconciliationRunRepoProvider)
                 .getHead(sessionId);
-            if (runHead != null && runHead.ordinal % 2 == 0 && isCurrent()) {
+            if (runHead != null && isCurrent()) {
+              final rewriteReviewAuthority =
+                  captureAutomaticRewriteReviewAuthority(
+                    charId: ctx.charId,
+                    sessionId: sessionId,
+                  );
               final rewriteOutcome = await ctx.ref
                   .read(automatedCardEvolutionServiceProvider)
-                  .runOneBatch(
-                    sessionId,
+                  .runAfterReconciliation(
+                    runHead,
                     onStage: (stage) {
                       if (!ctx.ref.mounted || !isCurrent()) return;
                       startStatus(
@@ -311,6 +313,11 @@ class LedgerStage {
                       );
                     },
                   );
+              emitAutomaticRewriteReviewIntent(
+                ctx.ref,
+                outcome: rewriteOutcome,
+                capturedAuthority: rewriteReviewAuthority,
+              );
               if (ctx.ref.mounted && isCurrent()) {
                 final isFailure = const {
                   'modelNotConfigured',

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -46,8 +46,9 @@ class ChatWebViewSurface extends ConsumerWidget {
     required this.imageGenActions,
     required this.scrollActions,
     required this.miscActions,
-    required this.isMounted,
     required this.isCurrentSession,
+    required this.lifecycleEpoch,
+    required this.isActive,
     required this.sessionSwitching,
     required this.refreshPanel,
     required this.bgImageBytes,
@@ -69,11 +70,12 @@ class ChatWebViewSurface extends ConsumerWidget {
   final ImageGenCallbacks imageGenActions;
   final ScrollCallbacks scrollActions;
   final MiscCallbacks miscActions;
-  final bool Function() isMounted;
 
   /// Prevents an async `onWebViewCreated` continuation from installing
   /// callbacks captured for a session that has already been replaced.
   final bool Function(String? sessionId) isCurrentSession;
+  final int lifecycleEpoch;
+  final bool Function(int epoch) isActive;
   final bool sessionSwitching;
   final Future<void> Function(String sessionId, String messageId) refreshPanel;
   final Uint8List? bgImageBytes;
@@ -198,14 +200,19 @@ class ChatWebViewSurface extends ConsumerWidget {
                 initialUrlRequest: chatWebViewInitialUrlRequest(),
                 initialSettings: chatWebViewInAppSettings(),
                 onWebViewCreated: (controller) async {
+                  final epoch = lifecycleEpoch;
+                  bool callbackIsActive() =>
+                      isActive(epoch) && isCurrentSession(sessionId);
+                  if (!callbackIsActive()) return;
                   PerfDebug.chatWebViewSurfaceCreated();
                   final jsBridgeService = await bridgeHost
                       .buildJsBridgeService();
-                  if (!isMounted() || !isCurrentSession(sessionId)) return;
+                  if (!callbackIsActive() || jsBridgeService == null) return;
                   final bridge = ChatBridgeController(
                     controller,
                     jsBridgeService,
                   );
+                  if (!callbackIsActive()) return;
                   final allowMessageScripts =
                       ref
                           .read(appSettingsProvider)
@@ -216,7 +223,7 @@ class ChatWebViewSurface extends ConsumerWidget {
                     'window.bridge?.setAllowMessageScripts('
                     '$allowMessageScripts)',
                   );
-                  if (!isMounted() || !isCurrentSession(sessionId)) return;
+                  if (!callbackIsActive()) return;
                   onBridgeReady(bridge);
                   PerfDebug.chatWebViewBridgeReady();
 
@@ -262,11 +269,11 @@ class ChatWebViewSurface extends ConsumerWidget {
                   bridge.onLinkClick = callbacks.onLinkClick;
                   bridge.onLoadMore = callbacks.onLoadMore;
                   bridge.onMessageScriptBlocked = () {
-                    if (!isMounted()) return;
+                    if (!callbackIsActive()) return;
                     // ignore: use_build_context_synchronously
                     unawaited(maybeShowMessageScriptsPrompt(context, ref));
                   };
-                  if (!isMounted() || !isCurrentSession(sessionId)) return;
+                  if (!callbackIsActive()) return;
 
                   // The ext-block callbacks run after `await` paths. The
                   // controller is created once per WebView lifetime so
@@ -277,7 +284,7 @@ class ChatWebViewSurface extends ConsumerWidget {
                     sessionId: sessionId,
                     // ignore: use_build_context_synchronously
                     context: context,
-                    isMounted: isMounted,
+                    isMounted: callbackIsActive,
                     refreshPanel: refreshPanel,
                   );
                   bridge.onExtBlocksRunAll = extBlocks.onRunAll();
@@ -288,11 +295,17 @@ class ChatWebViewSurface extends ConsumerWidget {
                   bridge.onExtBlockDelete = extBlocks.onDelete();
 
                   final isAlive = await controller.isLoading() == false;
-                  if (isAlive && isMounted() && isCurrentSession(sessionId)) {
+                  if (!callbackIsActive()) return;
+                  if (isAlive) {
                     await onInitWebView();
+                    if (!callbackIsActive()) return;
                   }
                 },
                 onLoadStop: (controller, url) async {
+                  final epoch = lifecycleEpoch;
+                  bool callbackIsActive() =>
+                      isActive(epoch) && isCurrentSession(sessionId);
+                  if (!callbackIsActive()) return;
                   PerfDebug.chatWebViewLoadStopped();
                   // The init path is also wired through onWebViewCreated. When
                   // load stop wins the race, run init here.
@@ -302,7 +315,9 @@ class ChatWebViewSurface extends ConsumerWidget {
                         'window.bridge?.setAllowMessageScripts('
                         '${ref.read(appSettingsProvider).value?.allowMessageScripts ?? false})',
                       );
+                  if (!callbackIsActive()) return;
                   await onInitWebView();
+                  if (!callbackIsActive()) return;
                 },
                 shouldOverrideUrlLoading: (controller, request) async {
                   return chatWebViewNavigationPolicy(request.request.url);

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -203,6 +203,8 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
   Future<void>? _initFuture;
   ChatWebViewWidget? _deferredSwitchFrom;
   bool _bridgeFailureNotified = false;
+  bool _lifecycleActive = true;
+  int _lifecycleEpoch = 0;
   VoidCallback? _clearBridgeRegistry;
   final ChatWebViewSyncState _syncState = ChatWebViewSyncState();
   late final ChatWebViewSyncDispatcher _syncDispatcher =
@@ -298,10 +300,27 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     overlayContextResolver: () => context,
     currentSessionId: () => widget.sessionId,
     currentCharacterId: () => widget.charId,
+    isActive: () => mounted && _lifecycleActive,
   );
 
   @override
+  void activate() {
+    super.activate();
+    _lifecycleActive = true;
+    ++_lifecycleEpoch;
+  }
+
+  @override
+  void deactivate() {
+    _lifecycleActive = false;
+    ++_lifecycleEpoch;
+    super.deactivate();
+  }
+
+  @override
   void dispose() {
+    _lifecycleActive = false;
+    ++_lifecycleEpoch;
     PerfDebug.chatWebViewWidgetDisposed();
     // Unregister bridge so the service doesn't hold a stale reference.
     _clearBridgeRegistry?.call();
@@ -1096,8 +1115,10 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       imageGenActions: widget.imageGenActions,
       scrollActions: widget.scrollActions,
       miscActions: widget.miscActions,
-      isMounted: () => mounted,
       isCurrentSession: (sessionId) => widget.sessionId == sessionId,
+      lifecycleEpoch: _lifecycleEpoch,
+      isActive: (epoch) =>
+          mounted && _lifecycleActive && epoch == _lifecycleEpoch,
       sessionSwitching: _sessionSwitching,
       refreshPanel: _refreshExtBlocksPanel,
       bgImageBytes: bgImageBytes,

--- a/lib/features/chat/widgets/magic_drawer.dart
+++ b/lib/features/chat/widgets/magic_drawer.dart
@@ -208,7 +208,9 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
 
   @override
   void dispose() {
+    ++_statsRequest;
     _debounceTimer?.cancel();
+    _statsService.dispose();
     _scrollController.dispose();
     super.dispose();
   }

--- a/test/card_evolution_observation_repo_test.dart
+++ b/test/card_evolution_observation_repo_test.dart
@@ -28,6 +28,8 @@ void main() {
     expect(found.evidenceClusters, [
       ['msg:1', 'msg:2'],
     ]);
+    expect(found.retrievalKeys, ['npc:Алиса']);
+    expect(found.targetKind, 'main_character_card');
   });
 
   test('confirm bumps repeat count and last confirmed run', () async {
@@ -168,6 +170,8 @@ CardEvolutionObservation _observation({
   evidenceClusters: const [
     ['msg:1', 'msg:2'],
   ],
+  retrievalKeys: const ['npc:Алиса'],
+  targetKind: 'main_character_card',
   cardFieldPath: 'personality',
   confidence: confidence,
   status: 'active',

--- a/test/card_evolution_observation_test.dart
+++ b/test/card_evolution_observation_test.dart
@@ -17,6 +17,8 @@ void main() {
         ['msg:1', 'msg:2'],
         ['msg:3'],
       ],
+      retrievalKeys: const ['npc:Алиса'],
+      targetKind: 'main_character_card',
       cardFieldPath: 'personality',
       lorebookEntryId: 'book:entry',
       confidence: 0.85,

--- a/test/card_rewrite_observation_pass_test.dart
+++ b/test/card_rewrite_observation_pass_test.dart
@@ -22,6 +22,7 @@ import 'package:glaze_flutter/core/models/character.dart';
 import 'package:glaze_flutter/core/services/card_rewriter/automated_card_evolution_service.dart';
 import 'package:glaze_flutter/core/services/card_rewriter/card_rewriter_contracts.dart';
 import 'package:glaze_flutter/core/services/card_rewriter/effective_canon_read_repository.dart';
+import 'package:glaze_flutter/core/utils/cast_helpers.dart';
 
 void main() {
   late _Fixture fixture;
@@ -123,7 +124,7 @@ void main() {
       expect(cardPrompt, isNotNull);
       expect(
         cardPrompt,
-        contains('Validated targets from observation journal'),
+        contains('Accumulated candidates from observation journal'),
       );
       expect(cardPrompt, contains('character.preference.trust'));
     },
@@ -163,15 +164,15 @@ void main() {
           return _ok(fixture.cardBatchOutput);
         })
         .runOneBatch('session');
-    // The observation goes through the full cycle: confirm (repeatCount 3)
-    // → promote → consume (after successful card writer apply).
+    // Proposal persistence is review-only, so promotion remains available
+    // until the user actually applies the proposal.
     final obs = await fixture.observationRepo.findById('obs-1');
     expect(obs, isNotNull);
-    expect(obs!.status, 'consumed');
+    expect(obs!.status, 'promoted');
     expect(obs.repeatCount, 3);
   });
 
-  test('successful apply consumes promoted observations', () async {
+  test('persisted proposal does not consume promoted observations', () async {
     await fixture.observationRepo.insertObservation(
       CardEvolutionObservation(
         id: 'obs-promoted',
@@ -198,7 +199,7 @@ void main() {
     expect(result.kind, 'persisted');
     expect(
       await fixture.observationRepo.getPromotedObservations('session'),
-      isEmpty,
+      hasLength(1),
     );
   });
 
@@ -386,6 +387,46 @@ void main() {
       );
     },
   );
+
+  test(
+    'automatic collector runs every reconciliation and writer every third',
+    () async {
+      final prompts = <String>[];
+      final service = fixture.service((_, prompt) async {
+        prompts.add(prompt);
+        return prompt.contains('observation journal keeper')
+            ? _ok('{"observations":[]}')
+            : _ok('{"operations":[]}');
+      });
+      for (var ordinal = 1; ordinal <= 3; ordinal++) {
+        final run = await fixture.seedReconciliationRun(ordinal: ordinal);
+        final result = await service.runAfterReconciliation(run);
+        expect(
+          result.kind,
+          ordinal < 3 ? 'collectorCompleted' : 'emptyModelProposal',
+        );
+      }
+      expect(
+        prompts.where((value) => value.contains('observation journal keeper')),
+        hasLength(3),
+      );
+      expect(
+        prompts.where((value) => value.contains('Glaze card rewriter')),
+        hasLength(1),
+      );
+      final collectors = await fixture.db
+          .select(fixture.db.cardEvolutionCollectorRuns)
+          .get();
+      expect(collectors, hasLength(3));
+      expect(collectors.every((run) => run.status == 'completed'), isTrue);
+      final claims = await fixture.db
+          .select(fixture.db.cardEvolutionClaims)
+          .get();
+      expect(claims.single.predecessorRunOrdinal, 3);
+      expect(claims.single.status, 'completed');
+      expect(claims.single.rewriteJobId, isNull);
+    },
+  );
 }
 
 AuxCallOutcome _ok(String text) =>
@@ -441,7 +482,20 @@ final class _Fixture {
     return _Fixture(db, repo, observationRepo);
   }
 
-  Future<void> seedReconciliationRun({required int ordinal}) async {
+  Future<LedgerReconciliationSuccessfulRunRow> seedReconciliationRun({
+    required int ordinal,
+  }) async {
+    final anchors = [
+      for (final message in _messages)
+        {
+          'agentSwipeId': 0,
+          'contentHash': computeHash(message['content']!),
+          'messageId': message['id'],
+          'role': message['role'],
+          'swipeId': 0,
+        },
+    ];
+    final anchorsJson = jsonEncode(anchors);
     await db.customStatement(
       'INSERT INTO reconciliation_successful_runs '
       '(id, session_id, ordinal, start_message_id, start_swipe_id, '
@@ -458,8 +512,8 @@ final class _Fixture {
         ordinal,
         'a1',
         'a1',
-        '[]',
-        'range-$ordinal',
+        anchorsJson,
+        computeHash(anchorsJson),
         '[]',
         'canon-stamp-$ordinal',
         'canon-hash-$ordinal',
@@ -471,6 +525,9 @@ final class _Fixture {
         ordinal * 10,
       ],
     );
+    return (db.select(
+      db.ledgerReconciliationSuccessfulRuns,
+    )..where((row) => row.id.equals('run-$ordinal'))).getSingle();
   }
 
   String get cardBatchOutput => jsonEncode({

--- a/test/card_rewrite_observation_pass_test.dart
+++ b/test/card_rewrite_observation_pass_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glaze_flutter/core/db/app_db.dart';
 import 'package:glaze_flutter/core/db/repositories/applied_canon_transition_repo.dart';
@@ -90,6 +91,7 @@ void main() {
   test(
     'promoted observation appears as validated target in card writer prompt',
     () async {
+      await fixture.seedReconciliationRun(ordinal: 1);
       await fixture.observationRepo.insertObservation(
         CardEvolutionObservation(
           id: 'obs-promoted',
@@ -102,6 +104,8 @@ void main() {
           evidenceClusters: const [
             ['a1', 'u1'],
           ],
+          retrievalKeys: const ['npc:Алиса'],
+          targetKind: 'main_character_card',
           cardFieldPath: 'personality',
           confidence: 0.9,
           status: 'promoted',
@@ -130,6 +134,78 @@ void main() {
     },
   );
 
+  test(
+    'writer excludes an active observation unrelated to current ranges',
+    () async {
+      await fixture.seedReconciliationRun(ordinal: 1);
+      await fixture.observationRepo.insertObservation(
+        CardEvolutionObservation(
+          id: 'obs-unrelated',
+          sessionId: 'session',
+          characterId: 'character',
+          runOrdinal: 1,
+          semanticScopeKey: 'relationship:Неизвестный',
+          observedChange: 'Must not be globally injected',
+          evidenceClusters: const [
+            ['a1'],
+          ],
+          retrievalKeys: const ['relationship:Неизвестный.секрет'],
+          targetKind: 'main_character_card',
+          confidence: 0.9,
+          status: 'active',
+          firstSeenRun: 1,
+          createdAt: 10,
+          updatedAt: 10,
+        ),
+      );
+      String? cardPrompt;
+      await fixture
+          .service((_, prompt) async {
+            cardPrompt = prompt;
+            return _ok(fixture.cardBatchOutput);
+          })
+          .runOneBatch('session');
+      expect(cardPrompt, isNot(contains('Must not be globally injected')));
+      expect(
+        await fixture.observationRepo.findById('obs-unrelated'),
+        isNotNull,
+      );
+    },
+  );
+
+  test('card writer excludes lorebook-target observations', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
+    await fixture.observationRepo.insertObservation(
+      CardEvolutionObservation(
+        id: 'npc-lore-only',
+        sessionId: 'session',
+        characterId: 'character',
+        runOrdinal: 1,
+        semanticScopeKey: 'npc:Алиса',
+        observedChange: 'NPC-owned lorebook-only fact',
+        evidenceClusters: const [
+          ['a1'],
+        ],
+        retrievalKeys: const ['npc:Алиса'],
+        targetKind: 'injected_lorebook_entry',
+        lorebookEntryId: 'book:alice',
+        confidence: 0.9,
+        status: 'active',
+        firstSeenRun: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      ),
+    );
+    String? cardPrompt;
+    await fixture
+        .service((_, prompt) async {
+          cardPrompt = prompt;
+          return _ok(fixture.cardBatchOutput);
+        })
+        .runOneBatch('session');
+    expect(cardPrompt, isNot(contains('NPC-owned lorebook-only fact')));
+  });
+
   test('promotion after threshold confirmations', () async {
     await fixture.seedReconciliationRun(ordinal: 1);
     await fixture.seedReconciliationRun(ordinal: 2);
@@ -146,6 +222,8 @@ void main() {
           ['a1'],
           ['u1'],
         ],
+        retrievalKeys: const ['npc:Алиса'],
+        targetKind: 'main_character_card',
         cardFieldPath: 'personality',
         confidence: 0.8,
         status: 'active',
@@ -288,6 +366,8 @@ void main() {
           evidenceClusters: const [
             ['a1'],
           ],
+          retrievalKeys: const ['npc:Алиса'],
+          targetKind: 'main_character_card',
           confidence: 0.7,
           status: 'active',
           firstSeenRun: 1,
@@ -305,6 +385,8 @@ void main() {
                       'action': 'contradict',
                       'scopeKey': 'character.preference.trust',
                       'evidenceMessageIds': ['a2'],
+                      'retrievalKeys': ['npc:Алиса'],
+                      'targetKind': 'main_character_card',
                       'confidence': 0.2,
                     },
                   ],
@@ -427,6 +509,358 @@ void main() {
       expect(claims.single.rewriteJobId, isNull);
     },
   );
+
+  test(
+    'first high reconciliation ordinal still becomes collector one',
+    () async {
+      final run = await fixture.seedReconciliationRun(ordinal: 40);
+      final result = await fixture
+          .service((_, prompt) async => _ok('{"observations":[]}'))
+          .runAfterReconciliation(run);
+      expect(result.kind, 'collectorCompleted');
+      final collector = await fixture.db
+          .select(fixture.db.cardEvolutionCollectorRuns)
+          .getSingle();
+      expect(collector.collectorOrdinal, 1);
+      expect(collector.reconciliationRunOrdinal, 40);
+    },
+  );
+
+  test('overdue writer uses exact completed collector boundary hash', () async {
+    var writerCalls = 0;
+    final service = fixture.service((_, prompt) async {
+      if (prompt.contains('observation journal keeper')) {
+        return _ok('{"observations":[]}');
+      }
+      writerCalls++;
+      return _ok(writerCalls == 1 ? 'invalid' : '{"operations":[]}');
+    });
+    for (final ordinal in [10, 20, 30, 40]) {
+      await service.runAfterReconciliation(
+        await fixture.seedReconciliationRun(ordinal: ordinal),
+      );
+    }
+    expect(writerCalls, 2);
+    final claim = await fixture.db
+        .select(fixture.db.cardEvolutionClaims)
+        .getSingle();
+    expect(claim.predecessorRunOrdinal, 3);
+    expect(claim.predecessorCursorHash, 'chain-30');
+  });
+
+  test('minimal no_evidence response is accepted', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
+    await fixture.seedReconciliationRun(ordinal: 2);
+    await fixture.observationRepo.insertObservation(
+      CardEvolutionObservation(
+        id: 'minimal-no-evidence',
+        sessionId: 'session',
+        characterId: 'character',
+        runOrdinal: 1,
+        semanticScopeKey: 'character.preference.trust',
+        observedChange: 'Tracked',
+        evidenceClusters: const [
+          ['a1'],
+        ],
+        retrievalKeys: const ['npc:Алиса'],
+        targetKind: 'main_character_card',
+        confidence: 0.5,
+        status: 'active',
+        firstSeenRun: 1,
+        createdAt: 10,
+        updatedAt: 10,
+      ),
+    );
+    await fixture
+        .service(
+          (_, prompt) async => prompt.contains('observation journal keeper')
+              ? _ok(
+                  '{"observations":[{"action":"no_evidence","scopeKey":"character.preference.trust"}]}',
+                )
+              : _ok(fixture.cardBatchOutput),
+        )
+        .runOneBatch('session');
+    expect(
+      (await fixture.observationRepo.findById(
+        'minimal-no-evidence',
+      ))!.updatedAt,
+      10,
+    );
+  });
+
+  test('tracker fields normalize to one stable NPC group target', () async {
+    final run = await fixture.seedReconciliationRun(
+      ordinal: 1,
+      opKeys: const ['npc:Квинн.location', 'npc:Квинн.current_goal'],
+    );
+    String? collectorPrompt;
+    await fixture
+        .service((_, prompt) async {
+          collectorPrompt = prompt;
+          return _ok('{"observations":[]}');
+        })
+        .runAfterReconciliation(run);
+    expect(collectorPrompt, contains('"key":"npc:Квинн"'));
+    expect(collectorPrompt, isNot(contains('npc:Квинн.location')));
+    expect(collectorPrompt, isNot(contains('npc:Квинн.current_goal')));
+  });
+
+  test(
+    'dormant NPC observation returns only on exact current mention',
+    () async {
+      Future<String> promptFor(
+        List<Map<String, String>> messages,
+        int ordinal,
+      ) async {
+        await fixture.observationRepo.insertObservation(
+          CardEvolutionObservation(
+            id: 'quinn-$ordinal',
+            sessionId: 'session',
+            characterId: 'character',
+            runOrdinal: 1,
+            semanticScopeKey: 'npc:Квинн',
+            observedChange: 'Квинн remembers the old promise',
+            evidenceClusters: const [
+              ['ancient-message'],
+            ],
+            retrievalKeys: const ['npc:Квинн'],
+            targetKind: 'main_character_card',
+            confidence: 0.8,
+            status: 'active',
+            firstSeenRun: 1,
+            createdAt: 1,
+            updatedAt: 1,
+          ),
+        );
+        final run = await fixture.seedReconciliationRun(
+          ordinal: ordinal,
+          messages: messages,
+          opKeys: const ['world:location'],
+        );
+        var prompt = '';
+        await fixture
+            .service((_, value) async {
+              prompt = value;
+              return _ok('{"observations":[]}');
+            })
+            .runAfterReconciliation(run);
+        return prompt;
+      }
+
+      final unrelated = await promptFor(_messages, 1000);
+      expect(unrelated, isNot(contains('Квинн remembers the old promise')));
+      await (fixture.db.delete(
+        fixture.db.cardEvolutionObservations,
+      )..where((row) => row.id.equals('quinn-1000'))).go();
+      const returned = [
+        {'id': 'a1', 'role': 'assistant', 'content': 'Квинн вошла в комнату.'},
+        {'id': 'u1', 'role': 'user', 'content': 'Я приветствую Квинн.'},
+        {'id': 'a2', 'role': 'assistant', 'content': 'assistant 2'},
+        {'id': 'u2', 'role': 'user', 'content': 'user 2'},
+      ];
+      final related = await promptFor(returned, 1001);
+      expect(related, contains('Квинн remembers the old promise'));
+    },
+  );
+
+  test(
+    'NPC mention fallback is token safe and arc groups retrieve directly',
+    () async {
+      await fixture.observationRepo.insertObservation(
+        CardEvolutionObservation(
+          id: 'quinn-token',
+          sessionId: 'session',
+          characterId: 'character',
+          runOrdinal: 1,
+          semanticScopeKey: 'npc:Квинн',
+          observedChange: 'No substring match',
+          evidenceClusters: const [
+            ['old'],
+          ],
+          retrievalKeys: const ['npc:Квинн'],
+          targetKind: 'main_character_card',
+          confidence: 0.8,
+          status: 'active',
+          firstSeenRun: 1,
+          createdAt: 1,
+          updatedAt: 1,
+        ),
+      );
+      await fixture.observationRepo.insertObservation(
+        CardEvolutionObservation(
+          id: 'arc-sponsor',
+          sessionId: 'session',
+          characterId: 'character',
+          runOrdinal: 1,
+          semanticScopeKey: 'arc:Спонсорство',
+          observedChange: 'Arc remains relevant',
+          evidenceClusters: const [
+            ['old'],
+          ],
+          retrievalKeys: const ['arc:Спонсорство'],
+          targetKind: 'main_character_card',
+          confidence: 0.8,
+          status: 'active',
+          firstSeenRun: 1,
+          createdAt: 1,
+          updatedAt: 1,
+        ),
+      );
+      const messages = [
+        {'id': 'a1', 'role': 'assistant', 'content': 'Квинни здесь.'},
+        {'id': 'u1', 'role': 'user', 'content': 'Продолжим.'},
+        {'id': 'a2', 'role': 'assistant', 'content': 'assistant 2'},
+        {'id': 'u2', 'role': 'user', 'content': 'user 2'},
+      ];
+      final run = await fixture.seedReconciliationRun(
+        ordinal: 1,
+        messages: messages,
+        opKeys: const ['arc:Спонсорство.status'],
+      );
+      var prompt = '';
+      await fixture
+          .service((_, value) async {
+            prompt = value;
+            return _ok('{"observations":[]}');
+          })
+          .runAfterReconciliation(run);
+      expect(prompt, contains('Arc remains relevant'));
+      expect(prompt, isNot(contains('No substring match')));
+    },
+  );
+
+  test('observation older than 200 rows is still retrieved', () async {
+    await fixture.observationRepo.insertObservation(
+      CardEvolutionObservation(
+        id: 'old-quinn',
+        sessionId: 'session',
+        characterId: 'character',
+        runOrdinal: 1,
+        semanticScopeKey: 'npc:Квинн',
+        observedChange: 'Old durable Quinn observation',
+        evidenceClusters: const [
+          ['ancient'],
+        ],
+        retrievalKeys: const ['npc:Квинн'],
+        targetKind: 'main_character_card',
+        confidence: 0.9,
+        status: 'active',
+        firstSeenRun: 1,
+        createdAt: 1,
+        updatedAt: 1,
+      ),
+    );
+    for (var index = 0; index < 220; index++) {
+      await fixture.observationRepo.insertObservation(
+        CardEvolutionObservation(
+          id: 'new-$index',
+          sessionId: 'session',
+          characterId: 'character',
+          runOrdinal: 1,
+          semanticScopeKey: 'arc:other-$index',
+          observedChange: 'unrelated $index',
+          evidenceClusters: const [
+            ['new'],
+          ],
+          retrievalKeys: ['arc:other-$index'],
+          targetKind: 'main_character_card',
+          confidence: 0.5,
+          status: 'active',
+          firstSeenRun: 1,
+          createdAt: index + 2,
+          updatedAt: index + 2,
+        ),
+      );
+    }
+    const messages = [
+      {'id': 'a1', 'role': 'assistant', 'content': 'Квинн вернулась.'},
+      {'id': 'u1', 'role': 'user', 'content': 'Привет, Квинн.'},
+      {'id': 'a2', 'role': 'assistant', 'content': 'assistant 2'},
+      {'id': 'u2', 'role': 'user', 'content': 'user 2'},
+    ];
+    final run = await fixture.seedReconciliationRun(
+      ordinal: 1,
+      messages: messages,
+      opKeys: const ['world:location'],
+    );
+    var prompt = '';
+    await fixture
+        .service((_, value) async {
+          prompt = value;
+          return _ok('{"observations":[]}');
+        })
+        .runAfterReconciliation(run);
+    expect(prompt, contains('Old durable Quinn observation'));
+  });
+
+  test(
+    'cadence waits for delivered plus three without skipping a gap',
+    () async {
+      final service = fixture.service(
+        (_, prompt) async => prompt.contains('observation journal keeper')
+            ? _ok('{"observations":[]}')
+            : _ok('{"operations":[]}'),
+      );
+      for (final ordinal in [1, 2]) {
+        final result = await service.runAfterReconciliation(
+          await fixture.seedReconciliationRun(ordinal: ordinal),
+        );
+        expect(result.kind, 'collectorCompleted');
+      }
+      final collectors = await fixture.db
+          .select(fixture.db.cardEvolutionCollectorRuns)
+          .get();
+      await (fixture.db.update(
+        fixture.db.cardEvolutionCollectorRuns,
+      )..where((row) => row.collectorOrdinal.equals(2))).write(
+        const CardEvolutionCollectorRunsCompanion(status: Value('claimed')),
+      );
+      final result = await service.runAfterReconciliation(
+        await fixture.seedReconciliationRun(ordinal: 3),
+      );
+      expect(result.kind, 'collectorUnavailable');
+      expect(
+        await fixture.db.select(fixture.db.cardEvolutionClaims).get(),
+        isEmpty,
+      );
+      expect(collectors, hasLength(2));
+    },
+  );
+
+  test('primary current groups survive retrieval target extras cap', () async {
+    final run = await fixture.seedReconciliationRun(
+      ordinal: 1,
+      opKeys: [
+        for (var index = 0; index < 85; index++) 'arc:Текущий$index.status',
+      ],
+    );
+    var prompt = '';
+    await fixture
+        .service((_, value) async {
+          prompt = value;
+          return _ok('{"observations":[]}');
+        })
+        .runAfterReconciliation(run);
+    expect(prompt, contains('"key":"arc:Текущий0"'));
+    expect(prompt, contains('"key":"arc:Текущий84"'));
+  });
+
+  test('snapshot bounds oversized tracker values deterministically', () async {
+    await fixture.db.customStatement(
+      'UPDATE tracker_rows SET value = ? WHERE session_id = ?',
+      ['Ж' * 50000, 'session'],
+    );
+    final run = await fixture.seedReconciliationRun(ordinal: 1);
+    var prompt = '';
+    await fixture
+        .service((_, value) async {
+          prompt = value;
+          return _ok('{"observations":[]}');
+        })
+        .runAfterReconciliation(run);
+    expect(prompt.length, lessThan(120000));
+    expect(RegExp('Ж{2001}').hasMatch(prompt), isFalse);
+  });
 }
 
 AuxCallOutcome _ok(String text) =>
@@ -464,6 +898,10 @@ final class _Fixture {
       'INSERT INTO chat_sessions (session_id, character_id, session_index, messages_json) VALUES (?, ?, 0, ?)',
       ['session', 'character', jsonEncode(_messages)],
     );
+    await db.customStatement(
+      'INSERT INTO tracker_rows (session_id, name, value) VALUES (?, ?, ?)',
+      ['session', 'npc:Алиса.доверие', 'растёт'],
+    );
     final reader = EffectiveCanonReadRepository(
       db: db,
       characterRepo: characters,
@@ -484,9 +922,16 @@ final class _Fixture {
 
   Future<LedgerReconciliationSuccessfulRunRow> seedReconciliationRun({
     required int ordinal,
+    List<Map<String, String>> messages = _messages,
+    List<String> opKeys = const ['npc:Алиса.доверие'],
+    List<String> presentEntities = const [],
   }) async {
+    await db.customStatement(
+      'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
+      [jsonEncode(messages), 'session'],
+    );
     final anchors = [
-      for (final message in _messages)
+      for (final message in messages)
         {
           'agentSwipeId': 0,
           'contentHash': computeHash(message['content']!),
@@ -517,7 +962,18 @@ final class _Fixture {
         '[]',
         'canon-stamp-$ordinal',
         'canon-hash-$ordinal',
-        '{"result":"ok"}',
+        jsonEncode({
+          'export': {
+            'ops': [
+              for (final key in opKeys) {'op': 'set', 'key': key, 'value': ''},
+            ],
+            'sceneState': {
+              'presentEntities': [
+                for (final name in presentEntities) {'name': name},
+              ],
+            },
+          },
+        }),
         'content-$ordinal',
         '',
         'chain-$ordinal',
@@ -564,6 +1020,8 @@ final class _Fixture {
         'scopeKey': 'character.preference.trust',
         'observedChange': 'Alice is becoming more trusting',
         'canonicalClaim': 'Alice has become more trusting over time',
+        'retrievalKeys': ['npc:Алиса'],
+        'targetKind': 'main_character_card',
         'evidenceMessageIds': ['a1', 'u1'],
         'cardFieldPath': 'personality',
         'confidence': 0.8,
@@ -577,6 +1035,8 @@ final class _Fixture {
         'action': 'confirm',
         'scopeKey': 'character.preference.trust',
         'observedChange': 'Alice is becoming more trusting',
+        'retrievalKeys': ['npc:Алиса'],
+        'targetKind': 'main_character_card',
         'confidence': 0.85,
         'evidenceMessageIds': ['a2', 'u2'],
       },

--- a/test/card_rewrite_operation_parser_test.dart
+++ b/test/card_rewrite_operation_parser_test.dart
@@ -70,18 +70,41 @@ void main() {
     expect(snapshot.transition.chatSessionId, isNull);
   });
 
-  test('canonicalizes title-cased scope subjects from model output', () {
+  test('preserves exact Unicode scope subjects from model output', () {
     final payload = validPayload();
-    (payload['patches'] as List).single['scopeKey'] = 'relationship:Danvi';
+    (payload['patches'] as List).single['scopeKey'] = 'relationship:Lucy:Danvi';
     (payload['transition'] as Map<String, Object?>)['scopeKey'] =
-        'relationship:Danvi';
+        'relationship:Lucy:Danvi';
 
     final result = parsePayload(payload);
 
     expect(result.isSuccess, isTrue, reason: result.detail);
-    expect(result.snapshot!.patches.single.scopeKey, 'relationship:danvi');
-    expect(result.snapshot!.transition.scopeKey, 'relationship:danvi');
+    expect(result.snapshot!.patches.single.scopeKey, 'relationship:Lucy:Danvi');
+    expect(result.snapshot!.transition.scopeKey, 'relationship:Lucy:Danvi');
   });
+
+  test(
+    'accepts nested Unicode relationship identities and rejects unsafe text',
+    () {
+      for (final scope in ['relationship:Гильда:Квинн']) {
+        final payload = validPayload();
+        (payload['patches'] as List).single['scopeKey'] = scope;
+        (payload['transition'] as Map<String, Object?>)['scopeKey'] = scope;
+        expect(parsePayload(payload).isSuccess, isTrue, reason: scope);
+      }
+      for (final scope in [
+        'relationship: Lucy',
+        'relationship:Гильда::Квинн',
+        'relationship:Lucy\u202eevil',
+        'relationship:Lucy\nDanvi',
+      ]) {
+        final payload = validPayload();
+        (payload['patches'] as List).single['scopeKey'] = scope;
+        (payload['transition'] as Map<String, Object?>)['scopeKey'] = scope;
+        expect(parsePayload(payload).isSuccess, isFalse, reason: scope);
+      }
+    },
+  );
 
   test('tolerates markdown fences and surrounding prose', () {
     final fenced =
@@ -141,7 +164,9 @@ void main() {
     (payload['patches'] as List).single['anchorSha256'] = 'not-a-real-hash';
 
     final operations = CardRewriteOperationParser.parseEvolutionBatch(
-      jsonEncode({'operations': [payload]}),
+      jsonEncode({
+        'operations': [payload],
+      }),
     );
 
     expect(operations, hasLength(1));
@@ -321,19 +346,22 @@ void main() {
     );
     final badTransitionScope = validPayload();
     (badTransitionScope['transition']! as Map<String, Object?>)['scopeKey'] =
-        'world:Bad!';
+        'world:Bad:Nested';
     expect(
       rejectionOf(badTransitionScope),
       CardRewriteOperationParseRejection.invalidScope,
     );
   });
 
-  test('accepts a large replacement when its patch contract is otherwise valid', () {
-    final oversized = '${'x' * 12001} {{char}} {{user}}';
-    final payload = validPayload()
-      ..['patches'] = [validPatch()..['value'] = oversized];
-    expect(parsePayload(payload).isSuccess, isTrue);
-  });
+  test(
+    'accepts a large replacement when its patch contract is otherwise valid',
+    () {
+      final oversized = '${'x' * 12001} {{char}} {{user}}';
+      final payload = validPayload()
+        ..['patches'] = [validPatch()..['value'] = oversized];
+      expect(parsePayload(payload).isSuccess, isTrue);
+    },
+  );
 
   test('rejects malformed transitions', () {
     final notObject = validPayload()..['transition'] = 'not-an-object';
@@ -595,7 +623,9 @@ void main() {
       );
 
       final encoded = RewriteOperationSnapshotCodec.encode(snapshot);
-      final decoded = RewriteOperationSnapshotCodec.tryDecode(jsonDecode(encoded));
+      final decoded = RewriteOperationSnapshotCodec.tryDecode(
+        jsonDecode(encoded),
+      );
 
       expect(decoded, isA<LorebookRewriteOperationSnapshot>());
       final lore = decoded! as LorebookRewriteOperationSnapshot;

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -78,7 +78,7 @@ void main() {
 
       // user_version matches the Drift schema version (app_db.dart schemaVersion).
       // Update this constant whenever a new migration step is added.
-      expect(version, 116);
+      expect(version, 117);
     });
 
     test(
@@ -232,7 +232,7 @@ void main() {
         final version = await upgraded
             .customSelect('PRAGMA user_version')
             .get();
-        expect(version.first.read<int>('user_version'), 116);
+        expect(version.first.read<int>('user_version'), 117);
         expect(names, contains('variant_group_id'));
         expect(names, contains('hidden'));
       },
@@ -262,7 +262,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
     });
 
     test(
@@ -611,7 +611,7 @@ void main() {
 
     test('current schema includes atomic character fact tables', () async {
       final version = await db.customSelect('PRAGMA user_version').getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
 
       final factColumns = await db
           .customSelect("PRAGMA table_info('character_knowledge_fact_rows')")
@@ -723,7 +723,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
     });
 
     test(
@@ -833,7 +833,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
     });
 
     test('v80 adds Responses API toggle defaulting to off', () async {
@@ -873,7 +873,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
     });
 
     test('v81 adds composite embedding source index', () async {
@@ -907,7 +907,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
     });
 
     test('v82 creates rewrite persistence schema and provenance columns', () async {
@@ -981,7 +981,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
     });
 
     test('v83 rebuilds interim text revision columns without losing rows', () async {
@@ -1433,7 +1433,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
 
       // Rows and payloads survive; legacy statuses pass through or are
       // normalized fail-closed, and new columns carry neutral defaults.
@@ -1638,7 +1638,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
       final row = await upgraded
           .customSelect(
             'SELECT blocks_json FROM studio_preset_rows WHERE preset_id = ?',
@@ -1754,7 +1754,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
       final check = await upgraded.customSelect('PRAGMA integrity_check').get();
       expect(check.single.read<String>('integrity_check'), 'ok');
     });
@@ -2269,6 +2269,60 @@ void main() {
       );
     });
 
+    test('v117 observation retrieval metadata is durable', () async {
+      final columns = await db
+          .customSelect("PRAGMA table_info('card_evolution_observations')")
+          .get();
+      expect(
+        columns.map((row) => row.read<String>('name')),
+        containsAll(['retrieval_keys_json', 'target_kind']),
+      );
+      final retrieval = columns.singleWhere(
+        (row) => row.read<String>('name') == 'retrieval_keys_json',
+      );
+      expect(retrieval.read<String?>('dflt_value'), "'[]'");
+    });
+
+    test('v116 to v117 safely backfills only exact legacy targets', () async {
+      final file = File(
+        '${Directory.systemTemp.path}/glaze_mig_observation_v117_${DateTime.now().microsecondsSinceEpoch}.db',
+      );
+      addTearDown(() async {
+        if (file.existsSync()) await file.delete();
+      });
+      final seeded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      await seeded.customSelect('SELECT 1').get();
+      await seeded.customStatement(
+        "INSERT INTO card_evolution_observations "
+        "(id,session_id,character_id,run_ordinal,semantic_scope_key,observed_change,evidence_message_ids,confidence,status,first_seen_run,created_at,updated_at,lorebook_entry_id) "
+        "VALUES ('lore','s','c',1,'npc:Люси','fact','[]',.8,'active',1,1,1,'book:entry'),"
+        "('unknown','s','c',1,'relationship:Люси','fact','[]',.8,'active',1,1,1,NULL)",
+      );
+      await seeded.customStatement(
+        'ALTER TABLE card_evolution_observations DROP COLUMN retrieval_keys_json',
+      );
+      await seeded.customStatement(
+        'ALTER TABLE card_evolution_observations DROP COLUMN target_kind',
+      );
+      await seeded.customStatement('PRAGMA user_version = 116');
+      await seeded.close();
+      final upgraded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      addTearDown(() => upgraded.close());
+      final rows = await upgraded
+          .customSelect(
+            'SELECT id,retrieval_keys_json,target_kind FROM card_evolution_observations ORDER BY id',
+          )
+          .get();
+      expect(rows.first.read<String>('retrieval_keys_json'), '["book:entry"]');
+      expect(rows.first.read<String>('target_kind'), 'injected_lorebook_entry');
+      expect(rows.last.read<String>('retrieval_keys_json'), '[]');
+      expect(rows.last.readNullable<String>('target_kind'), isNull);
+    });
+
     test(
       'v93 session lorebook evolution overlay has the session key',
       () async {
@@ -2364,7 +2418,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
     });
 
     test(
@@ -2461,7 +2515,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 116);
+      expect(version.read<int>('user_version'), 117);
     });
 
     test('v111 resolves the retired session_id_mode default', () async {
@@ -2604,7 +2658,8 @@ void main() {
       final rows = await upgraded
           .customSelect(
             'SELECT id, evidence_message_ids, evidence_clusters_json, repeat_count, '
-            'status FROM card_evolution_observations ORDER BY id',
+            'status, retrieval_keys_json, target_kind '
+            'FROM card_evolution_observations ORDER BY id',
           )
           .get();
       final gilda = rows.singleWhere(
@@ -2614,6 +2669,8 @@ void main() {
       expect(gilda.read<String>('evidence_clusters_json'), '[["m1","m2"]]');
       expect(gilda.read<int>('repeat_count'), 1);
       expect(gilda.read<String>('status'), 'active');
+      expect(gilda.read<String>('retrieval_keys_json'), '[]');
+      expect(gilda.readNullable<String>('target_kind'), isNull);
       final bad = rows.singleWhere((row) => row.read<String>('id') == 'bad');
       expect(bad.read<String>('evidence_message_ids'), '[]');
       expect(bad.read<String>('evidence_clusters_json'), '[]');

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -78,7 +78,7 @@ void main() {
 
       // user_version matches the Drift schema version (app_db.dart schemaVersion).
       // Update this constant whenever a new migration step is added.
-      expect(version, 115);
+      expect(version, 116);
     });
 
     test(
@@ -232,7 +232,7 @@ void main() {
         final version = await upgraded
             .customSelect('PRAGMA user_version')
             .get();
-        expect(version.first.read<int>('user_version'), 115);
+        expect(version.first.read<int>('user_version'), 116);
         expect(names, contains('variant_group_id'));
         expect(names, contains('hidden'));
       },
@@ -262,7 +262,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
     });
 
     test(
@@ -611,7 +611,7 @@ void main() {
 
     test('current schema includes atomic character fact tables', () async {
       final version = await db.customSelect('PRAGMA user_version').getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
 
       final factColumns = await db
           .customSelect("PRAGMA table_info('character_knowledge_fact_rows')")
@@ -723,7 +723,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
     });
 
     test(
@@ -833,7 +833,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
     });
 
     test('v80 adds Responses API toggle defaulting to off', () async {
@@ -873,7 +873,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
     });
 
     test('v81 adds composite embedding source index', () async {
@@ -907,7 +907,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
     });
 
     test('v82 creates rewrite persistence schema and provenance columns', () async {
@@ -981,7 +981,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
     });
 
     test('v83 rebuilds interim text revision columns without losing rows', () async {
@@ -1433,7 +1433,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
 
       // Rows and payloads survive; legacy statuses pass through or are
       // normalized fail-closed, and new columns carry neutral defaults.
@@ -1638,7 +1638,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
       final row = await upgraded
           .customSelect(
             'SELECT blocks_json FROM studio_preset_rows WHERE preset_id = ?',
@@ -1754,7 +1754,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
       final check = await upgraded.customSelect('PRAGMA integrity_check').get();
       expect(check.single.read<String>('integrity_check'), 'ok');
     });
@@ -2240,6 +2240,35 @@ void main() {
       },
     );
 
+    test('v116 collector journal has durable cadence identities', () async {
+      final columns = await db
+          .customSelect("PRAGMA table_info('card_evolution_collector_runs')")
+          .get();
+      expect(
+        columns.map((row) => row.read<String>('name')),
+        containsAll([
+          'collector_ordinal',
+          'reconciliation_run_id',
+          'reconciliation_chain_hash',
+          'range_hash',
+          'input_hash',
+          'status',
+          'lease_expires_at',
+          'completed_at',
+        ]),
+      );
+      final indexes = await db
+          .customSelect("PRAGMA index_list('card_evolution_collector_runs')")
+          .get();
+      expect(
+        indexes.map((row) => row.read<String>('name')),
+        containsAll([
+          'idx_card_evolution_collector_session_ordinal',
+          'idx_card_evolution_collector_reconciliation',
+        ]),
+      );
+    });
+
     test(
       'v93 session lorebook evolution overlay has the session key',
       () async {
@@ -2335,7 +2364,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
     });
 
     test(
@@ -2432,7 +2461,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 115);
+      expect(version.read<int>('user_version'), 116);
     });
 
     test('v111 resolves the retired session_id_mode default', () async {

--- a/test/rewrite_review_navigation_test.dart
+++ b/test/rewrite_review_navigation_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/card_evolution_repo.dart';
+import 'package:glaze_flutter/core/navigation/rewrite_review_navigation.dart';
+import 'package:glaze_flutter/core/services/generation_notification_service.dart';
+
+RewriteJobRow _job({String charId = 'char-1', String sessionId = 'session-1'}) {
+  return RewriteJobRow(
+    id: 'job-1',
+    chatSessionId: sessionId,
+    characterId: charId,
+    status: 'pendingReview',
+    requestJson: '{}',
+    basisRevision: 1,
+    basisRevisionHash: 'basis',
+    canonStamp: 'canon',
+    version: 1,
+    appliedCharacterRevision: 0,
+    appliedCharacterRevisionHash: '',
+    createdAt: 1,
+    updatedAt: 1,
+  );
+}
+
+void main() {
+  const policy = AutomaticRewriteReviewNavigationPolicy();
+  const authority = ActiveChatContext(
+    charId: 'char-1',
+    sessionId: 'session-1',
+    revision: 7,
+  );
+
+  test(
+    'policy permits only exact persisted result for unchanged authority',
+    () {
+      final target = policy.resolve(
+        outcome: CardEvolutionFinalizeOutcome('persisted', _job()),
+        capturedAuthority: authority,
+        currentAuthority: authority,
+      );
+
+      expect(target?.charId, 'char-1');
+      expect(target?.jobId, 'job-1');
+    },
+  );
+
+  test('policy rejects non-exact outcomes and stale authority revisions', () {
+    expect(
+      policy.resolve(
+        outcome: CardEvolutionFinalizeOutcome('alreadyCompleted', _job()),
+        capturedAuthority: authority,
+        currentAuthority: authority,
+      ),
+      isNull,
+    );
+    expect(
+      policy.resolve(
+        outcome: CardEvolutionFinalizeOutcome('persisted', _job()),
+        capturedAuthority: authority,
+        currentAuthority: const ActiveChatContext(
+          charId: 'char-1',
+          sessionId: 'session-1',
+          revision: 8,
+        ),
+      ),
+      isNull,
+    );
+  });
+
+  test('intent provider emits a monotonic sequence and encoded location', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(
+      rewriteReviewNavigationIntentProvider.notifier,
+    );
+
+    notifier.emit(
+      charId: 'char / one',
+      sessionId: 'session-1',
+      jobId: 'job/one',
+      authorityRevision: 7,
+    );
+    final first = container.read(rewriteReviewNavigationIntentProvider)!;
+    notifier.emit(
+      charId: 'char / one',
+      sessionId: 'session-1',
+      jobId: 'job/one',
+      authorityRevision: 7,
+    );
+    final second = container.read(rewriteReviewNavigationIntentProvider)!;
+
+    expect(first.sequence, 1);
+    expect(second.sequence, 2);
+    expect(second.location, '/character/char%20%2F%20one/rewrite/job%2Fone');
+  });
+}


### PR DESCRIPTION
## Summary

- run the durable observation collector after every successful Ledger reconciliation and run the writer only after each exact contiguous group of three collectors
- bind collector and writer snapshots to immutable reconciliation ranges, preserve retry/idempotency across restarts, and consume observations only after an approved apply
- retrieve durable observations through bounded, exact Unicode Ledger group identities, with strict main-card vs injected-lorebook routing and prompt-size limits
- automatically open persisted rewrite proposals for review when the originating chat remains active
- guard Magic Drawer and chat WebView async callbacks against widget deactivation/disposal

## Database

- schema 115 -> 116: durable card_evolution_collector_runs journal
- schema 116 -> 117: observation etrieval_keys_json and 	arget_kind metadata with conservative legacy backfill

## Verification

- targeted lutter analyze on changed implementation and test files: no issues
- broad targeted Flutter suite: 156 tests passed
- git diff --check passed

## Notes

- automatic proposals remain review-only; no card or lorebook changes are applied without approval
- unrelated local diagnostics and research files are not included in this PR