### PR TITLE
fix(lorebook): match SillyTavern /pattern/flags regex keys

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -104,7 +104,7 @@ lib/
 │   │   ├── memory_embedding_service.dart   # Indexes memory entries into embedding store
 │   │   ├── memory_injection_service.dart   # Scores + selects memory entries for injection
 │   │   ├── memory_budget.dart         # INV-PS4 token cap for memory injection
-│   │   ├── glaze_matcher.dart         # Pure regex keyword matching (3 whole-word modes)
+│   │   ├── glaze_matcher.dart         # Pure regex keyword matching (3 whole-word modes, ST `/pattern/flags` keys)
 │   │   ├── regex_service.dart         # Applies PresetRegex scripts to a string
 │   │   ├── preset_macro_attribution.dart # Preset macro source attribution (debug)
 │   │   ├── sse_client.dart           # SSE + non-streaming completions via Dio

--- a/lib/core/import/st_lorebook_importer.dart
+++ b/lib/core/import/st_lorebook_importer.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import '../llm/glaze_matcher.dart';
 import '../utils/id_generator.dart';
 import '../utils/time_helpers.dart';
 import '../models/lorebook.dart';
@@ -19,7 +20,7 @@ LorebookEntry _convertSTEntry(dynamic rawEntry, int index) {
 
   List<String> parseKeys(dynamic v) {
     if (v is List) return v.map((k) => k.toString().trim()).where((k) => k.isNotEmpty).toList();
-    if (v is String && v.isNotEmpty) return v.split(',').map((k) => k.trim()).where((k) => k.isNotEmpty).toList();
+    if (v is String && v.isNotEmpty) return splitLorebookKeys(v);
     return [];
   }
 

--- a/lib/core/llm/glaze_matcher.dart
+++ b/lib/core/llm/glaze_matcher.dart
@@ -5,6 +5,101 @@ const glazeBoundaries =
 
 enum WholeWordMode { no, yes, glaze }
 
+/// A key written in SillyTavern's `/pattern/flags` regex form.
+class RegexKey {
+  final String pattern;
+  final bool ignoreCase;
+  final bool multiLine;
+  final bool dotAll;
+
+  const RegexKey({
+    required this.pattern,
+    required this.ignoreCase,
+    required this.multiLine,
+    required this.dotAll,
+  });
+}
+
+/// JS regex flags allowed after the closing delimiter. `g`, `y` and `d` carry
+/// no meaning for a stateless `hasMatch`, so they are parsed and ignored.
+const _jsRegexFlags = 'gimsuyd';
+
+final _regexKeyShape = RegExp(r'^/(.+)/([a-z]*)$', dotAll: true);
+
+/// Parses a key written as `/pattern/flags`, or returns null when the key is a
+/// plain one. A trailing segment that is not a valid flag list keeps the key
+/// literal, so `/home/user` is still matched as text.
+RegexKey? parseRegexKey(String key) {
+  final match = _regexKeyShape.firstMatch(key);
+  if (match == null) return null;
+
+  final flags = match.group(2)!;
+  for (var i = 0; i < flags.length; i++) {
+    if (!_jsRegexFlags.contains(flags[i])) return null;
+  }
+
+  return RegexKey(
+    pattern: match.group(1)!,
+    ignoreCase: flags.contains('i'),
+    multiLine: flags.contains('m'),
+    dotAll: flags.contains('s'),
+  );
+}
+
+/// Splits a comma-separated key list without cutting `/pattern/flags` keys that
+/// contain a comma (e.g. `/Кент(?:а|у){1,2}/g`).
+List<String> splitLorebookKeys(String text) {
+  final keys = <String>[];
+  final buffer = StringBuffer();
+  var inRegex = false;
+  var inCharClass = false;
+  var escaped = false;
+  var segmentEmpty = true;
+
+  void flush() {
+    final key = buffer.toString().trim();
+    if (key.isNotEmpty) keys.add(key);
+    buffer.clear();
+    segmentEmpty = true;
+    inRegex = false;
+    inCharClass = false;
+    escaped = false;
+  }
+
+  for (var i = 0; i < text.length; i++) {
+    final ch = text[i];
+
+    if (inRegex) {
+      buffer.write(ch);
+      if (escaped) {
+        escaped = false;
+      } else if (ch == r'\') {
+        escaped = true;
+      } else if (ch == '[') {
+        inCharClass = true;
+      } else if (ch == ']') {
+        inCharClass = false;
+      } else if (ch == '/' && !inCharClass) {
+        // Closing delimiter — the trailing flags are plain text again.
+        inRegex = false;
+      }
+      continue;
+    }
+
+    if (ch == ',') {
+      flush();
+      continue;
+    }
+
+    if (ch == '/' && segmentEmpty) inRegex = true;
+    buffer.write(ch);
+    if (ch.trim().isNotEmpty) segmentEmpty = false;
+  }
+
+  flush();
+  return keys;
+}
+
 WholeWordMode resolveWholeWords(
   bool? entryValue,
   bool globalValue,
@@ -24,6 +119,22 @@ bool glazeCheckMatch(
   WholeWordMode wholeWords,
 ) {
   if (key.isEmpty) return false;
+
+  // A `/pattern/flags` key is an explicit regex, the form ST exports: the
+  // delimiters and flags are not part of the pattern, and whole-word wrapping
+  // never applies to it. Without this, the whole literal (slashes included)
+  // was compiled as the pattern and could only match text containing `/`.
+  final regexKey = parseRegexKey(key);
+  if (regexKey != null) {
+    final regex = _safeRegex(
+      regexKey.pattern,
+      caseSensitive && !regexKey.ignoreCase,
+      multiLine: regexKey.multiLine,
+      dotAll: regexKey.dotAll,
+    );
+    if (regex != null) return regex.hasMatch(text);
+    // Pathological or uncompilable — fall through to literal matching.
+  }
 
   if (wholeWords == WholeWordMode.glaze) {
     final escaped = RegExp.escape(key);
@@ -52,9 +163,7 @@ bool glazeCheckMatch(
   // pattern can otherwise block the prompt worker until its hard 60s kill.
   // Keep regex compatibility for ordinary keys, but fall back to literal
   // matching for patterns with known catastrophic-backtracking structure.
-  final regex = classifyRegexSafety(pattern) == RegexSafety.pathological
-      ? null
-      : _tryCreateRegex(pattern, caseSensitive);
+  final regex = _safeRegex(pattern, caseSensitive);
   if (regex != null) return regex.hasMatch(text);
 
   final haystack = caseSensitive ? text : text.toLowerCase();
@@ -72,9 +181,34 @@ bool glazeCheckMatch(
   return haystack.contains(needle);
 }
 
-RegExp? _tryCreateRegex(String pattern, bool caseSensitive) {
+RegExp? _safeRegex(
+  String pattern,
+  bool caseSensitive, {
+  bool multiLine = false,
+  bool dotAll = false,
+}) {
+  if (classifyRegexSafety(pattern) == RegexSafety.pathological) return null;
+  return _tryCreateRegex(
+    pattern,
+    caseSensitive,
+    multiLine: multiLine,
+    dotAll: dotAll,
+  );
+}
+
+RegExp? _tryCreateRegex(
+  String pattern,
+  bool caseSensitive, {
+  bool multiLine = false,
+  bool dotAll = false,
+}) {
   try {
-    return RegExp(pattern, caseSensitive: caseSensitive);
+    return RegExp(
+      pattern,
+      caseSensitive: caseSensitive,
+      multiLine: multiLine,
+      dotAll: dotAll,
+    );
   } catch (_) {
     return null;
   }

--- a/lib/features/lorebooks/lorebook_editor_screen.dart
+++ b/lib/features/lorebooks/lorebook_editor_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/llm/embedding_error_labels.dart';
+import '../../core/llm/glaze_matcher.dart';
 import '../../core/models/lorebook.dart';
 import '../../core/state/db_provider.dart';
 import '../../core/state/lorebook_embedding_provider.dart';
@@ -455,8 +456,8 @@ class _LorebookEditorScreenState extends ConsumerState<LorebookEditorScreen> {
     final base = _entries[_editIndex];
     final names = _parseList(_eCharFilter!.text);
     return base.copyWith(
-      keys: _parseList(_eKeys!.text),
-      secondaryKeys: _parseList(_eSecondary!.text),
+      keys: splitLorebookKeys(_eKeys!.text),
+      secondaryKeys: splitLorebookKeys(_eSecondary!.text),
       content: _eContent!.text,
       comment: _eComment!.text.trim(),
       order: int.tryParse(_eOrder!.text) ?? 100,

--- a/test/lorebook_regex_key_test.dart
+++ b/test/lorebook_regex_key_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/import/st_lorebook_importer.dart';
+import 'package:glaze_flutter/core/llm/glaze_matcher.dart';
+import 'package:glaze_flutter/core/llm/lorebook_scanner.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/models/lorebook.dart';
+
+void main() {
+  group('parseRegexKey', () {
+    test('strips delimiters and parses flags', () {
+      final parsed = parseRegexKey('/abc/gi');
+      expect(parsed, isNotNull);
+      expect(parsed!.pattern, 'abc');
+      expect(parsed.ignoreCase, isTrue);
+      expect(parsed.multiLine, isFalse);
+      expect(parsed.dotAll, isFalse);
+    });
+
+    test('accepts a regex key with no flags', () {
+      expect(parseRegexKey('/abc/')?.pattern, 'abc');
+    });
+
+    test('leaves plain keys alone', () {
+      expect(parseRegexKey('Kenta'), isNull);
+      expect(parseRegexKey('AC/DC'), isNull);
+      expect(parseRegexKey('/'), isNull);
+    });
+
+    test('a trailing segment that is not a flag list stays literal', () {
+      expect(parseRegexKey('/home/user'), isNull);
+    });
+  });
+
+  group('glazeCheckMatch with /pattern/flags keys', () {
+    test('matches a Cyrillic ST regex key against lowercased scan text', () {
+      const key = r'/(?:^|[^а-яА-ЯёЁ])Кент(?:а|ой|у)(?:[^а-яА-ЯёЁ]|)/g';
+      expect(
+        glazeCheckMatch(key, 'привет, кента, как дела?', false,
+            WholeWordMode.no),
+        isTrue,
+      );
+      expect(
+        glazeCheckMatch(key, 'ничего похожего тут нет', false,
+            WholeWordMode.no),
+        isFalse,
+      );
+    });
+
+    test('whole-word modes do not wrap a regex key', () {
+      const key = r'/(?:^|[^а-яА-ЯёЁ])Осак(?:а|и|е|у|ой)?/g';
+      for (final mode in WholeWordMode.values) {
+        expect(
+          glazeCheckMatch(key, 'мы в осаке', false, mode),
+          isTrue,
+          reason: 'failed for $mode',
+        );
+      }
+    });
+
+    test('the i flag overrides a case-sensitive entry', () {
+      expect(glazeCheckMatch('/kenta/i', 'Kenta', true, WholeWordMode.no),
+          isTrue);
+      expect(glazeCheckMatch('/kenta/g', 'Kenta', true, WholeWordMode.no),
+          isFalse);
+    });
+
+    test('the s flag lets . cross newlines', () {
+      expect(glazeCheckMatch('/a.b/s', 'a\nb', false, WholeWordMode.no),
+          isTrue);
+      expect(glazeCheckMatch('/a.b/g', 'a\nb', false, WholeWordMode.no),
+          isFalse);
+    });
+
+    test('an uncompilable regex key falls back to a literal match', () {
+      expect(
+        glazeCheckMatch('/(unclosed/g', 'text with /(unclosed/g inside', false,
+            WholeWordMode.no),
+        isTrue,
+      );
+    });
+
+    test('a pathological regex key falls back to a literal match', () {
+      // ReDoS guard: the pattern is never compiled, so the key can only match
+      // as text (it does not appear in the message).
+      expect(
+        glazeCheckMatch(r'/(a+)+$/g', '${'a' * 22}!', false, WholeWordMode.no),
+        isFalse,
+      );
+    });
+
+    test('bare patterns keep working as before', () {
+      expect(glazeCheckMatch('Kenta', 'meeting kenta today', false,
+          WholeWordMode.no),
+          isTrue);
+      expect(
+        glazeCheckMatch('(cat|dog)', 'a dog barks', false, WholeWordMode.no),
+        isTrue,
+      );
+    });
+  });
+
+  group('splitLorebookKeys', () {
+    test('splits plain keys on commas', () {
+      expect(splitLorebookKeys('a, b ,c'), ['a', 'b', 'c']);
+    });
+
+    test('keeps a comma inside a regex key intact', () {
+      expect(
+        splitLorebookKeys(r'/Кент(?:а|у){1,2}/g, Kenta'),
+        [r'/Кент(?:а|у){1,2}/g', 'Kenta'],
+      );
+    });
+
+    test('keeps a comma inside a character class intact', () {
+      expect(splitLorebookKeys(r'/[a,b]+/g, plain'), [r'/[a,b]+/g', 'plain']);
+    });
+
+    test('an escaped slash does not close the regex early', () {
+      expect(splitLorebookKeys(r'/a\/b,c/g'), [r'/a\/b,c/g']);
+    });
+
+    test('drops empty segments', () {
+      expect(splitLorebookKeys('a,,  , b'), ['a', 'b']);
+    });
+  });
+
+  test('ST lorebook with /pattern/g keys activates on a Russian message', () {
+    final imported = importSTLorebook({
+      'name': 'Regex book',
+      'entries': {
+        '0': {
+          'uid': 0,
+          'key': [
+            r'/(?:^|[^а-яА-ЯёЁ])Кент(?:а|ой|у)(?:[^а-яА-ЯёЁ]|)/g',
+            '/Kenta/g',
+          ],
+          'keysecondary': <String>[],
+          'comment': 'NPC - Takahashi Kenta',
+          'content': 'KENTA_ENTRY',
+          'constant': false,
+          'selectiveLogic': 1,
+          'order': 1,
+          'position': 0,
+          'disable': false,
+        },
+      },
+    });
+
+    final scanned = scanLorebooks(
+      history: const [
+        ChatMessage(id: 'm1', role: 'user', content: 'Что там с Кентой?'),
+      ],
+      char: null,
+      textToScan: '',
+      chatId: null,
+      lorebooks: [imported.lorebook],
+      globalSettings: const LorebookGlobalSettings(),
+      activations: const LorebookActivations(),
+    );
+
+    expect(scanned.map((e) => e.content), ['KENTA_ENTRY']);
+  });
+}


### PR DESCRIPTION
Keys exported by SillyTavern in `/pattern/flags` form were compiled as regexes verbatim, delimiters included. A key like `/(?:^|[^а-яА-ЯёЁ])Кент(?:а|ой|у)/g` therefore only matched text that literally contained a slash, so every entry of a regex-keyed lorebook stayed silent — reported against a lorebook whose 27 entries all use that key form.

## Changes

- `parseRegexKey` in `glaze_matcher.dart` recognises a `/pattern/flags` key, strips the delimiters and applies `i` / `m` / `s`. `g`, `y` and `d` are parsed and ignored — they carry no meaning for a stateless `RegExp.hasMatch`.
- `glazeCheckMatch` tries the regex-key branch first and skips whole-word wrapping for it: `\b…\b` (and the glaze boundary classes) around a full pattern breaks it. Same behaviour as ST, which never applies whole-word matching to a regex key.
- The `i` flag combines with the entry's own case sensitivity, so a case-sensitive entry can still carry a case-insensitive key.
- The ReDoS guard added in `nightly` still applies: a pattern `classifyRegexSafety` calls pathological, or one that does not compile, falls through to the existing literal-match path instead of being run.
- A trailing segment that is not a valid flag list keeps the key literal, so `/home/user` and `AC/DC` are matched as text exactly as before.
- `splitLorebookKeys` splits a comma-separated key list without cutting a regex key that contains a comma (`/Кент(?:а|у){1,2}/g`). Used by `_buildEditEntry` in `lorebook_editor_screen.dart` — opening such an entry in the editor used to save it back with the key severed — and by `parseKeys` in `st_lorebook_importer.dart`.
- `docs/ARCHITECTURE.md`: noted the ST key form on the `glaze_matcher.dart` line.

The matcher is shared, so `lorebook_coverage.dart` (the per-entry coverage diagnostic) reports correctly for these keys too.

## Verification

- Added `test/lorebook_regex_key_test.dart`: key parsing and flag handling, the whole-word bypass across all three `WholeWordMode` values, the literal fallbacks for uncompilable and pathological patterns, comma-safe splitting, and an end-to-end `importSTLorebook` + `scanLorebooks` case that activates a `/pattern/g`-keyed entry on a Russian message.
- **Not run locally**: this was written by an agent with no Flutter SDK available, so neither `flutter analyze` nor `flutter test` was executed. CI is the first actual run of both.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gx8f8hVBkPSWpVzPn7scij)_