### PR TITLE
fix(windows): keep chat sends and WebView initialization recoverable

### DIFF
--- a/lib/features/chat/chat_provider.dart
+++ b/lib/features/chat/chat_provider.dart
@@ -509,6 +509,9 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         state = AsyncData(current);
         return;
       }
+      // The append is now durable, so later setup work must not keep the
+      // composer blocked if a tracker or post-generation stage stalls.
+      _sendInFlight = false;
       if (durableAcceptance != null && !durableAcceptance.isCompleted) {
         durableAcceptance.complete(true);
       }

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -22,20 +22,13 @@ import 'chat_webview_trackpad_scroll.dart';
 import 'message_scripts_prompt_sheet.dart';
 import 'webview_callbacks.dart';
 
-/// `InAppWebView` widget with the chat-specific settings, the
-/// `onWebViewCreated` bridge-wiring sequence, the `onLoadStop`
-/// init kick, and bridge callback wiring.
+/// `InAppWebView` with chat-specific settings and bridge wiring.
 ///
-/// Extracted from `chat_webview_widget.dart` so the widget's
-/// `build` method does not have to inline the ~120 lines of
-/// `InAppWebViewSettings` + `onWebViewCreated` callback wiring.
-/// The widget still owns lifecycle: the surface is given hooks
-/// (`onBridgeReady`, `onInitWebView`) and the
-/// [ChatWebViewBridgeHost] via constructor injection.
-///
-/// The surface is a thin widget — it does not own any state and
-/// rebuilds when its parent does.
-class ChatWebViewSurface extends ConsumerWidget {
+/// On Windows, native view creation is asynchronous and the upstream platform
+/// widget is unsafe if disposed before creation returns. Delay mounting it for
+/// one Flutter frame, so a route dismissed immediately never starts a native
+/// creation that could later callback into a disposed widget.
+class ChatWebViewSurface extends ConsumerStatefulWidget {
   const ChatWebViewSurface({
     super.key,
     required this.bridgeHost,
@@ -71,8 +64,8 @@ class ChatWebViewSurface extends ConsumerWidget {
   final ScrollCallbacks scrollActions;
   final MiscCallbacks miscActions;
 
-  /// Prevents an async `onWebViewCreated` continuation from installing
-  /// callbacks captured for a session that has already been replaced.
+  /// Prevents an async native callback from installing bridge handlers for a
+  /// session that has since been replaced.
   final bool Function(String? sessionId) isCurrentSession;
   final int lifecycleEpoch;
   final bool Function(int epoch) isActive;
@@ -82,43 +75,42 @@ class ChatWebViewSurface extends ConsumerWidget {
   final double bgBlur;
   final double bgDim;
 
-  /// Chat-area background source: 'inherit' | 'color' | 'avatar' | 'custom'.
-  /// For 'inherit' and 'custom', [bgImageBytes] already carries the right
-  /// decoded image (global or chat-custom); 'color' uses [chatBgColor];
-  /// 'avatar' loads [chatBgAvatarPath] from disk.
+  /// Chat-area background source: inherit, color, avatar, or custom.
   final String chatBgMode;
   final Color? chatBgColor;
   final String? chatBgAvatarPath;
   final double bottomInset;
 
-  /// Called by the surface after the bridge is created and
-  /// registered in [chatBridgeRegistryProvider]. The parent widget
-  /// assigns the bridge to its own `_bridge` field.
+  /// Called after the surface has safely wired the JavaScript bridge.
   final void Function(ChatBridgeController bridge) onBridgeReady;
 
-  /// Called by the surface when the WebView reports it is alive
-  /// (`onWebViewCreated`) or when `onLoadStop` fires and the bridge
-  /// has not run init yet.
+  /// Starts the parent's idempotent WebView initialization.
   final Future<void> Function() onInitWebView;
 
-  /// The chat's own background — surface color, optional bg image, and dim.
-  /// Rendered both *behind* the transparent WebView (so there's no white flash
-  /// and `backdrop-filter` has something to sample) and, during a session
-  /// switch, *over* the WebView as an opaque cover so the kept-alive native
-  /// surface can't flash the previous session's content while the new one is
-  /// being pushed in.
-  Widget _background(BuildContext context) {
-    // In 'color' mode the base layer is the chosen solid color; otherwise the
-    // theme surface shows behind/around any image.
-    final Color base = chatBgMode == 'color' && chatBgColor != null
-        ? chatBgColor!
-        : Theme.of(context).colorScheme.surface;
+  @override
+  ConsumerState<ChatWebViewSurface> createState() => _ChatWebViewSurfaceState();
+}
 
-    // The image layer: 'avatar' loads from a file path, 'inherit'/'custom'
-    // use the pre-decoded [bgImageBytes]. 'color' has no image layer.
+class _ChatWebViewSurfaceState extends ConsumerState<ChatWebViewSurface> {
+  bool _mountNativeView = !Platform.isWindows;
+
+  @override
+  void initState() {
+    super.initState();
+    if (Platform.isWindows) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) setState(() => _mountNativeView = true);
+      });
+    }
+  }
+
+  Widget _background(BuildContext context) {
+    final base = widget.chatBgMode == 'color' && widget.chatBgColor != null
+        ? widget.chatBgColor!
+        : Theme.of(context).colorScheme.surface;
     Widget? image;
-    if (chatBgMode == 'avatar') {
-      final path = chatBgAvatarPath;
+    if (widget.chatBgMode == 'avatar') {
+      final path = widget.chatBgAvatarPath;
       if (path != null && path.isNotEmpty) {
         image = Image.file(
           File(path),
@@ -126,214 +118,181 @@ class ChatWebViewSurface extends ConsumerWidget {
           gaplessPlayback: true,
         );
       }
-    } else if (chatBgMode != 'color' && bgImageBytes != null) {
-      // Decoded bytes (same as GlazeBackground) because the data is a base64
-      // data URI, not a file path.
+    } else if (widget.chatBgMode != 'color' && widget.bgImageBytes != null) {
       image = Image.memory(
-        bgImageBytes!,
+        widget.bgImageBytes!,
         fit: BoxFit.cover,
         gaplessPlayback: true,
       );
     }
-
     return Stack(
       fit: StackFit.expand,
       children: [
         ColoredBox(color: base),
         if (image != null) ...[
-          if (bgBlur > 0)
+          if (widget.bgBlur > 0)
             ImageFiltered(
               imageFilter: ui.ImageFilter.blur(
-                sigmaX: bgBlur,
-                sigmaY: bgBlur,
+                sigmaX: widget.bgBlur,
+                sigmaY: widget.bgBlur,
                 tileMode: TileMode.clamp,
               ),
               child: image,
             )
           else
             image,
-          // Darkening only — the image itself stays opaque so the theme
-          // surface under it never bleeds through.
-          if (bgDim > 0)
-            Container(color: Colors.black.withValues(alpha: bgDim)),
+          if (widget.bgDim > 0)
+            Container(color: Colors.black.withValues(alpha: widget.bgDim)),
         ],
       ],
     );
   }
 
+  bool _callbackIsActive(int epoch) {
+    return widget.isActive(epoch) && widget.isCurrentSession(widget.sessionId);
+  }
+
+  Future<void> _onWebViewCreated(InAppWebViewController controller) async {
+    final epoch = widget.lifecycleEpoch;
+    if (!_callbackIsActive(epoch)) return;
+    PerfDebug.chatWebViewSurfaceCreated();
+    final jsBridgeService = await widget.bridgeHost.buildJsBridgeService();
+    if (!_callbackIsActive(epoch) || jsBridgeService == null) return;
+    final bridge = ChatBridgeController(controller, jsBridgeService);
+    final allowMessageScripts =
+        ref.read(appSettingsProvider).value?.allowMessageScripts ?? false;
+    await bridge.evalJs(
+      'window.bridge?.setAllowMessageScripts($allowMessageScripts)',
+    );
+    if (!_callbackIsActive(epoch)) return;
+    widget.onBridgeReady(bridge);
+    PerfDebug.chatWebViewBridgeReady();
+
+    final callbacks = ChatWebViewCallbacks(
+      ref: ref,
+      charId: widget.charId,
+      messageActions: widget.messageActions,
+      editActions: widget.editActions,
+      imageGenActions: widget.imageGenActions,
+      scrollActions: widget.scrollActions,
+      miscActions: widget.miscActions,
+    );
+    bridge.onMessageContext = callbacks.onMessageContext;
+    bridge.onSwipe = callbacks.onSwipe;
+    bridge.onChangeGreeting = callbacks.onChangeGreeting;
+    bridge.onHeaderScroll = callbacks.onHeaderScroll;
+    bridge.onScrollToBottomVisibility = callbacks.onScrollToBottomVisibility;
+    bridge.onRegenerate = callbacks.onRegenerate;
+    bridge.onSelectionAction = callbacks.onSelectionAction;
+    bridge.onSelectionChange = callbacks.onSelectionChange;
+    bridge.onEditSave = callbacks.onEditSave;
+    bridge.onEditCancel = callbacks.onEditCancel;
+    bridge.onEditFocusChange = callbacks.onEditFocusChange;
+    bridge.onImageClick = callbacks.onImageClick;
+    bridge.onImgDownload = callbacks.onImgDownload;
+    bridge.onGuidedSwipe = callbacks.onGuidedSwipe;
+    bridge.onMemoryClick = callbacks.onMemoryClick;
+    bridge.onToggleHidden = callbacks.onToggleHidden;
+    bridge.onToggleImageHidden = callbacks.onToggleImageHidden;
+    bridge.onInjectClick = callbacks.onInjectClick;
+    bridge.onImgRetry = callbacks.onImgRetry;
+    bridge.onImgEnableRetry = callbacks.onImgEnableRetry;
+    bridge.onImgFind = callbacks.onImgFind;
+    bridge.onImgRegen = callbacks.onImgRegen;
+    bridge.onImgOptions = callbacks.onImgOptions;
+    bridge.onImgCancel = callbacks.onImgCancel;
+    bridge.onStop = callbacks.onStop;
+    bridge.onLinkClick = callbacks.onLinkClick;
+    bridge.onLoadMore = callbacks.onLoadMore;
+    bridge.onMessageScriptBlocked = () {
+      if (_callbackIsActive(epoch)) {
+        // The callback owns the bridge lifecycle guard above.
+        // ignore: use_build_context_synchronously
+        unawaited(maybeShowMessageScriptsPrompt(context, ref));
+      }
+    };
+
+    if (!_callbackIsActive(epoch) || !mounted) return;
+    final extBlocks = ChatWebViewExtBlockCallbacks(
+      ref: ref,
+      charId: widget.charId,
+      sessionId: widget.sessionId,
+      // The mounted guard above protects this long-lived callback context.
+      // ignore: use_build_context_synchronously
+      context: context,
+      isMounted: () => _callbackIsActive(epoch),
+      refreshPanel: widget.refreshPanel,
+    );
+    bridge.onExtBlocksRunAll = extBlocks.onRunAll();
+    bridge.onExtBlockStop = extBlocks.onStop();
+    bridge.onExtBlockRegen = extBlocks.onRegen();
+    bridge.onExtBlockRegenImage = extBlocks.onRegenImage();
+    bridge.onExtBlockEdit = extBlocks.onEdit();
+    bridge.onExtBlockDelete = extBlocks.onDelete();
+
+    final isAlive = await controller.isLoading() == false;
+    if (isAlive && _callbackIsActive(epoch)) {
+      await widget.onInitWebView();
+    }
+  }
+
+  Future<void> _onLoadStop(InAppWebViewController controller, Uri? url) async {
+    final epoch = widget.lifecycleEpoch;
+    if (!_callbackIsActive(epoch)) return;
+    PerfDebug.chatWebViewLoadStopped();
+    await ref
+        .read(chatBridgeRegistryProvider(widget.charId))
+        ?.evalJs(
+          'window.bridge?.setAllowMessageScripts('
+          '${ref.read(appSettingsProvider).value?.allowMessageScripts ?? false})',
+        );
+    if (_callbackIsActive(epoch)) {
+      await widget.onInitWebView();
+    }
+  }
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final webViewEnvironment = chatWebViewEnvironment;
+  Widget build(BuildContext context) {
     ref.listen<AsyncValue<AppSettings>>(appSettingsProvider, (previous, next) {
       final oldValue = previous?.value?.allowMessageScripts ?? false;
       final newValue = next.value?.allowMessageScripts ?? false;
-      if (oldValue == newValue) return;
-      ref
-          .read(chatBridgeRegistryProvider(charId))
-          ?.evalJs('window.bridge?.setAllowMessageScripts($newValue)');
+      if (oldValue != newValue) {
+        ref
+            .read(chatBridgeRegistryProvider(widget.charId))
+            ?.evalJs('window.bridge?.setAllowMessageScripts($newValue)');
+      }
     });
     return Stack(
       children: [
-        // Background behind the transparent WebView.
         Positioned.fill(child: _background(context)),
-        // NOTE: the glass overlays (header, input pill, buttons) are NOT
-        // blurred here on the Flutter side. Their blur is reproduced entirely
-        // by CSS `backdrop-filter` strips *inside* the WebView (mirrored via
-        // setOverlayBlurRegions), which sample the WebView's own background
-        // copy (#bg-layer, with baked bg-blur + dim + noise) AND the messages
-        // in a single pass — the one source of truth for anything blurred.
-        // This removes the old Flutter BackdropFilter "sandwich" that could
-        // not reconcile with the in-WebView bg blur/dim and re-blurred every
-        // keyboard frame.
         Positioned.fill(
           child: IgnorePointer(
-            ignoring: sessionSwitching,
-            // Windows touchpad panning never reaches WebView2 on its own —
-            // see ChatWebViewTrackpadScroll. Sits inside the IgnorePointer so
-            // a session switch freezes it along with the rest of the input.
-            child: ChatWebViewTrackpadScroll(
-              charId: charId,
-              child: InAppWebView(
-                webViewEnvironment: webViewEnvironment,
-                keepAlive: chatWebViewKeepAliveForPlatform(),
-                initialFile: chatWebViewInitialFile(),
-                initialUrlRequest: chatWebViewInitialUrlRequest(),
-                initialSettings: chatWebViewInAppSettings(),
-                onWebViewCreated: (controller) async {
-                  final epoch = lifecycleEpoch;
-                  bool callbackIsActive() =>
-                      isActive(epoch) && isCurrentSession(sessionId);
-                  if (!callbackIsActive()) return;
-                  PerfDebug.chatWebViewSurfaceCreated();
-                  final jsBridgeService = await bridgeHost
-                      .buildJsBridgeService();
-                  if (!callbackIsActive() || jsBridgeService == null) return;
-                  final bridge = ChatBridgeController(
-                    controller,
-                    jsBridgeService,
-                  );
-                  if (!callbackIsActive()) return;
-                  final allowMessageScripts =
-                      ref
-                          .read(appSettingsProvider)
-                          .value
-                          ?.allowMessageScripts ??
-                      false;
-                  await bridge.evalJs(
-                    'window.bridge?.setAllowMessageScripts('
-                    '$allowMessageScripts)',
-                  );
-                  if (!callbackIsActive()) return;
-                  onBridgeReady(bridge);
-                  PerfDebug.chatWebViewBridgeReady();
-
-                  // Do not call clearAll() here — it races with _initWebViewOnce
-                  // (shows #loading-screen via JS) and broke UseVirtualScroll on
-                  // keep-alive re-attach. Initializer.setMessages resets the DOM.
-
-                  final callbacks = ChatWebViewCallbacks(
-                    ref: ref,
-                    charId: charId,
-                    messageActions: messageActions,
-                    editActions: editActions,
-                    imageGenActions: imageGenActions,
-                    scrollActions: scrollActions,
-                    miscActions: miscActions,
-                  );
-                  bridge.onMessageContext = callbacks.onMessageContext;
-                  bridge.onSwipe = callbacks.onSwipe;
-                  bridge.onChangeGreeting = callbacks.onChangeGreeting;
-                  bridge.onHeaderScroll = callbacks.onHeaderScroll;
-                  bridge.onScrollToBottomVisibility =
-                      callbacks.onScrollToBottomVisibility;
-                  bridge.onRegenerate = callbacks.onRegenerate;
-                  bridge.onSelectionAction = callbacks.onSelectionAction;
-                  bridge.onSelectionChange = callbacks.onSelectionChange;
-                  bridge.onEditSave = callbacks.onEditSave;
-                  bridge.onEditCancel = callbacks.onEditCancel;
-                  bridge.onEditFocusChange = callbacks.onEditFocusChange;
-                  bridge.onImageClick = callbacks.onImageClick;
-                  bridge.onImgDownload = callbacks.onImgDownload;
-                  bridge.onGuidedSwipe = callbacks.onGuidedSwipe;
-                  bridge.onMemoryClick = callbacks.onMemoryClick;
-                  bridge.onToggleHidden = callbacks.onToggleHidden;
-                  bridge.onToggleImageHidden = callbacks.onToggleImageHidden;
-                  bridge.onInjectClick = callbacks.onInjectClick;
-                  bridge.onImgRetry = callbacks.onImgRetry;
-                  bridge.onImgEnableRetry = callbacks.onImgEnableRetry;
-                  bridge.onImgFind = callbacks.onImgFind;
-                  bridge.onImgRegen = callbacks.onImgRegen;
-                  bridge.onImgOptions = callbacks.onImgOptions;
-                  bridge.onImgCancel = callbacks.onImgCancel;
-                  bridge.onStop = callbacks.onStop;
-                  bridge.onLinkClick = callbacks.onLinkClick;
-                  bridge.onLoadMore = callbacks.onLoadMore;
-                  bridge.onMessageScriptBlocked = () {
-                    if (!callbackIsActive()) return;
-                    // ignore: use_build_context_synchronously
-                    unawaited(maybeShowMessageScriptsPrompt(context, ref));
-                  };
-                  if (!callbackIsActive()) return;
-
-                  // The ext-block callbacks run after `await` paths. The
-                  // controller is created once per WebView lifetime so
-                  // the context capture is safe.
-                  final extBlocks = ChatWebViewExtBlockCallbacks(
-                    ref: ref,
-                    charId: charId,
-                    sessionId: sessionId,
-                    // ignore: use_build_context_synchronously
-                    context: context,
-                    isMounted: callbackIsActive,
-                    refreshPanel: refreshPanel,
-                  );
-                  bridge.onExtBlocksRunAll = extBlocks.onRunAll();
-                  bridge.onExtBlockStop = extBlocks.onStop();
-                  bridge.onExtBlockRegen = extBlocks.onRegen();
-                  bridge.onExtBlockRegenImage = extBlocks.onRegenImage();
-                  bridge.onExtBlockEdit = extBlocks.onEdit();
-                  bridge.onExtBlockDelete = extBlocks.onDelete();
-
-                  final isAlive = await controller.isLoading() == false;
-                  if (!callbackIsActive()) return;
-                  if (isAlive) {
-                    await onInitWebView();
-                    if (!callbackIsActive()) return;
-                  }
-                },
-                onLoadStop: (controller, url) async {
-                  final epoch = lifecycleEpoch;
-                  bool callbackIsActive() =>
-                      isActive(epoch) && isCurrentSession(sessionId);
-                  if (!callbackIsActive()) return;
-                  PerfDebug.chatWebViewLoadStopped();
-                  // The init path is also wired through onWebViewCreated. When
-                  // load stop wins the race, run init here.
-                  await ref
-                      .read(chatBridgeRegistryProvider(charId))
-                      ?.evalJs(
-                        'window.bridge?.setAllowMessageScripts('
-                        '${ref.read(appSettingsProvider).value?.allowMessageScripts ?? false})',
-                      );
-                  if (!callbackIsActive()) return;
-                  await onInitWebView();
-                  if (!callbackIsActive()) return;
-                },
-                shouldOverrideUrlLoading: (controller, request) async {
-                  return chatWebViewNavigationPolicy(request.request.url);
-                },
-              ),
-            ),
+            ignoring: widget.sessionSwitching,
+            // Windows touchpad panning is forwarded by this wrapper. Keeping it
+            // below IgnorePointer freezes native interaction during a switch.
+            child: _mountNativeView
+                ? ChatWebViewTrackpadScroll(
+                    charId: widget.charId,
+                    child: InAppWebView(
+                      webViewEnvironment: chatWebViewEnvironment,
+                      keepAlive: chatWebViewKeepAliveForPlatform(),
+                      initialFile: chatWebViewInitialFile(),
+                      initialUrlRequest: chatWebViewInitialUrlRequest(),
+                      initialSettings: chatWebViewInAppSettings(),
+                      onWebViewCreated: _onWebViewCreated,
+                      onLoadStop: _onLoadStop,
+                      shouldOverrideUrlLoading: (controller, request) async {
+                        return chatWebViewNavigationPolicy(request.request.url);
+                      },
+                    ),
+                  )
+                : const SizedBox.expand(),
           ),
         ),
-        // Opaque cover over the WebView while a new session is being pushed in.
-        // Hides the kept-alive native surface's previous-session content (which
-        // it composites for a frame on re-attach) behind the chat's own
-        // background, so switching shows an empty chat rather than a stale flash.
-        if (sessionSwitching)
+        if (widget.sessionSwitching)
           Positioned.fill(child: IgnorePointer(child: _background(context))),
-        if (sessionSwitching) const Center(child: GlazeSpinner()),
-        if (bottomInset > 0)
+        if (widget.sessionSwitching) const Center(child: GlazeSpinner()),
+        if (widget.bottomInset > 0)
           Positioned.fill(
             child: IgnorePointer(
               child: Container(

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -242,8 +242,8 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
 
   /// Polls for the bridge (set by the surface's `onWebViewCreated`) and runs
   /// the idempotent init once it exists. Bounded so it can never spin forever.
-  /// If the bridge never appears (e.g. WebView2 not installed on Windows), an
-  /// error dialog is shown so the user is not left with a blank screen.
+  /// A timeout diagnoses an incomplete native initialization; it cannot infer
+  /// the installation state of WebView2, which is also hit by lifecycle races.
   Future<void> _kickInitWhenReady() async {
     for (var i = 0; i < 50; i++) {
       if (!mounted) return;
@@ -254,20 +254,19 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       }
       await Future<void>.delayed(const Duration(milliseconds: 100));
     }
-    // Bridge never appeared after 5 seconds of polling — the native WebView
-    // could not be created (e.g. WebView2 Runtime missing on Windows, or
-    // environment setup failed at app startup). Show a diagnostic dialog
-    // instead of leaving a blank page.
+    // Bridge never appeared after 5 seconds of polling. This can be an actual
+    // platform failure, but can also be a native-view lifecycle race during a
+    // rapid route change, so do not claim a missing runtime without evidence.
     if (!mounted || _bridgeFailureNotified) return;
     _bridgeFailureNotified = true;
     debugPrint(
       '[ChatWebView] bridge was not created after 5s — '
-      'native WebView failed to initialize (WebView2 missing?)',
+      'native WebView did not finish initializing',
     );
     GlazeErrorDialog.show(
       context,
-      'Chat view could not be initialized. '
-      'On Windows, ensure "Microsoft Edge WebView2 Runtime" is installed.',
+      'Chat view is still initializing. Please return to the chat once more. '
+      'If this keeps happening, restart Glaze and check the diagnostic log.',
       prefix: 'Chat view failed to load',
     );
   }

--- a/test/chat_webview_windows_lifecycle_test.dart
+++ b/test/chat_webview_windows_lifecycle_test.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Windows defers native WebView mounting until after a stable frame', () {
+    final source = File(
+      'lib/features/chat/widgets/chat_webview_surface.dart',
+    ).readAsStringSync();
+
+    expect(source, contains('bool _mountNativeView = !Platform.isWindows;'));
+    expect(source, contains('WidgetsBinding.instance.addPostFrameCallback'));
+    expect(
+      source,
+      contains('if (mounted) setState(() => _mountNativeView = true)'),
+    );
+    expect(source, contains('child: _mountNativeView'));
+  });
+}


### PR DESCRIPTION
﻿## Chat Recovery
- Release `ChatNotifier._sendInFlight` immediately after the user message is durably appended, so an aborted or stalled post-generation pipeline cannot reject every later composer submission.
- Keep the composer acknowledgement tied to the durable append while `ChatState` generation flags remain the mutual-exclusion guard.

## Windows WebView Lifecycle
- Delay mounting the Windows `InAppWebView` until after one stable Flutter frame. A chat route dismissed immediately no longer starts native WebView creation that can callback after disposal in the upstream Windows plugin.
- Replace the unsupported WebView2-missing watchdog diagnosis with a lifecycle-neutral initialization message.
- Add a contract test covering deferred Windows native-view mounting.

## Verification
- `flutter analyze lib/features/chat/widgets/chat_webview_surface.dart lib/features/chat/widgets/chat_webview_widget.dart lib/features/chat/chat_provider.dart`
- `flutter test test/chat_webview_windows_lifecycle_test.dart test/characterization/webview_callback_contract_test.dart test/message_scripts_prompt_test.dart test/chat_input_bar_test.dart test/chat_draft_controller_test.dart` (33 passed)
