### PR TITLE
fix: recover reconciliation and session races

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -486,9 +486,10 @@ ST's own mode identifiers so prompts stay portable:
 
 It lives on the API connection, not the prompt preset: whether an endpoint
 accepts several system blocks or non-alternating roles is a property of the
-endpoint. (It replaces the preset-level `mergePrompts` flag, which squashed
-adjacent non-assistant *blocks* at build time; DB migration v118 carries the
-active preset's flag over to custom connections.)
+endpoint. It replaces the preset-level `mergePrompts` flag, which squashed
+adjacent non-assistant *blocks* at build time. DB migration v118 only adds the
+column with `none`; it deliberately does not infer a connection setting from
+any active preset.
 
 **Offered for `custom_chat_completion` only.** Every first-party protocol
 already normalizes what its wire format demands inside its own converter — the
@@ -514,6 +515,13 @@ match. Every mode is idempotent, and the rewritten request carries
 `promptPostProcessing: 'none'` so it can never be applied twice. The prompt
 preview builds bodies without a transport, so it calls
 `PostProcessingChatTransport.applyTo` itself.
+
+`single` would otherwise erase who spoke each chat turn when all roles become
+one `user` message. Chat-aware callers therefore attach effective `charName`
+and `userName` as request-only metadata. The post-processing decorator prefixes
+assistant and user text with those labels for both `messages` and
+`previousMessages`; the names are not stored in `ApiConfig`, serialized as a
+wire field, or added globally as `message.name`.
 
 ### Request Types
 

--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -2213,45 +2213,10 @@ class AppDatabase extends _$AppDatabase {
             .toSet();
         if (!names.contains('prompt_post_processing')) {
           await m.addColumn(apiConfigs, apiConfigs.promptPostProcessing);
-          await _carryOverPresetMergePrompts();
         }
       }
     },
   );
