### PR TITLE
fix(chat): preserve markdown when copying messages

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -400,11 +400,6 @@ export class Bridge {
   }
 
   _extractText(section) {
-    const host = section.querySelector('.msg-body .message-content');
-    if (host && host.shadowRoot) {
-      const root = host.shadowRoot.querySelector('.glaze-message');
-      if (root) return root.innerText || '';
-    }
     return section.dataset.rawText || '';
   }
 

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -74,12 +74,12 @@ void main() {
     stylessCss = _asset('styles.css').replaceAll('\r\n', '\n');
   });
 
-  group('rendered text copy', () {
-    test('message copy preserves rendered line boundaries', () {
+  group('message copy', () {
+    test('message copy preserves source markdown', () {
       final idx = bridgeControllerJs.indexOf('_extractText(section)');
       final body = bridgeControllerJs.substring(idx, idx + 500);
-      expect(body, contains('root.innerText'));
-      expect(body, isNot(contains('root.textContent')));
+      expect(body, contains("return section.dataset.rawText || '';"));
+      expect(body, isNot(contains('root.innerText')));
     });
 
     test('selection copy serializes cloned rendered ranges', () {


### PR DESCRIPTION
## Changes

- Copy the stored source Markdown for whole-message copy actions instead of extracting rendered `innerText` from the message DOM.
- Update the WebView asset regression test to require Markdown-preserving copy behavior while leaving arbitrary selection copy as rendered plain text.

## Verification

- `flutter test test/webview_assets_test.dart`
- `flutter test test/characterization/bridge_selection_edit_swipe_test.dart test/characterization/webview_callback_contract_test.dart`
- `flutter analyze` (completed with pre-existing warnings/infos and no errors)
- `git diff --check`