### PR TITLE
feat(prompt-inspector): reflect the connection's post-processing mode

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1264,6 +1264,7 @@
   "position_after": "After",
   "position_macro": "Macro",
   "label_messages_count": "Messages ({})",
+  "prompt_preview_merged_blocks": "Post-processing merged {} blocks into this message",
   "catalog_provider_chub_hint": "Open character library",
   "janitor_login_info_desc": "Janitor hides most characters from unauthorized users. You can log in using your account, and then Glaze will use your data to load characters. The data is not used for any other purpose. Alternatively, you can keep using the catalog without an account or import characters by link.",
   "janitor_login_button": "Log in with your Janitor.AI account",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -1238,6 +1238,7 @@
   "position_after": "После",
   "position_macro": "Макрос",
   "label_messages_count": "Сообщения ({})",
+  "prompt_preview_merged_blocks": "Постобработка объединила в это сообщение блоков: {}",
   "catalog_search_placeholder": "Поиск персонажей...",
   "catalog_total": "{count} персонажей",
   "catalog_empty": "Персонажи не найдены",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -515,6 +515,17 @@ match. Every mode is idempotent, and the rewritten request carries
 preview builds bodies without a transport, so it calls
 `PostProcessingChatTransport.applyTo` itself.
 
+The Prompt Inspector shows the same reshaped conversation in its **formatted**
+view, not just in the raw JSON:
+`features/chat/services/prompt_preview_post_processor.dart` replays the pass
+over the built `PromptMessage` list and returns one `PreviewMessage` per
+outgoing message, each carrying the blocks that were folded into it (so a
+merged card can show the union of their section flags, their joined block
+names, every attachment, and a badge with the block count). It never
+re-implements the rules: it runs the real `postProcessPrompt` over placeholder
+content — one unique token per built message — and reads the tokens back out of
+the result to recover which blocks landed where.
+
 ### Request Types
 
 | Type | State owner | Streaming | Abort |