-
-  /// "Merge Prompts" used to live on the prompt preset and squashed adjacent
-  /// non-assistant blocks at build time. It is an API-connection setting now
-  /// (`prompt_post_processing`), because whether a request may carry several
-  /// system blocks is a property of the endpoint, not of the prompt.
-  ///
-  /// The two settings sit on different entities, so there is no per-row
-  /// mapping. The active preset is the one whose behaviour the user is
-  /// actually living with, so if it had the flag on, custom connections adopt
-  /// the equivalent mode and nobody's prompt shape changes silently on
-  /// upgrade. Only custom connections: every first-party protocol squashes
-  /// same-role neighbours inside its own converter anyway, and the setting is
-  /// not offered there.
-  Future<void> _carryOverPresetMergePrompts() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      final activePresetId = prefs.getString('activePresetId');
-      if (activePresetId == null || activePresetId.isEmpty) return;
-      final rows = await customSelect(
-        'SELECT data_json FROM presets WHERE preset_id = ?',
-        variables: [Variable.withString(activePresetId)],
-      ).get();
-      if (rows.isEmpty) return;
-      final decoded = jsonDecode(rows.first.read<String>('data_json'));
-      if (decoded is! Map || decoded['mergePrompts'] != true) return;
-      await customStatement(
-        "UPDATE api_configs SET prompt_post_processing = 'merge_tools' "
-        "WHERE protocol = 'custom_chat_completion'",
-      );
-    } on Object catch (e) {
-      // A missing/unreadable preset must never block the schema upgrade.
-      debugPrint('[migration v118] mergePrompts carry-over skipped: $e');
-    }
-  }
 
   Future<void> _migrateStudioPresetBlocksToExplicitSemantics() async {
     final rows = await customSelect(

--- a/lib/core/db/repositories/card_evolution_collector_run_repo.dart
+++ b/lib/core/db/repositories/card_evolution_collector_run_repo.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart';
 
 import '../../utils/id_generator.dart';
 import '../app_db.dart';
+import 'ledger_reconciliation_run_repo.dart';
 
 final class CardEvolutionCollectorClaimOutcome {
   const CardEvolutionCollectorClaimOutcome(this.kind, [this.row]);
@@ -126,6 +127,48 @@ class CardEvolutionCollectorRunRepo {
     return changed == 1;
   }
 
+  /// Commits observation effects and collector completion atomically. If a
+  /// chat mutation removed the claimed collector while its model call was in
+  /// flight, no effects are applied.
+  Future<bool> completeWithEffects({
+    required String id,
+    required String ownerId,
+    required String modelOutputHash,
+    required int now,
+    required Future<void> Function() applyEffects,
+  }) => db.transaction(() async {
+    final claimed =
+        await (db.select(db.cardEvolutionCollectorRuns)..where(
+              (row) =>
+                  row.id.equals(id) &
+                  row.ownerId.equals(ownerId) &
+                  row.status.equals('claimed') &
+                  row.leaseExpiresAt.isBiggerThanValue(now),
+            ))
+            .getSingleOrNull();
+    if (claimed == null) return false;
+    await applyEffects();
+    final changed =
+        await (db.update(db.cardEvolutionCollectorRuns)..where(
+              (row) =>
+                  row.id.equals(id) &
+                  row.ownerId.equals(ownerId) &
+                  row.status.equals('claimed') &
+                  row.leaseExpiresAt.isBiggerThanValue(now),
+            ))
+            .write(
+              CardEvolutionCollectorRunsCompanion(
+                status: const Value('completed'),
+                modelOutputHash: Value(modelOutputHash),
+                completedAt: Value(now),
+              ),
+            );
+    if (changed != 1) {
+      throw StateError('Collector claim changed in transaction');
+    }
+    return true;
+  });
+
   Future<void> abandon({required String id, required String ownerId}) =>
       (db.delete(db.cardEvolutionCollectorRuns)..where(
             (row) =>
@@ -148,15 +191,72 @@ class CardEvolutionCollectorRunRepo {
   }
 
   Future<int> latestDeliveredWriterBoundary(String sessionId) async {
-    final row = await db
-        .customSelect(
-          'SELECT COALESCE(MAX(predecessor_run_ordinal), 0) AS ordinal '
-          'FROM card_evolution_claims '
-          "WHERE session_id = ? AND status = 'completed'",
-          variables: [Variable.withString(sessionId)],
-        )
-        .getSingle();
-    return row.read<int>('ordinal');
+    final claims =
+        await (db.select(db.cardEvolutionClaims)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..where((row) => row.status.equals('completed'))
+              ..where((row) => row.predecessorRunOrdinal.isBiggerThanValue(0))
+              ..orderBy([
+                (row) => OrderingTerm.desc(row.predecessorRunOrdinal),
+              ]))
+            .get();
+    for (final claim in claims) {
+      final boundary =
+          await (db.select(db.cardEvolutionCollectorRuns)
+                ..where((row) => row.sessionId.equals(sessionId))
+                ..where(
+                  (row) =>
+                      row.collectorOrdinal.equals(claim.predecessorRunOrdinal),
+                )
+                ..where((row) => row.status.equals('completed')))
+              .getSingleOrNull();
+      if (boundary != null &&
+          boundary.reconciliationChainHash == claim.predecessorCursorHash) {
+        return claim.predecessorRunOrdinal;
+      }
+    }
+    return 0;
+  }
+
+  /// Valid logical reconciliation runs which do not yet have a completed
+  /// collector. This is the durable backlog used to recover runs skipped by a
+  /// crash, a disabled model, or a superseded post-generation callback.
+  Future<List<LedgerReconciliationSuccessfulRunRow>> pendingValidRuns(
+    String sessionId, {
+    LedgerReconciliationSuccessfulRunRow? currentRun,
+  }) async {
+    final runs = await LedgerReconciliationRunRepo(db).readSession(sessionId);
+    if (currentRun != null &&
+        currentRun.sessionId == sessionId &&
+        !runs.any((run) => run.id == currentRun.id)) {
+      final invalidated =
+          await (db.select(db.ledgerReconciliationRunInvalidations)..where(
+                (row) =>
+                    row.sessionId.equals(sessionId) &
+                    row.runId.equals(currentRun.id),
+              ))
+              .getSingleOrNull();
+      // The orchestration caller already obtained this row as its current
+      // successful run. Keep that direct hand-off usable for legacy/imported
+      // chains which cannot be projected as a complete backlog; the collector
+      // snapshot still validates the run's live evidence fail-closed.
+      if (invalidated == null) runs.add(currentRun);
+    }
+    runs.sort((left, right) => left.ordinal.compareTo(right.ordinal));
+    final collectors =
+        await (db.select(db.cardEvolutionCollectorRuns)..where(
+              (row) =>
+                  row.sessionId.equals(sessionId) &
+                  row.status.equals('completed'),
+            ))
+            .get();
+    final completedIds = collectors
+        .map((row) => row.reconciliationRunId)
+        .toSet();
+    return [
+      for (final run in runs)
+        if (!completedIds.contains(run.id)) run,
+    ];
   }
 
   /// Exact three completed collectors ending at [boundary]. Gaps or claimed

--- a/lib/core/db/repositories/chat_repo.dart
+++ b/lib/core/db/repositories/chat_repo.dart
@@ -307,6 +307,21 @@ class ChatRepo implements SyncChatStore {
     );
   }
 
+  Future<ChatSession?> mutateMessagesWithBeforeWrite({
+    required String sessionId,
+    required List<ChatMessage> Function(List<ChatMessage> messages) mutate,
+    required int updatedAt,
+    required Future<void> Function(ChatSession before, ChatSession after)
+    beforeWrite,
+  }) => _mutateSession(
+    sessionId: sessionId,
+    updatedAt: updatedAt,
+    mutate: (session) => session.copyWith(
+      messages: mutate(List<ChatMessage>.from(session.messages)),
+    ),
+    beforeWrite: beforeWrite,
+  );
+
   /// Atomically transforms one message identified by its durable ID.
   Future<ChatSession?> mutateMessage({
     required String sessionId,
@@ -364,6 +379,17 @@ class ChatRepo implements SyncChatStore {
     required String sessionId,
     required ChatSession? Function(ChatSession session) mutate,
     int? updatedAt,
+  }) => _mutateSession(
+    sessionId: sessionId,
+    mutate: mutate,
+    updatedAt: updatedAt,
+  );
+
+  Future<ChatSession?> _mutateSession({
+    required String sessionId,
+    required ChatSession? Function(ChatSession session) mutate,
+    int? updatedAt,
+    Future<void> Function(ChatSession before, ChatSession after)? beforeWrite,
   }) async {
     return _db.transaction(() async {
       final row = await (_db.select(
@@ -374,6 +400,7 @@ class ChatRepo implements SyncChatStore {
       final current = _toModel(row);
       final updated = mutate(current);
       if (updated == null) return null;
+      if (beforeWrite != null) await beforeWrite(current, updated);
       final messagesJson = jsonEncode(
         updated.messages.map((e) => e.toJson()).toList(),
       );

--- a/lib/core/db/repositories/chat_repo.dart
+++ b/lib/core/db/repositories/chat_repo.dart
@@ -153,34 +153,50 @@ class ChatRepo implements SyncChatStore {
     required ChatMessage message,
     required int updatedAt,
   }) async {
-    return _db.transaction(() async {
-      final row = await (_db.select(
+    while (true) {
+      final snapshot = await (_db.select(
         _db.chatSessions,
       )..where((t) => t.sessionId.equals(sessionId))).getSingleOrNull();
-      if (row == null) return null;
+      if (snapshot == null) return null;
 
       final prepared = await _prepareUserMessageAppend(
-        row.messagesJson,
+        snapshot.messagesJson,
         message,
       );
 
-      await (_db.update(
-        _db.chatSessions,
-      )..where((t) => t.sessionId.equals(sessionId))).write(
-        ChatSessionsCompanion(
-          messagesJson: Value(prepared.messagesJson),
-          draft: const Value(''),
-          updatedAt: Value(updatedAt),
-        ),
+      final result = await _db.transaction<({bool retry, ChatSession? value})>(
+        () async {
+          final current = await (_db.select(
+            _db.chatSessions,
+          )..where((t) => t.sessionId.equals(sessionId))).getSingleOrNull();
+          if (current == null) return (retry: false, value: null);
+          if (current.messagesJson != snapshot.messagesJson) {
+            return (retry: true, value: null);
+          }
+          await (_db.update(
+            _db.chatSessions,
+          )..where((t) => t.sessionId.equals(sessionId))).write(
+            ChatSessionsCompanion(
+              messagesJson: Value(prepared.messagesJson),
+              draft: const Value(''),
+              updatedAt: Value(updatedAt),
+            ),
+          );
+          return (
+            retry: false,
+            value: _toModel(
+              current.copyWith(
+                messagesJson: prepared.messagesJson,
+                draft: const Value(''),
+                updatedAt: updatedAt,
+              ),
+              messages: prepared.messages,
+            ),
+          );
+        },
       );
-
-      final updatedRow = row.copyWith(
-        messagesJson: prepared.messagesJson,
-        draft: const Value(''),
-        updatedAt: updatedAt,
-      );
-      return _toModel(updatedRow, messages: prepared.messages);
-    });
+      if (!result.retry) return result.value;
+    }
   }
 
   /// Atomically appends a user message, clears the draft, and records that the
@@ -199,14 +215,14 @@ class ChatRepo implements SyncChatStore {
     if (expectedPrecedingAssistant.sessionId != sessionId) {
       return null;
     }
-    return _db.transaction(() async {
-      final row = await (_db.select(
+    while (true) {
+      final snapshot = await (_db.select(
         _db.chatSessions,
       )..where((t) => t.sessionId.equals(sessionId))).getSingleOrNull();
-      if (row == null) return null;
+      if (snapshot == null) return null;
 
       final prepared = await _prepareAcceptedUserMessageAppend(
-        messagesJson: row.messagesJson,
+        messagesJson: snapshot.messagesJson,
         message: message,
         expectedPrecedingAssistant: expectedPrecedingAssistant,
       );
@@ -214,54 +230,73 @@ class ChatRepo implements SyncChatStore {
 
       // A retry after a completed transaction must not append the same user
       // message or a second acceptance event.
-      if (!prepared.didAppend)
-        return _toModel(row, messages: prepared.messages);
-
-      final manifest =
-          await (_db.select(_db.lorebookUseManifests)
-                ..where((t) => t.sessionId.equals(sessionId))
-                ..where(
-                  (t) =>
-                      t.messageId.equals(expectedPrecedingAssistant.messageId),
-                )
-                ..where(
-                  (t) => t.swipeId.equals(expectedPrecedingAssistant.swipeId),
-                )
-                ..where(
-                  (t) => t.agentSwipeId.equals(
-                    expectedPrecedingAssistant.agentSwipeId,
-                  ),
-                ))
-              .getSingleOrNull();
-
-      await (_db.update(
-        _db.chatSessions,
-      )..where((t) => t.sessionId.equals(sessionId))).write(
-        ChatSessionsCompanion(
-          messagesJson: Value(prepared.messagesJson),
-          draft: const Value(''),
-          updatedAt: Value(updatedAt),
-        ),
-      );
-
-      if (manifest != null) {
-        await LorebookUseManifestRepo(_db).insertVariationAcceptance(
-          acceptanceId: 'variation:$sessionId:${message.id}',
-          identity: expectedPrecedingAssistant,
-          acceptedByUserMessageId: message.id,
-          acceptedAt: updatedAt,
-        );
+      if (!prepared.didAppend) {
+        return _toModel(snapshot, messages: prepared.messages);
       }
 
-      return _toModel(
-        row.copyWith(
-          messagesJson: prepared.messagesJson,
-          draft: const Value(''),
-          updatedAt: updatedAt,
-        ),
-        messages: prepared.messages,
+      final result = await _db.transaction<({bool retry, ChatSession? value})>(
+        () async {
+          final row = await (_db.select(
+            _db.chatSessions,
+          )..where((t) => t.sessionId.equals(sessionId))).getSingleOrNull();
+          if (row == null) return (retry: false, value: null);
+          if (row.messagesJson != snapshot.messagesJson) {
+            return (retry: true, value: null);
+          }
+
+          final manifest =
+              await (_db.select(_db.lorebookUseManifests)
+                    ..where((t) => t.sessionId.equals(sessionId))
+                    ..where(
+                      (t) => t.messageId.equals(
+                        expectedPrecedingAssistant.messageId,
+                      ),
+                    )
+                    ..where(
+                      (t) =>
+                          t.swipeId.equals(expectedPrecedingAssistant.swipeId),
+                    )
+                    ..where(
+                      (t) => t.agentSwipeId.equals(
+                        expectedPrecedingAssistant.agentSwipeId,
+                      ),
+                    ))
+                  .getSingleOrNull();
+
+          await (_db.update(
+            _db.chatSessions,
+          )..where((t) => t.sessionId.equals(sessionId))).write(
+            ChatSessionsCompanion(
+              messagesJson: Value(prepared.messagesJson),
+              draft: const Value(''),
+              updatedAt: Value(updatedAt),
+            ),
+          );
+
+          if (manifest != null) {
+            await LorebookUseManifestRepo(_db).insertVariationAcceptance(
+              acceptanceId: 'variation:$sessionId:${message.id}',
+              identity: expectedPrecedingAssistant,
+              acceptedByUserMessageId: message.id,
+              acceptedAt: updatedAt,
+            );
+          }
+
+          return (
+            retry: false,
+            value: _toModel(
+              row.copyWith(
+                messagesJson: prepared.messagesJson,
+                draft: const Value(''),
+                updatedAt: updatedAt,
+              ),
+              messages: prepared.messages,
+            ),
+          );
+        },
       );
-    });
+      if (!result.retry) return result.value;
+    }
   }
 
   /// Updates only the draft column, and only if [expectedMessageCount] still
@@ -1330,7 +1365,8 @@ class ChatRepo implements SyncChatStore {
 }
 
 /// Decoding and encoding a long chat history is CPU-bound. Keep it out of the
-/// UI isolate while the repository transaction protects the read-modify-write.
+/// UI isolate. Callers do this before opening a short compare-and-swap
+/// transaction so an isolate delay cannot occupy the database executor.
 Future<_PreparedUserMessageAppend> _prepareUserMessageAppend(
   String messagesJson,
   ChatMessage message,

--- a/lib/core/db/repositories/ledger_reconciliation_run_repo.dart
+++ b/lib/core/db/repositories/ledger_reconciliation_run_repo.dart
@@ -323,6 +323,84 @@ class LedgerReconciliationRunRepo {
             ..limit(1))
           .getSingleOrNull();
 
+  /// Logically invalidates the first reconciliation whose immutable evidence
+  /// references one of [messageIds], plus its already-written causal suffix.
+  /// Trigger messages are not anchors, so deleting a trigger does not touch the
+  /// completed range it caused.
+  ///
+  /// Caller owns the surrounding transaction.
+  Future<List<String>> invalidateForMessageMutation({
+    required String sessionId,
+    required Set<String> messageIds,
+    required String reason,
+    required int createdAt,
+  }) async {
+    if (messageIds.isEmpty) return const [];
+    final rows =
+        await (_db.select(_db.ledgerReconciliationSuccessfulRuns)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..orderBy([(row) => OrderingTerm.asc(row.ordinal)]))
+            .get();
+    final existingInvalidations = await (_db.select(
+      _db.ledgerReconciliationRunInvalidations,
+    )..where((row) => row.sessionId.equals(sessionId))).get();
+    final alreadyInvalidated = existingInvalidations
+        .map((row) => row.runId)
+        .toSet();
+    var firstAffected = -1;
+    for (var i = 0; i < rows.length; i++) {
+      if (alreadyInvalidated.contains(rows[i].id)) continue;
+      try {
+        final anchors = _decodeAnchors(rows[i].anchorsJson);
+        if (anchors.any((anchor) => messageIds.contains(anchor.messageId))) {
+          firstAffected = i;
+          break;
+        }
+      } catch (_) {
+        // Malformed immutable history remains an integrity failure; mutation
+        // invalidation must not disguise it.
+        return const [];
+      }
+    }
+    if (firstAffected < 0) return const [];
+    final affected = rows.sublist(firstAffected);
+    for (final row in affected) {
+      await _db
+          .into(_db.ledgerReconciliationRunInvalidations)
+          .insert(
+            LedgerReconciliationRunInvalidationsCompanion.insert(
+              sessionId: sessionId,
+              runId: row.id,
+              causeMessageId: messageIds.first,
+              reason: reason,
+              createdAt: createdAt,
+            ),
+            mode: InsertMode.insertOrIgnore,
+          );
+    }
+
+    // Observations are aggregates rather than per-collector events, so a
+    // suffix-only rollback cannot reliably subtract confirmations or
+    // promotions derived from invalid evidence. Reset the derived collector
+    // lane and rebuild it from the valid reconciliation backlog.
+    final affectedIds = affected.map((row) => row.id).toSet();
+    final hasAffectedCollector =
+        await (_db.select(_db.cardEvolutionCollectorRuns)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..where((row) => row.reconciliationRunId.isIn(affectedIds))
+              ..limit(1))
+            .getSingleOrNull();
+    if (hasAffectedCollector != null) {
+      await (_db.delete(
+        _db.cardEvolutionCollectorRuns,
+      )..where((row) => row.sessionId.equals(sessionId))).go();
+      await (_db.delete(
+        _db.cardEvolutionObservations,
+      )..where((row) => row.sessionId.equals(sessionId))).go();
+    }
+    return affectedIds.toList(growable: false);
+  }
+
   /// Copies all reconciliation runs from [fromSessionId] to [toSessionId],
   /// preserving the ordinal chain. Only runs whose endpoint message falls
   /// within the branched slice ([messageIds]) are copied. The chain hashes
@@ -404,7 +482,18 @@ class LedgerReconciliationRunRepo {
       return <LedgerReconciliationSuccessfulRunRow>[];
     }
     final invalidatedIds = invalidated.map((row) => row.runId).toSet();
-    return rows.where((row) => !invalidatedIds.contains(row.id)).toList();
+    final visible = <LedgerReconciliationSuccessfulRunRow>[];
+    for (final row in rows) {
+      if (invalidatedIds.contains(row.id)) continue;
+      // Legacy databases may contain mutations made before production began
+      // recording invalidations. Treat the first such stale row and its
+      // physical suffix as logically unavailable without corrupting physical
+      // hash-chain integrity. A later mutation records explicit suffix
+      // invalidations, allowing newly appended valid rows to be visible again.
+      if (!await _storedRowMatchesCurrentEvidence(row)) break;
+      visible.add(row);
+    }
+    return visible;
   }
 
   Future<List<LedgerReconciliationCursorRow>> readCursors(
@@ -555,8 +644,37 @@ class LedgerReconciliationRunRepo {
           row.endSwipeId == run.end.swipeId &&
           row.endAgentSwipeId == run.end.agentSwipeId &&
           row.contentHash == run.contentHash &&
-          row.chainHash == run.chainHash &&
-          await _anchorsMatchSession(run) &&
+          row.chainHash == run.chainHash;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  Future<bool> _storedRowMatchesCurrentEvidence(
+    LedgerReconciliationSuccessfulRunRow row,
+  ) async {
+    try {
+      final anchors = _decodeAnchors(row.anchorsJson);
+      final refs = _decodeRefs(row.acceptedManifestRefsJson);
+      final result = jsonDecode(row.canonicalResultJson);
+      final ops = jsonDecode(row.opsAppliedJson);
+      if (result is! Map<Object?, Object?> || ops is! List) return false;
+      final run = LedgerReconciliationRun(
+        id: row.id,
+        sessionId: row.sessionId,
+        ordinal: row.ordinal,
+        anchors: anchors,
+        acceptedManifestRefs: refs,
+        effectiveCanonStamp: row.effectiveCanonStamp,
+        effectiveCanonRevision: row.effectiveCanonRevision,
+        effectiveCanonHash: row.effectiveCanonHash,
+        canonicalResult: Map<String, dynamic>.from(result),
+        predecessorChainHash: row.predecessorChainHash,
+        contractVersion: row.contractVersion,
+        opsApplied: List<String>.from(ops),
+        createdAt: row.createdAt,
+      );
+      return await _anchorsMatchSession(run) &&
           await _refsMatchAcceptedManifests(run);
     } catch (_) {
       return false;

--- a/lib/core/llm/agent_runner.dart
+++ b/lib/core/llm/agent_runner.dart
@@ -67,6 +67,8 @@ class AgentRunner {
     ResolvedAgentConfig? preResolvedConfig,
     String? apiConfigId,
     StudioTurnConfigSnapshot? turnConfig,
+    String? charName,
+    String? userName,
     // Explicit budget for a batched run: the group's summed token budget and
     // minimum temperature. Non-null wins over both the global override and the
     // agent spec's own values — an agent carries none of its own (§4).
@@ -95,6 +97,8 @@ class AgentRunner {
         preResolvedConfig: preResolvedConfig,
         apiConfigId: apiConfigId,
         turnConfig: turnConfig,
+        charName: charName,
+        userName: userName,
         batchMaxTokens: batchMaxTokens,
         batchTemperature: batchTemperature,
         onFinalResponseUpdate: onFinalResponseUpdate,
@@ -130,6 +134,8 @@ class AgentRunner {
     ResolvedAgentConfig? preResolvedConfig,
     String? apiConfigId,
     StudioTurnConfigSnapshot? turnConfig,
+    String? charName,
+    String? userName,
     int? batchMaxTokens,
     double? batchTemperature,
     void Function(String text, String? reasoning)? onFinalResponseUpdate,
@@ -230,7 +236,8 @@ class AgentRunner {
                 : studio.studioControllerRequestReasoningOverride
                 ? studio.studioControllerRequestReasoning
                 : null,
-            showNativeReasoning: studio.studioControllerShowNativeReasoningOverride
+            showNativeReasoning:
+                studio.studioControllerShowNativeReasoningOverride
                 ? studio.studioControllerShowNativeReasoning
                 : null,
             omitReasoning: studio.studioControllerDisableReasoning
@@ -259,6 +266,8 @@ class AgentRunner {
       tagEnd: effectiveResolved.reasoningTagEnd,
       headerModel: isFinalResponse ? 'reasoning_model'.tr() : null,
       headerInline: isFinalResponse ? 'reasoning_inline'.tr() : null,
+      charName: charName,
+      userName: userName,
       onFinalResponseUpdate: onFinalResponseUpdate,
       onIntermediateUpdate: onIntermediateUpdate,
     );

--- a/lib/core/llm/agent_stream_runner.dart
+++ b/lib/core/llm/agent_stream_runner.dart
@@ -45,6 +45,8 @@ class AgentStreamRunner {
     String? tagEnd,
     String? headerModel,
     String? headerInline,
+    String? charName,
+    String? userName,
     void Function(String text, String? reasoning)? onFinalResponseUpdate,
     void Function(String text)? onIntermediateUpdate,
   }) async {
@@ -109,6 +111,8 @@ class AgentStreamRunner {
       cacheBreakpointMode: resolved.cacheBreakpointMode,
       sessionIdMode: resolved.sessionIdMode,
       promptPostProcessing: resolved.promptPostProcessing,
+      charName: charName,
+      userName: userName,
       extraRequestParameters: resolved.extraRequestParameters,
     );
     final transport = _pickTransport(resolved.protocol);

--- a/lib/core/llm/studio_agent_executor.dart
+++ b/lib/core/llm/studio_agent_executor.dart
@@ -110,6 +110,8 @@ class StudioAgentExecutor {
         cancelToken: cancelToken,
         apiConfigId: apiConfigId,
         turnConfig: turnConfig,
+        charName: context.macroContext.charName,
+        userName: context.macroContext.userName,
         onIntermediateUpdate: onIntermediateUpdate,
       );
       return StudioStageBrief(
@@ -188,6 +190,8 @@ class StudioAgentExecutor {
           cancelToken: cancelToken,
           apiConfigId: apiConfigId,
           turnConfig: turnConfig,
+          charName: context.macroContext.charName,
+          userName: context.macroContext.userName,
         );
         final text = result.text.trim();
         return StudioStageBrief(
@@ -305,6 +309,8 @@ class StudioAgentExecutor {
       cancelToken: cancelToken,
       apiConfigId: apiConfigId,
       turnConfig: turnConfig,
+      charName: context.macroContext.charName,
+      userName: context.macroContext.userName,
       onFinalResponseUpdate: onFinalResponseUpdate,
     );
   }

--- a/lib/core/llm/studio_batch_coordinator.dart
+++ b/lib/core/llm/studio_batch_coordinator.dart
@@ -110,6 +110,8 @@ class StudioBatchCoordinator {
           turnConfig: turnConfig,
           batchMaxTokens: group.batchMaxTokens,
           batchTemperature: group.batchTemperature,
+          charName: context.macroContext.charName,
+          userName: context.macroContext.userName,
         );
         final parsed = _batcher.parseBatchResponse(result.text, group);
         if (_allOk(parsed)) return parsed;

--- a/lib/core/llm/studio_ledger_reconciliation.dart
+++ b/lib/core/llm/studio_ledger_reconciliation.dart
@@ -28,7 +28,10 @@ class LedgerReconciliationPlan {
 }
 
 class LedgerReconciliationPlanner {
-  static const interval = 6;
+  /// Five newly accepted assistant turns are reviewed when the following
+  /// assistant turn is generated. The trigger itself is never part of the
+  /// review range.
+  static const acceptedAssistantsPerRun = 5;
   static const maxMessages = 20;
 
   const LedgerReconciliationPlanner();
@@ -51,6 +54,7 @@ class LedgerReconciliationPlanner {
     required List<ChatMessage> messages,
     required String currentAssistantMessageId,
     LedgerReconciliationCheckpoint? checkpoint,
+    String? previousEndMessageId,
   }) {
     final currentIndex = messages.indexWhere(
       (message) => message.id == currentAssistantMessageId,
@@ -61,20 +65,25 @@ class LedgerReconciliationPlanner {
         .take(currentIndex)
         .where(_isAcceptedAssistant)
         .toList(growable: false);
-    // Trigger once the Nth assistant has just been generated
-    // (N = interval, 2*interval, ...). acceptedAssistants holds a1..a(N-1);
-    // the freshly generated aN is the current message and is excluded from
-    // the review range so its brand-new snapshot cannot be rewritten. A
-    // reroll of aN produces the same boundary (a1..a(N-1)) and is
-    // deduplicated by the checkpoint; a(N+1) must never re-run or rewrite
-    // the older boundary.
-    if (acceptedAssistants.isEmpty ||
-        (acceptedAssistants.length + 1) % interval != 0) {
+    var previousAcceptedIndex = -1;
+    if (previousEndMessageId != null) {
+      previousAcceptedIndex = acceptedAssistants.indexWhere(
+        (message) => message.id == previousEndMessageId,
+      );
+      // A durable logical head that is no longer in the transcript must not
+      // silently reset cadence to the beginning.
+      if (previousAcceptedIndex < 0) return null;
+    }
+    final firstUnprocessed = previousAcceptedIndex + 1;
+    final unprocessedCount = acceptedAssistants.length - firstUnprocessed;
+    if (unprocessedCount < acceptedAssistantsPerRun) {
       return null;
     }
 
+    final endAssistant =
+        acceptedAssistants[firstUnprocessed + acceptedAssistantsPerRun - 1];
     final endIndex = messages.indexWhere(
-      (message) => message.id == acceptedAssistants.last.id,
+      (message) => message.id == endAssistant.id,
     );
     final plan = _buildPlan(messages: messages, endIndex: endIndex);
     if (plan == null) return null;

--- a/lib/core/llm/transport/chat_transport_request.dart
+++ b/lib/core/llm/transport/chat_transport_request.dart
@@ -65,6 +65,11 @@ class ChatTransportRequest {
   /// transports themselves always see already-processed messages.
   final String promptPostProcessing;
 
+  /// Effective chat speaker names used by SillyTavern `single` processing.
+  /// Request metadata only: transports do not serialize these as message names.
+  final String? charName;
+  final String? userName;
+
   /// Optional tool definitions for native tool-call support (OpenAI format).
   /// When non-null, the request includes `tools` and `tool_choice` in the body.
   /// Transports that don't support tools will ignore this field.
@@ -92,7 +97,8 @@ class ChatTransportRequest {
       sessionId != null &&
       sessionId!.isNotEmpty &&
       (sessionIdMode == 'always' ||
-          (sessionIdMode == 'openrouter' && endpoint.contains('openrouter.ai')));
+          (sessionIdMode == 'openrouter' &&
+              endpoint.contains('openrouter.ai')));
 
   const ChatTransportRequest({
     required this.endpoint,
@@ -124,6 +130,8 @@ class ChatTransportRequest {
     this.cacheBreakpointMode = 'depth',
     this.sessionIdMode = 'openrouter',
     this.promptPostProcessing = 'none',
+    this.charName,
+    this.userName,
     this.tools,
     this.toolChoice,
     this.useSystemInstruction = true,
@@ -142,6 +150,8 @@ class ChatTransportRequest {
     List<Map<String, dynamic>>? previousMessages,
     List<Map<String, dynamic>>? tools,
     String? toolChoice,
+    String? charName,
+    String? userName,
   }) => ChatTransportRequest(
     endpoint: apiConfig.endpoint,
     apiKey: apiConfig.apiKey,
@@ -172,6 +182,8 @@ class ChatTransportRequest {
     cacheBreakpointMode: apiConfig.cacheBreakpointMode,
     sessionIdMode: apiConfig.sessionIdMode,
     promptPostProcessing: apiConfig.promptPostProcessing,
+    charName: charName,
+    userName: userName,
     tools: tools,
     toolChoice: toolChoice,
     useSystemInstruction: apiConfig.useSystemInstruction,
@@ -214,6 +226,8 @@ class ChatTransportRequest {
     cacheBreakpointMode: cacheBreakpointMode,
     sessionIdMode: sessionIdMode,
     promptPostProcessing: 'none',
+    charName: charName,
+    userName: userName,
     tools: tools,
     toolChoice: toolChoice,
     useSystemInstruction: useSystemInstruction,

--- a/lib/core/llm/transport/openrouter_chat_transport.dart
+++ b/lib/core/llm/transport/openrouter_chat_transport.dart
@@ -108,6 +108,8 @@ class OpenRouterChatTransport implements ChatTransport {
       // top-level `cache_control` field. Cache markers are now on the
       // message parts via the helpers above.
       cacheControlTtl: 'off',
+      charName: input.charName,
+      userName: input.userName,
       extraRequestParameters: input.extraRequestParameters,
     );
   }

--- a/lib/core/llm/transport/post_processing_chat_transport.dart
+++ b/lib/core/llm/transport/post_processing_chat_transport.dart
@@ -50,10 +50,20 @@ class PostProcessingChatTransport implements ChatTransport {
     final mode = PromptPostProcessing.normalize(request.promptPostProcessing);
     if (mode == PromptPostProcessing.none) return request;
     return request.withMessages(
-      postProcessPrompt(request.messages, mode),
+      postProcessPrompt(
+        request.messages,
+        mode,
+        charName: request.charName,
+        userName: request.userName,
+      ),
       previousMessages: request.previousMessages == null
           ? null
-          : postProcessPrompt(request.previousMessages!, mode),
+          : postProcessPrompt(
+              request.previousMessages!,
+              mode,
+              charName: request.charName,
+              userName: request.userName,
+            ),
     );
   }
 

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -108,7 +108,19 @@ class AutomatedCardEvolutionService {
     }
     final sessionId = reconciliationRun.sessionId;
     final active = _inFlight[sessionId];
-    if (active != null) return active;
+    if (active != null) {
+      // Do not silently absorb a newer reconciliation while the previous
+      // collector is running. Re-enter after it finishes; the durable backlog
+      // makes this idempotent when the newer callback names the same head.
+      return () async {
+        try {
+          await active;
+        } catch (_) {
+          // A failed active attempt must not discard the newer durable head.
+        }
+        return runAfterReconciliation(reconciliationRun, onStage: onStage);
+      }();
+    }
     final future = _runAutomatic(reconciliationRun, onStage: onStage);
     _inFlight[sessionId] = future;
     return future.whenComplete(() => _inFlight.remove(sessionId));
@@ -118,9 +130,15 @@ class AutomatedCardEvolutionService {
     LedgerReconciliationSuccessfulRunRow reconciliationRun, {
     void Function(AutomatedCardEvolutionStage stage)? onStage,
   }) async {
-    final collector = await _runCollector(reconciliationRun, onStage: onStage);
-    if (!collector) {
-      return const CardEvolutionFinalizeOutcome('collectorUnavailable');
+    final pending = await collectorRunRepo.pendingValidRuns(
+      reconciliationRun.sessionId,
+      currentRun: reconciliationRun,
+    );
+    for (final run in pending) {
+      final collected = await _runCollector(run, onStage: onStage);
+      if (!collected) {
+        return const CardEvolutionFinalizeOutcome('collectorUnavailable');
+      }
     }
     final delivered = await collectorRunRepo.latestDeliveredWriterBoundary(
       reconciliationRun.sessionId,
@@ -382,17 +400,19 @@ class AutomatedCardEvolutionService {
         sessionId,
         snapshot,
         claim.row!.collectorOrdinal,
+        finalize: (output, applyEffects) =>
+            collectorRunRepo.completeWithEffects(
+              id: claimId!,
+              ownerId: ownerId!,
+              modelOutputHash: computeHash(output),
+              now: currentTimestampSeconds(),
+              applyEffects: applyEffects,
+            ),
       );
       if (output == null) return false;
       await _checkPromotions(sessionId);
-      final completed = await collectorRunRepo.complete(
-        id: claimId,
-        ownerId: ownerId,
-        modelOutputHash: computeHash(output),
-        now: currentTimestampSeconds(),
-      );
-      if (completed) claimId = null;
-      return completed;
+      claimId = null;
+      return true;
     } catch (_) {
       return false;
     } finally {
@@ -405,8 +425,10 @@ class AutomatedCardEvolutionService {
   Future<String?> _runObservationPass(
     String sessionId,
     CardEvolutionObservationSnapshot snapshot,
-    int runOrdinal,
-  ) async {
+    int runOrdinal, {
+    Future<bool> Function(String output, Future<void> Function() applyEffects)?
+    finalize,
+  }) async {
     final config = await resolveModel();
     final activeMaps = _extractAccumulatedObservations(
       snapshot.selectedInputJson,
@@ -437,34 +459,46 @@ class AutomatedCardEvolutionService {
       if (validEvidenceIds == null) return null;
       final retrievalTargets = _retrievalTargets(snapshot.selectedInputJson);
       if (retrievalTargets == null) return null;
-      final now = currentTimestampSeconds();
-      for (final action in actions) {
-        if (!validEvidenceIds.containsAll(action.evidenceMessageIds)) continue;
-        if (!retrievalTargets.keys.toSet().containsAll(action.retrievalKeys)) {
-          continue;
+      Future<void> applyEffects() async {
+        final now = currentTimestampSeconds();
+        for (final action in actions) {
+          if (!validEvidenceIds.containsAll(action.evidenceMessageIds)) {
+            continue;
+          }
+          if (!retrievalTargets.keys.toSet().containsAll(
+            action.retrievalKeys,
+          )) {
+            continue;
+          }
+          final loreIdentity = action.lorebookEntryId;
+          final hasExactLoreTarget =
+              loreIdentity != null &&
+              action.retrievalKeys.contains(loreIdentity) &&
+              retrievalTargets[loreIdentity] == 'injected_lorebook_entry';
+          if ((action.targetKind == 'injected_lorebook_entry' &&
+                  !hasExactLoreTarget) ||
+              (action.targetKind == 'main_character_card' &&
+                  (loreIdentity != null ||
+                      action.retrievalKeys.any(
+                        (key) =>
+                            retrievalTargets[key] == 'injected_lorebook_entry',
+                      )))) {
+            continue;
+          }
+          await _applyObservationAction(
+            sessionId: sessionId,
+            characterId: snapshot.character.id,
+            runOrdinal: runOrdinal,
+            now: now,
+            action: action,
+          );
         }
-        final loreIdentity = action.lorebookEntryId;
-        final hasExactLoreTarget =
-            loreIdentity != null &&
-            action.retrievalKeys.contains(loreIdentity) &&
-            retrievalTargets[loreIdentity] == 'injected_lorebook_entry';
-        if ((action.targetKind == 'injected_lorebook_entry' &&
-                !hasExactLoreTarget) ||
-            (action.targetKind == 'main_character_card' &&
-                (loreIdentity != null ||
-                    action.retrievalKeys.any(
-                      (key) =>
-                          retrievalTargets[key] == 'injected_lorebook_entry',
-                    )))) {
-          continue;
-        }
-        await _applyObservationAction(
-          sessionId: sessionId,
-          characterId: snapshot.character.id,
-          runOrdinal: runOrdinal,
-          now: now,
-          action: action,
-        );
+      }
+
+      if (finalize != null) {
+        if (!await finalize(outcome.text!, applyEffects)) return null;
+      } else {
+        await applyEffects();
       }
       return outcome.text;
     } finally {

--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -132,6 +132,10 @@ class ChatMessageService {
         .map((message) => message.id)
         .where((id) => id.isNotEmpty)
         .toSet();
+    final deletedMessageIds = validIndices
+        .map((index) => session.messages[index].id)
+        .where((id) => id.isNotEmpty)
+        .toSet();
     final newMessages = <ChatMessage>[
       for (var i = 0; i < session.messages.length; i++)
         if (!validIndices.contains(i)) session.messages[i],
@@ -155,6 +159,7 @@ class ChatMessageService {
       deletedIndices: validIndices,
       earliestDeletedIndex: earliestDeletedIndex,
       invalidatedMessageIds: invalidatedMessageIds,
+      deletedMessageIds: deletedMessageIds,
     );
   }
 
@@ -201,6 +206,14 @@ class ChatMessageService {
         session.id,
         invalidatedMessageIds,
       );
+      await _ref
+          .read(ledgerReconciliationRunRepoProvider)
+          .invalidateForMessageMutation(
+            sessionId: session.id,
+            messageIds: plan.deletedMessageIds,
+            reason: 'message_deleted',
+            createdAt: currentTimestampSeconds(),
+          );
       await knowledgeRepo.retractForMessages(session.id, invalidatedMessageIds);
       await memoryBookRepo.deleteForMessages(session.id, invalidatedMessageIds);
       await snapshotRepo.deleteForMessages(session.id, invalidatedMessageIds);
@@ -521,6 +534,14 @@ class ChatMessageService {
           ..[messageIndex] = replacement,
         updatedAt: currentTimestampSeconds(),
       );
+      await _ref
+          .read(ledgerReconciliationRunRepoProvider)
+          .invalidateForMessageMutation(
+            sessionId: session.id,
+            messageIds: {messageId},
+            reason: 'variation_deleted',
+            createdAt: currentTimestampSeconds(),
+          );
 
       if (!removeAgentSwipe) {
         // Manifest anchors are immutable. Green-index compaction would make
@@ -1018,7 +1039,7 @@ class ChatMessageService {
     }
     final messageId = snapshot.messages[messageIndex].id;
     final repo = _ref.read(chatRepoProvider);
-    final durable = await repo.mutateMessages(
+    final durable = await repo.mutateMessagesWithBeforeWrite(
       sessionId: snapshot.id,
       updatedAt: currentTimestampSeconds(),
       mutate: (messages) {
@@ -1027,6 +1048,7 @@ class ChatMessageService {
         final latest = snapshot.copyWith(messages: messages);
         return mutate(latest, latestIndex).messages;
       },
+      beforeWrite: _invalidateChangedReconciliationAnchors,
     );
     if (durable == null) return snapshot;
     ChatSessionService.updateCache(durable);
@@ -1039,16 +1061,62 @@ class ChatMessageService {
     ChatSession Function(ChatSession latest) mutate,
   ) async {
     final repo = _ref.read(chatRepoProvider);
-    final durable = await repo.mutateMessages(
+    final durable = await repo.mutateMessagesWithBeforeWrite(
       sessionId: snapshot.id,
       updatedAt: currentTimestampSeconds(),
       mutate: (messages) =>
           mutate(snapshot.copyWith(messages: messages)).messages,
+      beforeWrite: _invalidateChangedReconciliationAnchors,
     );
     if (durable == null) return snapshot;
     ChatSessionService.updateCache(durable);
     return durable;
   }
+
+  Future<void> _invalidateChangedReconciliationAnchors(
+    ChatSession before,
+    ChatSession after,
+  ) async {
+    final beforeById = {
+      for (final message in before.messages) message.id: message,
+    };
+    final afterById = {
+      for (final message in after.messages) message.id: message,
+    };
+    final beforeIndexById = {
+      for (final entry in before.messages.indexed) entry.$2.id: entry.$1,
+    };
+    final afterIndexById = {
+      for (final entry in after.messages.indexed) entry.$2.id: entry.$1,
+    };
+    final changedIds = <String>{};
+    for (final entry in beforeById.entries) {
+      final next = afterById[entry.key];
+      if (next == null ||
+          beforeIndexById[entry.key] != afterIndexById[entry.key] ||
+          !_sameReconciliationEvidence(entry.value, next)) {
+        if (entry.key.isNotEmpty) changedIds.add(entry.key);
+      }
+    }
+    if (changedIds.isEmpty) return;
+    await _ref
+        .read(ledgerReconciliationRunRepoProvider)
+        .invalidateForMessageMutation(
+          sessionId: before.id,
+          messageIds: changedIds,
+          reason: 'message_evidence_changed',
+          createdAt: currentTimestampSeconds(),
+        );
+  }
+
+  static bool _sameReconciliationEvidence(ChatMessage a, ChatMessage b) =>
+      a.role == b.role &&
+      a.content == b.content &&
+      a.swipeId == b.swipeId &&
+      a.agentSwipeId == b.agentSwipeId &&
+      a.isHidden == b.isHidden &&
+      a.isError == b.isError &&
+      a.isTyping == b.isTyping;
 }
 
 /// Everything a message deletion needs, computed synchronously by
@@ -1074,11 +1142,17 @@ class MessageDeletionPlan {
   /// facts and ext blocks anchored to these ids no longer describe the chat.
   final Set<String> invalidatedMessageIds;
 
+  /// Only physically deleted messages. Reconciliation invalidation matches
+  /// these against immutable anchors; the wider causal suffix is used by the
+  /// mutable Ledger/memory rollback only.
+  final Set<String> deletedMessageIds;
+
   const MessageDeletionPlan({
     required this.session,
     required this.deletedIndices,
     required this.earliestDeletedIndex,
     required this.invalidatedMessageIds,
+    required this.deletedMessageIds,
   });
 }
 

--- a/lib/features/chat/chat_provider.dart
+++ b/lib/features/chat/chat_provider.dart
@@ -74,6 +74,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
   final String arg;
   bool _buildComplete = false;
   bool _sendInFlight = false;
+  int _sessionChangesInFlight = 0;
 
   /// Reflects the active session's generation state into
   /// [generatingSessionsProvider]. Called on every state transition; membership
@@ -346,34 +347,109 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       _swipeCtrl.setGreeting(messageIndex, direction);
 
   Future<void> switchSession(int sessionIndex) =>
-      _sessionCtrl.switchSession(sessionIndex);
+      _runSessionChange(() => _sessionCtrl.switchSession(sessionIndex));
 
-  Future<void> createNewSession() => _sessionCtrl.createNewSession();
+  Future<void> createNewSession() =>
+      _runSessionChange(_sessionCtrl.createNewSession);
 
   Future<List<ChatSession>> getSessions() => _sessionCtrl.getSessions();
 
-  Future<void> branchSession(int index) => _sessionCtrl.branchSession(index);
+  Future<void> branchSession(int index) =>
+      _runSessionChange(() => _sessionCtrl.branchSession(index));
 
-  Future<void> newSession() => _sessionCtrl.createNewSession();
+  Future<void> newSession() => _runSessionChange(_sessionCtrl.createNewSession);
+
+  Future<void> _runSessionChange(Future<void> Function() operation) async {
+    _sessionChangesInFlight++;
+    try {
+      await operation();
+    } finally {
+      _sessionChangesInFlight--;
+    }
+  }
 
   Future<void> saveDraft(String draftText) => _draftCtrl.saveDraft(draftText);
+
+  /// Starts a send only when this notifier can take ownership immediately and
+  /// resolves true after the user message is durably appended. UI callers keep
+  /// the composer intact on a busy guard or persistence failure.
+  Future<bool> trySendMessage(
+    String text, {
+    String? guidanceText,
+    String? imageDataUrl,
+  }) {
+    if (!ref.mounted ||
+        _sendInFlight ||
+        _sessionChangesInFlight > 0 ||
+        ref.read(editingMessageIdProvider(arg)) != null) {
+      return Future.value(false);
+    }
+    final current = state.value;
+    if (current == null ||
+        current.isGenerating ||
+        current.isGeneratingImage ||
+        current.isPostGenRunning ||
+        _isMemoryDraftActive(current)) {
+      return Future.value(false);
+    }
+
+    final durableAcceptance = Completer<bool>();
+    unawaited(
+      _sendMessage(
+        text,
+        guidanceText: guidanceText,
+        imageDataUrl: imageDataUrl,
+        durableAcceptance: durableAcceptance,
+      ).catchError((Object error, StackTrace stackTrace) {
+        debugPrint('[ChatNotifier] accepted send failed: $error\n$stackTrace');
+        if (!durableAcceptance.isCompleted) {
+          durableAcceptance.complete(false);
+        }
+      }),
+    );
+    return durableAcceptance.future;
+  }
 
   Future<void> sendMessage(
     String text, {
     String? guidanceText,
     String? imageDataUrl,
+  }) => _sendMessage(
+    text,
+    guidanceText: guidanceText,
+    imageDataUrl: imageDataUrl,
+  );
+
+  Future<void> _sendMessage(
+    String text, {
+    String? guidanceText,
+    String? imageDataUrl,
+    Completer<bool>? durableAcceptance,
   }) async {
-    if (!ref.mounted) return;
-    if (_sendInFlight) return;
-    if (ref.read(editingMessageIdProvider(arg)) != null) return;
+    if (!ref.mounted) {
+      durableAcceptance?.complete(false);
+      return;
+    }
+    if (_sendInFlight) {
+      durableAcceptance?.complete(false);
+      return;
+    }
+    if (ref.read(editingMessageIdProvider(arg)) != null) {
+      durableAcceptance?.complete(false);
+      return;
+    }
     final current = state.value;
     if (current == null ||
         current.isGenerating ||
         current.isGeneratingImage ||
         current.isPostGenRunning) {
+      durableAcceptance?.complete(false);
       return;
     }
-    if (_isMemoryDraftActive(current)) return;
+    if (_isMemoryDraftActive(current)) {
+      durableAcceptance?.complete(false);
+      return;
+    }
     _sendInFlight = true;
 
     try {
@@ -432,6 +508,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         // The session row is gone — roll the optimistic append back.
         state = AsyncData(current);
         return;
+      }
+      if (durableAcceptance != null && !durableAcceptance.isCompleted) {
+        durableAcceptance.complete(true);
       }
       // Commit the exact visible green/blue swipe, never whichever Ledger call
       // happened to finish most recently.
@@ -524,6 +603,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         }
       }
     } finally {
+      if (durableAcceptance != null && !durableAcceptance.isCompleted) {
+        durableAcceptance.complete(false);
+      }
       _sendInFlight = false;
     }
   }

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -473,8 +473,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
                 ),
                 if (awaitingTargetSession)
                   const Positioned.fill(
-                    child: IgnorePointer(
-                      child: Center(child: GlazeSpinner()),
+                    child: AbsorbPointer(
+                      child: ColoredBox(
+                        color: Colors.transparent,
+                        child: Center(child: GlazeSpinner()),
+                      ),
                     ),
                   ),
               ],
@@ -1854,6 +1857,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                           widget.state.messages,
                                         );
                                     return ChatInputBar(
+                                      key: ValueKey(widget.state.session?.id),
                                       focusNode: widget.drawerCtrl.inputFocus,
                                       initialDraft:
                                           widget.state.session?.draft ?? '',
@@ -1933,48 +1937,66 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                       canSend: () =>
                                           _ensurePersonaSelected() &&
                                           _ensureApiSelected(),
-                                      onSend: (text) {
-                                        if (text.trim().isEmpty) return;
-                                        _webViewStateKey.currentState
-                                            ?.requestScrollToBottomOnAppend();
-                                        ref
+                                      onSend: (text) async {
+                                        if (text.trim().isEmpty) {
+                                          return false;
+                                        }
+                                        final accepted = await ref
                                             .read(
                                               chatProvider(
                                                 widget.charId,
                                               ).notifier,
                                             )
-                                            .sendMessage(text);
+                                            .trySendMessage(text);
+                                        if (accepted) {
+                                          await _webViewStateKey.currentState
+                                              ?.requestScrollToBottomOnAppend();
+                                        }
+                                        return accepted;
                                       },
-                                      onSendWithGuidance: (text, guidance) {
-                                        if (text.trim().isEmpty) return;
-                                        _webViewStateKey.currentState
-                                            ?.requestScrollToBottomOnAppend();
-                                        ref
+                                      onSendWithGuidance: (text, guidance) async {
+                                        if (text.trim().isEmpty) {
+                                          return false;
+                                        }
+                                        final accepted = await ref
                                             .read(
                                               chatProvider(
                                                 widget.charId,
                                               ).notifier,
                                             )
-                                            .sendMessage(
+                                            .trySendMessage(
                                               text,
                                               guidanceText: guidance,
                                             );
+                                        if (accepted) {
+                                          await _webViewStateKey.currentState
+                                              ?.requestScrollToBottomOnAppend();
+                                        }
+                                        return accepted;
                                       },
                                       onSendWithImage:
-                                          (text, guidanceText, imageDataUrl) {
-                                            _webViewStateKey.currentState
-                                                ?.requestScrollToBottomOnAppend();
-                                            ref
+                                          (
+                                            text,
+                                            guidanceText,
+                                            imageDataUrl,
+                                          ) async {
+                                            final accepted = await ref
                                                 .read(
                                                   chatProvider(
                                                     widget.charId,
                                                   ).notifier,
                                                 )
-                                                .sendMessage(
+                                                .trySendMessage(
                                                   text,
                                                   guidanceText: guidanceText,
                                                   imageDataUrl: imageDataUrl,
                                                 );
+                                            if (accepted) {
+                                              await _webViewStateKey
+                                                  .currentState
+                                                  ?.requestScrollToBottomOnAppend();
+                                            }
+                                            return accepted;
                                           },
                                       isGenerating: widget.state.isGenerating,
                                       isGeneratingImage:

--- a/lib/features/chat/controllers/chat_draft_controller.dart
+++ b/lib/features/chat/controllers/chat_draft_controller.dart
@@ -9,6 +9,8 @@ class ChatDraftController {
   final void Function(AsyncValue<ChatState>) _setState;
   final AsyncValue<ChatState> Function() _getState;
 
+  int _saveEpoch = 0;
+
   ChatDraftController({
     required this._ref,
     required this._setState,
@@ -21,19 +23,31 @@ class ChatDraftController {
     if (current == null || current.session == null) return;
     if (current.session!.draft == draftText) return;
 
+    final sessionId = current.session!.id;
+    final expectedMessageCount = current.session!.messages.length;
+    final epoch = ++_saveEpoch;
     final updatedSession = await _ref
         .read(chatRepoProvider)
         .updateDraftIfMessageCount(
-          sessionId: current.session!.id,
+          sessionId: sessionId,
           draft: draftText,
-          expectedMessageCount: current.session!.messages.length,
+          expectedMessageCount: expectedMessageCount,
         );
     if (!_ref.mounted) return;
+    if (epoch != _saveEpoch) return;
     if (updatedSession == null) return;
-    ChatSessionService.updateCache(updatedSession);
-    final latest = _getState().value ?? current;
-    _setState(
-      AsyncData(latest.copyWith(session: updatedSession)),
+    final latest = _getState().value;
+    // A draft completion belongs only to the exact session snapshot that
+    // started it. Never let a delayed debounce switch the UI back to an old
+    // session or replace a newer optimistic/durable message list.
+    if (latest?.session?.id != sessionId ||
+        latest!.session!.messages.length != expectedMessageCount) {
+      return;
+    }
+    final sessionWithDraft = latest.session!.copyWith(
+      draft: updatedSession.draft,
     );
+    ChatSessionService.updateCache(sessionWithDraft);
+    _setState(AsyncData(latest.copyWith(session: sessionWithDraft)));
   }
 }

--- a/lib/features/chat/controllers/chat_session_controller.dart
+++ b/lib/features/chat/controllers/chat_session_controller.dart
@@ -45,12 +45,13 @@ class ChatSessionController {
       _setState(
         AsyncData(ChatState(session: session, visibleStartIndex: start)),
       );
-    } catch (_) {
+    } catch (error, stackTrace) {
       if (epoch != _switchEpoch) return;
       final current = _getState().value;
       if (current != null) {
         _setState(AsyncData(current));
       }
+      Error.throwWithStackTrace(error, stackTrace);
     }
   }
 

--- a/lib/features/chat/services/impersonation_service.dart
+++ b/lib/features/chat/services/impersonation_service.dart
@@ -171,6 +171,8 @@ class ImpersonationService {
         apiConfig,
         messages: apiMessages,
         sessionId: session.id,
+        charName: character?.name ?? 'Character',
+        userName: persona?.name ?? 'User',
       ),
       cancelToken: cancelToken,
       onUpdate: (delta, reasoningDelta) {

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -213,10 +213,15 @@ class LedgerStage {
           ledgerReconciliationCheckpointRepoProvider,
         );
         final checkpoint = await checkpointRepo.get(sessionId);
+        final reconciliationRunRepo = ctx.ref.read(
+          ledgerReconciliationRunRepoProvider,
+        );
+        final previousRunHead = await reconciliationRunRepo.getHead(sessionId);
         final plan = const LedgerReconciliationPlanner().plan(
           messages: messages,
           currentAssistantMessageId: targetMessage.id,
           checkpoint: checkpoint,
+          previousEndMessageId: previousRunHead?.endMessageId,
         );
         if (plan != null && isCurrent()) {
           await _recordReconciliationDiag(
@@ -291,9 +296,7 @@ class LedgerStage {
           if (reconciliationResult.status == 'ok' &&
               pipeline.cardRewriter.enabled &&
               isCurrent()) {
-            final runHead = await ctx.ref
-                .read(ledgerReconciliationRunRepoProvider)
-                .getHead(sessionId);
+            final runHead = await reconciliationRunRepo.getHead(sessionId);
             if (runHead != null && isCurrent()) {
               final rewriteReviewAuthority =
                   captureAutomaticRewriteReviewAuthority(

--- a/lib/features/chat/services/stream_generation_service.dart
+++ b/lib/features/chat/services/stream_generation_service.dart
@@ -519,6 +519,8 @@ class StreamGenerationService {
           messages: apiMessages,
           sessionId: session.id,
           previousMessages: previousApiMessages,
+          charName: inputs.character.name,
+          userName: inputs.persona?.name ?? 'User',
         ),
         cancelToken: cancelToken,
         onUpdate: (delta, reasoningDelta) {

--- a/lib/features/chat/widgets/chat_input_bar.dart
+++ b/lib/features/chat/widgets/chat_input_bar.dart
@@ -26,14 +26,17 @@ Border _uiBorder(BuildContext context, ThemePreset preset) {
 }
 
 class ChatInputBar extends ConsumerStatefulWidget {
-  final ValueChanged<String> onSend;
+  /// Returns true only when the host accepted ownership of the send. The
+  /// composer is cleared only in that case.
+  final Future<bool> Function(String text) onSend;
 
   /// Guard invoked right before a send is dispatched. When it returns false the
   /// send is aborted and the composed text/image are kept intact so the host
   /// can show a prerequisite modal (e.g. "no provider selected") without losing
   /// what the user typed. When null, sending is always allowed.
   final bool Function()? canSend;
-  final void Function(String text, String? guidance)? onSendWithGuidance;
+  final Future<bool> Function(String text, String? guidance)?
+  onSendWithGuidance;
   final bool isGenerating;
   final bool isGeneratingImage;
 
@@ -43,7 +46,11 @@ class ChatInputBar extends ConsumerStatefulWidget {
   final bool isPostGenRunning;
   final VoidCallback? onStop;
   final VoidCallback? onMagicDrawer;
-  final void Function(String text, String? guidanceText, String imageDataUrl)?
+  final Future<bool> Function(
+    String text,
+    String? guidanceText,
+    String imageDataUrl,
+  )?
   onSendWithImage;
   final VoidCallback? onFullScreen;
   final VoidCallback? onQuickReplies;
@@ -147,6 +154,7 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
   /// locked and draft persistence is paused so the streamed text is not saved
   /// as the user's draft.
   bool _isImpersonating = false;
+  bool _isDispatchingSend = false;
 
   @override
   void initState() {
@@ -296,8 +304,8 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
     });
   }
 
-  void _handleSend() {
-    if (widget.isEditingMessage) return;
+  Future<void> _handleSend() async {
+    if (widget.isEditingMessage || _isDispatchingSend) return;
     final text = _controller.text;
     final hasImage = _attachedImageDataUrl != null;
     if (text.trim().isEmpty && !hasImage) return;
@@ -305,17 +313,36 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
     // and image so nothing is lost while the host shows its modal.
     if (widget.canSend != null && !widget.canSend!()) return;
     final imageDataUrl = _attachedImageDataUrl;
-    if (imageDataUrl != null) {
-      final guidance =
-          _guidanceMode && _guidanceController.text.trim().isNotEmpty
-          ? _guidanceController.text.trim()
-          : null;
-      widget.onSendWithImage?.call(text, guidance, imageDataUrl);
-    } else if (_guidanceMode && _guidanceController.text.trim().isNotEmpty) {
-      widget.onSendWithGuidance?.call(text, _guidanceController.text.trim());
-    } else {
-      if (text.trim().isEmpty) return;
-      widget.onSend(text);
+    _isDispatchingSend = true;
+    bool accepted;
+    try {
+      if (imageDataUrl != null) {
+        final guidance =
+            _guidanceMode && _guidanceController.text.trim().isNotEmpty
+            ? _guidanceController.text.trim()
+            : null;
+        accepted =
+            await widget.onSendWithImage?.call(text, guidance, imageDataUrl) ??
+            false;
+      } else if (_guidanceMode && _guidanceController.text.trim().isNotEmpty) {
+        accepted =
+            await widget.onSendWithGuidance?.call(
+              text,
+              _guidanceController.text.trim(),
+            ) ??
+            false;
+      } else {
+        if (text.trim().isEmpty) return;
+        accepted = await widget.onSend(text);
+      }
+    } finally {
+      _isDispatchingSend = false;
+    }
+    if (!mounted || !accepted) return;
+    // The user may edit the composer while the durable write is pending. Clear
+    // only the exact payload that was accepted, never newer text.
+    if (_controller.text != text || _attachedImageDataUrl != imageDataUrl) {
+      return;
     }
     _controller.clear();
     _guidanceController.clear();

--- a/lib/features/chat/widgets/magic_drawer.dart
+++ b/lib/features/chat/widgets/magic_drawer.dart
@@ -630,9 +630,20 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
             ?.session
             ?.sessionIndex;
         if (target == current) return;
-        await ref
-            .read(chatProvider(widget.charId).notifier)
-            .switchSession(target);
+        try {
+          await ref
+              .read(chatProvider(widget.charId).notifier)
+              .switchSession(target)
+              .timeout(const Duration(seconds: 30));
+        } catch (error) {
+          if (mounted) {
+            GlazeErrorDialog.show(
+              context,
+              error,
+              prefix: 'Failed to switch chat session',
+            );
+          }
+        }
       case SessionPickerAction.newSession:
         await ref.read(chatProvider(widget.charId).notifier).newSession();
       case SessionPickerAction.importChat:

--- a/lib/features/chat/widgets/prompt_preview_screen.dart
+++ b/lib/features/chat/widgets/prompt_preview_screen.dart
@@ -60,6 +60,8 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
   PromptResult? _result;
   ApiConfig? _apiConfig;
   String? _sessionId;
+  String? _charName;
+  String? _userName;
   Map<String, dynamic>? _requestBody;
   bool _loading = true;
   _SectionFilter _filter = _SectionFilter.all;
@@ -90,6 +92,8 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
       );
       _apiConfig = payload.apiConfig;
       _sessionId = session.id;
+      _charName = payload.character.name;
+      _userName = payload.persona?.name ?? 'User';
 
       final result = await buildPromptInIsolate(
         payload,
@@ -547,36 +551,12 @@ class _PromptPreviewScreenState extends ConsumerState<PromptPreviewScreen> {
       // preview builds bodies directly, so it applies the same pass itself —
       // otherwise the preview would show an unmerged prompt.
       final request = PostProcessingChatTransport.applyTo(
-        ChatTransportRequest(
-          endpoint: cfg.endpoint,
-          apiKey: cfg.apiKey,
-          model: cfg.model,
+        ChatTransportRequest.fromApiConfig(
+          cfg,
           messages: apiMessages,
-          maxTokens: cfg.maxTokens,
-          temperature: cfg.temperature,
-          topP: cfg.topP,
-          topK: cfg.topK,
-          frequencyPenalty: cfg.frequencyPenalty,
-          presencePenalty: cfg.presencePenalty,
-          stream: cfg.stream,
-          requestReasoning: cfg.requestReasoning,
-          useResponsesApi: cfg.useResponsesApi,
-          reasoningEffort: cfg.reasoningEffort,
-          omitTemperature: cfg.omitTemperature,
-          omitTopP: cfg.omitTopP,
-          omitTopK: cfg.omitTopK,
-          omitFrequencyPenalty: cfg.omitFrequencyPenalty,
-          omitPresencePenalty: cfg.omitPresencePenalty,
-          omitReasoning: cfg.omitReasoning,
-          omitReasoningEffort: cfg.omitReasoningEffort,
-          showNativeReasoning: cfg.showNativeReasoning,
           sessionId: _sessionId,
-          cacheControlTtl: cfg.cacheControlTtl,
-          cacheBreakpointMode: cfg.cacheBreakpointMode,
-          sessionIdMode: cfg.sessionIdMode,
-          promptPostProcessing: cfg.promptPostProcessing,
-          useSystemInstruction: cfg.useSystemInstruction,
-          extraRequestParameters: cfg.extraRequestParameters,
+          charName: _charName,
+          userName: _userName,
         ),
       );
 

--- a/lib/features/extensions/services/info_block_service.dart
+++ b/lib/features/extensions/services/info_block_service.dart
@@ -169,6 +169,8 @@ class InfoBlockService {
         apiConfig: apiConfig,
         blockConfig: blockConfig,
         requestMessages: assembly.messages,
+        charName: character?.name,
+        userName: personaModel?.name ?? persona ?? 'User',
         cancelToken: cancelToken,
         onStreamUpdate: onStreamUpdate,
       );
@@ -478,6 +480,8 @@ class InfoBlockService {
     required ApiConfig apiConfig,
     required BlockConfig blockConfig,
     required List<Map<String, dynamic>> requestMessages,
+    required String? charName,
+    required String userName,
     CancelToken? cancelToken,
     void Function(String accumulated)? onStreamUpdate,
   }) async {
@@ -496,6 +500,8 @@ class InfoBlockService {
               : apiConfig.model,
           messages: requestMessages,
           stream: useStream,
+          charName: charName,
+          userName: userName,
         ),
         cancelToken: cancelToken,
         onUpdate: useStream

--- a/lib/features/settings/theme_preview.dart
+++ b/lib/features/settings/theme_preview.dart
@@ -230,7 +230,7 @@ class _PreviewChatScene extends StatelessWidget {
           ChatInputBar(
             focusNode: FocusNode(canRequestFocus: false, skipTraversal: true),
             isGenerating: false,
-            onSend: (_) {},
+            onSend: (_) async => true,
             initialDraft: '',
           ),
         ],

--- a/test/agent_stream_runner_test.dart
+++ b/test/agent_stream_runner_test.dart
@@ -67,10 +67,14 @@ void main() {
         isFinalResponse: true,
         cancelToken: CancelToken(),
         timeoutMs: 100,
+        charName: 'Character',
+        userName: 'User',
       );
 
       expect(result.text, 'complete response');
       expect(transport.request?.receiveTimeoutMs, 0);
+      expect(transport.request?.charName, 'Character');
+      expect(transport.request?.userName, 'User');
     },
   );
 

--- a/test/characterization/session_switch_race_test.dart
+++ b/test/characterization/session_switch_race_test.dart
@@ -684,12 +684,12 @@ void main() {
 
       // Try to switch to a non-existent session (index 99).
       // switchToSession will throw StateError.
-      await ctrl.switchSession(99);
+      await expectLater(ctrl.switchSession(99), throwsA(isA<StateError>()));
 
-      // Catch block fires — restores the state to session 0.
-      // This is correct error recovery behavior.
+      // The active state stays intact, and the failure is propagated so the
+      // caller can show an error instead of reporting a successful switch.
       expect(box.value.value?.session?.sessionIndex, 0,
-          reason: 'Catch block restored session 0 after error');
+          reason: 'Session 0 remains active after the failed switch');
     });
 
     test('switch then createNewSession — only the new session writes state', () async {

--- a/test/chat_draft_controller_test.dart
+++ b/test/chat_draft_controller_test.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/chat_repo.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:glaze_flutter/features/chat/chat_state.dart';
+import 'package:glaze_flutter/features/chat/controllers/chat_draft_controller.dart';
+
+class _DelayedDraftRepo extends ChatRepo {
+  final Completer<void> started = Completer<void>();
+  final Completer<ChatSession?> completion = Completer<ChatSession?>();
+
+  _DelayedDraftRepo(super.db);
+
+  @override
+  Future<ChatSession?> updateDraftIfMessageCount({
+    required String sessionId,
+    required String draft,
+    required int expectedMessageCount,
+  }) {
+    if (!started.isCompleted) started.complete();
+    return completion.future;
+  }
+}
+
+void main() {
+  late AppDatabase db;
+  late _DelayedDraftRepo repo;
+  late ProviderContainer container;
+
+  const message = ChatMessage(
+    id: 'm1',
+    role: 'assistant',
+    content: 'hello',
+    timestamp: 1,
+  );
+  const sessionA = ChatSession(
+    id: 'a',
+    characterId: 'c1',
+    sessionIndex: 0,
+    messages: [message],
+  );
+  const sessionB = ChatSession(
+    id: 'b',
+    characterId: 'c1',
+    sessionIndex: 1,
+    messages: [message],
+  );
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = _DelayedDraftRepo(db);
+    container = ProviderContainer(
+      overrides: [chatRepoProvider.overrideWithValue(repo)],
+    );
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await db.close();
+  });
+
+  test(
+    'delayed draft completion cannot switch the active session back',
+    () async {
+      AsyncValue<ChatState> state = const AsyncData(
+        ChatState(session: sessionA),
+      );
+      final controller = ChatDraftController(
+        ref: container.read(Provider((ref) => ref)),
+        setState: (next) => state = next,
+        getState: () => state,
+      );
+
+      final pending = controller.saveDraft('draft A');
+      await repo.started.future;
+      state = const AsyncData(ChatState(session: sessionB));
+      repo.completion.complete(sessionA.copyWith(draft: 'draft A'));
+      await pending;
+
+      expect(state.value!.session!.id, 'b');
+    },
+  );
+
+  test('delayed draft completion cannot remove a newer message', () async {
+    AsyncValue<ChatState> state = const AsyncData(ChatState(session: sessionA));
+    final controller = ChatDraftController(
+      ref: container.read(Provider((ref) => ref)),
+      setState: (next) => state = next,
+      getState: () => state,
+    );
+
+    final pending = controller.saveDraft('draft A');
+    await repo.started.future;
+    state = AsyncData(
+      ChatState(
+        session: sessionA.copyWith(
+          messages: [
+            message,
+            const ChatMessage(
+              id: 'u1',
+              role: 'user',
+              content: 'new',
+              timestamp: 2,
+            ),
+          ],
+        ),
+      ),
+    );
+    repo.completion.complete(sessionA.copyWith(draft: 'draft A'));
+    await pending;
+
+    expect(state.value!.messages.map((item) => item.id), ['m1', 'u1']);
+  });
+}

--- a/test/chat_input_bar_test.dart
+++ b/test/chat_input_bar_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -22,13 +24,17 @@ void main() {
       String initialDraft = '',
       void Function(String? guidance)? onImpersonate,
       VoidCallback? onStop,
+      bool acceptSend = true,
     }) {
       sentMessages = [];
       return ProviderScope(
         child: MaterialApp(
           home: Scaffold(
             body: ChatInputBar(
-              onSend: (text) => sentMessages.add(text),
+              onSend: (text) async {
+                sentMessages.add(text);
+                return acceptSend;
+              },
               isGenerating: false,
               isGeneratingImage: isGeneratingImage,
               focusNode: focusNode,
@@ -119,6 +125,48 @@ void main() {
       await tester.tap(find.byIcon(Icons.send_rounded));
 
       expect(sentMessages, isEmpty);
+    });
+
+    testWidgets('rejected send keeps the composed text', (tester) async {
+      await tester.pumpWidget(
+        buildChatInputBar(initialDraft: 'keep me', acceptSend: false),
+      );
+
+      await tester.tap(find.byIcon(Icons.send_rounded));
+      await tester.pump();
+
+      expect(sentMessages, ['keep me']);
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.controller!.text, 'keep me');
+    });
+
+    testWidgets('pending send does not clear text before durable acceptance', (
+      tester,
+    ) async {
+      final accepted = Completer<bool>();
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: ChatInputBar(
+                initialDraft: 'wait for db',
+                isGenerating: false,
+                onSend: (_) => accepted.future,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.send_rounded));
+      await tester.pump();
+      var textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.controller!.text, 'wait for db');
+
+      accepted.complete(true);
+      await tester.pump();
+      textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.controller!.text, isEmpty);
     });
 
     testWidgets('image generation stop button remains tappable', (

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -2518,12 +2518,12 @@ void main() {
       expect(version.read<int>('user_version'), 118);
     });
 
-    test('v118 adds prompt post-processing, off unless the active preset '
-        'merged prompts', () async {
+    test('v118 adds prompt post-processing with none for every config', () async {
       Future<Map<String, String>> upgradeWith(
         Map<String, Object> prefs,
-        String? presetJson,
-      ) async {
+        String? presetJson, {
+        bool removeColumn = true,
+      }) async {
         final file = File(
           '${Directory.systemTemp.path}/glaze_mig_ppp_${DateTime.now().microsecondsSinceEpoch}.db',
         );
@@ -2551,9 +2551,16 @@ void main() {
             ['preset', 'Preset', presetJson],
           );
         }
-        await seeded.customStatement(
-          'ALTER TABLE api_configs DROP COLUMN prompt_post_processing',
-        );
+        if (removeColumn) {
+          await seeded.customStatement(
+            'ALTER TABLE api_configs DROP COLUMN prompt_post_processing',
+          );
+        } else {
+          await seeded.customStatement(
+            "UPDATE api_configs SET prompt_post_processing = 'single' "
+            "WHERE config_id = 'custom'",
+          );
+        }
         await seeded.customStatement('PRAGMA user_version = 117');
         await seeded.close();
 
@@ -2575,13 +2582,13 @@ void main() {
         };
       }
 
-      // No preset selected: nothing to carry over.
+      // No preset selected.
       expect(await upgradeWith(const {}, null), {
         'custom': 'none',
         'anthropic': 'none',
       });
 
-      // Active preset never merged: the connection stays untouched.
+      // An inactive merge setting does not affect connection rows.
       expect(
         await upgradeWith(const {
           'activePresetId': 'preset',
@@ -2589,21 +2596,25 @@ void main() {
         {'custom': 'none', 'anthropic': 'none'},
       );
 
-      // Active preset merged: adopt the equivalent mode so the prompt shape
-      // the user is living with does not change under them.
+      // The legacy preset flag is intentionally not carried over, including
+      // for custom connections.
       expect(
         await upgradeWith(const {
           'activePresetId': 'preset',
         }, '{"id":"preset","name":"Preset","mergePrompts":true}'),
-        // The tool-preserving half, matching what the picker stores. Only the
-        // custom connection: first-party protocols normalize in their own
-        // converter and never offer the setting.
-        {'custom': 'merge_tools', 'anthropic': 'none'},
+        {'custom': 'none', 'anthropic': 'none'},
       );
 
-      // A dangling preset id must not block the upgrade.
+      // A dangling preset id also cannot affect or block the upgrade.
       expect(await upgradeWith(const {'activePresetId': 'missing'}, null), {
         'custom': 'none',
+        'anthropic': 'none',
+      });
+
+      // A partially/previously applied schema change is left intact rather
+      // than trying to add the column again or rewriting existing choices.
+      expect(await upgradeWith(const {}, null, removeColumn: false), {
+        'custom': 'single',
         'anthropic': 'none',
       });
     });

--- a/test/ledger_reconciliation_run_repo_test.dart
+++ b/test/ledger_reconciliation_run_repo_test.dart
@@ -312,6 +312,54 @@ void main() {
       expect(second.predecessorChainHash, first.chainHash);
     },
   );
+
+  test('message mutation invalidates anchored run suffix, not trigger', () async {
+    await _seedSession(db);
+    final first = _run();
+    expect(await repo.append(first), isA<ReconciliationRunAppended>());
+
+    expect(
+      await repo.invalidateForMessageMutation(
+        sessionId: 'session',
+        messageIds: {'user'},
+        reason: 'message_deleted',
+        createdAt: 2,
+      ),
+      isEmpty,
+    );
+    expect((await repo.getHead('session'))?.id, 'run-1');
+
+    final invalidated = await repo.invalidateForMessageMutation(
+      sessionId: 'session',
+      messageIds: {'message'},
+      reason: 'message_deleted',
+      createdAt: 3,
+    );
+    expect(invalidated, ['run-1']);
+    expect(await repo.getHead('session'), isNull);
+
+    await db.customStatement(
+      "UPDATE chat_sessions SET messages_json = '[{\"id\":\"user\",\"role\":\"user\",\"content\":\"accepted\"}]' WHERE session_id = 'session'",
+    );
+    expect(await repo.validateChain('session'), isA<ReconciliationRunValid>());
+  });
+
+  test(
+    'legacy stale evidence hides logical suffix without breaking chain',
+    () async {
+      await _seedSession(db);
+      expect(await repo.append(_run()), isA<ReconciliationRunAppended>());
+      await db.customStatement(
+        "UPDATE chat_sessions SET messages_json = '[{\"id\":\"user\",\"role\":\"user\",\"content\":\"accepted\"}]' WHERE session_id = 'session'",
+      );
+      expect(
+        await repo.validateChain('session'),
+        isA<ReconciliationRunValid>(),
+      );
+      expect(await repo.readSession('session'), isEmpty);
+      expect(await repo.getHead('session'), isNull);
+    },
+  );
 }
 
 Future<void> _seedSession(AppDatabase db) => db.customStatement(

--- a/test/llm/transport/chat_transport_request_mapping_test.dart
+++ b/test/llm/transport/chat_transport_request_mapping_test.dart
@@ -175,6 +175,8 @@ void main() {
       previousMessages: previousMessages,
       tools: tools,
       toolChoice: 'required',
+      charName: 'Character',
+      userName: 'User Name',
     );
 
     expect(request.model, 'override-model');
@@ -184,5 +186,14 @@ void main() {
     expect(request.previousMessages, same(previousMessages));
     expect(request.tools, same(tools));
     expect(request.toolChoice, 'required');
+    expect(request.charName, 'Character');
+    expect(request.userName, 'User Name');
+
+    final rewritten = request.withMessages(const [
+      {'role': 'user', 'content': 'Rewritten'},
+    ]);
+    expect(rewritten.charName, 'Character');
+    expect(rewritten.userName, 'User Name');
+    expect(rewritten.promptPostProcessing, 'none');
   });
 }

--- a/test/llm/transport/post_processing_chat_transport_test.dart
+++ b/test/llm/transport/post_processing_chat_transport_test.dart
@@ -29,21 +29,28 @@ class _RecordingTransport implements ChatTransport {
 
 ChatTransportRequest _request({
   required String mode,
+  List<Map<String, dynamic>>? messages,
   List<Map<String, dynamic>>? previousMessages,
+  String? charName,
+  String? userName,
 }) => ChatTransportRequest(
   endpoint: 'https://example.test',
   apiKey: 'key',
   model: 'model',
-  messages: [
-    {'role': 'system', 'content': 'a'},
-    {'role': 'system', 'content': 'b'},
-    {'role': 'user', 'content': 'hi'},
-  ],
+  messages:
+      messages ??
+      [
+        {'role': 'system', 'content': 'a'},
+        {'role': 'system', 'content': 'b'},
+        {'role': 'user', 'content': 'hi'},
+      ],
   maxTokens: 100,
   temperature: 0.7,
   topP: 0.9,
   promptPostProcessing: mode,
   previousMessages: previousMessages,
+  charName: charName,
+  userName: userName,
 );
 
 void main() {
@@ -85,6 +92,37 @@ void main() {
     ]);
   });
 
+  test('single labels speakers in current and previous conversations', () {
+    final processed = PostProcessingChatTransport.applyTo(
+      _request(
+        mode: PromptPostProcessing.single,
+        charName: 'Helga',
+        userName: 'Danvi',
+        messages: [
+          {'role': 'user', 'content': 'Current question'},
+          {'role': 'assistant', 'content': 'Current answer'},
+        ],
+        previousMessages: [
+          {'role': 'user', 'content': 'Earlier question'},
+          {'role': 'assistant', 'content': 'Earlier answer'},
+        ],
+      ),
+    );
+
+    expect(processed.messages, [
+      {
+        'role': 'user',
+        'content': 'Danvi: Current question\n\nHelga: Current answer',
+      },
+    ]);
+    expect(processed.previousMessages, [
+      {
+        'role': 'user',
+        'content': 'Danvi: Earlier question\n\nHelga: Earlier answer',
+      },
+    ]);
+  });
+
   test('the processed request cannot be post-processed a second time', () {
     final processed = PostProcessingChatTransport.applyTo(
       _request(mode: PromptPostProcessing.merge),
@@ -104,5 +142,7 @@ void main() {
     expect(processed.maxTokens, original.maxTokens);
     expect(processed.temperature, original.temperature);
     expect(processed.topP, original.topP);
+    expect(processed.charName, original.charName);
+    expect(processed.userName, original.userName);
   });
 }

--- a/test/studio_ledger_test.dart
+++ b/test/studio_ledger_test.dart
@@ -227,7 +227,7 @@ void main() {
 
     const planner = LedgerReconciliationPlanner();
 
-    test('runs on the Nth assistant once for the previous N-1 turns', () {
+    test('runs after each five new assistants and excludes the trigger', () {
       final messages = [
         ..._conversation(5),
         const ChatMessage(id: 'u6', role: 'user', content: 'User turn 6'),
@@ -261,6 +261,26 @@ void main() {
         ),
         isNull,
       );
+      final nextMessages = [
+        ..._conversation(10),
+        const ChatMessage(id: 'u11', role: 'user', content: 'User turn 11'),
+        const ChatMessage(
+          id: 'a11',
+          role: 'assistant',
+          content: 'Assistant turn 11',
+        ),
+      ];
+      final next = planner.plan(
+        messages: nextMessages,
+        currentAssistantMessageId: 'a11',
+        previousEndMessageId: 'a5',
+        checkpoint: checkpoint,
+      );
+      expect(next, isNotNull);
+      expect(next!.endMessage.id, 'a10');
+      expect(next.messageIds, isNot(contains('a11')));
+      // Rolling context remains intentionally overlapping.
+      expect(next.messageIds, contains('a5'));
       expect(
         planner.plan(
           messages: [
@@ -334,14 +354,15 @@ void main() {
       expect(plan.messageIds, isNot(contains('hidden')));
     });
 
-    test('review range is bounded to twenty messages', () {
-      final messages = _conversation(12);
+    test('review range is bounded to twenty physical messages', () {
+      final messages = _conversation(11);
       final plan = planner.plan(
         messages: messages,
-        currentAssistantMessageId: 'a12',
+        currentAssistantMessageId: 'a11',
+        previousEndMessageId: 'a5',
       )!;
       expect(plan.messages, hasLength(20));
-      expect(plan.endMessage.id, 'a11');
+      expect(plan.endMessage.id, 'a10');
     });
 
     test(


### PR DESCRIPTION
## Summary
- recover interrupted Studio reconciliation chains and preserve durable collector/reconciliation state
- keep sends, drafts, and UI state attached to the correct chat session across session-switch races
- keep prompt post-processing disabled on migration and preserve speaker labels in SillyTavern-style single prompts

## Validation
- targeted Flutter suite: 88 tests passed
- focused Flutter analysis of prompt post-processing changes: no issues
- reconciliation, draft, input-bar, session-race, migration, and transport tests added or updated

## Commits
- 2406844c fix(studio): recover reconciliation chain
- 006b1f1b fix(chat): preserve sends across session races
- df5e5a0e fix(api): preserve speakers in single prompts