### PR TITLE
fix(chat): preserve reconciliation after tail deletion

### DIFF
--- a/lib/core/services/backup/js_api_config_importer.dart
+++ b/lib/core/services/backup/js_api_config_importer.dart
@@ -79,8 +79,9 @@ class JsApiConfigImporter extends BackupHelpers {
         final pMode = p['mode'] as String?;
         if (pMode == 'embedding' ||
             pMode == 'image_gen' ||
-            pMode == 'memory_books')
+            pMode == 'memory_books') {
           continue;
+        }
         if (pid != resolved.llmProfileId) {
           final ep = (p['endpoint'] as String?) ?? '';
           final ak = (p['apiKey'] as String?) ?? (p['key'] as String?) ?? '';

--- a/lib/core/services/backup/tavo_backup_importer.dart
+++ b/lib/core/services/backup/tavo_backup_importer.dart
@@ -597,16 +597,20 @@ class TavoBackupImporter {
           cardData.addAll(v2Data);
         } else if ((s['name'] as String?)?.isNotEmpty == true) {
           cardData['name'] = s['name'];
-          if (s['description'] != null)
+          if (s['description'] != null) {
             cardData['description'] = s['description'];
+          }
           if (s['first_mes'] != null) cardData['first_mes'] = s['first_mes'];
           if (s['scenario'] != null) cardData['scenario'] = s['scenario'];
-          if (s['personality'] != null)
+          if (s['personality'] != null) {
             cardData['personality'] = s['personality'];
-          if (s['mes_example'] != null)
+          }
+          if (s['mes_example'] != null) {
             cardData['mes_example'] = s['mes_example'];
-          if (s['system_prompt'] != null)
+          }
+          if (s['system_prompt'] != null) {
             cardData['system_prompt'] = s['system_prompt'];
+          }
           final altGreet = s['alternate_greetings'];
           if (altGreet is String) {
             try {

--- a/lib/core/services/card_rewriter/effective_canon_read_repository.dart
+++ b/lib/core/services/card_rewriter/effective_canon_read_repository.dart
@@ -37,23 +37,16 @@ class EffectiveCanonReadRepository {
   /// Runtime-only compatibility boundary. Apply uses the primary constructor,
   /// whose raw state is always read from its own [AppDatabase].
   EffectiveCanonReadRepository.runtime({
-    required AppDatabase db,
-    required CharacterRepo characterRepo,
-    required CharacterRevisionRepo revisionRepo,
-    required CharacterSessionBaselineRepo baselineRepo,
-    required CharacterKnowledgeFactRepo factRepo,
-    required AppliedCanonTransitionRepo transitionRepo,
-    required CanonTransitionFactRefRepo transitionFactRefRepo,
+    required this.db,
+    required this.characterRepo,
+    required this.revisionRepo,
+    required this.baselineRepo,
+    required this.factRepo,
+    required this.transitionRepo,
+    required this.transitionFactRefRepo,
     required Future<LedgerRawTrackerState> Function(String sessionId)
     loadRawTrackerState,
-  }) : db = db,
-       characterRepo = characterRepo,
-       revisionRepo = revisionRepo,
-       baselineRepo = baselineRepo,
-       factRepo = factRepo,
-       transitionRepo = transitionRepo,
-       transitionFactRefRepo = transitionFactRefRepo,
-       _rawTrackerStateReader = LedgerRawTrackerStateReader(db),
+  }) : _rawTrackerStateReader = LedgerRawTrackerStateReader(db),
        _runtimeRawTrackerStateLoader = loadRawTrackerState;
 
   final AppDatabase db;

--- a/lib/core/services/migration_service.dart
+++ b/lib/core/services/migration_service.dart
@@ -381,14 +381,18 @@ class MigrationService {
         if (r is! Map<String, dynamic>) continue;
         final normalized = Map<String, dynamic>.from(r);
         if (!normalized.containsKey('id')) normalized['id'] = _generateId();
-        if (!normalized.containsKey('name'))
+        if (!normalized.containsKey('name')) {
           normalized['name'] = r['scriptName'] ?? '';
-        if (!normalized.containsKey('regex'))
+        }
+        if (!normalized.containsKey('regex')) {
           normalized['regex'] = r['findRegex'] ?? '';
-        if (!normalized.containsKey('replacement'))
+        }
+        if (!normalized.containsKey('replacement')) {
           normalized['replacement'] = r['replaceString'] ?? '';
-        if (!normalized.containsKey('trimOut'))
+        }
+        if (!normalized.containsKey('trimOut')) {
           normalized['trimOut'] = _joinTrimStrings(r['trimStrings']);
+        }
         if (r['isEnabled'] is bool) {
           normalized['disabled'] = !(r['isEnabled'] as bool);
         }

--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -210,7 +210,12 @@ class ChatMessageService {
           .read(ledgerReconciliationRunRepoProvider)
           .invalidateForMessageMutation(
             sessionId: session.id,
-            messageIds: plan.deletedMessageIds,
+            // Deleting an earlier message changes the causal transcript for
+            // every later reconciliation range, even when the deleted message
+            // itself was not one of that run's anchors. Conversely, deleting
+            // only a trailing trigger must leave an already-completed range
+            // intact.
+            messageIds: invalidatedMessageIds,
             reason: 'message_deleted',
             createdAt: currentTimestampSeconds(),
           );
@@ -221,7 +226,7 @@ class ChatMessageService {
         sessionId: session.id,
         messageIds: invalidatedMessageIds,
       );
-      await checkpointRepo.deleteBySessionId(session.id);
+      await checkpointRepo.deleteForMessages(session.id, invalidatedMessageIds);
       await trackerRepo.replaceLedgerState(
         session.id,
         fallbackSnapshot?.trackers ?? const [],

--- a/lib/features/chat/controllers/chat_message_ops_controller.dart
+++ b/lib/features/chat/controllers/chat_message_ops_controller.dart
@@ -1,3 +1,6 @@
+// Named public constructor arguments intentionally initialize private fields.
+// ignore_for_file: prefer_initializing_formals
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/features/chat/controllers/chat_swipe_controller.dart
+++ b/lib/features/chat/controllers/chat_swipe_controller.dart
@@ -1,3 +1,6 @@
+// Named public constructor arguments intentionally initialize private fields.
+// ignore_for_file: prefer_initializing_formals
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/chat_message.dart';

--- a/lib/features/cloud_sync/services/sync_controller.dart
+++ b/lib/features/cloud_sync/services/sync_controller.dart
@@ -7,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/state/character_provider.dart';
 import '../../../core/state/active_studio_preset_provider.dart';
 import '../../../core/state/chat_session_ops_provider.dart';
-import '../../../core/state/db_provider.dart';
 import '../../../core/state/lorebook_provider.dart';
 import '../../../core/state/shared_prefs_provider.dart';
 import '../../../shared/theme/theme_provider.dart';

--- a/test/chat_delete_plan_test.dart
+++ b/test/chat_delete_plan_test.dart
@@ -3,8 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_checkpoint_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_run_repo.dart';
 import 'package:glaze_flutter/core/models/chat_message.dart';
 import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:glaze_flutter/core/utils/cast_helpers.dart';
 import 'package:glaze_flutter/features/chat/chat_message_service.dart';
 
 final _messageServiceProvider = Provider(ChatMessageService.new);
@@ -37,9 +40,10 @@ void main() {
     final session = _session(5);
     await container.read(chatRepoProvider).put(session);
 
-    final plan = container
-        .read(_messageServiceProvider)
-        .planDeleteMessages(session, {1, 3});
+    final plan = container.read(_messageServiceProvider).planDeleteMessages(
+      session,
+      {1, 3},
+    );
 
     expect(plan, isNotNull);
     expect(plan!.session.messages.map((m) => m.id), ['m0', 'm2', 'm4']);
@@ -100,4 +104,160 @@ void main() {
     expect(persisted?.messages.map((m) => m.id), ['m0', 'm2', 'm4']);
     expect(persisted?.deletedMessageCount, 2);
   });
+
+  test(
+    'tail deletion preserves completed reconciliation range and checkpoint',
+    () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      final container = ProviderContainer(
+        overrides: [appDbProvider.overrideWithValue(db)],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await db.close();
+      });
+
+      final session = _session(6);
+      await container.read(chatRepoProvider).put(session);
+      await _seedReconciliation(container, session);
+
+      final service = container.read(_messageServiceProvider);
+      final plan = service.planDeleteMessages(session, {4, 5})!;
+      await service.commitDeleteMessages(session, plan);
+
+      expect(
+        await container
+            .read(ledgerReconciliationCheckpointRepoProvider)
+            .get(session.id),
+        isNotNull,
+      );
+      expect(
+        (await container
+                .read(ledgerReconciliationRunRepoProvider)
+                .getHead(session.id))
+            ?.id,
+        'run-1',
+      );
+      expect(
+        (await db.select(db.cardEvolutionCollectorRuns).get()).map(
+          (row) => row.id,
+        ),
+        ['collector-1'],
+      );
+    },
+  );
+
+  for (final testCase in const [
+    (name: 'inside', deletedIndex: 2),
+    (name: 'before', deletedIndex: 0),
+  ]) {
+    test(
+      '${testCase.name} range deletion invalidates reconciliation and checkpoint',
+      () async {
+        final db = AppDatabase.forTesting(NativeDatabase.memory());
+        final container = ProviderContainer(
+          overrides: [appDbProvider.overrideWithValue(db)],
+        );
+        addTearDown(() async {
+          container.dispose();
+          await db.close();
+        });
+
+        final session = _session(6);
+        await container.read(chatRepoProvider).put(session);
+        await _seedReconciliation(container, session);
+
+        final service = container.read(_messageServiceProvider);
+        final plan = service.planDeleteMessages(session, {
+          testCase.deletedIndex,
+        })!;
+        await service.commitDeleteMessages(session, plan);
+
+        expect(
+          await container
+              .read(ledgerReconciliationCheckpointRepoProvider)
+              .get(session.id),
+          isNull,
+        );
+        expect(
+          await container
+              .read(ledgerReconciliationRunRepoProvider)
+              .getHead(session.id),
+          isNull,
+        );
+        final invalidations = await db
+            .select(db.ledgerReconciliationRunInvalidations)
+            .get();
+        expect(invalidations.map((row) => row.runId), ['run-1']);
+        expect(await db.select(db.cardEvolutionCollectorRuns).get(), isEmpty);
+      },
+    );
+  }
+}
+
+Future<void> _seedReconciliation(
+  ProviderContainer container,
+  ChatSession session,
+) async {
+  final messages = session.messages.sublist(1, 4);
+  const checkpoint = LedgerReconciliationCheckpoint(
+    sessionId: 's1',
+    startMessageId: 'm1',
+    endMessageId: 'm3',
+    endSwipeId: 0,
+    endAgentSwipeId: 0,
+    messageIds: ['m1', 'm2', 'm3'],
+    rangeHash: 'checkpoint-hash',
+  );
+  await container
+      .read(ledgerReconciliationCheckpointRepoProvider)
+      .upsert(checkpoint);
+  final run = LedgerReconciliationRun(
+    id: 'run-1',
+    sessionId: session.id,
+    ordinal: 1,
+    anchors: [
+      for (final message in messages)
+        ReconciliationAnchor(
+          messageId: message.id,
+          swipeId: message.swipeId,
+          agentSwipeId: message.agentSwipeId,
+          role: message.role,
+          contentHash: computeHash(message.content),
+        ),
+    ],
+    acceptedManifestRefs: const [],
+    effectiveCanonStamp: 'canon',
+    effectiveCanonRevision: 1,
+    effectiveCanonHash: 'canon-hash',
+    canonicalResult: const {'facts': <String>[]},
+    predecessorChainHash: '',
+    contractVersion: 1,
+    opsApplied: const [],
+    createdAt: 1,
+  );
+  final result = await container
+      .read(ledgerReconciliationRunRepoProvider)
+      .append(run);
+  expect(result, isA<ReconciliationRunAppended>());
+  final db = container.read(appDbProvider);
+  await db
+      .into(db.cardEvolutionCollectorRuns)
+      .insert(
+        CardEvolutionCollectorRunsCompanion.insert(
+          id: 'collector-1',
+          sessionId: session.id,
+          characterId: session.characterId,
+          collectorOrdinal: 1,
+          reconciliationRunId: run.id,
+          reconciliationRunOrdinal: run.ordinal,
+          reconciliationChainHash: run.chainHash,
+          rangeHash: run.rangeHash,
+          inputHash: 'input-hash',
+          ownerId: 'owner',
+          status: 'completed',
+          leaseExpiresAt: 1,
+          createdAt: 1,
+        ),
+      );
 }

--- a/test/cleaner_disabled_post_gen_test.dart
+++ b/test/cleaner_disabled_post_gen_test.dart
@@ -92,9 +92,9 @@ void main() {
                 ),
           );
 
-      // The turn just generated is the 6th assistant, i.e. the reconciliation
-      // cadence boundary: the planner fires on the Nth assistant and reviews
-      // up to a(N-1), leaving the fresh aN out of the range.
+      // The turn just generated follows five completed interaction chunks.
+      // The opening assistant belongs to the first chunk; the fresh a6 is only
+      // the acceptance trigger and remains outside the reconciliation range.
       const assistant = ChatMessage(
         id: 'a6',
         role: 'assistant',
@@ -102,6 +102,11 @@ void main() {
         timestamp: 1,
       );
       final messages = <ChatMessage>[
+        const ChatMessage(
+          id: 'a0',
+          role: 'assistant',
+          content: 'Opening message',
+        ),
         for (var turn = 1; turn <= 5; turn++) ...[
           ChatMessage(id: 'u$turn', role: 'user', content: 'User turn $turn'),
           ChatMessage(

--- a/test/manual_studio_ledger_service_test.dart
+++ b/test/manual_studio_ledger_service_test.dart
@@ -35,7 +35,6 @@ void main() {
   late ApiConfig activeApi;
   late Future<List<ApiConfig>> Function() loadApiConfigs;
 
-  const user1 = ChatMessage(id: 'u1', role: 'user', content: 'First');
   const assistant1 = ChatMessage(id: 'a1', role: 'assistant', content: 'One');
   const user2 = ChatMessage(id: 'u2', role: 'user', content: 'Second');
   const assistant2 = ChatMessage(id: 'a2', role: 'assistant', content: 'Two');
@@ -94,7 +93,7 @@ void main() {
 
   Future<void> putSession(
     String id, {
-    List<ChatMessage> messages = const [user1, assistant1, user2, assistant2],
+    List<ChatMessage> messages = const [assistant1, user2, assistant2],
   }) {
     return chatRepo.put(
       ChatSession(
@@ -244,7 +243,6 @@ void main() {
       await putSession(
         'session',
         messages: const [
-          user1,
           assistant1,
           user2,
           ChatMessage(id: 'a2', role: 'assistant', content: 'Changed'),
@@ -273,7 +271,6 @@ void main() {
       await putSession(
         'session',
         messages: const [
-          user1,
           assistant1,
           user2,
           ChatMessage(id: 'a2', role: 'assistant', content: 'Changed'),

--- a/test/studio_preset_independence_test.dart
+++ b/test/studio_preset_independence_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/core/llm/generation_context_inputs.dart';
 import 'package:glaze_flutter/core/llm/studio/studio_context_preparer.dart';
-import 'package:glaze_flutter/core/llm/studio/studio_context.dart';
 import 'package:glaze_flutter/core/llm/studio_brief_deduper.dart';
 import 'package:glaze_flutter/core/llm/studio_brief_parser.dart';
 import 'package:glaze_flutter/core/llm/studio_message_builder.dart';
@@ -181,16 +180,19 @@ void main() {
       );
     }
 
-    final withOrdinaryA = buildWithOrdinaryRegex('<ordinary-a>', '</ordinary-a>');
-    final withOrdinaryB = buildWithOrdinaryRegex('<ordinary-b>', '</ordinary-b>');
+    final withOrdinaryA = buildWithOrdinaryRegex(
+      '<ordinary-a>',
+      '</ordinary-a>',
+    );
+    final withOrdinaryB = buildWithOrdinaryRegex(
+      '<ordinary-b>',
+      '</ordinary-b>',
+    );
     final withEmpty = buildWithOrdinaryRegex('', '');
 
     expect(withOrdinaryB, withOrdinaryA);
     expect(withEmpty, withOrdinaryA);
-    expect(
-      withOrdinaryA.join(),
-      contains('<api-think>carefully</api-think>'),
-    );
+    expect(withOrdinaryA.join(), contains('<api-think>carefully</api-think>'));
     expect(withOrdinaryA.join(), isNot(contains('ordinary')));
   });
 


### PR DESCRIPTION
## Summary
- preserve completed Ledger reconciliation runs and checkpoints when only trailing messages are deleted
- invalidate the causal reconciliation suffix when deletion occurs before or inside a reconciled range
- retain or clear Card Evolution collector runs according to the affected reconciliation lineage

## Tests
- flutter test test/chat_delete_plan_test.dart
- flutter test test/ledger_reconciliation_run_repo_test.dart test/studio_ledger_test.dart
- flutter analyze lib/features/chat/chat_message_service.dart test/chat_delete_plan_test.dart