--- a/lib/features/chat/services/prompt_preview_post_processor.dart
+++ b/lib/features/chat/services/prompt_preview_post_processor.dart
@@ -1,0 +1,170 @@
+/// Replays the connection's prompt post-processing over the built prompt so
+/// the Prompt Inspector's formatted view shows the messages that actually
+/// leave the device, not the block list the builder produced.
+///
+/// The raw JSON view already goes through
+/// `PostProcessingChatTransport.applyTo`, so without this the two halves of
+/// the same tab disagree the moment a mode other than `none` is selected: the
+/// JSON shows three merged messages while the cards above it still list
+/// twenty separate blocks.
+///
+/// The pass itself is never re-implemented here — [postProcessPrompt] is the
+/// single source of truth for what each mode does. Provenance is recovered by
+/// running the real pass over placeholder content: every built message is
+/// swapped for a unique token, so each output message's text is exactly the
+/// tokens of the blocks that landed in it, joined by the merge separator.
+/// Reading the tokens back gives an exact block → message mapping without a
+/// second, drift-prone copy of the merge rules.
+library;
+
+import '../../../core/llm/converters/prompt_post_processing.dart';
+import '../../../core/llm/history_assembler.dart';
+
+/// One row of the formatted preview: the message as it will be sent, plus the
+/// built blocks that were folded into it.
+class PreviewMessage {
+  /// The outgoing message. For a merged row, [PromptMessage.content] is the
+  /// concatenation of every source's content and the classification flags are
+  /// the union of the sources', so the section filters keep working.
+  final PromptMessage message;
+
+  /// The built blocks this row came from, in prompt order. Empty for the
+  /// filler turn the strict modes insert, which corresponds to no block.
+  final List<PromptMessage> sources;
+
+  const PreviewMessage({required this.message, required this.sources});
+
+  /// True when post-processing folded several blocks into this one message.
+  bool get isMerged => sources.length > 1;
+
+  /// Every image carried by the sources. A merge can pull several attachments
+  /// into one message, so the card renders the list rather than a single path.
+  List<String> get imagePaths => [
+    for (final source in sources)
+      if (source.hasImage) source.imagePath!,
+  ];
+}
+
+/// Separator [postProcessPrompt] uses when it glues two messages together.
+const String _mergeSeparator = '\n\n';
+
+/// Stand-in content for one built message. NUL cannot appear in prompt text,
+/// so a token never collides with real content, and it carries no newline, so
+/// it always survives the merge as a chunk of its own.
+const String _tokenPrefix = '\u0000glaze-preview-';
+const String _tokenSuffix = '\u0000';
+
+/// Applies [mode] to [messages] and returns the resulting rows.
+///
+/// With [PromptPostProcessing.none] every message passes through untouched,
+/// one row each — including blocks with empty content, which the inspector has
+/// always listed even though the request omits them. Any other mode reproduces
+/// the request faithfully instead, so empty blocks are dropped first exactly
+/// as `buildApiMessages` drops them.
+List<PreviewMessage> buildPreviewMessages(
+  List<PromptMessage> messages,
+  String mode,
+) {
+  final normalized = PromptPostProcessing.normalize(mode);
+  if (normalized == PromptPostProcessing.none) {
+    return [
+      for (final message in messages)
+        PreviewMessage(message: message, sources: [message]),
+    ];
+  }
+
+  final included = messages
+      .where((message) => message.content.trim().isNotEmpty || message.hasImage)
+      .toList();
+
+  final tagged = [
+    for (var i = 0; i < included.length; i++)
+      {'role': included[i].role, 'content': '$_tokenPrefix$i$_tokenSuffix'},
+  ];
+
+  final processed = postProcessPrompt(tagged, normalized);
+
+  final rows = <PreviewMessage>[];
+  for (final message in processed) {
+    final role = (message['role'] as String?) ?? 'user';
+    final content = message['content'];
+    final text = content is String ? content : '';
+
+    final sources = <PromptMessage>[];
+    final chunks = <String>[];
+    for (final chunk in text.split(_mergeSeparator)) {
+      final index = _tokenIndex(chunk);
+      if (index == null || index >= included.length) {
+        // Not a token: text the pass itself introduced, i.e. the filler turn.
+        chunks.add(chunk);
+        continue;
+      }
+      final source = included[index];
+      sources.add(source);
+      if (source.content.isNotEmpty) chunks.add(source.content);
+    }
+
+    rows.add(
+      PreviewMessage(
+        message: _synthesize(role, chunks.join(_mergeSeparator), sources),
+        sources: sources,
+      ),
+    );
+  }
+  return rows;
+}
+
+/// Parses a token back into its source index; null for anything else.
+int? _tokenIndex(String chunk) {
+  if (!chunk.startsWith(_tokenPrefix) || !chunk.endsWith(_tokenSuffix)) {
+    return null;
+  }
+  return int.tryParse(
+    chunk.substring(_tokenPrefix.length, chunk.length - _tokenSuffix.length),
+  );
+}
+
+/// Builds the message a row displays. A single source keeps its own metadata;
+/// a merge unions the flags and joins the block names, since the merged text
+/// really is all of those blocks.
+PromptMessage _synthesize(
+  String role,
+  String content,
+  List<PromptMessage> sources,
+) {
+  if (sources.length == 1) {
+    final source = sources.single;
+    return PromptMessage(
+      role: role,
+      content: content,
+      blockId: source.blockId,
+      depth: source.depth,
+      isHistory: source.isHistory,
+      isDepth: source.isDepth,
+      isLorebook: source.isLorebook,
+      isSummary: source.isSummary,
+      blockName: source.blockName,
+      sourceMessageId: source.sourceMessageId,
+      reasoningContent: source.reasoningContent,
+      imagePath: source.imagePath,
+    );
+  }
+
+  final names = <String>[];
+  for (final source in sources) {
+    final name = source.blockName;
+    if (name != null && name.isNotEmpty && !names.contains(name)) {
+      names.add(name);
+    }
+  }
+
+  return PromptMessage(
+    role: role,
+    content: content,
+    isHistory: sources.any((s) => s.isHistory),
+    isDepth: sources.any((s) => s.isDepth),
+    isLorebook: sources.any((s) => s.isLorebook),
+    isSummary: sources.any((s) => s.isSummary),
+    blockName: names.isEmpty ? null : names.join(' + '),
+  );
+}

--- a/lib/features/chat/widgets/prompt_preview_screen.dart
+++ b/lib/features/chat/widgets/prompt_preview_screen.dart
@@ -6,6 +6,7 @@ import 'package:gpt_markdown/gpt_markdown.dart';
 
 import 'dart:convert';
 
