### PR TITLE
fix(prompt): treat only zero-length preset blocks as empty

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -691,6 +691,23 @@ Rules (enforced in `lib/core/llm/prompt_builder.dart:_assembleMessages` via `app
 5. The block is still subject to the standard `enabled` and `isStashed` gates — disabled or stashed blocks are ignored.
 6. The append happens in `_assembleMessages` **after** `HistoryAssembler.assemble(history)` and **before** `interleaveDepthWithHistory`, so depth blocks are still positioned by history depth and regex pipeline sees a single merged user message.
 
+### INV-PS10: A block is empty only when nothing at all is left of it
+
+Emptiness is measured the way SillyTavern measures it (`openai.js` `getChat`, which keeps any string a JS truthiness check accepts): **a block is empty only when its content has zero length.** Spaces and newlines are content the preset author typed on purpose, so a whitespace-only block survives every gate and is sent to the model.
+
+Enforced at four points, all on the untrimmed string:
+
+1. `resolveBlockContent()` — `rawContent.isEmpty` before macros, `macroResult.text.isEmpty` after them (`lib/core/llm/prompt_block_resolver.dart`).
+2. `_assembleMessages` — `content.isEmpty` decides whether a block becomes a message (`lib/core/llm/prompt_builder.dart`).
+3. The final message filter in `buildPrompt`, same file.
+4. `buildApiMessages()` — `content.isNotEmpty || hasImage` (`lib/core/llm/history_assembler.dart`), mirrored by `buildPreviewMessages()` so the inspector shows what the request carries.
+
+Consequences:
+
+- Block content is **never trimmed** on the way out. Leading and trailing newlines an author typed reach the provider verbatim. Authors who want trimming have the explicit `{{trim}}` macro — see INV-PS7 step 5, which is opt-in and not applied automatically.
+- A block that expands down to whitespace (e.g. `{{setvar::flag::1}}\n`) is a real message carrying that whitespace. Only an expansion down to a zero-length string takes the setvar accounting-only path described in INV-PS5.
+- Two places stay trim-based on purpose, because neither emits a block as its own message: `applyAppendToLastMessage` (INV-PS9) joins block text into an existing user message, where whitespace would only add blank lines; and lorebook attribution reporting, which maps rendered entries back to snapshots.
+
 ---
 
 ## 6. Stream vs Non-Stream Parity

--- a/lib/core/llm/history_assembler.dart
+++ b/lib/core/llm/history_assembler.dart
@@ -98,7 +98,7 @@ class PromptMessage {
     return {
       'role': role,
       'content': [
-        if (content.trim().isNotEmpty) {'type': 'text', 'text': content},
+        if (content.isNotEmpty) {'type': 'text', 'text': content},
         {
           'type': 'image_url',
           'image_url': {'url': imagePath},
@@ -142,8 +142,10 @@ List<Map<String, dynamic>> buildApiMessages(
   List<PromptMessage> messages, {
   int reasoningHistoryCount = 0,
 }) {
+  // Same emptiness rule as the block resolver: only a zero-length string counts
+  // as empty. Spaces and newlines are content and go out to the provider.
   final included = messages
-      .where((message) => message.content.trim().isNotEmpty || message.hasImage)
+      .where((message) => message.content.isNotEmpty || message.hasImage)
       .toList();
   final result = included.map((message) => message.toApiMap()).toList();
   if (reasoningHistoryCount == 0 || reasoningHistoryCount < -1) return result;

--- a/lib/core/llm/prompt_block_resolver.dart
+++ b/lib/core/llm/prompt_block_resolver.dart
@@ -98,7 +98,12 @@ ResolvedContent? resolveBlockContent({
     notifyObj.varsChanged = true;
   }
 
-  if (macroResult.text.trim().isEmpty) {
+  // Emptiness is measured the way SillyTavern measures it: a block is empty
+  // only when nothing at all is left, not when nothing *printable* is left.
+  // A block holding just spaces or newlines is content the author put there on
+  // purpose, so it survives and reaches the model (ST: `openai.js` `getChat`,
+  // which keeps any string a JS truthiness check accepts).
+  if (macroResult.text.isEmpty) {
     final setvarPayload = setvarDefinitionsForAccounting(content);
     if (setvarPayload.isEmpty) return null;
     return ResolvedContent(

--- a/lib/core/llm/prompt_builder.dart
+++ b/lib/core/llm/prompt_builder.dart
@@ -676,8 +676,11 @@ PromptResult _assembleMessages({
         );
       }
     } else {
-      final content = block.content.trim();
-      final accountingContent = block.contentForAccounting.trim();
+      // Content goes out as the author wrote it — no trimming. Trimming here
+      // would collapse a spaces-and-newlines block back to empty and drop it
+      // one line below, which is exactly what SillyTavern does not do.
+      final content = block.content;
+      final accountingContent = block.contentForAccounting;
 
       // setvar-only blocks: no LLM-visible text, but definitions count toward preset.
       if (content.isEmpty) {
@@ -889,7 +892,7 @@ PromptResult _assembleMessages({
         }
       }
       historySeen++;
-    } else if (msg.content.trim().isNotEmpty) {
+    } else if (msg.content.isNotEmpty) {
       finalMessages.add(msg);
     }
   }

--- a/lib/features/chat/services/prompt_preview_post_processor.dart
+++ b/lib/features/chat/services/prompt_preview_post_processor.dart
@@ -76,7 +76,7 @@ List<PreviewMessage> buildPreviewMessages(
   }
 
   final included = messages
-      .where((message) => message.content.trim().isNotEmpty || message.hasImage)
+      .where((message) => message.content.isNotEmpty || message.hasImage)
       .toList();
 
   final tagged = [

--- a/test/prompt_block_empty_check_test.dart
+++ b/test/prompt_block_empty_check_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/llm/history_assembler.dart';
+import 'package:glaze_flutter/core/llm/macro_engine.dart';
+import 'package:glaze_flutter/core/llm/prompt_block_resolver.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+
+/// A preset block counts as empty only when nothing at all is left of it —
+/// the same rule SillyTavern applies in `openai.js` (`getChat` keeps every
+/// string a JS truthiness check accepts). A block holding just spaces or
+/// newlines is content the author typed on purpose, so it survives and is
+/// sent, and the text it carries is never trimmed on the way out.
+void main() {
+  Character makeChar() => Character(
+    id: 'c1',
+    name: 'Alice',
+    description: 'A test character.',
+    personality: 'Cheerful and helpful.',
+    scenario: 'Meeting at a cafe.',
+  );
+
+  MacroContext makeCtx() =>
+      const MacroContext(charName: 'Alice', charId: 'c1', sessionId: 's1');
+
+  ResolvedContent? resolve(String rawContent) => resolveBlockContent(
+    id: 'custom',
+    rawContent: rawContent,
+    role: 'system',
+    char: makeChar(),
+    persona: null,
+    macroCtx: makeCtx(),
+    sessionVars: const {},
+    globalVars: const {},
+    summaryContent: null,
+    summaryPrefix: null,
+    notifyObj: NotifyObj(),
+  );
+
+  group('block emptiness', () {
+    test('a zero-length block is dropped', () {
+      expect(resolve(''), isNull);
+    });
+
+    test('a spaces-only block survives', () {
+      final result = resolve('   ');
+      expect(result, isNotNull);
+      expect(result!.content, '   ');
+    });
+
+    test('a newlines-only block survives', () {
+      final result = resolve('\n\n');
+      expect(result, isNotNull);
+      expect(result!.content, '\n\n');
+    });
+
+    test('a block that macros expand down to whitespace survives', () {
+      // {{summary}} resolves to nothing here, leaving only the newline the
+      // author typed around it.
+      final result = resolve('{{summary}}\n');
+      expect(result, isNotNull);
+      expect(result!.content, '\n');
+    });
+
+    test('a block that macros expand down to nothing is dropped', () {
+      expect(resolve('{{summary}}'), isNull);
+    });
+
+    test('surrounding whitespace is preserved, not trimmed away', () {
+      final result = resolve('\n  You are a helpful assistant.  \n');
+      expect(result, isNotNull);
+      expect(result!.content, '\n  You are a helpful assistant.  \n');
+    });
+
+    test('a setvar-only block still resolves to accounting content only', () {
+      final result = resolve('{{setvar::flag::1}}');
+      expect(result, isNotNull);
+      expect(result!.content, isEmpty);
+      expect(result.contentForAccounting, isNotEmpty);
+    });
+  });
+
+  group('buildApiMessages', () {
+    test('drops zero-length messages and keeps whitespace ones', () {
+      final messages = buildApiMessages(const [
+        PromptMessage(role: 'system', content: 'kept'),
+        PromptMessage(role: 'system', content: ''),
+        PromptMessage(role: 'system', content: '   '),
+      ]);
+
+      expect(messages, hasLength(2));
+      expect(messages[0]['content'], 'kept');
+      expect(messages[1]['content'], '   ');
+    });
+
+    test('does not trim the content it sends', () {
+      final messages = buildApiMessages(const [
+        PromptMessage(role: 'system', content: '\nmain prompt\n'),
+      ]);
+
+      expect(messages.single['content'], '\nmain prompt\n');
+    });
+  });
+}

--- a/test/prompt_preview_post_processing_test.dart
+++ b/test/prompt_preview_post_processing_test.dart
@@ -62,12 +62,23 @@ void main() {
   test('merge drops the empty blocks the request drops', () {
     final rows = buildPreviewMessages(const [
       PromptMessage(role: 'system', content: 'kept'),
-      PromptMessage(role: 'system', content: '   '),
+      PromptMessage(role: 'system', content: ''),
     ], PromptPostProcessing.merge);
 
     expect(rows, hasLength(1));
     expect(rows.single.message.content, 'kept');
     expect(rows.single.sources, hasLength(1));
+  });
+
+  test('merge keeps a whitespace-only block, matching the request', () {
+    final rows = buildPreviewMessages(const [
+      PromptMessage(role: 'system', content: 'kept'),
+      PromptMessage(role: 'system', content: '   '),
+    ], PromptPostProcessing.merge);
+
+    expect(rows, hasLength(1));
+    expect(rows.single.message.content, 'kept\n\n   ');
+    expect(rows.single.sources, hasLength(2));
   });
 
   test('semi relabels every system block after the first', () {


### PR DESCRIPTION
A preset block holding nothing but spaces or newlines was silently dropped from the prompt. Every emptiness gate in the prompt path measured the *trimmed* string, so whitespace an author typed on purpose collapsed to nothing and the block vanished.

SillyTavern measures the raw string instead (`openai.js` `getChat` keeps any string a JS truthiness check accepts), so the same preset produced a different prompt in each app. This aligns Glaze with that rule: a block is empty only when its content has zero length.

## Changes

- Measure block emptiness on the untrimmed content in `resolveBlockContent` (`lib/core/llm/prompt_block_resolver.dart`), so a block that macros expand down to whitespace survives instead of being discarded
- Measure it the same way in `_assembleMessages` and in the final message filter (`lib/core/llm/prompt_builder.dart`), and in `buildApiMessages` (`lib/core/llm/history_assembler.dart`) — all four gates now agree, so a block cannot pass one and die on the next
- Stop trimming block content on the way out in `_assembleMessages`: leading and trailing newlines now reach the provider verbatim, matching ST. Authors who want trimming still have the explicit `{{trim}}` macro (INV-PS7 step 5), which is opt-in and unaffected
- Apply the same rule in `buildPreviewMessages` (`lib/features/chat/services/prompt_preview_post_processor.dart`) so the prompt inspector keeps showing what the request actually carries
- Leave `applyAppendToLastMessage` and lorebook attribution reporting trim-based — neither emits a block as its own message, and whitespace merged into someone else's user message is only blank lines
- Document the rule as INV-PS10 in `docs/INVARIANTS.md`, including the two deliberate exceptions above

## Behaviour notes

- The setvar accounting-only path (INV-PS5) is unchanged: it still triggers on an expansion down to a zero-length string. A block written as `{{setvar::flag::1}}` followed by a newline is now a real message carrying that newline, where before it was dropped
- Depth-inserted blocks follow the same uniform rule here. Upstream ST trims its in-chat injections specifically (`populationInjectionPrompts`), so this is a deliberate, known divergence rather than an oversight

## Verification

- New `test/prompt_block_empty_check_test.dart` covers the rule at both ends: zero-length dropped, spaces-only and newlines-only kept, macro-expanded-to-whitespace kept, macro-expanded-to-nothing dropped, surrounding whitespace preserved, setvar-only still accounting-only, plus `buildApiMessages` keeping whitespace and not trimming
- Updated `test/prompt_preview_post_processing_test.dart`: the existing case now uses a zero-length block, and a new case asserts a whitespace-only block is kept and merged
- `flutter analyze` and `flutter test` were **not** run — the agent environment has no Flutter SDK. CI is the gate for both

---
_Generated by [Claude Code](https://claude.ai/code/session_014SEUUKcwGw1cPLKXmby1q3)_