### PR TITLE
fix(studio): align reconciliation chunk cadence

### DIFF
--- a/lib/core/db/repositories/card_evolution_collector_run_repo.dart
+++ b/lib/core/db/repositories/card_evolution_collector_run_repo.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
 import 'package:drift/drift.dart';
 
 import '../../utils/id_generator.dart';
@@ -11,6 +14,24 @@ final class CardEvolutionCollectorClaimOutcome {
   final CardEvolutionCollectorRunRow? row;
 
   bool get canRun => kind == 'claimed' || kind == 'existing';
+}
+
+final class CardEvolutionCollectorPair {
+  const CardEvolutionCollectorPair(this.first, this.boundary);
+
+  final LedgerReconciliationSuccessfulRunRow first;
+  final LedgerReconciliationSuccessfulRunRow boundary;
+
+  List<LedgerReconciliationSuccessfulRunRow> get runs => [first, boundary];
+
+  String get rangeHash => sha256
+      .convert(
+        utf8.encode(
+          '${first.id}\u001f${first.rangeHash}\u001e'
+          '${boundary.id}\u001f${boundary.rangeHash}',
+        ),
+      )
+      .toString();
 }
 
 /// Durable collector lease and completion journal. A valid empty observation
@@ -27,6 +48,7 @@ class CardEvolutionCollectorRunRepo {
     required String ownerId,
     required int now,
     required int leaseSeconds,
+    String? rangeHash,
   }) => db.transaction(() async {
     final existing =
         await (db.select(db.cardEvolutionCollectorRuns)..where(
@@ -86,7 +108,7 @@ class CardEvolutionCollectorRunRepo {
               reconciliationRunId: reconciliationRun.id,
               reconciliationRunOrdinal: reconciliationRun.ordinal,
               reconciliationChainHash: reconciliationRun.chainHash,
-              rangeHash: reconciliationRun.rangeHash,
+              rangeHash: rangeHash ?? reconciliationRun.rangeHash,
               inputHash: inputHash,
               ownerId: ownerId,
               status: 'claimed',
@@ -136,6 +158,7 @@ class CardEvolutionCollectorRunRepo {
     required String modelOutputHash,
     required int now,
     required Future<void> Function() applyEffects,
+    Future<bool> Function()? validateEvidence,
   }) => db.transaction(() async {
     final claimed =
         await (db.select(db.cardEvolutionCollectorRuns)..where(
@@ -147,6 +170,7 @@ class CardEvolutionCollectorRunRepo {
             ))
             .getSingleOrNull();
     if (claimed == null) return false;
+    if (validateEvidence != null && !await validateEvidence()) return false;
     await applyEffects();
     final changed =
         await (db.update(db.cardEvolutionCollectorRuns)..where(
@@ -218,45 +242,88 @@ class CardEvolutionCollectorRunRepo {
     return 0;
   }
 
-  /// Valid logical reconciliation runs which do not yet have a completed
-  /// collector. This is the durable backlog used to recover runs skipped by a
-  /// crash, a disabled model, or a superseded post-generation callback.
-  Future<List<LedgerReconciliationSuccessfulRunRow>> pendingValidRuns(
+  /// Missing non-overlapping pairs from the valid logical reconciliation
+  /// projection. One collector is anchored to each pair's second run.
+  Future<List<CardEvolutionCollectorPair>> pendingValidPairs(
     String sessionId, {
     LedgerReconciliationSuccessfulRunRow? currentRun,
   }) async {
-    final runs = await LedgerReconciliationRunRepo(db).readSession(sessionId);
-    if (currentRun != null &&
-        currentRun.sessionId == sessionId &&
-        !runs.any((run) => run.id == currentRun.id)) {
-      final invalidated =
-          await (db.select(db.ledgerReconciliationRunInvalidations)..where(
-                (row) =>
-                    row.sessionId.equals(sessionId) &
-                    row.runId.equals(currentRun.id),
-              ))
-              .getSingleOrNull();
-      // The orchestration caller already obtained this row as its current
-      // successful run. Keep that direct hand-off usable for legacy/imported
-      // chains which cannot be projected as a complete backlog; the collector
-      // snapshot still validates the run's live evidence fail-closed.
-      if (invalidated == null) runs.add(currentRun);
+    final runs = await _validOrLegacyRuns(sessionId, currentRun: currentRun);
+    var collectors = await (db.select(
+      db.cardEvolutionCollectorRuns,
+    )..where((row) => row.sessionId.equals(sessionId))).get();
+    final expectedPairs = <String, CardEvolutionCollectorPair>{};
+    for (var index = 0; index + 1 < runs.length; index += 2) {
+      final pair = CardEvolutionCollectorPair(runs[index], runs[index + 1]);
+      expectedPairs[pair.boundary.id] = pair;
     }
-    runs.sort((left, right) => left.ordinal.compareTo(right.ordinal));
-    final collectors =
-        await (db.select(db.cardEvolutionCollectorRuns)..where(
-              (row) =>
-                  row.sessionId.equals(sessionId) &
-                  row.status.equals('completed'),
-            ))
-            .get();
-    final completedIds = collectors
-        .map((row) => row.reconciliationRunId)
-        .toSet();
-    return [
-      for (final run in runs)
-        if (!completedIds.contains(run.id)) run,
-    ];
+    final incompatibleJournal = collectors.any((collector) {
+      final pair = expectedPairs[collector.reconciliationRunId];
+      return pair == null || collector.rangeHash != pair.rangeHash;
+    });
+    if (incompatibleJournal) {
+      // Pre-pair collectors cannot prove that both reconciliations were seen.
+      // Rebuild the durable journal and its aggregate effects conservatively.
+      await db.transaction(() async {
+        await (db.delete(
+          db.cardEvolutionCollectorRuns,
+        )..where((row) => row.sessionId.equals(sessionId))).go();
+        await (db.delete(
+          db.cardEvolutionObservations,
+        )..where((row) => row.sessionId.equals(sessionId))).go();
+      });
+      collectors = const [];
+    }
+    final completedByBoundary = {
+      for (final row in collectors)
+        if (row.status == 'completed') row.reconciliationRunId: row,
+    };
+    final pairs = <CardEvolutionCollectorPair>[];
+    for (var index = 0; index + 1 < runs.length; index += 2) {
+      final boundary = runs[index + 1];
+      final pair = CardEvolutionCollectorPair(runs[index], boundary);
+      final completed = completedByBoundary[boundary.id];
+      if (completed == null || completed.rangeHash != pair.rangeHash) {
+        pairs.add(pair);
+      }
+    }
+    return pairs;
+  }
+
+  /// Resolves collector boundaries back to their exact two-run logical pairs.
+  Future<List<LedgerReconciliationSuccessfulRunRow>> runsForCollectors(
+    String sessionId,
+    List<CardEvolutionCollectorRunRow> collectors,
+  ) async {
+    if (collectors.isEmpty) return const [];
+    final runs = await _validOrLegacyRuns(sessionId);
+    final byBoundary = <String, CardEvolutionCollectorPair>{};
+    for (var index = 0; index + 1 < runs.length; index += 2) {
+      final pair = CardEvolutionCollectorPair(runs[index], runs[index + 1]);
+      byBoundary[pair.boundary.id] = pair;
+    }
+    final result = <LedgerReconciliationSuccessfulRunRow>[];
+    for (final collector in collectors) {
+      final pair = byBoundary[collector.reconciliationRunId];
+      if (pair == null ||
+          pair.boundary.chainHash != collector.reconciliationChainHash ||
+          pair.rangeHash != collector.rangeHash) {
+        return const [];
+      }
+      result.addAll(pair.runs);
+    }
+    return result;
+  }
+
+  Future<List<LedgerReconciliationSuccessfulRunRow>> _validOrLegacyRuns(
+    String sessionId, {
+    LedgerReconciliationSuccessfulRunRow? currentRun,
+  }) async {
+    final runRepo = LedgerReconciliationRunRepo(db);
+    final logical = await runRepo.readSession(sessionId);
+    // Pairing needs an authoritative predecessor. Never infer one from raw
+    // rows when the canonical logical chain cannot be projected.
+    return logical;
   }
 
   /// Exact three completed collectors ending at [boundary]. Gaps or claimed

--- a/lib/core/db/repositories/card_evolution_repo.dart
+++ b/lib/core/db/repositories/card_evolution_repo.dart
@@ -11,6 +11,7 @@ import '../../llm/prompt/exact_lorebook_manifest.dart';
 import '../../utils/cast_helpers.dart';
 import '../../utils/id_generator.dart';
 import '../app_db.dart';
+import 'card_evolution_collector_run_repo.dart';
 import 'manual_rewrite_job_repo.dart';
 import 'session_lorebook_evolution_repo.dart';
 
@@ -523,6 +524,30 @@ class CardEvolutionRepo {
     );
   });
 
+  /// Builds one collector snapshot from two consecutive valid logical
+  /// reconciliations. Both immutable histories remain available as evidence.
+  Future<CardEvolutionObservationSnapshot?> buildObservationSnapshotForRuns(
+    List<LedgerReconciliationSuccessfulRunRow> runs,
+  ) => db.transaction(() async {
+    if (runs.length != 2 || runs[0].sessionId != runs[1].sessionId) return null;
+    final sessionId = runs.first.sessionId;
+    final selected = await _selectInput(
+      sessionId,
+      reconciliationRunIds: [for (final run in runs) run.id],
+    );
+    if (selected == null) return null;
+    final session = await (db.select(
+      db.chatSessions,
+    )..where((row) => row.sessionId.equals(sessionId))).getSingleOrNull();
+    if (session == null) return null;
+    final assembled = await _assemble(sessionId, session.characterId);
+    if (assembled == null || assembled.$2.requiresBaselineDecision) return null;
+    return CardEvolutionObservationSnapshot(
+      character: assembled.$2.character,
+      selectedInputJson: selected,
+    );
+  });
+
   /// Counts successful Ledger reconciliations for the session. The observation
   /// pass runs on every even count (every 2nd reconciliation cadence).
   Future<int> countSuccessfulReconciliations(String sessionId) async {
@@ -555,7 +580,7 @@ class CardEvolutionRepo {
 
   Future<String?> _selectedInputForClaim(CardEvolutionClaimRow claim) async {
     final runIds = await _reconciliationRunIdsForClaim(claim);
-    if (claim.predecessorRunOrdinal > 0 && runIds.length != 3) return null;
+    if (claim.predecessorRunOrdinal > 0 && runIds.length != 6) return null;
     final selected = await _selectInput(
       claim.sessionId,
       reconciliationRunIds: runIds,
@@ -936,7 +961,12 @@ class CardEvolutionRepo {
         rows.last.reconciliationChainHash != claim.predecessorCursorHash) {
       return const [];
     }
-    return [for (final row in rows) row.reconciliationRunId];
+    return [
+      for (final run in await CardEvolutionCollectorRunRepo(
+        db,
+      ).runsForCollectors(claim.sessionId, rows))
+        run.id,
+    ];
   }
 
   List<Object?>? _selectReconciliationHistories({

--- a/lib/core/llm/studio_ledger_reconciliation.dart
+++ b/lib/core/llm/studio_ledger_reconciliation.dart
@@ -28,10 +28,11 @@ class LedgerReconciliationPlan {
 }
 
 class LedgerReconciliationPlanner {
-  /// Five newly accepted assistant turns are reviewed when the following
-  /// assistant turn is generated. The trigger itself is never part of the
-  /// review range.
-  static const acceptedAssistantsPerRun = 5;
+  /// Five accepted interaction chunks are reviewed when the following
+  /// assistant turn is generated. The chat-opening assistant belongs to the
+  /// first `assistant-user-assistant` chunk; later chunks are `user-assistant`.
+  /// The next turn is only the acceptance trigger and is never reviewed.
+  static const acceptedChunksPerRun = 5;
   static const maxMessages = 20;
 
   const LedgerReconciliationPlanner();
@@ -47,7 +48,10 @@ class LedgerReconciliationPlanner {
       (message) => message.id == endAssistantMessageId,
     );
     if (endIndex < 0 || !_isAcceptedAssistant(messages[endIndex])) return null;
-    return _buildPlan(messages: messages, endIndex: endIndex);
+    final chunks = _parseCompletedChunks(messages.take(endIndex + 1));
+    if (chunks == null || chunks.isEmpty) return null;
+    if (chunks.last.endAssistant.id != endAssistantMessageId) return null;
+    return _buildPlan(chunks: chunks, mandatoryStart: chunks.length - 1);
   }
 
   LedgerReconciliationPlan? plan({
@@ -59,33 +63,35 @@ class LedgerReconciliationPlanner {
     final currentIndex = messages.indexWhere(
       (message) => message.id == currentAssistantMessageId,
     );
-    if (currentIndex < 0) return null;
-
-    final acceptedAssistants = messages
-        .take(currentIndex)
-        .where(_isAcceptedAssistant)
-        .toList(growable: false);
-    var previousAcceptedIndex = -1;
-    if (previousEndMessageId != null) {
-      previousAcceptedIndex = acceptedAssistants.indexWhere(
-        (message) => message.id == previousEndMessageId,
-      );
-      // A durable logical head that is no longer in the transcript must not
-      // silently reset cadence to the beginning.
-      if (previousAcceptedIndex < 0) return null;
-    }
-    final firstUnprocessed = previousAcceptedIndex + 1;
-    final unprocessedCount = acceptedAssistants.length - firstUnprocessed;
-    if (unprocessedCount < acceptedAssistantsPerRun) {
+    if (currentIndex < 0 || !_isAcceptedAssistant(messages[currentIndex])) {
       return null;
     }
 
-    final endAssistant =
-        acceptedAssistants[firstUnprocessed + acceptedAssistantsPerRun - 1];
-    final endIndex = messages.indexWhere(
-      (message) => message.id == endAssistant.id,
+    final chunks = _parseCompletedChunks(
+      messages.take(currentIndex),
+      allowTrailingUser: true,
     );
-    final plan = _buildPlan(messages: messages, endIndex: endIndex);
+    if (chunks == null) return null;
+    var previousChunkIndex = -1;
+    if (previousEndMessageId != null) {
+      previousChunkIndex = chunks.indexWhere(
+        (chunk) => chunk.endAssistant.id == previousEndMessageId,
+      );
+      // A durable logical head that is no longer in the transcript must not
+      // silently reset cadence to the beginning.
+      if (previousChunkIndex < 0) return null;
+    }
+    final firstUnprocessed = previousChunkIndex + 1;
+    final unprocessedCount = chunks.length - firstUnprocessed;
+    if (unprocessedCount < acceptedChunksPerRun) {
+      return null;
+    }
+
+    final mandatoryEnd = firstUnprocessed + acceptedChunksPerRun;
+    final plan = _buildPlan(
+      chunks: chunks.sublist(0, mandatoryEnd),
+      mandatoryStart: firstUnprocessed,
+    );
     if (plan == null) return null;
     final end = plan.endMessage;
     final hash = plan.rangeHash;
@@ -99,18 +105,30 @@ class LedgerReconciliationPlanner {
   }
 
   LedgerReconciliationPlan? _buildPlan({
-    required List<ChatMessage> messages,
-    required int endIndex,
+    required List<_LedgerReviewChunk> chunks,
+    required int mandatoryStart,
   }) {
-    final end = messages[endIndex];
-    final startIndex = endIndex + 1 > maxMessages
-        ? endIndex + 1 - maxMessages
-        : 0;
-    final range = messages
-        .sublist(startIndex, endIndex + 1)
-        .where(_isReviewable)
+    if (chunks.isEmpty ||
+        mandatoryStart < 0 ||
+        mandatoryStart >= chunks.length) {
+      return null;
+    }
+    var start = mandatoryStart;
+    var count = chunks
+        .skip(mandatoryStart)
+        .fold<int>(0, (sum, chunk) => sum + chunk.messages.length);
+    if (count > maxMessages) return null;
+    while (start > 0) {
+      final older = chunks[start - 1];
+      if (count + older.messages.length > maxMessages) break;
+      start--;
+      count += older.messages.length;
+    }
+    final range = chunks
+        .sublist(start)
+        .expand((chunk) => chunk.messages)
         .toList(growable: false);
-    if (range.isEmpty) return null;
+    final end = chunks.last.endAssistant;
 
     final hash = sha256
         .convert(
@@ -146,6 +164,41 @@ class LedgerReconciliationPlanner {
       !message.isError &&
       !message.isHidden &&
       message.content.trim().isNotEmpty;
+
+  List<_LedgerReviewChunk>? _parseCompletedChunks(
+    Iterable<ChatMessage> source, {
+    bool allowTrailingUser = false,
+  }) {
+    final messages = source.where(_isReviewable).toList(growable: false);
+    if (messages.isEmpty || !_isAcceptedAssistant(messages.first)) return null;
+    final chunks = <_LedgerReviewChunk>[];
+    var index = 1;
+    while (index < messages.length) {
+      final user = messages[index];
+      if (user.role != 'user') return null;
+      if (index + 1 >= messages.length) {
+        return allowTrailingUser ? chunks : null;
+      }
+      final assistant = messages[index + 1];
+      if (!_isAcceptedAssistant(assistant)) return null;
+      chunks.add(
+        _LedgerReviewChunk([
+          if (chunks.isEmpty) messages.first,
+          user,
+          assistant,
+        ]),
+      );
+      index += 2;
+    }
+    return chunks;
+  }
+}
+
+final class _LedgerReviewChunk {
+  const _LedgerReviewChunk(this.messages);
+
+  final List<ChatMessage> messages;
+  ChatMessage get endAssistant => messages.last;
 }
 
 class StudioLedgerReconciliationPrompt {

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -97,8 +97,8 @@ class AutomatedCardEvolutionService {
     return _runWriter(sessionId, onStage: onStage);
   }
 
-  /// Automatic lane: collect once for this immutable reconciliation, then run
-  /// at most one overdue writer cycle for each completed group of three.
+  /// Automatic lane: collect each completed pair of valid reconciliations,
+  /// then run at most one overdue writer cycle per three collectors.
   Future<CardEvolutionFinalizeOutcome> runAfterReconciliation(
     LedgerReconciliationSuccessfulRunRow reconciliationRun, {
     void Function(AutomatedCardEvolutionStage stage)? onStage,
@@ -130,12 +130,12 @@ class AutomatedCardEvolutionService {
     LedgerReconciliationSuccessfulRunRow reconciliationRun, {
     void Function(AutomatedCardEvolutionStage stage)? onStage,
   }) async {
-    final pending = await collectorRunRepo.pendingValidRuns(
+    final pending = await collectorRunRepo.pendingValidPairs(
       reconciliationRun.sessionId,
       currentRun: reconciliationRun,
     );
-    for (final run in pending) {
-      final collected = await _runCollector(run, onStage: onStage);
+    for (final pair in pending) {
+      final collected = await _runCollector(pair, onStage: onStage);
       if (!collected) {
         return const CardEvolutionFinalizeOutcome('collectorUnavailable');
       }
@@ -157,12 +157,20 @@ class AutomatedCardEvolutionService {
     if (boundaryRuns.length != 3) {
       return const CardEvolutionFinalizeOutcome('collectorUnavailable');
     }
+    final reconciliationRuns = await collectorRunRepo.runsForCollectors(
+      reconciliationRun.sessionId,
+      boundaryRuns,
+    );
+    if (reconciliationRuns.length != 6) {
+      return const CardEvolutionFinalizeOutcome('collectorUnavailable');
+    }
     return _runWriter(
       reconciliationRun.sessionId,
       onStage: onStage,
       throughCollectorOrdinal: dueBoundary,
       collectorBoundaryHash: boundaryRuns.last.reconciliationChainHash,
       collectorBoundaryRuns: boundaryRuns,
+      reconciliationRunIds: [for (final run in reconciliationRuns) run.id],
     );
   }
 
@@ -172,6 +180,7 @@ class AutomatedCardEvolutionService {
     int throughCollectorOrdinal = 0,
     String collectorBoundaryHash = '',
     List<CardEvolutionCollectorRunRow> collectorBoundaryRuns = const [],
+    List<String>? reconciliationRunIds,
   }) async {
     onStage?.call(AutomatedCardEvolutionStage.cardRewriter);
     final owner = 'evolution-owner-${generateId()}';
@@ -183,9 +192,9 @@ class AutomatedCardEvolutionService {
       leaseSeconds: leaseSeconds,
       throughCollectorOrdinal: throughCollectorOrdinal,
       collectorBoundaryHash: collectorBoundaryHash,
-      reconciliationRunIds: [
-        for (final run in collectorBoundaryRuns) run.reconciliationRunId,
-      ],
+      reconciliationRunIds:
+          reconciliationRunIds ??
+          [for (final run in collectorBoundaryRuns) run.reconciliationRunId],
     );
     final claim = claimed.claim;
     if (claim == null) return CardEvolutionFinalizeOutcome(claimed.kind);
@@ -371,16 +380,15 @@ class AutomatedCardEvolutionService {
   }
 
   Future<bool> _runCollector(
-    LedgerReconciliationSuccessfulRunRow reconciliationRun, {
+    CardEvolutionCollectorPair pair, {
     void Function(AutomatedCardEvolutionStage stage)? onStage,
   }) async {
+    final reconciliationRun = pair.boundary;
     final sessionId = reconciliationRun.sessionId;
     String? claimId;
     String? ownerId;
     try {
-      final snapshot = await repo.buildObservationSnapshotForRun(
-        reconciliationRun,
-      );
+      final snapshot = await repo.buildObservationSnapshotForRuns(pair.runs);
       if (snapshot == null) return false;
       ownerId = 'collector-owner-${generateId()}';
       final now = currentTimestampSeconds();
@@ -391,6 +399,7 @@ class AutomatedCardEvolutionService {
         ownerId: ownerId,
         now: now,
         leaseSeconds: leaseSeconds,
+        rangeHash: pair.rangeHash,
       );
       if (claim.kind == 'completed') return true;
       if (!claim.canRun || claim.row == null) return false;
@@ -406,6 +415,15 @@ class AutomatedCardEvolutionService {
               ownerId: ownerId!,
               modelOutputHash: computeHash(output),
               now: currentTimestampSeconds(),
+              validateEvidence: () async {
+                final logical = await collectorRunRepo.runsForCollectors(
+                  sessionId,
+                  [claim.row!],
+                );
+                return logical.length == 2 &&
+                    logical[0].id == pair.first.id &&
+                    logical[1].id == pair.boundary.id;
+              },
               applyEffects: applyEffects,
             ),
       );

--- a/test/card_rewrite_observation_pass_test.dart
+++ b/test/card_rewrite_observation_pass_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
-import 'package:drift/drift.dart' show Value;
+import 'package:drift/drift.dart' show OrderingTerm, Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glaze_flutter/core/db/app_db.dart';
 import 'package:glaze_flutter/core/db/repositories/applied_canon_transition_repo.dart';
@@ -14,6 +14,7 @@ import 'package:glaze_flutter/core/db/repositories/character_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/character_revision_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/character_session_baseline_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_raw_tracker_state_reader.dart';
+import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_run_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/manual_rewrite_job_repo.dart';
 import 'package:glaze_flutter/core/llm/aux_llm_client.dart';
 import 'package:glaze_flutter/core/llm/aux_retry_runner.dart';
@@ -471,7 +472,7 @@ void main() {
   );
 
   test(
-    'automatic collector runs every reconciliation and writer every third',
+    'automatic collector runs every second reconciliation and writer every third collector',
     () async {
       final prompts = <String>[];
       final service = fixture.service((_, prompt) async {
@@ -480,12 +481,12 @@ void main() {
             ? _ok('{"observations":[]}')
             : _ok('{"operations":[]}');
       });
-      for (var ordinal = 1; ordinal <= 3; ordinal++) {
+      for (var ordinal = 1; ordinal <= 6; ordinal++) {
         final run = await fixture.seedReconciliationRun(ordinal: ordinal);
         final result = await service.runAfterReconciliation(run);
         expect(
           result.kind,
-          ordinal < 3 ? 'collectorCompleted' : 'emptyModelProposal',
+          ordinal < 6 ? 'collectorCompleted' : 'emptyModelProposal',
         );
       }
       expect(
@@ -500,6 +501,7 @@ void main() {
           .select(fixture.db.cardEvolutionCollectorRuns)
           .get();
       expect(collectors, hasLength(3));
+      expect(collectors.map((run) => run.reconciliationRunOrdinal), [2, 4, 6]);
       expect(collectors.every((run) => run.status == 'completed'), isTrue);
       final claims = await fixture.db
           .select(fixture.db.cardEvolutionClaims)
@@ -511,8 +513,9 @@ void main() {
   );
 
   test(
-    'first high reconciliation ordinal still becomes collector one',
+    'first high logical reconciliation pair becomes collector one',
     () async {
+      await fixture.seedReconciliationRun(ordinal: 39);
       final run = await fixture.seedReconciliationRun(ordinal: 40);
       final result = await fixture
           .service((_, prompt) async => _ok('{"observations":[]}'))
@@ -522,7 +525,7 @@ void main() {
           .select(fixture.db.cardEvolutionCollectorRuns)
           .getSingle();
       expect(collector.collectorOrdinal, 1);
-      expect(collector.reconciliationRunOrdinal, 40);
+      expect(collector.reconciliationRunOrdinal, 2);
     },
   );
 
@@ -535,7 +538,7 @@ void main() {
       writerCalls++;
       return _ok(writerCalls == 1 ? 'invalid' : '{"operations":[]}');
     });
-    for (final ordinal in [10, 20, 30, 40]) {
+    for (final ordinal in [10, 20, 30, 40, 50, 60, 70, 80]) {
       await service.runAfterReconciliation(
         await fixture.seedReconciliationRun(ordinal: ordinal),
       );
@@ -545,7 +548,10 @@ void main() {
         .select(fixture.db.cardEvolutionClaims)
         .getSingle();
     expect(claim.predecessorRunOrdinal, 3);
-    expect(claim.predecessorCursorHash, 'chain-30');
+    final boundary = await (fixture.db.select(
+      fixture.db.cardEvolutionCollectorRuns,
+    )..where((row) => row.collectorOrdinal.equals(3))).getSingle();
+    expect(claim.predecessorCursorHash, boundary.reconciliationChainHash);
   });
 
   test('minimal no_evidence response is accepted', () async {
@@ -589,8 +595,9 @@ void main() {
   });
 
   test('tracker fields normalize to one stable NPC group target', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
     final run = await fixture.seedReconciliationRun(
-      ordinal: 1,
+      ordinal: 2,
       opKeys: const ['npc:Квинн.location', 'npc:Квинн.current_goal'],
     );
     String? collectorPrompt;
@@ -632,6 +639,11 @@ void main() {
             updatedAt: 1,
           ),
         );
+        await fixture.seedReconciliationRun(
+          ordinal: ordinal - 1,
+          messages: messages,
+          opKeys: const ['world:location'],
+        );
         final run = await fixture.seedReconciliationRun(
           ordinal: ordinal,
           messages: messages,
@@ -652,13 +664,22 @@ void main() {
       await (fixture.db.delete(
         fixture.db.cardEvolutionObservations,
       )..where((row) => row.id.equals('quinn-1000'))).go();
+      await fixture.db.transaction(
+        () => LedgerReconciliationRunRepo(fixture.db)
+            .invalidateForMessageMutation(
+              sessionId: 'session',
+              messageIds: const {'a1'},
+              reason: 'test_evidence_change',
+              createdAt: 1001,
+            ),
+      );
       const returned = [
         {'id': 'a1', 'role': 'assistant', 'content': 'Квинн вошла в комнату.'},
         {'id': 'u1', 'role': 'user', 'content': 'Я приветствую Квинн.'},
         {'id': 'a2', 'role': 'assistant', 'content': 'assistant 2'},
         {'id': 'u2', 'role': 'user', 'content': 'user 2'},
       ];
-      final related = await promptFor(returned, 1001);
+      final related = await promptFor(returned, 1002);
       expect(related, contains('Квинн remembers the old promise'));
     },
   );
@@ -712,8 +733,13 @@ void main() {
         {'id': 'a2', 'role': 'assistant', 'content': 'assistant 2'},
         {'id': 'u2', 'role': 'user', 'content': 'user 2'},
       ];
-      final run = await fixture.seedReconciliationRun(
+      await fixture.seedReconciliationRun(
         ordinal: 1,
+        messages: messages,
+        opKeys: const ['arc:Спонсорство.status'],
+      );
+      final run = await fixture.seedReconciliationRun(
+        ordinal: 2,
         messages: messages,
         opKeys: const ['arc:Спонсорство.status'],
       );
@@ -778,8 +804,13 @@ void main() {
       {'id': 'a2', 'role': 'assistant', 'content': 'assistant 2'},
       {'id': 'u2', 'role': 'user', 'content': 'user 2'},
     ];
-    final run = await fixture.seedReconciliationRun(
+    await fixture.seedReconciliationRun(
       ordinal: 1,
+      messages: messages,
+      opKeys: const ['world:location'],
+    );
+    final run = await fixture.seedReconciliationRun(
+      ordinal: 2,
       messages: messages,
       opKeys: const ['world:location'],
     );
@@ -801,7 +832,7 @@ void main() {
             ? _ok('{"observations":[]}')
             : _ok('{"operations":[]}'),
       );
-      for (final ordinal in [1, 2]) {
+      for (final ordinal in [1, 2, 3, 4]) {
         final result = await service.runAfterReconciliation(
           await fixture.seedReconciliationRun(ordinal: ordinal),
         );
@@ -815,8 +846,11 @@ void main() {
       )..where((row) => row.collectorOrdinal.equals(2))).write(
         const CardEvolutionCollectorRunsCompanion(status: Value('claimed')),
       );
+      await service.runAfterReconciliation(
+        await fixture.seedReconciliationRun(ordinal: 5),
+      );
       final result = await service.runAfterReconciliation(
-        await fixture.seedReconciliationRun(ordinal: 3),
+        await fixture.seedReconciliationRun(ordinal: 6),
       );
       expect(result.kind, 'collectorUnavailable');
       expect(
@@ -828,8 +862,9 @@ void main() {
   );
 
   test('primary current groups survive retrieval target extras cap', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
     final run = await fixture.seedReconciliationRun(
-      ordinal: 1,
+      ordinal: 2,
       opKeys: [
         for (var index = 0; index < 85; index++) 'arc:Текущий$index.status',
       ],
@@ -930,56 +965,51 @@ final class _Fixture {
       'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
       [jsonEncode(messages), 'session'],
     );
-    final anchors = [
+    final anchors = <ReconciliationAnchor>[
       for (final message in messages)
-        {
-          'agentSwipeId': 0,
-          'contentHash': computeHash(message['content']!),
-          'messageId': message['id'],
-          'role': message['role'],
-          'swipeId': 0,
-        },
+        ReconciliationAnchor(
+          agentSwipeId: 0,
+          contentHash: computeHash(message['content']!),
+          messageId: message['id']!,
+          role: message['role']!,
+          swipeId: 0,
+        ),
     ];
-    final anchorsJson = jsonEncode(anchors);
-    await db.customStatement(
-      'INSERT INTO reconciliation_successful_runs '
-      '(id, session_id, ordinal, start_message_id, start_swipe_id, '
-      'start_agent_swipe_id, end_message_id, end_swipe_id, '
-      'end_agent_swipe_id, anchors_json, range_hash, '
-      'accepted_manifest_refs_json, effective_canon_stamp, '
-      'effective_canon_revision, effective_canon_hash, '
-      'canonical_result_json, content_hash, predecessor_chain_hash, '
-      'chain_hash, contract_version, ops_applied_json, created_at) '
-      'VALUES (?, ?, ?, ?, 0, 0, ?, 0, 0, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, 1, ?, ?)',
-      [
-        'run-$ordinal',
-        'session',
-        ordinal,
-        'a1',
-        'a1',
-        anchorsJson,
-        computeHash(anchorsJson),
-        '[]',
-        'canon-stamp-$ordinal',
-        'canon-hash-$ordinal',
-        jsonEncode({
-          'export': {
-            'ops': [
-              for (final key in opKeys) {'op': 'set', 'key': key, 'value': ''},
+    final existing =
+        await (db.select(db.ledgerReconciliationSuccessfulRuns)
+              ..where((row) => row.sessionId.equals('session'))
+              ..orderBy([(row) => OrderingTerm.desc(row.ordinal)])
+              ..limit(1))
+            .getSingleOrNull();
+    final run = LedgerReconciliationRun(
+      id: 'run-$ordinal',
+      sessionId: 'session',
+      ordinal: (existing?.ordinal ?? 0) + 1,
+      anchors: anchors,
+      acceptedManifestRefs: const [],
+      effectiveCanonStamp: 'canon-stamp-$ordinal',
+      effectiveCanonRevision: 1,
+      effectiveCanonHash: 'canon-hash-$ordinal',
+      canonicalResult: {
+        'export': {
+          'ops': [
+            for (final key in opKeys) {'op': 'set', 'key': key, 'value': ''},
+          ],
+          'sceneState': {
+            'presentEntities': [
+              for (final name in presentEntities) {'name': name},
             ],
-            'sceneState': {
-              'presentEntities': [
-                for (final name in presentEntities) {'name': name},
-              ],
-            },
           },
-        }),
-        'content-$ordinal',
-        '',
-        'chain-$ordinal',
-        '[]',
-        ordinal * 10,
-      ],
+        },
+      },
+      predecessorChainHash: existing?.chainHash ?? '',
+      contractVersion: 1,
+      opsApplied: const [],
+      createdAt: ordinal * 10,
+    );
+    expect(
+      await LedgerReconciliationRunRepo(db).append(run),
+      isA<ReconciliationRunAppended>(),
     );
     return (db.select(
       db.ledgerReconciliationSuccessfulRuns,

--- a/test/studio_ledger_test.dart
+++ b/test/studio_ledger_test.dart
@@ -124,7 +124,13 @@ List<Tracker> _makeTrackers(
 }
 
 List<ChatMessage> _conversation(int assistantCount) {
-  final messages = <ChatMessage>[];
+  final messages = <ChatMessage>[
+    const ChatMessage(
+      id: 'a0',
+      role: 'assistant',
+      content: 'Opening assistant message',
+    ),
+  ];
   for (var i = 1; i <= assistantCount; i++) {
     messages.add(ChatMessage(id: 'u$i', role: 'user', content: 'User turn $i'));
     messages.add(
@@ -208,6 +214,7 @@ void main() {
   group('Ledger reconciliation', () {
     test('manual plan ends at the requested assistant and stays bounded', () {
       final messages = <ChatMessage>[
+        const ChatMessage(id: 'a0', role: 'assistant', content: 'Opening'),
         for (var i = 1; i <= 12; i++) ...[
           ChatMessage(id: 'u$i', role: 'user', content: 'User $i'),
           ChatMessage(id: 'a$i', role: 'assistant', content: 'Assistant $i'),
@@ -243,6 +250,19 @@ void main() {
       );
       expect(plan, isNotNull);
       expect(plan!.endMessage.id, 'a5');
+      expect(plan.messageIds, [
+        'a0',
+        'u1',
+        'a1',
+        'u2',
+        'a2',
+        'u3',
+        'a3',
+        'u4',
+        'a4',
+        'u5',
+        'a5',
+      ]);
 
       final checkpoint = LedgerReconciliationCheckpoint(
         sessionId: 's',
@@ -279,8 +299,12 @@ void main() {
       expect(next, isNotNull);
       expect(next!.endMessage.id, 'a10');
       expect(next.messageIds, isNot(contains('a11')));
-      // Rolling context remains intentionally overlapping.
+      expect(next.messages, hasLength(18));
+      expect(next.startMessageId, 'u2');
+      // Rolling context remains intentionally overlapping, but chunk 1 is
+      // never split merely to fill the two remaining message slots.
       expect(next.messageIds, contains('a5'));
+      expect(next.messageIds, isNot(contains('a0')));
       expect(
         planner.plan(
           messages: [
@@ -318,7 +342,7 @@ void main() {
         rangeHash: original.rangeHash,
       );
       final changed = [...messages];
-      changed[9] = changed[9].copyWith(content: 'Changed accepted swipe');
+      changed[10] = changed[10].copyWith(content: 'Changed accepted swipe');
       expect(
         planner.plan(
           messages: changed,
@@ -361,7 +385,8 @@ void main() {
         currentAssistantMessageId: 'a11',
         previousEndMessageId: 'a5',
       )!;
-      expect(plan.messages, hasLength(20));
+      expect(plan.messages, hasLength(18));
+      expect(plan.startMessageId, 'u2');
       expect(plan.endMessage.id, 'a10');
     });
 
@@ -401,6 +426,7 @@ void main() {
 
     test('candidate keys include mentioned entity siblings and provenance', () {
       final messages = [
+        const ChatMessage(id: 'a0', role: 'assistant', content: 'Opening.'),
         const ChatMessage(id: 'u1', role: 'user', content: 'Where is Lucy?'),
         const ChatMessage(id: 'a1', role: 'assistant', content: 'Lucy waits.'),
       ];
@@ -442,6 +468,7 @@ void main() {
 
     test('candidate keys and values share a hard bounded set', () {
       final messages = [
+        const ChatMessage(id: 'a0', role: 'assistant', content: 'Opening.'),
         const ChatMessage(id: 'u1', role: 'user', content: 'Continue.'),
         const ChatMessage(id: 'a1', role: 'assistant', content: 'Continued.'),
       ];


### PR DESCRIPTION
## Summary
- plan reconciliation over five accepted whole chat chunks while keeping the trigger outside immutable evidence
- retain overlapping historical context without splitting chunks at the 20-message cap
- collect Card Evolution after each pair of valid reconciliations and give each writer all six reconciliation runs
- rebuild incompatible legacy collector journals and revalidate pair evidence before committing observation effects

## Verification
- dart analyze scoped changed production/tests
- flutter test test/studio_ledger_test.dart test/card_rewrite_observation_pass_test.dart test/ledger_reconciliation_run_repo_test.dart test/chat_bulk_delete_test.dart (98 passed)