+import '../../../core/llm/converters/prompt_post_processing.dart';
 import '../../../core/llm/history_assembler.dart';
 import '../../../core/llm/prompt_builder.dart';
 import '../../../core/llm/prompt_isolate.dart';
@@ -22,6 +23,7 @@ import '../../../core/llm/transport/openrouter_chat_transport.dart';
 import '../../../core/llm/transport/post_processing_chat_transport.dart';
 import '../../../core/llm/tokenizer.dart';
 import '../../../core/models/api_config.dart';
+import '../services/prompt_preview_post_processor.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_filter_chip_bar.dart';
 import '../../../shared/widgets/glaze_tab_bar.dart';
@@ -61,6 +63,10 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
   ApiConfig? _apiConfig;
   String? _sessionId;
   Map<String, dynamic>? _requestBody;
+
+  /// The built prompt after the connection's post-processing mode, computed
+  /// once per build rather than per frame. Empty until the first prompt lands.
+  List<PreviewMessage> _previewMessages = const [];
   bool _loading = true;
   _SectionFilter _filter = _SectionFilter.all;
   int _dataTabIndex = 0;
@@ -101,6 +107,10 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
       if (mounted) {
         setState(() {
           _result = result;
+          _previewMessages = buildPreviewMessages(
+            result.messages,
+            _apiConfig?.promptPostProcessing ?? PromptPostProcessing.none,
+          );
           _requestBody = _buildRequestBody();
           _loading = false;
         });
@@ -320,10 +330,8 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
                     padding: const EdgeInsets.fromLTRB(12, 0, 12, 24),
                     sliver: SliverList(
                       delegate: SliverChildBuilderDelegate(
-                        (context, i) => _PromptMessageCard(
-                          message: _filteredMessages[i],
-                          index: i,
-                        ),
+                        (context, i) =>
+                            _PromptMessageCard(row: _filteredMessages[i]),
                         childCount: _filteredMessages.length,
                       ),
                     ),
@@ -437,6 +445,19 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
       items.add(_ParamItem(label: 'label_model'.tr(), value: model));
     }
 
