### PR TITLE
fix(windows): stop the app swallowing desktop clicks when maximized

### DIFF
--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -198,6 +198,16 @@ Win32Window::MessageHandler(HWND hwnd,
       return 0;
     }
     case WM_SIZE: {
+      // Maximizing or minimizing can swallow the WM_*BUTTONUP that would have
+      // ended a drag started inside the Flutter view, leaving the view holding
+      // the Win32 mouse capture (the engine takes it on every button down).
+      // A held capture routes *every* mouse event on the desktop into this
+      // process, so the desktop, the taskbar and other apps stop reacting to
+      // clicks until the window is restored or minimized.
+      if (wparam == SIZE_MAXIMIZED || wparam == SIZE_MINIMIZED) {
+        ReleaseChildContentCapture();
+      }
+
       RECT rect = GetClientArea();
       if (child_content_ != nullptr) {
         // Size and position the child window.
@@ -208,6 +218,16 @@ Win32Window::MessageHandler(HWND hwnd,
     }
 
     case WM_ACTIVATE:
+      // WM_ACTIVATE also fires with WA_INACTIVE when the user clicks the
+      // desktop, the taskbar or another window. Taking focus there pulls
+      // activation straight back into this window, so clicks outside the app
+      // look like they do nothing - most visibly when the window is maximized
+      // and covers the whole screen. Only grab focus while activating, and let
+      // DefWindowProc run the default deactivation.
+      if (LOWORD(wparam) == WA_INACTIVE) {
+        ReleaseChildContentCapture();
+        break;
+      }
       if (child_content_ != nullptr) {
         SetFocus(child_content_);
       }
@@ -230,6 +250,15 @@ void Win32Window::Destroy() {
   }
   if (g_active_window_count == 0) {
     WindowClassRegistrar::GetInstance()->UnregisterWindowClass();
+  }
+}
+
+void Win32Window::ReleaseChildContentCapture() {
+  // Only drop a capture held by the hosted Flutter view. The frame's own
+  // capture during an interactive move/resize belongs to DefWindowProc's modal
+  // loop and must be left alone.
+  if (child_content_ != nullptr && GetCapture() == child_content_) {
+    ReleaseCapture();
   }
 }
 

--- a/windows/runner/win32_window.h
+++ b/windows/runner/win32_window.h
@@ -84,6 +84,11 @@ class Win32Window {
                                   WPARAM const wparam,
                                   LPARAM const lparam) noexcept;
 
+  // Releases the Win32 mouse capture when it is held by the hosted Flutter
+  // view. A leaked capture makes the whole desktop stop responding to the
+  // mouse, because every mouse event is routed to the capturing window.
+  void ReleaseChildContentCapture();
+
   // Retrieves a class instance pointer for |window|
   static Win32Window* GetThisFromHandle(HWND const window) noexcept;
 


### PR DESCRIPTION
With the window maximized on Windows, clicks on the desktop, the taskbar and other windows stopped registering until Glaze was restored to a window or minimized.

Two independent causes in the Win32 runner, both in `windows/runner/win32_window.cpp`:

1. `WM_ACTIVATE` called `SetFocus(child_content_)` for every activation message, including `WA_INACTIVE`. `WM_ACTIVATE` also fires when the user clicks away, and `SetFocus` activates the focused window's top-level parent — so activation was pulled straight back into Glaze and the click outside looked ignored. Most visible with a maximized window, where there is nowhere else to click.
2. The engine calls `SetCapture` on every mouse-button down and `ReleaseCapture` on button up. A `WM_*BUTTONUP` lost across a window state change (maximize/minimize) leaves the capture held, and a window holding the Win32 mouse capture receives *every* mouse event on the desktop — the system stops reacting to clicks entirely.

## Changes

- Take keyboard focus only while the window is being activated; on `WA_INACTIVE` fall through to `DefWindowProc` for the default deactivation.
- Release a mouse capture left behind by the hosted Flutter view on deactivation and on maximize/minimize (new `Win32Window::ReleaseChildContentCapture`).
- Only the child view's capture is dropped — the frame's own capture during an interactive move/resize belongs to `DefWindowProc`'s modal loop and is left untouched, so dragging and resizing the window keep working.
- Comments kept ASCII-only: `windows/CMakeLists.txt` compiles the runner with `/WX` and no `/utf-8`, so a non-ASCII character in a comment can turn C4819 into a build error.

## Verification

- `flutter analyze` / `flutter test` — unaffected, no Dart code changed; covered by CI.
- **Not yet verified on a Windows build.** The change is C++ runner-only and could not be compiled or exercised in the agent environment (Linux, no Windows toolchain). Needs `flutter build windows` plus a manual check: maximize the window, then click the desktop and the taskbar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eja4ZfAoi9yHUFCT4SnEfa)_