### PR TITLE
ci: pin Flutter and refresh contract tests

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -179,6 +179,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -318,6 +319,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -397,6 +399,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -536,6 +539,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -177,6 +177,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -316,6 +317,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -395,6 +397,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -519,6 +522,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 

--- a/test/card_rewriter_contracts_test.dart
+++ b/test/card_rewriter_contracts_test.dart
@@ -80,9 +80,10 @@ void main() {
   test('scope grammar accepts only the defined semantic mappings', () {
     for (final key in const [
       'npc:ada',
-      'relationship:ada-lovelace',
+      'relationship:Lucy:Danvi',
       'arc:act_1',
       'world:earth-2',
+      'world:Bad',
       'scene.opening.bridge',
     ]) {
       expect(CardRewriteScope.tryParse(key), isNotNull, reason: key);
@@ -91,7 +92,9 @@ void main() {
       'character:ada',
       'scene:opening',
       'npc:',
-      'world:Bad',
+      'world:Bad:Nested',
+      'relationship:ada-lovelace',
+      'relationship:Lucy::Danvi',
     ]) {
       expect(CardRewriteScope.tryParse(key), isNull, reason: key);
     }

--- a/test/studio_prompt_filtering_test.dart
+++ b/test/studio_prompt_filtering_test.dart
@@ -733,24 +733,25 @@ void main() {
   });
 
   group('Studio agent envelope lane ownership', () {
-    const guardAgent = StudioAgent(
-      id: 'guard',
-      name: 'Anti-Loop & Prose Guard',
-    );
-
     test('runtime leaves numeric response budgets to the active preset', () {
-      final guard = StudioControllerOntology.specs.firstWhere(
-        (spec) => spec.id == 'guard',
-      );
-      final envelope = const StudioPromptText().intermediateRuntimeEnvelope(
-        guard,
-        guardAgent,
-      );
+      for (final id in const ['guard_ru', 'guard_en']) {
+        final guard = StudioControllerOntology.specs.firstWhere(
+          (spec) => spec.id == id,
+        );
+        final guardAgent = StudioAgent(id: id, name: guard.name);
+        final envelope = const StudioPromptText().intermediateRuntimeEnvelope(
+          guard,
+          guardAgent,
+        );
 
-      expect(envelope.toLowerCase(), isNot(contains('paragraph')));
-      expect(envelope.toLowerCase(), isNot(contains('word budget')));
-      expect(guard.purpose.toLowerCase(), isNot(contains('paragraph')));
-      expect(guard.outputContract.toLowerCase(), isNot(contains('paragraph')));
+        expect(envelope.toLowerCase(), isNot(contains('paragraph')));
+        expect(envelope.toLowerCase(), isNot(contains('word budget')));
+        expect(guard.purpose.toLowerCase(), isNot(contains('paragraph')));
+        expect(
+          guard.outputContract.toLowerCase(),
+          isNot(contains('paragraph')),
+        );
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- pin Flutter 3.44.9 in CI, branch-build, and release workflows
- update Card Rewriter scope grammar fixtures for two-party relationships and case-preserving identities
- cover both guard_ru and guard_en Studio lanes

## Verification
- flutter test test/card_rewriter_contracts_test.dart test/studio_prompt_filtering_test.dart
- git diff --check