+    // Post-processing reshapes the conversation without leaving a trace in the
+    // body, so the message list would otherwise be the only hint it ran. Shown
+    // only when it is on — every other connection would carry a "None" chip.
+    if (_postProcessingMode != PromptPostProcessing.none) {
+      final base = PromptPostProcessing.baseOf(_postProcessingMode);
+      items.add(
+        _ParamItem(
+          label: 'section_prompt_post_processing'.tr(),
+          value: 'prompt_post_processing_$base'.tr(),
+        ),
+      );
+    }
+
     void add(String label, dynamic value) {
       if (value is Map) {
         value.forEach((k, v) => add('$label.$k', v));
@@ -461,22 +482,27 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
     return items;
   }
 
-  List<PromptMessage> get _filteredMessages {
-    final msgs = _previewMessages;
+  /// Section filters read the post-processed message: a merged row carries the
+  /// union of its sources' flags, so it still shows up under `history` or
+  /// `lorebook` when one of the blocks folded into it was of that kind.
+  List<PreviewMessage> get _filteredMessages {
+    final rows = _previewMessages;
     return switch (_filter) {
-      _SectionFilter.all => msgs,
+      _SectionFilter.all => rows,
       _SectionFilter.system =>
-        msgs
-            .where((m) => m.role == 'system' && !m.isHistory && !m.isLorebook)
+        rows
+            .where(
+              (r) =>
+                  r.message.role == 'system' &&
+                  !r.message.isHistory &&
+                  !r.message.isLorebook,
+            )
             .toList(),
-      _SectionFilter.lorebook => msgs.where((m) => m.isLorebook).toList(),
-      _SectionFilter.history => msgs.where((m) => m.isHistory).toList(),
-      _SectionFilter.depth => msgs.where((m) => m.isDepth).toList(),
+      _SectionFilter.lorebook =>
+        rows.where((r) => r.message.isLorebook).toList(),
+      _SectionFilter.history => rows.where((r) => r.message.isHistory).toList(),
+      _SectionFilter.depth => rows.where((r) => r.message.isDepth).toList(),
     };
-  }
-
-  List<PromptMessage> get _previewMessages {
-    return _result?.messages ?? const [];
   }
 
   void _copyContent() {
@@ -484,7 +510,8 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
     if (_dataTabIndex == 0) {
       if (_previewTabIndex == 0) {
         if (_result == null) return;
-        final json = _previewMessages.map((m) {
+        final json = _previewMessages.map((row) {
+          final m = row.message;
           final map = <String, dynamic>{'role': m.role, 'content': m.content};
           if (m.isLorebook) map['lorebook'] = true;
           if (m.blockName != null) map['block'] = m.blockName;
@@ -618,6 +645,11 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
     if (body == null) return '';
     return const JsonEncoder.withIndent('  ').convert(body);
   }
+
+  /// The connection's post-processing mode, normalized the same way the
+  /// transport decorator normalizes it.
+  String get _postProcessingMode =>
+      PromptPostProcessing.normalize(_apiConfig?.promptPostProcessing);
 
   /// Human-readable name of the active protocol, used as the parameters
   /// section header.
@@ -781,9 +813,8 @@ class _ParamItem extends StatelessWidget {
 }
 
 class _PromptMessageCard extends StatefulWidget {
-  final PromptMessage message;
-  final int index;
-  const _PromptMessageCard({required this.message, required this.index});
+  final PreviewMessage row;
+  const _PromptMessageCard({required this.row});
 
   @override
   State<_PromptMessageCard> createState() => _PromptMessageCardState();
@@ -794,7 +825,8 @@ class _PromptMessageCardState extends State<_PromptMessageCard> {
 
   @override
   Widget build(BuildContext context) {
-    final msg = widget.message;
+    final msg = widget.row.message;
+    final images = widget.row.imagePaths;
     final tokenCount = estimateTokens(msg.content);
 
     return Card(
@@ -816,6 +848,10 @@ class _PromptMessageCardState extends State<_PromptMessageCard> {
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   _buildRoleChip(msg.role),
+                  if (widget.row.isMerged) ...[
+                    const SizedBox(width: 4),
+                    _MergedBadge(count: widget.row.sources.length),
+                  ],
                   if (msg.blockName != null) ...[
                     const SizedBox(width: 8),
                     Flexible(
@@ -877,18 +913,18 @@ class _PromptMessageCardState extends State<_PromptMessageCard> {
                   ),
                 ),
               ],
-              if (!_expanded && msg.hasImage) ...[
-                const SizedBox(height: 8),
-                PromptAttachmentPreview(imagePath: msg.imagePath!),
-              ],
+              // A merge can pull several attachments into one message, so every
+              // source image is listed rather than just the first.
+              if (!_expanded)
+                for (final path in images) ...[
+                  const SizedBox(height: 8),
+                  PromptAttachmentPreview(imagePath: path),
+                ],
               if (_expanded) ...[
                 const SizedBox(height: 8),
-                if (msg.hasImage) ...[
-                  PromptAttachmentPreview(
-                    imagePath: msg.imagePath!,
-                    expanded: true,
-                  ),
-                  if (msg.content.isNotEmpty) const SizedBox(height: 8),
+                for (final path in images) ...[
+                  PromptAttachmentPreview(imagePath: path, expanded: true),
+                  const SizedBox(height: 8),
                 ],
                 if (msg.content.isNotEmpty)
                   Container(
@@ -934,6 +970,43 @@ class _PromptMessageCardState extends State<_PromptMessageCard> {
       child: Text(
         role.toUpperCase(),
         style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700, color: fg),
+      ),
+    );
+  }
+}
+
+/// How many built blocks post-processing folded into this one message.
+/// Without it a merged card reads as one oversized block and nothing on screen
+/// says the connection reshaped the prompt.
+class _MergedBadge extends StatelessWidget {
+  final int count;
+  const _MergedBadge({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: 'prompt_preview_merged_blocks'.tr(args: ['$count']),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+        decoration: BoxDecoration(
+          color: context.cs.primary.withValues(alpha: 0.15),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.merge_rounded, size: 11, color: context.cs.primary),
+            const SizedBox(width: 2),
+            Text(
+              '$count',
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                color: context.cs.primary,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/test/prompt_preview_post_processing_test.dart
+++ b/test/prompt_preview_post_processing_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/converters/prompt_post_processing.dart';
+import 'package:glaze_flutter/core/llm/history_assembler.dart';
+import 'package:glaze_flutter/features/chat/services/prompt_preview_post_processor.dart';
+
+void main() {
+  const built = [
+    PromptMessage(
+      role: 'system',
+      content: 'main prompt',
+      blockName: 'Main Prompt',
+    ),
+    PromptMessage(
+      role: 'system',
+      content: 'lore entry',
+      blockName: 'Lorebook',
+      isLorebook: true,
+    ),
+    PromptMessage(role: 'user', content: 'hi', isHistory: true),
+    PromptMessage(role: 'assistant', content: 'hello', isHistory: true),
+  ];
+
+  List<String> rolesOf(List<PreviewMessage> rows) => [
+    for (final row in rows) row.message.role,
+  ];
+
+  List<String> contentsOf(List<PreviewMessage> rows) => [
+    for (final row in rows) row.message.content,
+  ];
+
+  test('none leaves every built block as its own row', () {
+    final rows = buildPreviewMessages(built, PromptPostProcessing.none);
+
+    expect(rows, hasLength(built.length));
+    expect(contentsOf(rows), [
+      'main prompt',
+      'lore entry',
+      'hi',
+      'hello',
+    ]);
+    expect(rows.every((r) => !r.isMerged), isTrue);
+  });
+
+  test('none keeps empty blocks the request would drop', () {
+    final rows = buildPreviewMessages(const [
+      PromptMessage(role: 'system', content: ''),
+    ], PromptPostProcessing.none);
+
+    expect(rows, hasLength(1));
+  });
+
+  test('merge folds consecutive same-role blocks into one row', () {
+    final rows = buildPreviewMessages(built, PromptPostProcessing.merge);
+
+    expect(rolesOf(rows), ['system', 'user', 'assistant']);
+    expect(rows.first.message.content, 'main prompt\n\nlore entry');
+    expect(rows.first.isMerged, isTrue);
+    expect(rows.first.sources, hasLength(2));
+    // The merged row inherits every source's classification, so the section
+    // filters still find it.
+    expect(rows.first.message.isLorebook, isTrue);
+    expect(rows.first.message.blockName, 'Main Prompt + Lorebook');
+    expect(rows[1].isMerged, isFalse);
+    expect(rows[1].message.blockName, isNull);
+  });
+
+  test('merge drops the empty blocks the request drops', () {
+    final rows = buildPreviewMessages(const [
+      PromptMessage(role: 'system', content: 'kept'),
+      PromptMessage(role: 'system', content: '   '),
+    ], PromptPostProcessing.merge);
+
+    expect(rows, hasLength(1));
+    expect(rows.single.message.content, 'kept');
+    expect(rows.single.sources, hasLength(1));
+  });
+
+  test('semi relabels every system block after the first', () {
+    final rows = buildPreviewMessages(const [
+      PromptMessage(role: 'system', content: 'main'),
+      PromptMessage(role: 'user', content: 'hi'),
+      PromptMessage(role: 'system', content: 'jailbreak'),
+    ], PromptPostProcessing.semi);
+
+    expect(rolesOf(rows), ['system', 'user']);
+    expect(rows[1].message.content, 'hi\n\njailbreak');
+    expect(rows[1].sources, hasLength(2));
+  });
+
+  test('strict surfaces the filler turn as a row with no source block', () {
+    final rows = buildPreviewMessages(const [
+      PromptMessage(role: 'system', content: 'main'),
+      PromptMessage(role: 'assistant', content: 'opening line'),
+    ], PromptPostProcessing.strict);
+
+    expect(rolesOf(rows), ['system', 'user', 'assistant']);
+    expect(rows[1].message.content, promptPostProcessingPlaceholder);
+    expect(rows[1].sources, isEmpty);
+    expect(rows[1].isMerged, isFalse);
+  });
+
+  test('single collapses the whole prompt into one user row', () {
+    final rows = buildPreviewMessages(built, PromptPostProcessing.single);
+
+    expect(rows, hasLength(1));
+    expect(rows.single.message.role, 'user');
+    expect(rows.single.sources, hasLength(built.length));
+    expect(
+      rows.single.message.content,
+      'main prompt\n\nlore entry\n\nhi\n\nhello',
+    );
+  });
+
+  test('the tool-preserving half of a family behaves like the family', () {
+    expect(
+      contentsOf(buildPreviewMessages(built, PromptPostProcessing.mergeTools)),
+      contentsOf(buildPreviewMessages(built, PromptPostProcessing.merge)),
+    );
+  });
+
+  test('an unknown mode is treated as no post-processing', () {
+    final rows = buildPreviewMessages(built, 'not-a-mode');
+
+    expect(rows, hasLength(built.length));
+  });
+
+  test('merged rows keep every attachment folded into them', () {
+    const png = 'data:image/png;base64,AAAA';
+    const jpg = 'data:image/jpeg;base64,BBBB';
+    final rows = buildPreviewMessages(const [
+      PromptMessage(role: 'user', content: 'look', imagePath: png),
+      PromptMessage(role: 'user', content: '', imagePath: jpg),
+    ], PromptPostProcessing.merge);
+
+    expect(rows, hasLength(1));
+    expect(rows.single.imagePaths, [png, jpg]);
+    // The image-only block contributes no text, so nothing dangles behind the
+    // merge separator.
+    expect(rows.single.message.content, 'look');
+  });
+
+  // The preview must not drift from the transport: the rows it lists are the
+  // messages the request actually carries.
+  for (final mode in const [
+    PromptPostProcessing.merge,
+    PromptPostProcessing.semi,
+    PromptPostProcessing.strict,
+    PromptPostProcessing.single,
+  ]) {
+    test('$mode rows match what the request body carries', () {
+      final rows = buildPreviewMessages(built, mode);
+      final sent = postProcessPrompt(buildApiMessages(built), mode);
+
+      expect(rolesOf(rows), [for (final m in sent) m['role']]);
+      expect(contentsOf(rows), [for (final m in sent) m['content']]);
+    });
+  }
+}


### PR DESCRIPTION
The raw JSON half of the Prompt Inspector's Request tab already runs `PostProcessingChatTransport.applyTo`, but the message cards above it kept listing the blocks exactly as the builder produced them. With any `ApiConfig.promptPostProcessing` mode other than `none` the two halves of the same tab disagreed: the JSON showed three merged messages while the cards still showed twenty separate blocks, and the message count and the section filters counted the pre-merge list.

## Changes

- Add `features/chat/services/prompt_preview_post_processor.dart` — replays the connection's post-processing pass over the built `PromptMessage` list and returns one `PreviewMessage` per outgoing message, each carrying the blocks that were folded into it
- Recover that block → message mapping without a second copy of the merge rules: `buildPreviewMessages` runs the real `postProcessPrompt` over placeholder content (one unique token per built message) and reads the tokens back out of the result, so the preview cannot drift from `prompt_post_processing.dart`
- Drive the formatted list, the message count in `_SummaryBar`, the section filter chips and the copy action off those rows in `prompt_preview_screen.dart`
- Give a merged card the union of its sources' section flags (so the `history` / `lorebook` filters still find it), their joined block names (`Main Prompt + Lorebook`, matching INV-PS9's preview attribution), and every attachment folded into it rather than only the first
- Badge a merged card with the number of blocks it came from; the filler user turn the strict modes insert shows up as its own row with no source block
- Surface the active mode as a parameter chip next to the protocol's parameters — post-processing leaves no trace in the request body, so nothing else on screen said it ran
- Keep `none` byte-identical to the previous behaviour, empty blocks included
- Document the replay in `docs/ARCHITECTURE.md` § Prompt post-processing, and add the `prompt_preview_merged_blocks` string in `en` / `ru`

Out of scope: the Context tab's token breakdown is grouped by section, and post-processing changes how the text is split into messages rather than which text is included (bar the `\n\n` separators and the strict filler), so its numbers stay valid and it is untouched.

## Verification

- `flutter analyze --no-fatal-infos --no-fatal-warnings` — no errors, nothing reported in the changed files
- `flutter test` — full suite green (Flutter 3.44.9, the version CI pins)
- New `test/prompt_preview_post_processing_test.dart` covers each mode, the empty-block and attachment cases, the ST-imported `*_tools` values and unknown modes; for every mode it also asserts the rows match `postProcessPrompt(buildApiMessages(...))` role-for-role and content-for-content, so the preview stays pinned to what the transport sends

---
_Generated by [Claude Code](https://claude.ai/code/session_01H68dA8AK6T35nneaf9VhdU)_