### PR TITLE
fix(sync): preserve reconciliation provenance across devices

### DIFF
--- a/lib/core/application/sync_repo_interfaces.dart
+++ b/lib/core/application/sync_repo_interfaces.dart
@@ -128,3 +128,16 @@ abstract class SyncCharacterKnowledgeStore {
   Future<void> applyBySessionId(String sessionId, Map<String, dynamic> data);
   Future<void> deleteBySessionId(String sessionId);
 }
+
+/// Merge-only reconciliation and Card Evolution provenance for one session.
+/// Implementations must never replace a longer immutable chain with a stale
+/// device's shorter copy.
+abstract class SyncReconciliationStateStore {
+  Future<List<String>> getAllSessionIds();
+  Future<Map<String, dynamic>?> getBySessionId(String sessionId);
+  Future<Map<String, dynamic>> mergeBySessionId(
+    String sessionId,
+    Map<String, dynamic> data,
+  );
+  Future<void> deleteBySessionId(String sessionId);
+}

--- a/lib/core/db/repositories/ledger_reconciliation_run_repo.dart
+++ b/lib/core/db/repositories/ledger_reconciliation_run_repo.dart
@@ -160,6 +160,9 @@ class LedgerReconciliationRunRepo {
   LedgerReconciliationRunRepo(this._db);
   final AppDatabase _db;
 
+  Future<bool> anchorsMatchSession(LedgerReconciliationRun run) =>
+      _anchorsMatchSession(run);
+
   /// Caller owns the transaction. This method never opens a nested transaction.
   Future<ReconciliationRunIntegrity> append(LedgerReconciliationRun run) async {
     final valid = await _validate(run);

--- a/lib/core/db/repositories/studio_config_repo.dart
+++ b/lib/core/db/repositories/studio_config_repo.dart
@@ -56,7 +56,18 @@ class StudioConfigRepo implements SyncStudioConfigStore {
   Future<StudioConfig?> getById(String id) => getBySessionId(id);
 
   @override
-  Future<void> put(StudioConfig config) => upsert(config);
+  Future<void> put(StudioConfig config) {
+    return db
+        .into(db.studioConfigRows)
+        .insertOnConflictUpdate(
+          StudioConfigRowsCompanion.insert(
+            sessionId: config.sessionId,
+            enabled: Value(config.enabled),
+            createdAt: Value(config.createdAt),
+            updatedAt: Value(config.updatedAt),
+          ),
+        );
+  }
 
   Future<void> upsert(StudioConfig config) {
     return db

--- a/lib/core/db/repositories/summary_repo.dart
+++ b/lib/core/db/repositories/summary_repo.dart
@@ -43,6 +43,26 @@ class SummaryRepo extends DatabaseAccessor<AppDatabase>
     );
   }
 
+  Future<void> putSynced({
+    required String sessionId,
+    required String content,
+    required int messageCount,
+    required bool enabled,
+    required String? prompt,
+    required int updatedAt,
+  }) async {
+    await into(chatSummaries).insertOnConflictUpdate(
+      ChatSummariesCompanion.insert(
+        sessionId: sessionId,
+        content: content,
+        enabled: Value(enabled),
+        messageCount: Value(messageCount),
+        prompt: Value(prompt),
+        updatedAt: Value(updatedAt),
+      ),
+    );
+  }
+
   Future<void> setEnabled({
     required String sessionId,
     required bool enabled,

--- a/lib/core/state/character_provider.dart
+++ b/lib/core/state/character_provider.dart
@@ -453,6 +453,7 @@ class CharactersNotifier extends AsyncNotifier<List<Character>> {
       await SyncDeletionTracker.record('memory_book', sid);
       await SyncDeletionTracker.record('tracker_value', sid);
       await SyncDeletionTracker.record('tracker_snapshot', sid);
+      await SyncDeletionTracker.record('reconciliation_state', sid);
       if (result.studioConfigSessionIds.contains(sid)) {
         await SyncDeletionTracker.record('studio_config', sid);
       }

--- a/lib/features/chat_history/chat_history_provider.dart
+++ b/lib/features/chat_history/chat_history_provider.dart
@@ -249,6 +249,7 @@ class ChatHistoryNotifier extends AsyncNotifier<List<ChatSessionInfo>> {
     await SyncDeletionTracker.record('memory_book', sessionId);
     await SyncDeletionTracker.record('tracker_value', sessionId);
     await SyncDeletionTracker.record('tracker_snapshot', sessionId);
+    await SyncDeletionTracker.record('reconciliation_state', sessionId);
     if (studioConfig != null) {
       await SyncDeletionTracker.record('studio_config', sessionId);
     }

--- a/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
+++ b/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
@@ -642,20 +642,26 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
         await _clearReconciliationLane(sessionId);
       }
       await _mergeSourceRows(sessionId, data);
-      await _mergeRuns(sessionId, _maps(data['runs']));
-      await _mergeInvalidations(sessionId, _maps(data['invalidations']));
+      final importedComplete = await _mergeRuns(sessionId, _maps(data['runs']));
+      await _mergeInvalidations(
+        sessionId,
+        _maps(data['invalidations']),
+        ignoreUnknown: !importedComplete,
+      );
       final collectors = _maps(data['collectors']);
       final resetDerivedLane = await _resetDerivedLaneForInvalidations(
         sessionId,
         collectors,
       );
-      if (!resetDerivedLane) {
+      if (importedComplete && !resetDerivedLane) {
         await _mergeCollectors(sessionId, collectors);
         await _mergeObservations(sessionId, _maps(data['observations']));
       }
-      await _mergeCompletedClaims(sessionId, _maps(data['completedClaims']));
+      if (importedComplete) {
+        await _mergeCompletedClaims(sessionId, _maps(data['completedClaims']));
+      }
     });
-    return (await getBySessionId(sessionId))!;
+    return await getBySessionId(sessionId) ?? _emptyPayload(sessionId);
   }
 
   Future<_RunMergeDecision> _resolveRunMerge(
@@ -695,6 +701,15 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
         .map(LedgerReconciliationSuccessfulRunRow.fromJson)
         .where((run) => !incomingInvalidatedIds.contains(run.id))
         .toList();
+    final repo = LedgerReconciliationRunRepo(_db);
+    final incomingMatchesChat = await Future.wait(
+      incomingVisible.map((row) => repo.anchorsMatchSession(_runFromRow(row))),
+    );
+    if (incomingMatchesChat.any((matches) => !matches)) {
+      return localVisible.isNotEmpty
+          ? _RunMergeDecision.keepLocal
+          : _RunMergeDecision.replaceLocal;
+    }
     if (localVisible.isEmpty || incomingVisible.isEmpty) {
       if (incomingVisible.isNotEmpty) return _RunMergeDecision.replaceLocal;
       if (localVisible.isNotEmpty) return _RunMergeDecision.keepLocal;
@@ -823,7 +838,7 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
     }
   }
 
-  Future<void> _mergeRuns(
+  Future<bool> _mergeRuns(
     String sessionId,
     List<Map<String, dynamic>> incoming,
   ) async {
@@ -849,17 +864,22 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
       final row = LedgerReconciliationSuccessfulRunRow.fromJson(incoming[i]);
       _requireSession(sessionId, row.sessionId);
       final result = await repo.append(_runFromRow(row));
+      if (result is ReconciliationRunMalformed) return false;
       if (result is! ReconciliationRunAppended &&
           result is! ReconciliationRunIdempotent) {
-        throw StateError('Invalid reconciliation chain import: $result');
+        throw StateError(
+          'Invalid reconciliation chain import: ${_integrityReason(result)}',
+        );
       }
     }
+    return true;
   }
 
   Future<void> _mergeInvalidations(
     String sessionId,
-    List<Map<String, dynamic>> incoming,
-  ) async {
+    List<Map<String, dynamic>> incoming, {
+    bool ignoreUnknown = false,
+  }) async {
     final runIds =
         (await (_db.select(
               _db.ledgerReconciliationSuccessfulRuns,
@@ -870,6 +890,7 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
       final row = LedgerReconciliationRunInvalidationRow.fromJson(json);
       _requireSession(sessionId, row.sessionId);
       if (!runIds.contains(row.runId)) {
+        if (ignoreUnknown) continue;
         throw StateError('Invalidation references an unknown run');
       }
       await _db
@@ -1238,5 +1259,28 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
     });
   }
 }
+
+Map<String, dynamic> _emptyPayload(String sessionId) => {
+  '__reconciliationState': true,
+  'schemaVersion': 1,
+  'sessionId': sessionId,
+  'runs': <dynamic>[],
+  'invalidations': <dynamic>[],
+  'manifests': <dynamic>[],
+  'manifestEntries': <dynamic>[],
+  'acceptances': <dynamic>[],
+  'collectors': <dynamic>[],
+  'observations': <dynamic>[],
+  'completedClaims': <dynamic>[],
+};
+
+String _integrityReason(ReconciliationRunIntegrity integrity) =>
+    switch (integrity) {
+      ReconciliationRunMalformed(:final reason) => reason,
+      ReconciliationRunChainGap(:final reason) => reason,
+      ReconciliationRunConcurrencyConflict(:final reason) => reason,
+      ReconciliationRunConflict(:final reason) => reason,
+      _ => integrity.runtimeType.toString(),
+    };
 
 enum _RunMergeDecision { merge, keepLocal, replaceLocal }

--- a/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
+++ b/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
@@ -7,11 +7,14 @@ import '../../../core/db/app_db.dart';
 import '../../../core/db/repositories/character_folder_repo.dart';
 import '../../../core/db/repositories/extension_presets_repository.dart';
 import '../../../core/db/repositories/info_blocks_repository.dart';
+import '../../../core/db/repositories/card_evolution_collector_run_repo.dart';
+import '../../../core/db/repositories/ledger_reconciliation_run_repo.dart';
 import '../../../core/db/repositories/summary_repo.dart';
 import '../../../core/db/repositories/tracker_snapshot_repo.dart';
 import '../../../core/db/repositories/tracker_repo.dart';
 import '../../../core/models/tracker.dart';
 import '../../../core/models/tracker_snapshot.dart';
+import '../../../core/utils/cast_helpers.dart';
 import '../../extensions/models/extension_preset.dart';
 import '../../extensions/models/extensions_settings.dart';
 import '../../extensions/models/info_block.dart';
@@ -525,3 +528,714 @@ class CharacterKnowledgeSyncStore implements SyncCharacterKnowledgeStore {
     )..where((row) => row.chatSessionId.equals(sessionId))).go();
   }
 }
+
+/// Merge-only adapter for immutable reconciliation history and its derived
+/// Card Evolution collector lane. Stale devices may contribute a prefix, but
+/// can never truncate or replace a chain that reaches farther in the chat.
+class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
+  ReconciliationStateSyncStore(this._db);
+
+  final AppDatabase _db;
+
+  @override
+  Future<List<String>> getAllSessionIds() async {
+    final rows = await _db
+        .customSelect(
+          'SELECT DISTINCT session_id FROM reconciliation_successful_runs',
+        )
+        .get();
+    return rows.map((row) => row.read<String>('session_id')).toList();
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getBySessionId(String sessionId) async {
+    final runs =
+        await (_db.select(_db.ledgerReconciliationSuccessfulRuns)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..orderBy([(row) => OrderingTerm.asc(row.ordinal)]))
+            .get();
+    if (runs.isEmpty) return null;
+    final invalidations = await (_db.select(
+      _db.ledgerReconciliationRunInvalidations,
+    )..where((row) => row.sessionId.equals(sessionId))).get();
+    invalidations.sort((a, b) {
+      final run = a.runId.compareTo(b.runId);
+      if (run != 0) return run;
+      final message = a.causeMessageId.compareTo(b.causeMessageId);
+      return message != 0 ? message : a.reason.compareTo(b.reason);
+    });
+    final manifests = await (_db.select(
+      _db.lorebookUseManifests,
+    )..where((row) => row.sessionId.equals(sessionId))).get();
+    manifests.sort((a, b) => _manifestKey(a).compareTo(_manifestKey(b)));
+    final manifestEntries = await (_db.select(
+      _db.lorebookUseManifestEntries,
+    )..where((row) => row.sessionId.equals(sessionId))).get();
+    manifestEntries.sort(
+      (a, b) => _manifestEntryKey(a).compareTo(_manifestEntryKey(b)),
+    );
+    final acceptances = await (_db.select(
+      _db.lorebookUseAcceptanceRecords,
+    )..where((row) => row.sessionId.equals(sessionId))).get();
+    acceptances.sort((a, b) => a.acceptanceId.compareTo(b.acceptanceId));
+    final collectors =
+        await (_db.select(_db.cardEvolutionCollectorRuns)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..where((row) => row.status.equals('completed'))
+              ..orderBy([(row) => OrderingTerm.asc(row.collectorOrdinal)]))
+            .get();
+    final observations = await (_db.select(
+      _db.cardEvolutionObservations,
+    )..where((row) => row.sessionId.equals(sessionId))).get();
+    observations.sort(
+      (a, b) => a.semanticScopeKey.compareTo(b.semanticScopeKey),
+    );
+    final claims =
+        await (_db.select(_db.cardEvolutionClaims)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..where((row) => row.status.equals('completed')))
+            .get();
+    final completedCollectorBoundaries = {
+      for (final row in collectors)
+        (row.collectorOrdinal, row.reconciliationChainHash),
+    };
+    claims.removeWhere(
+      (row) => !completedCollectorBoundaries.contains((
+        row.predecessorRunOrdinal,
+        row.predecessorCursorHash,
+      )),
+    );
+    claims.sort((a, b) => a.inputHash.compareTo(b.inputHash));
+    return {
+      '__reconciliationState': true,
+      'schemaVersion': 1,
+      'sessionId': sessionId,
+      'runs': runs.map((row) => row.toJson()).toList(),
+      'invalidations': invalidations.map(_invalidationForSync).toList(),
+      'manifests': manifests.map((row) => row.toJson()).toList(),
+      'manifestEntries': manifestEntries.map((row) => row.toJson()).toList(),
+      'acceptances': acceptances.map((row) => row.toJson()).toList(),
+      'collectors': collectors.map(_collectorForSync).toList(),
+      'observations': observations.map(_observationForSync).toList(),
+      'completedClaims': claims.map(_claimForSync).toList(),
+    };
+  }
+
+  @override
+  Future<Map<String, dynamic>> mergeBySessionId(
+    String sessionId,
+    Map<String, dynamic> data,
+  ) async {
+    if (data['__reconciliationState'] != true ||
+        data['schemaVersion'] != 1 ||
+        data['sessionId'] != sessionId) {
+      throw const FormatException('Invalid reconciliation sync payload');
+    }
+    await _db.transaction(() async {
+      final runDecision = await _resolveRunMerge(
+        sessionId,
+        _maps(data['runs']),
+        _maps(data['invalidations']),
+      );
+      if (runDecision == _RunMergeDecision.keepLocal) return;
+      if (runDecision == _RunMergeDecision.replaceLocal) {
+        await _clearReconciliationLane(sessionId);
+      }
+      await _mergeSourceRows(sessionId, data);
+      await _mergeRuns(sessionId, _maps(data['runs']));
+      await _mergeInvalidations(sessionId, _maps(data['invalidations']));
+      final collectors = _maps(data['collectors']);
+      final resetDerivedLane = await _resetDerivedLaneForInvalidations(
+        sessionId,
+        collectors,
+      );
+      if (!resetDerivedLane) {
+        await _mergeCollectors(sessionId, collectors);
+        await _mergeObservations(sessionId, _maps(data['observations']));
+      }
+      await _mergeCompletedClaims(sessionId, _maps(data['completedClaims']));
+    });
+    return (await getBySessionId(sessionId))!;
+  }
+
+  Future<_RunMergeDecision> _resolveRunMerge(
+    String sessionId,
+    List<Map<String, dynamic>> incoming,
+    List<Map<String, dynamic>> incomingInvalidations,
+  ) async {
+    incoming.sort(
+      (a, b) => (a['ordinal'] as int).compareTo(b['ordinal'] as int),
+    );
+    final local =
+        await (_db.select(_db.ledgerReconciliationSuccessfulRuns)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..orderBy([(row) => OrderingTerm.asc(row.ordinal)]))
+            .get();
+    final overlap = local.length < incoming.length
+        ? local.length
+        : incoming.length;
+    var divergent = false;
+    for (var i = 0; i < overlap; i++) {
+      final cloud = LedgerReconciliationSuccessfulRunRow.fromJson(incoming[i]);
+      _requireSession(sessionId, cloud.sessionId);
+      if (!_sameDataClass(local[i], cloud)) {
+        divergent = true;
+        break;
+      }
+    }
+    if (!divergent) return _RunMergeDecision.merge;
+
+    final localVisible = await LedgerReconciliationRunRepo(
+      _db,
+    ).readSession(sessionId);
+    final incomingInvalidatedIds = incomingInvalidations
+        .map((row) => row['runId'] as String)
+        .toSet();
+    final incomingVisible = incoming
+        .map(LedgerReconciliationSuccessfulRunRow.fromJson)
+        .where((run) => !incomingInvalidatedIds.contains(run.id))
+        .toList();
+    if (localVisible.isEmpty || incomingVisible.isEmpty) {
+      if (incomingVisible.isNotEmpty) return _RunMergeDecision.replaceLocal;
+      if (localVisible.isNotEmpty) return _RunMergeDecision.keepLocal;
+      throw StateError('Divergent reconciliation chains have no live head');
+    }
+
+    final chat = await _db
+        .customSelect(
+          'SELECT messages_json FROM chat_sessions WHERE session_id = ?',
+          variables: [Variable.withString(sessionId)],
+        )
+        .getSingleOrNull();
+    if (chat == null) {
+      throw StateError('Cannot resolve reconciliation chains without chat');
+    }
+    final messageIds = (jsonDecode(chat.read<String>('messages_json')) as List)
+        .cast<Map<String, dynamic>>()
+        .map((message) => message['id'] as String)
+        .toList();
+    final localHead = localVisible.last;
+    final incomingHead = incomingVisible.last;
+    final localEndpoint = messageIds.indexOf(localHead.endMessageId);
+    final incomingEndpoint = messageIds.indexOf(incomingHead.endMessageId);
+    if (localEndpoint < 0 || incomingEndpoint < 0) {
+      throw StateError('Reconciliation endpoint is absent from chat');
+    }
+    if (incomingEndpoint > localEndpoint) {
+      return _RunMergeDecision.replaceLocal;
+    }
+    if (localEndpoint > incomingEndpoint) {
+      return _RunMergeDecision.keepLocal;
+    }
+    if (incomingHead.createdAt != localHead.createdAt) {
+      return incomingHead.createdAt > localHead.createdAt
+          ? _RunMergeDecision.replaceLocal
+          : _RunMergeDecision.keepLocal;
+    }
+    return incomingHead.chainHash.compareTo(localHead.chainHash) > 0
+        ? _RunMergeDecision.replaceLocal
+        : _RunMergeDecision.keepLocal;
+  }
+
+  Future<void> _clearReconciliationLane(String sessionId) async {
+    await (_db.delete(
+      _db.ledgerReconciliationCheckpoints,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.cardEvolutionCollectorRuns,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.cardEvolutionObservations,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.cardEvolutionClaims,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.ledgerReconciliationRunInvalidations,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.ledgerReconciliationSuccessfulRuns,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.lorebookUseAcceptanceRecords,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.lorebookUseManifestEntries,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.lorebookUseManifests,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+  }
+
+  Future<void> _mergeSourceRows(
+    String sessionId,
+    Map<String, dynamic> data,
+  ) async {
+    for (final json in _maps(data['manifests'])) {
+      final row = LorebookUseManifestRow.fromJson(json);
+      _requireSession(sessionId, row.sessionId);
+      final existing =
+          await (_db.select(_db.lorebookUseManifests)..where(
+                (table) =>
+                    table.sessionId.equals(row.sessionId) &
+                    table.messageId.equals(row.messageId) &
+                    table.swipeId.equals(row.swipeId) &
+                    table.agentSwipeId.equals(row.agentSwipeId),
+              ))
+              .getSingleOrNull();
+      _requireExact(existing, row);
+      if (existing == null) {
+        await _db.into(_db.lorebookUseManifests).insert(row);
+      }
+    }
+    for (final json in _maps(data['manifestEntries'])) {
+      final row = LorebookUseManifestEntryRow.fromJson(json);
+      _requireSession(sessionId, row.sessionId);
+      final existing =
+          await (_db.select(_db.lorebookUseManifestEntries)..where(
+                (table) =>
+                    table.sessionId.equals(row.sessionId) &
+                    table.messageId.equals(row.messageId) &
+                    table.swipeId.equals(row.swipeId) &
+                    table.agentSwipeId.equals(row.agentSwipeId) &
+                    table.lorebookId.equals(row.lorebookId) &
+                    table.entryId.equals(row.entryId) &
+                    table.entryOrder.equals(row.entryOrder),
+              ))
+              .getSingleOrNull();
+      _requireExact(existing, row);
+      if (existing == null) {
+        await _db.into(_db.lorebookUseManifestEntries).insert(row);
+      }
+    }
+    for (final json in _maps(data['acceptances'])) {
+      final row = LorebookUseAcceptanceRecordRow.fromJson(json);
+      _requireSession(sessionId, row.sessionId);
+      final existing =
+          await (_db.select(_db.lorebookUseAcceptanceRecords)
+                ..where((table) => table.acceptanceId.equals(row.acceptanceId)))
+              .getSingleOrNull();
+      _requireExact(existing, row);
+      if (existing == null) {
+        await _db.into(_db.lorebookUseAcceptanceRecords).insert(row);
+      }
+    }
+  }
+
+  Future<void> _mergeRuns(
+    String sessionId,
+    List<Map<String, dynamic>> incoming,
+  ) async {
+    incoming.sort(
+      (a, b) => (a['ordinal'] as int).compareTo(b['ordinal'] as int),
+    );
+    final local =
+        await (_db.select(_db.ledgerReconciliationSuccessfulRuns)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..orderBy([(row) => OrderingTerm.asc(row.ordinal)]))
+            .get();
+    final overlap = local.length < incoming.length
+        ? local.length
+        : incoming.length;
+    for (var i = 0; i < overlap; i++) {
+      final cloud = LedgerReconciliationSuccessfulRunRow.fromJson(incoming[i]);
+      if (!_sameDataClass(local[i], cloud)) {
+        throw StateError('Divergent reconciliation chains for $sessionId');
+      }
+    }
+    final repo = LedgerReconciliationRunRepo(_db);
+    for (var i = local.length; i < incoming.length; i++) {
+      final row = LedgerReconciliationSuccessfulRunRow.fromJson(incoming[i]);
+      _requireSession(sessionId, row.sessionId);
+      final result = await repo.append(_runFromRow(row));
+      if (result is! ReconciliationRunAppended &&
+          result is! ReconciliationRunIdempotent) {
+        throw StateError('Invalid reconciliation chain import: $result');
+      }
+    }
+  }
+
+  Future<void> _mergeInvalidations(
+    String sessionId,
+    List<Map<String, dynamic>> incoming,
+  ) async {
+    final runIds =
+        (await (_db.select(
+              _db.ledgerReconciliationSuccessfulRuns,
+            )..where((row) => row.sessionId.equals(sessionId))).get())
+            .map((row) => row.id)
+            .toSet();
+    for (final json in incoming) {
+      final row = LedgerReconciliationRunInvalidationRow.fromJson(json);
+      _requireSession(sessionId, row.sessionId);
+      if (!runIds.contains(row.runId)) {
+        throw StateError('Invalidation references an unknown run');
+      }
+      await _db
+          .into(_db.ledgerReconciliationRunInvalidations)
+          .insert(
+            LedgerReconciliationRunInvalidationsCompanion.insert(
+              sessionId: row.sessionId,
+              runId: row.runId,
+              causeMessageId: row.causeMessageId,
+              reason: row.reason,
+              createdAt: row.createdAt,
+            ),
+            mode: InsertMode.insertOrIgnore,
+          );
+    }
+  }
+
+  Future<bool> _resetDerivedLaneForInvalidations(
+    String sessionId,
+    List<Map<String, dynamic>> incomingCollectors,
+  ) async {
+    final invalidatedRunIds =
+        (await (_db.select(
+              _db.ledgerReconciliationRunInvalidations,
+            )..where((row) => row.sessionId.equals(sessionId))).get())
+            .map((row) => row.runId)
+            .toSet();
+    if (invalidatedRunIds.isEmpty) return false;
+    final affectedCollector =
+        await (_db.select(_db.cardEvolutionCollectorRuns)
+              ..where((row) => row.sessionId.equals(sessionId))
+              ..where((row) => row.reconciliationRunId.isIn(invalidatedRunIds))
+              ..limit(1))
+            .getSingleOrNull();
+    final incomingAffected = incomingCollectors.any(
+      (row) => invalidatedRunIds.contains(row['reconciliationRunId']),
+    );
+    if (affectedCollector == null && !incomingAffected) return false;
+    await (_db.delete(
+      _db.cardEvolutionCollectorRuns,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    await (_db.delete(
+      _db.cardEvolutionObservations,
+    )..where((row) => row.sessionId.equals(sessionId))).go();
+    return true;
+  }
+
+  Future<void> _mergeCollectors(
+    String sessionId,
+    List<Map<String, dynamic>> incoming,
+  ) async {
+    final runRepo = LedgerReconciliationRunRepo(_db);
+    final runs = await runRepo.readSession(sessionId);
+    final pairs = <String, CardEvolutionCollectorPair>{};
+    for (var i = 0; i + 1 < runs.length; i += 2) {
+      final pair = CardEvolutionCollectorPair(runs[i], runs[i + 1]);
+      pairs[pair.boundary.id] = pair;
+    }
+    for (final json in incoming) {
+      final row = CardEvolutionCollectorRunRow.fromJson(json);
+      _requireSession(sessionId, row.sessionId);
+      final pair = pairs[row.reconciliationRunId];
+      if (row.status != 'completed' ||
+          pair == null ||
+          pair.boundary.ordinal != row.reconciliationRunOrdinal ||
+          pair.boundary.chainHash != row.reconciliationChainHash ||
+          pair.rangeHash != row.rangeHash) {
+        throw StateError('Invalid collector provenance import');
+      }
+      final existing =
+          await (_db.select(_db.cardEvolutionCollectorRuns)..where(
+                (table) =>
+                    table.sessionId.equals(sessionId) &
+                    table.collectorOrdinal.equals(row.collectorOrdinal),
+              ))
+              .getSingleOrNull();
+      if (existing != null && existing.status == 'claimed') {
+        await (_db.delete(
+          _db.cardEvolutionCollectorRuns,
+        )..where((item) => item.id.equals(existing.id))).go();
+      }
+      final completed = existing?.status == 'completed' ? existing : null;
+      _requireExact(completed, row, normalize: _collectorForSync);
+      if (completed == null) {
+        await _db
+            .into(_db.cardEvolutionCollectorRuns)
+            .insert(row.copyWith(ownerId: 'cloud-sync', leaseExpiresAt: 0));
+      }
+    }
+  }
+
+  Future<void> _mergeObservations(
+    String sessionId,
+    List<Map<String, dynamic>> incoming,
+  ) async {
+    for (final json in incoming) {
+      final cloud = CardEvolutionObservationRow.fromJson(json);
+      _requireSession(sessionId, cloud.sessionId);
+      final local =
+          await (_db.select(_db.cardEvolutionObservations)..where(
+                (row) =>
+                    row.sessionId.equals(sessionId) &
+                    row.semanticScopeKey.equals(cloud.semanticScopeKey),
+              ))
+              .getSingleOrNull();
+      if (local == null) {
+        await _db
+            .into(_db.cardEvolutionObservations)
+            .insert(
+              cloud.copyWith(
+                id: _observationId(sessionId, cloud.semanticScopeKey),
+              ),
+            );
+        continue;
+      }
+      if (local.characterId != cloud.characterId ||
+          local.targetKind != cloud.targetKind ||
+          local.cardFieldPath != cloud.cardFieldPath ||
+          local.lorebookEntryId != cloud.lorebookEntryId ||
+          local.observedChange != cloud.observedChange ||
+          local.canonicalClaim != cloud.canonicalClaim) {
+        throw StateError('Divergent observation identity');
+      }
+      final clusters = _mergeClusters(
+        local.evidenceClustersJson,
+        cloud.evidenceClustersJson,
+      );
+      final evidence = <String>{for (final cluster in clusters) ...cluster};
+      final retrievalKeys = <String>{
+        ..._strings(local.retrievalKeysJson),
+        ..._strings(cloud.retrievalKeysJson),
+      }.toList()..sort();
+      await (_db.update(
+        _db.cardEvolutionObservations,
+      )..where((row) => row.id.equals(local.id))).write(
+        CardEvolutionObservationsCompanion(
+          evidenceClustersJson: Value(jsonEncode(clusters)),
+          evidenceMessageIds: Value(jsonEncode(evidence.toList()..sort())),
+          retrievalKeysJson: Value(jsonEncode(retrievalKeys)),
+          runOrdinal: Value(
+            local.runOrdinal < cloud.runOrdinal
+                ? local.runOrdinal
+                : cloud.runOrdinal,
+          ),
+          repeatCount: Value(clusters.length),
+          firstSeenRun: Value(
+            local.firstSeenRun < cloud.firstSeenRun
+                ? local.firstSeenRun
+                : cloud.firstSeenRun,
+          ),
+          lastConfirmedRun: Value(
+            _maxNullable(local.lastConfirmedRun, cloud.lastConfirmedRun),
+          ),
+          confidence: Value(
+            local.confidence > cloud.confidence
+                ? local.confidence
+                : cloud.confidence,
+          ),
+          status: Value(_mergedObservationStatus(local.status, cloud.status)),
+          updatedAt: Value(
+            local.updatedAt > cloud.updatedAt
+                ? local.updatedAt
+                : cloud.updatedAt,
+          ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _mergeCompletedClaims(
+    String sessionId,
+    List<Map<String, dynamic>> incoming,
+  ) async {
+    for (final json in incoming) {
+      final row = CardEvolutionClaimRow.fromJson(json);
+      _requireSession(sessionId, row.sessionId);
+      if (row.status != 'completed') continue;
+      final boundary =
+          await (_db.select(_db.cardEvolutionCollectorRuns)..where(
+                (item) =>
+                    item.sessionId.equals(sessionId) &
+                    item.collectorOrdinal.equals(row.predecessorRunOrdinal) &
+                    item.status.equals('completed'),
+              ))
+              .getSingleOrNull();
+      if (boundary == null ||
+          boundary.reconciliationChainHash != row.predecessorCursorHash) {
+        continue;
+      }
+      final existing =
+          await (_db.select(_db.cardEvolutionClaims)..where(
+                (item) =>
+                    item.sessionId.equals(sessionId) &
+                    item.inputHash.equals(row.inputHash),
+              ))
+              .getSingleOrNull();
+      if (existing != null && existing.status == 'claimed') {
+        await (_db.delete(
+          _db.cardEvolutionClaims,
+        )..where((item) => item.id.equals(existing.id))).go();
+      }
+      final completed = existing?.status == 'completed' ? existing : null;
+      if (completed == null) {
+        await _db
+            .into(_db.cardEvolutionClaims)
+            .insert(
+              row.copyWith(
+                ownerId: 'cloud-sync',
+                leaseExpiresAt: 0,
+                rewriteJobId: const Value(null),
+              ),
+            );
+      } else if (!_sameDataClass(completed, row, normalize: _claimForSync)) {
+        throw StateError('Conflicting completed writer boundary');
+      }
+    }
+  }
+
+  static void _requireExact(
+    DataClass? existing,
+    DataClass incoming, {
+    Map<String, dynamic> Function(DataClass row)? normalize,
+  }) {
+    if (existing != null &&
+        !_sameDataClass(existing, incoming, normalize: normalize)) {
+      throw StateError('Conflicting immutable sync row');
+    }
+  }
+
+  static bool _sameDataClass(
+    DataClass first,
+    DataClass second, {
+    Map<String, dynamic> Function(DataClass row)? normalize,
+  }) {
+    final firstJson = normalize?.call(first) ?? first.toJson();
+    final secondJson = normalize?.call(second) ?? second.toJson();
+    return jsonEncode(firstJson) == jsonEncode(secondJson);
+  }
+
+  static Map<String, dynamic> _collectorForSync(DataClass value) {
+    final row = value as CardEvolutionCollectorRunRow;
+    return {...row.toJson(), 'ownerId': '', 'leaseExpiresAt': 0};
+  }
+
+  static Map<String, dynamic> _invalidationForSync(
+    LedgerReconciliationRunInvalidationRow row,
+  ) => {...row.toJson(), 'id': 0};
+
+  static Map<String, dynamic> _observationForSync(
+    CardEvolutionObservationRow row,
+  ) => {
+    ...row.toJson(),
+    'id': _observationId(row.sessionId, row.semanticScopeKey),
+  };
+
+  static String _observationId(String sessionId, String semanticScopeKey) =>
+      'cloud-observation-${computeHash('$sessionId\u001f$semanticScopeKey')}';
+
+  static String _manifestKey(LorebookUseManifestRow row) =>
+      '${row.messageId}\u001f${row.swipeId}\u001f${row.agentSwipeId}';
+
+  static String _manifestEntryKey(LorebookUseManifestEntryRow row) =>
+      '${row.messageId}\u001f${row.swipeId}\u001f${row.agentSwipeId}'
+      '\u001f${row.lorebookId}\u001f${row.entryId}\u001f${row.entryOrder}';
+
+  static Map<String, dynamic> _claimForSync(DataClass value) {
+    final row = value as CardEvolutionClaimRow;
+    return {
+      ...row.toJson(),
+      'ownerId': '',
+      'leaseExpiresAt': 0,
+      'rewriteJobId': null,
+    };
+  }
+
+  LedgerReconciliationRun _runFromRow(
+    LedgerReconciliationSuccessfulRunRow row,
+  ) {
+    final anchors = (jsonDecode(row.anchorsJson) as List)
+        .cast<Map<String, dynamic>>()
+        .map(
+          (item) => ReconciliationAnchor(
+            messageId: item['messageId'] as String,
+            swipeId: item['swipeId'] as int,
+            agentSwipeId: item['agentSwipeId'] as int,
+            role: item['role'] as String,
+            contentHash: item['contentHash'] as String,
+          ),
+        )
+        .toList();
+    final refs = (jsonDecode(row.acceptedManifestRefsJson) as List)
+        .cast<Map<String, dynamic>>()
+        .map(
+          (item) => AcceptedManifestRef(
+            acceptanceId: item['acceptanceId'] as String,
+            sessionId: item['sessionId'] as String,
+            messageId: item['messageId'] as String,
+            swipeId: item['swipeId'] as int,
+            agentSwipeId: item['agentSwipeId'] as int,
+            manifestHash: item['manifestHash'] as String,
+            acceptedByUserMessageId: item['acceptedByUserMessageId'] as String,
+          ),
+        )
+        .toList();
+    return LedgerReconciliationRun(
+      id: row.id,
+      sessionId: row.sessionId,
+      ordinal: row.ordinal,
+      anchors: anchors,
+      acceptedManifestRefs: refs,
+      effectiveCanonStamp: row.effectiveCanonStamp,
+      effectiveCanonRevision: row.effectiveCanonRevision,
+      effectiveCanonHash: row.effectiveCanonHash,
+      canonicalResult: Map<String, dynamic>.from(
+        jsonDecode(row.canonicalResultJson) as Map,
+      ),
+      predecessorChainHash: row.predecessorChainHash,
+      contractVersion: row.contractVersion,
+      opsApplied: (jsonDecode(row.opsAppliedJson) as List).cast<String>(),
+      createdAt: row.createdAt,
+    );
+  }
+
+  static List<Map<String, dynamic>> _maps(Object? value) =>
+      (value as List? ?? const []).cast<Map<String, dynamic>>();
+
+  static List<String> _strings(String value) =>
+      (jsonDecode(value) as List).cast<String>();
+
+  static void _requireSession(String expected, String actual) {
+    if (actual != expected) throw const FormatException('Session mismatch');
+  }
+
+  static List<List<String>> _mergeClusters(String first, String second) {
+    final result = <List<String>>[];
+    for (final encoded in [first, second]) {
+      for (final raw in jsonDecode(encoded) as List) {
+        final cluster = (raw as List).cast<String>().toSet().toList()..sort();
+        if (!result.any((item) => _sameStrings(item, cluster))) {
+          result.add(cluster);
+        }
+      }
+    }
+    result.sort((a, b) => a.join('\u001f').compareTo(b.join('\u001f')));
+    return result;
+  }
+
+  static bool _sameStrings(List<String> a, List<String> b) =>
+      a.length == b.length && a.indexed.every((item) => item.$2 == b[item.$1]);
+
+  static int? _maxNullable(int? a, int? b) {
+    if (a == null) return b;
+    if (b == null) return a;
+    return a > b ? a : b;
+  }
+
+  static String _mergedObservationStatus(String a, String b) {
+    const rank = {'active': 0, 'promoted': 1, 'expired': 2, 'consumed': 3};
+    return rank[a]! >= rank[b]! ? a : b;
+  }
+
+  @override
+  Future<void> deleteBySessionId(String sessionId) async {
+    await _db.transaction(() async {
+      await _clearReconciliationLane(sessionId);
+    });
+  }
+}
+
+enum _RunMergeDecision { merge, keepLocal, replaceLocal }

--- a/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
+++ b/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
@@ -718,9 +718,10 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
     final incomingHead = incomingVisible.last;
     final localEndpoint = messageIds.indexOf(localHead.endMessageId);
     final incomingEndpoint = messageIds.indexOf(incomingHead.endMessageId);
-    if (localEndpoint < 0 || incomingEndpoint < 0) {
-      throw StateError('Reconciliation endpoint is absent from chat');
+    if (localEndpoint < 0 && incomingEndpoint >= 0) {
+      return _RunMergeDecision.replaceLocal;
     }
+    if (incomingEndpoint < 0) return _RunMergeDecision.keepLocal;
     if (incomingEndpoint > localEndpoint) {
       return _RunMergeDecision.replaceLocal;
     }

--- a/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
+++ b/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
@@ -187,12 +187,13 @@ class ChatSummarySyncStore implements SyncChatSummaryStore {
   Future<void> putRaw(Map<String, dynamic> summary) async {
     final sessionId = summary['sessionId'] as String? ?? '';
     if (sessionId.isEmpty) return;
-    await _repo.put(
+    await _repo.putSynced(
       sessionId: sessionId,
       content: summary['content'] as String? ?? '',
       messageCount: summary['messageCount'] as int? ?? 0,
-      enabled: summary['enabled'] as bool?,
+      enabled: summary['enabled'] as bool? ?? true,
       prompt: summary['prompt'] as String?,
+      updatedAt: summary['updatedAt'] as int? ?? 0,
     );
   }
 

--- a/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
+++ b/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
@@ -654,11 +654,14 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
         collectors,
       );
       if (importedComplete && !resetDerivedLane) {
-        await _mergeCollectors(sessionId, collectors);
-        await _mergeObservations(sessionId, _maps(data['observations']));
-      }
-      if (importedComplete) {
-        await _mergeCompletedClaims(sessionId, _maps(data['completedClaims']));
+        final collectorsValid = await _mergeCollectors(sessionId, collectors);
+        if (collectorsValid) {
+          await _mergeObservations(sessionId, _maps(data['observations']));
+          await _mergeCompletedClaims(
+            sessionId,
+            _maps(data['completedClaims']),
+          );
+        }
       }
     });
     return await getBySessionId(sessionId) ?? _emptyPayload(sessionId);
@@ -938,7 +941,7 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
     return true;
   }
 
-  Future<void> _mergeCollectors(
+  Future<bool> _mergeCollectors(
     String sessionId,
     List<Map<String, dynamic>> incoming,
   ) async {
@@ -949,8 +952,8 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
       final pair = CardEvolutionCollectorPair(runs[i], runs[i + 1]);
       pairs[pair.boundary.id] = pair;
     }
-    for (final json in incoming) {
-      final row = CardEvolutionCollectorRunRow.fromJson(json);
+    final rows = incoming.map(CardEvolutionCollectorRunRow.fromJson).toList();
+    for (final row in rows) {
       _requireSession(sessionId, row.sessionId);
       final pair = pairs[row.reconciliationRunId];
       if (row.status != 'completed' ||
@@ -958,8 +961,10 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
           pair.boundary.ordinal != row.reconciliationRunOrdinal ||
           pair.boundary.chainHash != row.reconciliationChainHash ||
           pair.rangeHash != row.rangeHash) {
-        throw StateError('Invalid collector provenance import');
+        return false;
       }
+    }
+    for (final row in rows) {
       final existing =
           await (_db.select(_db.cardEvolutionCollectorRuns)..where(
                 (table) =>
@@ -980,6 +985,7 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
             .insert(row.copyWith(ownerId: 'cloud-sync', leaseExpiresAt: 0));
       }
     }
+    return true;
   }
 
   Future<void> _mergeObservations(

--- a/lib/features/cloud_sync/services/sync_controller.dart
+++ b/lib/features/cloud_sync/services/sync_controller.dart
@@ -257,6 +257,7 @@ class SyncController {
         .where((c) => c.key != conflict.key)
         .toList();
     conflictsNotifier.state = optimistic;
+    statusNotifier.state = SyncStatus.syncing;
 
     try {
       await service.resolveConflict(conflict, choice);
@@ -271,6 +272,7 @@ class SyncController {
           setError: (value) => errorNotifier.state = value,
         );
       }
+      statusNotifier.state = SyncStatus.conflict;
       return null;
     } catch (e) {
       // Roll back optimistic removal on error.
@@ -290,6 +292,7 @@ class SyncController {
     final progressNotifier = _ref.read(syncProgressProvider.notifier);
     // Optimistically clear all conflict rows immediately.
     conflictsNotifier.state = [];
+    statusNotifier.state = SyncStatus.syncing;
     try {
       await service.resolveAllConflicts(choice);
       conflictsNotifier.state = List.from(service.conflicts);

--- a/lib/features/cloud_sync/services/sync_engine.dart
+++ b/lib/features/cloud_sync/services/sync_engine.dart
@@ -333,6 +333,7 @@ class SyncEngine {
     final entries = cloudManifest.entries.values.toList();
     final conflicts = <SyncConflict>[];
     final pullEntries = <SyncManifestEntry>[];
+    final acceptedCloudEntries = <SyncManifestEntry>[];
 
     for (final cloudEntry in entries) {
       final localEntry = localManifest.entries[cloudEntry.key];
@@ -355,6 +356,7 @@ class SyncEngine {
         localEntry,
         cloudManifest,
       )) {
+        acceptedCloudEntries.add(cloudEntry);
         continue;
       }
 
@@ -404,12 +406,17 @@ class SyncEngine {
         localManifest,
         cloudManifest,
         onProgress,
+        acceptedCloudEntries: acceptedCloudEntries,
       );
     } else if (conflicts.isEmpty) {
       onProgress(
         const SyncProgress(current: 0, total: 0, message: 'Nothing to pull'),
       );
-      await _finalizePull(localManifest, cloudManifest);
+      await _finalizePull(
+        localManifest,
+        cloudManifest,
+        acceptedCloudEntries: acceptedCloudEntries,
+      );
     } else {
       await _saveCloudManifestForPendingPull(cloudManifest);
     }
@@ -429,6 +436,7 @@ class SyncEngine {
     );
 
     final pullEntries = <SyncManifestEntry>[];
+    final acceptedCloudEntries = <SyncManifestEntry>[];
 
     for (final cloudEntry in cloudManifest.entries.values) {
       final localEntry = localManifest.entries[cloudEntry.key];
@@ -441,6 +449,7 @@ class SyncEngine {
         localEntry,
         cloudManifest,
       )) {
+        acceptedCloudEntries.add(cloudEntry);
         continue;
       }
       if (SyncConflictDetector.needsConflict(localEntry, cloudEntry)) {
@@ -459,12 +468,17 @@ class SyncEngine {
         localManifest,
         cloudManifest,
         onProgress,
+        acceptedCloudEntries: acceptedCloudEntries,
       );
     } else {
       onProgress(
         const SyncProgress(current: 0, total: 0, message: 'Nothing to pull'),
       );
-      await _finalizePull(localManifest, cloudManifest);
+      await _finalizePull(
+        localManifest,
+        cloudManifest,
+        acceptedCloudEntries: acceptedCloudEntries,
+      );
     }
 
     // A local conflict winner must become cloud truth immediately. In
@@ -484,9 +498,11 @@ class SyncEngine {
     List<SyncManifestEntry> pullEntries,
     SyncManifest localManifest,
     SyncManifest cloudManifest,
-    void Function(SyncProgress) onProgress,
-  ) async {
+    void Function(SyncProgress) onProgress, {
+    List<SyncManifestEntry> acceptedCloudEntries = const [],
+  }) async {
     final tasks = <Future<void> Function()>[];
+    final appliedEntries = <SyncManifestEntry>[];
     var processed = 0;
 
     for (final entry in pullEntries) {
@@ -500,6 +516,7 @@ class SyncEngine {
           ),
         );
         await _pullEntry(entry);
+        appliedEntries.add(entry);
       });
     }
 
@@ -521,7 +538,11 @@ class SyncEngine {
       taskErrors = result.errors;
     }
 
-    await _finalizePull(localManifest, cloudManifest);
+    await _finalizePull(
+      localManifest,
+      cloudManifest,
+      acceptedCloudEntries: [...acceptedCloudEntries, ...appliedEntries],
+    );
 
     if (taskErrors != null && taskErrors.isNotEmpty) {
       throw SyncQueueAggregateError(taskErrors);
@@ -530,17 +551,25 @@ class SyncEngine {
 
   Future<void> _finalizePull(
     SyncManifest localManifest,
-    SyncManifest cloudManifest,
-  ) async {
+    SyncManifest cloudManifest, {
+    List<SyncManifestEntry> acceptedCloudEntries = const [],
+  }) async {
     final rebuilt = await _manifestBuilder.buildLocalManifest(
       cloudManifest: cloudManifest,
     );
+    final entries = Map<String, SyncManifestEntry>.from(rebuilt.entries);
+    for (final entry in acceptedCloudEntries) {
+      if (entry.type == 'reconciliation_state') {
+        entries.putIfAbsent(entry.key, () => entry);
+      }
+    }
     await _manifestBuilder.writeLocalManifest(
       rebuilt.copyWith(
         createdAt: cloudManifest.createdAt != 0
             ? cloudManifest.createdAt
             : rebuilt.createdAt,
         lastSync: DateTime.now().millisecondsSinceEpoch,
+        entries: entries,
       ),
     );
     await _manifestBuilder.clearDeleted();

--- a/lib/features/cloud_sync/services/sync_engine.dart
+++ b/lib/features/cloud_sync/services/sync_engine.dart
@@ -728,6 +728,16 @@ class SyncEngine {
         final cloudHash = SyncSerialization.computeMemoryBookHash(cloudData);
         final equal = localHash == cloudHash;
         return equal;
+      case 'studio_config':
+        final localConfig = await _studioConfigStore.getById(cloudEntry.id);
+        if (localConfig == null) return false;
+        final cloudData = await SyncSerialization.readCloudEntity(
+          _adapter,
+          cloudEntry,
+        );
+        if (cloudData == null) return false;
+        return SyncSerialization.computeStudioConfigHash(cloudData) ==
+            SyncSerialization.computeStudioConfigHash(localConfig.toJson());
       case 'api_presets':
         if (cloudManifest.apiKeysIncluded) return false;
         final localAll = await _apiRepo.getAll();

--- a/lib/features/cloud_sync/services/sync_engine.dart
+++ b/lib/features/cloud_sync/services/sync_engine.dart
@@ -59,6 +59,7 @@ class SyncEngine {
   final SyncCharacterFolderStore? _characterFolderStore;
   final SyncMemoryGraphStore? _memoryGraphStore;
   final SyncCharacterKnowledgeStore? _characterKnowledgeStore;
+  final SyncReconciliationStateStore? _reconciliationStateStore;
   final SessionDeletionStore _sessionDeletionStore;
   final CharacterDeletionStore _characterDeletionStore;
   final Future<void> Function(LorebookActivations) _saveLorebookActivations;
@@ -92,8 +93,9 @@ class SyncEngine {
     this._characterKnowledgeStore,
     this._sessionDeletionStore,
     this._characterDeletionStore,
-    this._saveLorebookActivations,
-  ) {
+    this._saveLorebookActivations, [
+    this._reconciliationStateStore,
+  ]) {
     _binarySyncer = SyncBinaryAssetSyncer(
       _adapter,
       _characterRepo,
@@ -124,9 +126,9 @@ class SyncEngine {
     await _adapter.ensureFolder('$cloudBase/chat_summaries');
     await _adapter.ensureFolder('$cloudBase/memory_graphs');
     await _adapter.ensureFolder('$cloudBase/character_knowledge');
+    await _adapter.ensureFolder('$cloudBase/reconciliation_state');
 
     onProgress(const SyncProgress(message: 'Building sync manifest...'));
-    final localManifest = await _manifestBuilder.buildLocalManifest();
     SyncManifest? cloudManifest;
     try {
       final raw = await _adapter.download(cloudPath('manifest', 'manifest'));
@@ -139,6 +141,10 @@ class SyncEngine {
       debugPrint('[sync] cloud manifest download failed: $e\n$st');
       rethrow;
     }
+    await _mergeCloudReconciliationState(cloudManifest);
+    final localManifest = await _manifestBuilder.buildLocalManifest(
+      cloudManifest: cloudManifest,
+    );
 
     final entries = localManifest.entries.values.toList();
     final candidatePaths = cloudManifest == null
@@ -699,6 +705,15 @@ class SyncEngine {
     if (cloudEntry.hash == localEntry.hash) return true;
 
     switch (cloudEntry.type) {
+      case 'reconciliation_state':
+        final store = _reconciliationStateStore;
+        if (store == null) return false;
+        final cloudData = await SyncSerialization.readRequiredCloudEntity(
+          _adapter,
+          cloudEntry,
+        );
+        final merged = await store.mergeBySessionId(cloudEntry.id, cloudData);
+        return SyncSerialization.computeSyncHash(merged) == cloudEntry.hash;
       case 'memory_book':
         final localMb = await _memoryBookRepo.getBySessionId(cloudEntry.id);
         if (localMb == null) return false;
@@ -828,6 +843,9 @@ class SyncEngine {
         case 'character_knowledge':
           if (_characterKnowledgeStore == null) return null;
           return _characterKnowledgeStore.getBySessionId(id);
+        case 'reconciliation_state':
+          if (_reconciliationStateStore == null) return null;
+          return _reconciliationStateStore.getBySessionId(id);
         default:
           return null;
       }
@@ -925,8 +943,15 @@ class SyncEngine {
             await _characterKnowledgeStore.applyBySessionId(id, data);
           }
           break;
+        case 'reconciliation_state':
+          if (_reconciliationStateStore != null) {
+            await _reconciliationStateStore.mergeBySessionId(id, data);
+          }
+          break;
       }
-    } catch (_) {}
+    } catch (_) {
+      if (type == 'reconciliation_state') rethrow;
+    }
   }
 
   Future<void> _applyCloudInfoBlocks(
@@ -1254,9 +1279,46 @@ class SyncEngine {
             await _characterKnowledgeStore.deleteBySessionId(id);
           }
           break;
+        case 'reconciliation_state':
+          if (_reconciliationStateStore != null) {
+            await _reconciliationStateStore.deleteBySessionId(id);
+          }
+          break;
         // extensions_settings has no meaningful "delete" — it's always present.
       }
     } catch (_) {}
+  }
+
+  Future<void> _mergeCloudReconciliationState(
+    SyncManifest? cloudManifest,
+  ) async {
+    final store = _reconciliationStateStore;
+    if (store == null || cloudManifest == null) return;
+    for (final entry in cloudManifest.entries.values) {
+      if (entry.type != 'reconciliation_state' || entry.deleted) continue;
+      if (await _manifestBuilder.isDeleted(entry.type, entry.id) ||
+          await _manifestBuilder.isDeleted('chat', entry.id)) {
+        continue;
+      }
+      if (await _chatRepo.getById(entry.id) == null) {
+        final chatEntry = cloudManifest.entries[entryKey('chat', entry.id)];
+        if (chatEntry == null || chatEntry.deleted) {
+          throw StateError(
+            'Reconciliation state has no owning cloud chat: ${entry.id}',
+          );
+        }
+        final chatData = await SyncSerialization.readRequiredCloudEntity(
+          _adapter,
+          chatEntry,
+        );
+        await _chatRepo.put(ChatSession.fromJson(chatData));
+      }
+      final cloudData = await SyncSerialization.readRequiredCloudEntity(
+        _adapter,
+        entry,
+      );
+      await store.mergeBySessionId(entry.id, cloudData);
+    }
   }
 
   Future<Map<String, dynamic>?> _readLocalStorage() async {

--- a/lib/features/cloud_sync/services/sync_engine.dart
+++ b/lib/features/cloud_sync/services/sync_engine.dart
@@ -712,8 +712,11 @@ class SyncEngine {
           _adapter,
           cloudEntry,
         );
-        final merged = await store.mergeBySessionId(cloudEntry.id, cloudData);
-        return SyncSerialization.computeSyncHash(merged) == cloudEntry.hash;
+        await store.mergeBySessionId(cloudEntry.id, cloudData);
+        // This aggregate intentionally normalizes or discards stale derived
+        // provenance. A successful merge is therefore semantic equality even
+        // when the resulting canonical payload no longer has the cloud hash.
+        return true;
       case 'memory_book':
         final localMb = await _memoryBookRepo.getBySessionId(cloudEntry.id);
         if (localMb == null) return false;

--- a/lib/features/cloud_sync/services/sync_manifest.dart
+++ b/lib/features/cloud_sync/services/sync_manifest.dart
@@ -430,6 +430,28 @@ class SyncManifestBuilder implements SyncManifestProvider {
           hash: hash,
         );
       }
+      final chatSessionIds = sessions
+          .map((session) => session.sessionId)
+          .toSet();
+      for (final previousEntry in previous.entries.values) {
+        if (previousEntry.type != 'reconciliation_state' ||
+            entries.containsKey(previousEntry.key) ||
+            !chatSessionIds.contains(previousEntry.id)) {
+          continue;
+        }
+        final cloudEntry = cloudManifest?.entries[previousEntry.key];
+        if (cloudEntry == null ||
+            cloudEntry.deleted ||
+            cloudEntry.hash != previousEntry.hash ||
+            await isDeleted(previousEntry.type, previousEntry.id) ||
+            await isDeleted('chat', previousEntry.id)) {
+          continue;
+        }
+        // A cloud state may normalize to no durable runs (for example, stale
+        // legacy anchors). Keep its accepted manifest marker so it is not
+        // downloaded and rejected again on every pull.
+        entries[previousEntry.key] = cloudEntry;
+      }
     }
 
     await _addSingletons(entries, previous, now, cloudManifest);

--- a/lib/features/cloud_sync/services/sync_manifest.dart
+++ b/lib/features/cloud_sync/services/sync_manifest.dart
@@ -279,7 +279,7 @@ class SyncManifestBuilder implements SyncManifestProvider {
     for (final config in studioConfigs) {
       final id = config.sessionId;
       final json = config.toJson();
-      final hash = SyncSerialization.computeSyncHash(json);
+      final hash = SyncSerialization.computeStudioConfigHash(json);
       final key = entryKey('studio_config', id);
       final prevEntry = previous.entries[key];
       final cloudEntry = cloudManifest?.entries[key];

--- a/lib/features/cloud_sync/services/sync_manifest.dart
+++ b/lib/features/cloud_sync/services/sync_manifest.dart
@@ -28,6 +28,7 @@ class SyncManifestBuilder implements SyncManifestProvider {
   final SyncCharacterFolderStore? _characterFolderStore;
   final SyncMemoryGraphStore? _memoryGraphStore;
   final SyncCharacterKnowledgeStore? _characterKnowledgeStore;
+  final SyncReconciliationStateStore? _reconciliationStateStore;
   final SyncImageStore? _imageStore;
 
   static const _manifestKey = 'gz_sync_manifest_v2';
@@ -54,6 +55,7 @@ class SyncManifestBuilder implements SyncManifestProvider {
     this._characterFolderStore,
     this._memoryGraphStore,
     this._characterKnowledgeStore,
+    this._reconciliationStateStore,
     this._imageStore,
   });
 
@@ -405,6 +407,31 @@ class SyncManifestBuilder implements SyncManifestProvider {
       }
     }
 
+    if (_reconciliationStateStore != null) {
+      final sessionIds = await _reconciliationStateStore.getAllSessionIds();
+      for (final sessionId in sessionIds) {
+        final state = await _reconciliationStateStore.getBySessionId(sessionId);
+        if (state == null) continue;
+        final hash = SyncSerialization.computeSyncHash(state);
+        final key = entryKey('reconciliation_state', sessionId);
+        final prevEntry = previous.entries[key];
+        final cloudEntry = cloudManifest?.entries[key];
+        final updatedAt = _resolveUpdatedAt(
+          hash: hash,
+          prevEntry: prevEntry,
+          cloudEntry: cloudEntry,
+          now: now,
+        );
+        entries[key] = SyncManifestEntry(
+          type: 'reconciliation_state',
+          id: sessionId,
+          path: cloudPath('reconciliation_state', sessionId),
+          updatedAt: updatedAt,
+          hash: hash,
+        );
+      }
+    }
+
     await _addSingletons(entries, previous, now, cloudManifest);
     await _addDeletedEntries(entries, now);
 
@@ -677,5 +704,14 @@ class SyncManifestBuilder implements SyncManifestProvider {
   Future<void> clearDeleted() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(_deletedKey);
+  }
+
+  @override
+  Future<bool> isDeleted(String type, String id) async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_deletedKey);
+    if (raw == null) return false;
+    final deleted = (jsonDecode(raw) as List).cast<Map<String, dynamic>>();
+    return deleted.any((row) => row['type'] == type && row['id'] == id);
   }
 }

--- a/lib/features/cloud_sync/services/sync_serialization.dart
+++ b/lib/features/cloud_sync/services/sync_serialization.dart
@@ -32,6 +32,13 @@ class SyncSerialization {
     return sha256.convert(utf8.encode(json)).toString();
   }
 
+  static String computeStudioConfigHash(Map<String, dynamic> json) {
+    final content = Map<String, dynamic>.from(json)
+      ..remove('createdAt')
+      ..remove('updatedAt');
+    return computeSyncHash(content);
+  }
+
   /// Device-local / derived fields excluded so parity does not false-conflict.
   static const _memoryBookSettingsHashKeys = {
     'enabled',

--- a/lib/features/cloud_sync/services/sync_serialization.dart
+++ b/lib/features/cloud_sync/services/sync_serialization.dart
@@ -191,4 +191,20 @@ class SyncSerialization {
       return null;
     }
   }
+
+  static Future<Map<String, dynamic>> readRequiredCloudEntity(
+    CloudAdapter adapter,
+    SyncManifestEntry entry,
+  ) async {
+    final raw = await adapter.download(entry.path);
+    if (raw.isEmpty) {
+      throw StateError('Empty cloud entity: ${entry.key}');
+    }
+    if (raw.length > maxSyncPayloadBytes) {
+      throw Exception(
+        'Payload exceeds ${maxSyncPayloadBytes ~/ 1024 ~/ 1024}MB limit',
+      );
+    }
+    return jsonDecode(raw) as Map<String, dynamic>;
+  }
 }

--- a/lib/features/cloud_sync/services/sync_service.dart
+++ b/lib/features/cloud_sync/services/sync_service.dart
@@ -41,6 +41,7 @@ class SyncService {
   final SyncCharacterFolderStore? _characterFolderStore;
   final SyncMemoryGraphStore? _memoryGraphStore;
   final SyncCharacterKnowledgeStore? _characterKnowledgeStore;
+  final SyncReconciliationStateStore? _reconciliationStateStore;
   final SessionDeletionStore _sessionDeletionStore;
   final CharacterDeletionStore _characterDeletionStore;
   final Future<void> Function(LorebookActivations) _saveLorebookActivations;
@@ -111,6 +112,7 @@ class SyncService {
     this._characterFolderStore,
     this._memoryGraphStore,
     this._characterKnowledgeStore,
+    this._reconciliationStateStore,
     required SessionDeletionStore sessionDeletionStore,
     required CharacterDeletionStore characterDeletionStore,
     required Future<void> Function(LorebookActivations) saveLorebookActivations,
@@ -147,6 +149,7 @@ class SyncService {
     characterFolderStore: _characterFolderStore,
     memoryGraphStore: _memoryGraphStore,
     characterKnowledgeStore: _characterKnowledgeStore,
+    reconciliationStateStore: _reconciliationStateStore,
     imageStore: _imageStorage,
   );
 
@@ -177,6 +180,7 @@ class SyncService {
     _sessionDeletionStore,
     _characterDeletionStore,
     _saveLorebookActivations,
+    _reconciliationStateStore,
   );
 
   Future<void> init() async {

--- a/lib/features/cloud_sync/services/sync_service.dart
+++ b/lib/features/cloud_sync/services/sync_service.dart
@@ -57,6 +57,7 @@ class SyncService {
   bool _autoSyncEnabled = false;
   int _autoSyncMessageCount = 5;
   int _messageCounter = 0;
+  bool _operationInProgress = false;
 
   final DropboxAuth _dropboxAuth = DropboxAuth();
   final GDriveAuth _gdriveAuth = GDriveAuth();
@@ -212,56 +213,76 @@ class SyncService {
     void Function(SyncProgress)? onProgress,
     bool includeApiKeys = false,
   }) async {
-    await _withSyncForeground(() async {
-      _status = SyncStatus.syncing;
-      _lastError = null;
+    if (_operationInProgress) {
+      throw StateError('Sync operation already in progress');
+    }
+    _operationInProgress = true;
+    try {
+      await _withSyncForeground(() async {
+        _status = SyncStatus.syncing;
+        _lastError = null;
 
-      try {
-        final engine = _engine;
-        await engine.pushEntities(
-          onProgress: onProgress ?? (_) {},
-          includeApiKeys: includeApiKeys,
-        );
-        _lastSyncTime = DateTime.now().millisecondsSinceEpoch;
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setInt('gz_sync_last', _lastSyncTime!);
-        _status = SyncStatus.idle;
-      } catch (e) {
-        _lastError = e.toString();
-        _status = SyncStatus.error;
-        rethrow;
-      }
-    });
-  }
-
-  Future<void> fullPull({void Function(SyncProgress)? onProgress}) async {
-    await _withSyncForeground(() async {
-      _status = SyncStatus.syncing;
-      _lastError = null;
-      _conflicts.clear();
-      _resolvedAsCloud.clear();
-      _resolvedAsLocal = false;
-
-      try {
-        final engine = _engine;
-        await engine.pullEntities(
-          onProgress: onProgress ?? (_) {},
-          onConflict: (c) => _conflicts.add(c),
-        );
-        if (_conflicts.isNotEmpty) {
-          _status = SyncStatus.conflict;
-        } else {
+        try {
+          final engine = _engine;
+          await engine.pushEntities(
+            onProgress: onProgress ?? (_) {},
+            includeApiKeys: includeApiKeys,
+          );
           _lastSyncTime = DateTime.now().millisecondsSinceEpoch;
           final prefs = await SharedPreferences.getInstance();
           await prefs.setInt('gz_sync_last', _lastSyncTime!);
           _status = SyncStatus.idle;
+        } catch (e) {
+          _lastError = e.toString();
+          _status = SyncStatus.error;
+          rethrow;
         }
-      } catch (e) {
-        _lastError = e.toString();
-        _status = SyncStatus.error;
-        rethrow;
-      }
-    });
+      });
+    } finally {
+      _operationInProgress = false;
+    }
+  }
+
+  Future<void> fullPull({void Function(SyncProgress)? onProgress}) async {
+    if (_operationInProgress) {
+      throw StateError('Sync operation already in progress');
+    }
+    _operationInProgress = true;
+    try {
+      await _withSyncForeground(() async {
+        _status = SyncStatus.syncing;
+        _lastError = null;
+        _conflicts.clear();
+        _resolvedAsCloud.clear();
+        _resolvedAsLocal = false;
+
+        try {
+          final engine = _engine;
+          await engine.pullEntities(
+            onProgress: onProgress ?? (_) {},
+            onConflict: (c) {
+              if (_conflicts.every((existing) => existing.key != c.key)) {
+                _conflicts.add(c);
+              }
+            },
+          );
+          if (_conflicts.isNotEmpty) {
+            _status = SyncStatus.conflict;
+          } else {
+            _lastSyncTime = DateTime.now().millisecondsSinceEpoch;
+            final prefs = await SharedPreferences.getInstance();
+            await prefs.setInt('gz_sync_last', _lastSyncTime!);
+            _status = SyncStatus.idle;
+          }
+        } catch (e) {
+          _lastError = e.toString();
+          _status = SyncStatus.error;
+          rethrow;
+        }
+      });
+    } finally {
+      _operationInProgress = false;
+    }
   }
 
   Future<void> fullSync({
@@ -299,13 +320,14 @@ class SyncService {
     if (_conflicts.isEmpty) return;
     final conflicts = List<SyncConflict>.from(_conflicts);
     try {
-      for (final conflict in conflicts) {
-        await _engine.resolveConflict(conflict, choice);
-        if (choice == 'cloud') {
-          _resolvedAsCloud.add(conflict.key);
-        } else {
-          _resolvedAsLocal = true;
-        }
+      if (choice == 'cloud') {
+        _resolvedAsCloud.addAll(
+          conflicts
+              .map((conflict) => conflict.key)
+              .where((key) => !_resolvedAsCloud.contains(key)),
+        );
+      } else {
+        _resolvedAsLocal = true;
       }
       _conflicts.clear();
     } catch (e) {
@@ -319,6 +341,10 @@ class SyncService {
   /// cloud-resolved keys). Does NOT trigger a pull — call [applyPendingPull]
   /// once all conflicts have been resolved.
   Future<void> resolveConflict(SyncConflict conflict, String choice) async {
+    if (_operationInProgress) {
+      throw StateError('Sync operation already in progress');
+    }
+    _operationInProgress = true;
     try {
       await _engine.resolveConflict(conflict, choice);
       if (choice == 'cloud') {
@@ -331,6 +357,8 @@ class SyncService {
       _lastError = e.toString();
       _status = SyncStatus.error;
       rethrow;
+    } finally {
+      _operationInProgress = false;
     }
   }
 
@@ -339,28 +367,36 @@ class SyncService {
   Future<void> applyPendingPullAfterResolve({
     required void Function(SyncProgress) onProgress,
   }) async {
-    await _withSyncForeground(() async {
-      try {
-        _status = SyncStatus.syncing;
-        await _engine.applyPendingPull(
-          onProgress: onProgress,
-          resolvedAsCloud: _resolvedAsCloud.isNotEmpty
-              ? List.from(_resolvedAsCloud)
-              : null,
-          pushLocalChanges: _resolvedAsLocal,
-        );
-        _resolvedAsCloud.clear();
-        _resolvedAsLocal = false;
-        _lastSyncTime = DateTime.now().millisecondsSinceEpoch;
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setInt('gz_sync_last', _lastSyncTime!);
-        _status = SyncStatus.idle;
-      } catch (e) {
-        _lastError = e.toString();
-        _status = SyncStatus.error;
-        rethrow;
-      }
-    });
+    if (_operationInProgress) {
+      throw StateError('Sync operation already in progress');
+    }
+    _operationInProgress = true;
+    try {
+      await _withSyncForeground(() async {
+        try {
+          _status = SyncStatus.syncing;
+          await _engine.applyPendingPull(
+            onProgress: onProgress,
+            resolvedAsCloud: _resolvedAsCloud.isNotEmpty
+                ? List.from(_resolvedAsCloud)
+                : null,
+            pushLocalChanges: _resolvedAsLocal,
+          );
+          _resolvedAsCloud.clear();
+          _resolvedAsLocal = false;
+          _lastSyncTime = DateTime.now().millisecondsSinceEpoch;
+          final prefs = await SharedPreferences.getInstance();
+          await prefs.setInt('gz_sync_last', _lastSyncTime!);
+          _status = SyncStatus.idle;
+        } catch (e) {
+          _lastError = e.toString();
+          _status = SyncStatus.error;
+          rethrow;
+        }
+      });
+    } finally {
+      _operationInProgress = false;
+    }
   }
 
   Future<void> _withSyncForeground(Future<void> Function() action) async {

--- a/lib/features/cloud_sync/sync_models.dart
+++ b/lib/features/cloud_sync/sync_models.dart
@@ -107,7 +107,8 @@ class SyncManifest {
   ///   8 — added `studio_preset` entity type (DB-backed StudioPresetRows).
   ///   9 — added `local_storage` singleton for global PipelineSettings.
   ///  11 — added `character_knowledge` (atomic facts + session baseline).
-  static const int currentVersion = 11;
+  ///  12 — added merge-only `reconciliation_state` provenance.
+  static const int currentVersion = 12;
 
   final int version;
   final String deviceId;
@@ -222,6 +223,8 @@ String cloudPath(String type, String id) {
       return '$cloudBase/memory_graphs/$id.json';
     case 'character_knowledge':
       return '$cloudBase/character_knowledge/$id.json';
+    case 'reconciliation_state':
+      return '$cloudBase/reconciliation_state/$id.json';
     case 'lorebooks':
       return '$cloudBase/lorebooks.json';
     case 'api_presets':

--- a/lib/features/cloud_sync/sync_provider.dart
+++ b/lib/features/cloud_sync/sync_provider.dart
@@ -50,6 +50,9 @@ final syncServiceProvider = FutureProvider<SyncService>((ref) async {
     characterKnowledgeStore: CharacterKnowledgeSyncStore(
       ref.watch(appDbProvider),
     ),
+    reconciliationStateStore: ReconciliationStateSyncStore(
+      ref.watch(appDbProvider),
+    ),
     sessionDeletionStore: ref.watch(sessionDeletionRepoProvider),
     characterDeletionStore: ref.watch(characterDeletionRepoProvider),
     saveLorebookActivations: saveLorebookActivations,

--- a/lib/features/cloud_sync/sync_repo_interfaces.dart
+++ b/lib/features/cloud_sync/sync_repo_interfaces.dart
@@ -32,4 +32,5 @@ abstract class SyncManifestProvider {
   Future<void> clearLocalManifest();
   Future<void> clearDeleted();
   Future<String> getDeviceId();
+  Future<bool> isDeleted(String type, String id);
 }

--- a/test/chat_summary_sync_store_test.dart
+++ b/test/chat_summary_sync_store_test.dart
@@ -1,0 +1,26 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/summary_repo.dart';
+import 'package:glaze_flutter/features/cloud_sync/adapters/ext_blocks_sync_stores.dart';
+
+void main() {
+  test('cloud summary import preserves its updatedAt', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = SummaryRepo(db);
+    final store = ChatSummarySyncStore(repo);
+    final cloud = <String, dynamic>{
+      'sessionId': 'session',
+      'content': 'Cloud summary',
+      'enabled': false,
+      'messageCount': 12,
+      'prompt': 'Keep this prompt',
+      'updatedAt': 1234,
+    };
+
+    await store.putRaw(cloud);
+
+    expect(await store.getBySessionId('session'), cloud);
+  });
+}

--- a/test/ext_blocks_sync_test.dart
+++ b/test/ext_blocks_sync_test.dart
@@ -448,6 +448,9 @@ class InMemoryManifestProvider implements SyncManifestProvider {
 
   @override
   Future<void> clearDeleted() async {}
+
+  @override
+  Future<bool> isDeleted(String type, String id) async => false;
   @override
   Future<String> getDeviceId() => _builder.getDeviceId();
 }

--- a/test/reconciliation_state_sync_store_test.dart
+++ b/test/reconciliation_state_sync_store_test.dart
@@ -285,6 +285,31 @@ void main() {
     );
   });
 
+  test(
+    'stale collector provenance is discarded without failing sync',
+    () async {
+      final runs = await _appendChain(sourceDb, 2);
+      await _completeCollector(sourceDb, runs);
+      final payload = (await sourceStore.getBySessionId('session'))!;
+      final collectors = (payload['collectors'] as List)
+          .cast<Map<String, dynamic>>();
+      payload['collectors'] = [
+        {...collectors.single, 'rangeHash': 'legacy-stale-range'},
+      ];
+
+      final merged = await targetStore.mergeBySessionId('session', payload);
+
+      expect(merged['runs'], hasLength(2));
+      expect(merged['collectors'], isEmpty);
+      expect(
+        await CardEvolutionCollectorRunRepo(
+          targetDb,
+        ).pendingValidPairs('session'),
+        hasLength(1),
+      );
+    },
+  );
+
   test('active collector claims and leases are omitted', () async {
     final runs = await _appendChain(sourceDb, 2);
     final first = await _storedRun(sourceDb, runs.first.id);

--- a/test/reconciliation_state_sync_store_test.dart
+++ b/test/reconciliation_state_sync_store_test.dart
@@ -67,7 +67,12 @@ void main() {
   test(
     'divergent chains at the same endpoint converge deterministically',
     () async {
-      await _appendChain(targetDb, 1, resultPrefix: 'local');
+      await _appendChain(
+        targetDb,
+        1,
+        resultPrefix: 'local',
+        progressingEndpoints: true,
+      );
       await _appendChain(sourceDb, 1, resultPrefix: 'cloud');
       final sourcePayload = (await sourceStore.getBySessionId('session'))!;
       final targetPayload = (await targetStore.getBySessionId('session'))!;
@@ -93,12 +98,7 @@ void main() {
         resultPrefix: 'cloud',
         progressingEndpoints: true,
       );
-      await _appendChain(
-        targetDb,
-        1,
-        resultPrefix: 'local',
-        progressingEndpoints: true,
-      );
+      await _appendChain(targetDb, 1, resultPrefix: 'local');
 
       await targetStore.mergeBySessionId(
         'session',
@@ -130,6 +130,72 @@ void main() {
         resultPrefix: 'local',
         progressingEndpoints: true,
       );
+
+      final merged = await targetStore.mergeBySessionId(
+        'session',
+        (await sourceStore.getBySessionId('session'))!,
+      );
+
+      expect(
+        (merged['runs'] as List).map((run) => (run as Map)['chainHash']),
+        local.map((run) => run.chainHash),
+      );
+    },
+  );
+
+  test(
+    'a divergent incoming chain replaces a local head absent from chat',
+    () async {
+      await _appendChain(
+        targetDb,
+        1,
+        resultPrefix: 'local',
+        progressingEndpoints: true,
+      );
+      final incoming = await _appendChain(
+        sourceDb,
+        2,
+        resultPrefix: 'cloud',
+        progressingEndpoints: true,
+      );
+      await _replaceMessages(targetDb, [
+        _messages[1],
+        _messages[2],
+        _messages[3],
+        _messages[4],
+      ]);
+
+      await targetStore.mergeBySessionId(
+        'session',
+        (await sourceStore.getBySessionId('session'))!,
+      );
+
+      final stored = await LedgerReconciliationRunRepo(
+        targetDb,
+      ).readSession('session');
+      expect(
+        stored.map((run) => run.chainHash),
+        incoming.map((run) => run.chainHash),
+      );
+    },
+  );
+
+  test(
+    'a divergent incoming head absent from chat preserves local state',
+    () async {
+      await _appendChain(
+        sourceDb,
+        2,
+        resultPrefix: 'cloud',
+        progressingEndpoints: true,
+      );
+      final local = await _appendChain(
+        targetDb,
+        1,
+        resultPrefix: 'local',
+        progressingEndpoints: true,
+      );
+      await _replaceMessages(targetDb, _messages.take(3).toList());
 
       final merged = await targetStore.mergeBySessionId(
         'session',
@@ -368,6 +434,14 @@ Future<void> _seedSession(AppDatabase db) => db.customStatement(
   '(session_id, character_id, session_index, messages_json) '
   'VALUES (?, ?, 0, ?)',
   ['session', 'character', jsonEncode(_messages)],
+);
+
+Future<void> _replaceMessages(
+  AppDatabase db,
+  List<Map<String, Object>> messages,
+) => db.customStatement(
+  'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
+  [jsonEncode(messages), 'session'],
 );
 
 Future<List<LedgerReconciliationRun>> _appendChain(

--- a/test/reconciliation_state_sync_store_test.dart
+++ b/test/reconciliation_state_sync_store_test.dart
@@ -1,0 +1,582 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/card_evolution_collector_run_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/card_evolution_observation_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_run_repo.dart';
+import 'package:glaze_flutter/core/models/card_evolution_observation.dart';
+import 'package:glaze_flutter/core/utils/cast_helpers.dart';
+import 'package:glaze_flutter/features/cloud_sync/adapters/ext_blocks_sync_stores.dart';
+
+void main() {
+  late AppDatabase sourceDb;
+  late AppDatabase targetDb;
+  late ReconciliationStateSyncStore sourceStore;
+  late ReconciliationStateSyncStore targetStore;
+
+  setUp(() async {
+    sourceDb = AppDatabase.forTesting(NativeDatabase.memory());
+    targetDb = AppDatabase.forTesting(NativeDatabase.memory());
+    sourceStore = ReconciliationStateSyncStore(sourceDb);
+    targetStore = ReconciliationStateSyncStore(targetDb);
+    await Future.wait([_seedSession(sourceDb), _seedSession(targetDb)]);
+  });
+
+  tearDown(() async {
+    await sourceDb.close();
+    await targetDb.close();
+  });
+
+  test('imports an immutable chain and makes its head authoritative', () async {
+    final sourceRuns = await _appendChain(sourceDb, 2);
+    final payload = (await sourceStore.getBySessionId('session'))!;
+
+    final merged = await targetStore.mergeBySessionId('session', payload);
+
+    expect((merged['runs'] as List), hasLength(2));
+    final head = await LedgerReconciliationRunRepo(targetDb).getHead('session');
+    expect(head?.id, sourceRuns.last.id);
+    expect(head?.chainHash, sourceRuns.last.chainHash);
+  });
+
+  test(
+    'a stale shorter incoming chain never truncates local history',
+    () async {
+      await _appendChain(sourceDb, 2);
+      final localRuns = await _appendChain(targetDb, 3);
+
+      await targetStore.mergeBySessionId(
+        'session',
+        (await sourceStore.getBySessionId('session'))!,
+      );
+
+      final stored = await LedgerReconciliationRunRepo(
+        targetDb,
+      ).readSession('session');
+      expect(stored.map((row) => row.id), ['run-1', 'run-2', 'run-3']);
+      expect(
+        (await LedgerReconciliationRunRepo(targetDb).getHead('session'))?.id,
+        localRuns.last.id,
+      );
+    },
+  );
+
+  test(
+    'divergent chains at the same endpoint converge deterministically',
+    () async {
+      await _appendChain(targetDb, 1, resultPrefix: 'local');
+      await _appendChain(sourceDb, 1, resultPrefix: 'cloud');
+      final sourcePayload = (await sourceStore.getBySessionId('session'))!;
+      final targetPayload = (await targetStore.getBySessionId('session'))!;
+
+      await Future.wait([
+        sourceStore.mergeBySessionId('session', targetPayload),
+        targetStore.mergeBySessionId('session', sourcePayload),
+      ]);
+
+      expect(
+        await targetStore.getBySessionId('session'),
+        equals(await sourceStore.getBySessionId('session')),
+      );
+    },
+  );
+
+  test(
+    'a divergent incoming chain replaces local when its endpoint is newer',
+    () async {
+      final incoming = await _appendChain(
+        sourceDb,
+        3,
+        resultPrefix: 'cloud',
+        progressingEndpoints: true,
+      );
+      await _appendChain(
+        targetDb,
+        1,
+        resultPrefix: 'local',
+        progressingEndpoints: true,
+      );
+
+      await targetStore.mergeBySessionId(
+        'session',
+        (await sourceStore.getBySessionId('session'))!,
+      );
+
+      final stored = await LedgerReconciliationRunRepo(
+        targetDb,
+      ).readSession('session');
+      expect(
+        stored.map((run) => run.chainHash),
+        incoming.map((run) => run.chainHash),
+      );
+    },
+  );
+
+  test(
+    'a divergent stale incoming chain preserves farther local endpoint',
+    () async {
+      await _appendChain(
+        sourceDb,
+        1,
+        resultPrefix: 'cloud',
+        progressingEndpoints: true,
+      );
+      final local = await _appendChain(
+        targetDb,
+        3,
+        resultPrefix: 'local',
+        progressingEndpoints: true,
+      );
+
+      final merged = await targetStore.mergeBySessionId(
+        'session',
+        (await sourceStore.getBySessionId('session'))!,
+      );
+
+      expect(
+        (merged['runs'] as List).map((run) => (run as Map)['chainHash']),
+        local.map((run) => run.chainHash),
+      );
+    },
+  );
+
+  test('completed collector round-trip consumes its valid pair', () async {
+    final runs = await _appendChain(sourceDb, 2);
+    final collectorRepo = CardEvolutionCollectorRunRepo(sourceDb);
+    final claim = await collectorRepo.claim(
+      reconciliationRun: await _storedRun(sourceDb, runs.last.id),
+      characterId: 'character',
+      inputHash: 'collector-input',
+      ownerId: 'owner',
+      now: 10,
+      leaseSeconds: 30,
+      rangeHash: CardEvolutionCollectorPair(
+        await _storedRun(sourceDb, runs.first.id),
+        await _storedRun(sourceDb, runs.last.id),
+      ).rangeHash,
+    );
+    expect(
+      await collectorRepo.complete(
+        id: claim.row!.id,
+        ownerId: 'owner',
+        modelOutputHash: 'output',
+        now: 11,
+      ),
+      isTrue,
+    );
+
+    await targetStore.mergeBySessionId(
+      'session',
+      (await sourceStore.getBySessionId('session'))!,
+    );
+
+    expect(
+      await CardEvolutionCollectorRunRepo(
+        targetDb,
+      ).pendingValidPairs('session'),
+      isEmpty,
+    );
+  });
+
+  test('active collector claims and leases are omitted', () async {
+    final runs = await _appendChain(sourceDb, 2);
+    final first = await _storedRun(sourceDb, runs.first.id);
+    final boundary = await _storedRun(sourceDb, runs.last.id);
+    await CardEvolutionCollectorRunRepo(sourceDb).claim(
+      reconciliationRun: boundary,
+      characterId: 'character',
+      inputHash: 'collector-input',
+      ownerId: 'active-owner',
+      now: 10,
+      leaseSeconds: 30,
+      rangeHash: CardEvolutionCollectorPair(first, boundary).rangeHash,
+    );
+
+    final payload = (await sourceStore.getBySessionId('session'))!;
+    expect(payload['collectors'], isEmpty);
+
+    await targetStore.mergeBySessionId('session', payload);
+    expect(
+      await targetDb.select(targetDb.cardEvolutionCollectorRuns).get(),
+      isEmpty,
+    );
+  });
+
+  test(
+    'incoming completed collector replaces local claim at boundary',
+    () async {
+      final sourceRuns = await _appendChain(sourceDb, 2);
+      final targetRuns = await _appendChain(targetDb, 2);
+      final completed = await _completeCollector(sourceDb, sourceRuns);
+      final local = await _claimCollector(
+        targetDb,
+        targetRuns,
+        ownerId: 'local',
+      );
+
+      await targetStore.mergeBySessionId(
+        'session',
+        (await sourceStore.getBySessionId('session'))!,
+      );
+
+      final stored = await targetDb
+          .select(targetDb.cardEvolutionCollectorRuns)
+          .get();
+      expect(stored, hasLength(1));
+      expect(stored.single.id, completed.id);
+      expect(stored.single.status, 'completed');
+      expect(stored.single.ownerId, 'cloud-sync');
+      expect(stored.single.id, isNot(local.id));
+    },
+  );
+
+  test('conflicting manifest entry evidence rolls back the merge', () async {
+    await _appendChain(sourceDb, 1);
+    await _appendChain(targetDb, 1);
+    await _insertManifestEvidence(sourceDb, evidence: '{"source":true}');
+    await _insertManifestEvidence(targetDb, evidence: '{"target":true}');
+    await sourceDb.customStatement(
+      'INSERT INTO lorebook_use_manifests '
+      '(session_id, message_id, swipe_id, agent_swipe_id, manifest_json, '
+      'manifest_hash, manifest_schema_version, final_prompt_hash, '
+      'preset_snapshot_hash, created_at) VALUES (?, ?, 0, 0, ?, ?, 1, ?, ?, 2)',
+      ['session', 'user-1', '{}', 'second', 'prompt', 'preset'],
+    );
+    final before = (await targetStore.getBySessionId('session'))!;
+
+    await expectLater(
+      targetStore.mergeBySessionId(
+        'session',
+        (await sourceStore.getBySessionId('session'))!,
+      ),
+      throwsStateError,
+    );
+
+    expect(await targetStore.getBySessionId('session'), equals(before));
+  });
+
+  test('observation merge is commutative and convergent', () async {
+    await _appendChain(sourceDb, 2);
+    await _appendChain(targetDb, 2);
+    await _insertObservation(
+      sourceDb,
+      id: 'source-observation',
+      runOrdinal: 2,
+      clusters: const [
+        ['message-3', 'message-2'],
+      ],
+      retrievalKeys: const ['npc:Alice', 'trait:trust'],
+      confidence: 0.8,
+      status: 'promoted',
+      firstSeenRun: 2,
+      lastConfirmedRun: 5,
+      updatedAt: 20,
+    );
+    await _insertObservation(
+      targetDb,
+      id: 'target-observation',
+      runOrdinal: 1,
+      clusters: const [
+        ['message-1'],
+      ],
+      retrievalKeys: const ['npc:Alice', 'arc:alliance'],
+      confidence: 0.6,
+      status: 'consumed',
+      firstSeenRun: 1,
+      lastConfirmedRun: 4,
+      updatedAt: 10,
+    );
+    final sourcePayload = (await sourceStore.getBySessionId('session'))!;
+    final targetPayload = (await targetStore.getBySessionId('session'))!;
+
+    await Future.wait([
+      sourceStore.mergeBySessionId('session', targetPayload),
+      targetStore.mergeBySessionId('session', sourcePayload),
+    ]);
+
+    final source = (await sourceStore.getBySessionId('session'))!;
+    final target = (await targetStore.getBySessionId('session'))!;
+    expect(target['observations'], equals(source['observations']));
+    final observation = (target['observations'] as List).single as Map;
+    expect(jsonDecode(observation['evidenceClustersJson'] as String), [
+      ['message-1'],
+      ['message-2', 'message-3'],
+    ]);
+    expect(jsonDecode(observation['retrievalKeysJson'] as String), [
+      'arc:alliance',
+      'npc:Alice',
+      'trait:trust',
+    ]);
+    expect(observation, containsPair('confidence', 0.8));
+    expect(observation, containsPair('firstSeenRun', 1));
+    expect(observation, containsPair('lastConfirmedRun', 5));
+    expect(observation, containsPair('status', 'consumed'));
+  });
+
+  test('synced invalidation clears derived lane without deleting claims or '
+      'resurrecting stale collectors', () async {
+    final runs = await _appendChain(sourceDb, 2);
+    final collector = await _completeCollector(sourceDb, runs);
+    await _insertObservation(sourceDb);
+    await _insertCompletedClaim(sourceDb, collector);
+    final stalePayload = (await sourceStore.getBySessionId('session'))!;
+    await targetStore.mergeBySessionId('session', stalePayload);
+
+    final invalidatedPayload = Map<String, dynamic>.from(stalePayload)
+      ..['invalidations'] = [
+        {
+          'id': 0,
+          'sessionId': 'session',
+          'runId': runs.last.id,
+          'causeMessageId': 'opening-assistant',
+          'reason': 'message deleted',
+          'createdAt': 30,
+        },
+      ];
+    await targetStore.mergeBySessionId('session', invalidatedPayload);
+
+    expect(
+      await targetDb.select(targetDb.cardEvolutionCollectorRuns).get(),
+      isEmpty,
+    );
+    expect(
+      await targetDb.select(targetDb.cardEvolutionObservations).get(),
+      isEmpty,
+    );
+    expect(
+      await targetDb.select(targetDb.cardEvolutionClaims).get(),
+      hasLength(1),
+    );
+
+    await targetStore.mergeBySessionId('session', stalePayload);
+    expect(
+      await targetDb.select(targetDb.cardEvolutionCollectorRuns).get(),
+      isEmpty,
+    );
+    expect(
+      await targetDb.select(targetDb.cardEvolutionClaims).get(),
+      hasLength(1),
+    );
+  });
+}
+
+Future<void> _seedSession(AppDatabase db) => db.customStatement(
+  'INSERT INTO chat_sessions '
+  '(session_id, character_id, session_index, messages_json) '
+  'VALUES (?, ?, 0, ?)',
+  ['session', 'character', jsonEncode(_messages)],
+);
+
+Future<List<LedgerReconciliationRun>> _appendChain(
+  AppDatabase db,
+  int count, {
+  String resultPrefix = 'result',
+  bool progressingEndpoints = false,
+}) async {
+  final repo = LedgerReconciliationRunRepo(db);
+  final runs = <LedgerReconciliationRun>[];
+  var predecessor = '';
+  for (var ordinal = 1; ordinal <= count; ordinal++) {
+    final run = LedgerReconciliationRun(
+      id: 'run-$ordinal',
+      sessionId: 'session',
+      ordinal: ordinal,
+      anchors: [
+        progressingEndpoints ? _progressAnchor(ordinal) : _openingAnchor,
+      ],
+      acceptedManifestRefs: const [],
+      effectiveCanonStamp: 'stamp-$ordinal',
+      effectiveCanonRevision: ordinal,
+      effectiveCanonHash: 'canon-$ordinal',
+      canonicalResult: {
+        'facts': ['$resultPrefix-$ordinal'],
+      },
+      predecessorChainHash: predecessor,
+      contractVersion: 1,
+      opsApplied: const [],
+      createdAt: ordinal,
+    );
+    expect(await repo.append(run), isA<ReconciliationRunAppended>());
+    runs.add(run);
+    predecessor = run.chainHash;
+  }
+  return runs;
+}
+
+Future<LedgerReconciliationSuccessfulRunRow> _storedRun(
+  AppDatabase db,
+  String id,
+) => (db.select(
+  db.ledgerReconciliationSuccessfulRuns,
+)..where((row) => row.id.equals(id))).getSingle();
+
+Future<CardEvolutionCollectorRunRow> _claimCollector(
+  AppDatabase db,
+  List<LedgerReconciliationRun> runs, {
+  required String ownerId,
+}) async {
+  final first = await _storedRun(db, runs.first.id);
+  final boundary = await _storedRun(db, runs.last.id);
+  final claim = await CardEvolutionCollectorRunRepo(db).claim(
+    reconciliationRun: boundary,
+    characterId: 'character',
+    inputHash: 'collector-input',
+    ownerId: ownerId,
+    now: 10,
+    leaseSeconds: 30,
+    rangeHash: CardEvolutionCollectorPair(first, boundary).rangeHash,
+  );
+  return claim.row!;
+}
+
+Future<CardEvolutionCollectorRunRow> _completeCollector(
+  AppDatabase db,
+  List<LedgerReconciliationRun> runs,
+) async {
+  final row = await _claimCollector(db, runs, ownerId: 'owner');
+  expect(
+    await CardEvolutionCollectorRunRepo(db).complete(
+      id: row.id,
+      ownerId: 'owner',
+      modelOutputHash: 'output',
+      now: 11,
+    ),
+    isTrue,
+  );
+  return (db.select(
+    db.cardEvolutionCollectorRuns,
+  )..where((item) => item.id.equals(row.id))).getSingle();
+}
+
+Future<void> _insertManifestEvidence(
+  AppDatabase db, {
+  required String evidence,
+}) async {
+  await db.customStatement(
+    'INSERT INTO lorebook_use_manifests '
+    '(session_id, message_id, swipe_id, agent_swipe_id, manifest_json, '
+    'manifest_hash, manifest_schema_version, final_prompt_hash, '
+    'preset_snapshot_hash, created_at) VALUES (?, ?, 0, 0, ?, ?, 1, ?, ?, 1)',
+    ['session', 'opening-assistant', '{}', 'manifest', 'prompt', 'preset'],
+  );
+  await db.customStatement(
+    'INSERT INTO lorebook_use_manifest_entries '
+    '(session_id, message_id, swipe_id, agent_swipe_id, lorebook_id, '
+    'entry_id, entry_order, evidence_json) VALUES (?, ?, 0, 0, ?, ?, 0, ?)',
+    ['session', 'opening-assistant', 'lorebook', 'entry', evidence],
+  );
+}
+
+Future<void> _insertObservation(
+  AppDatabase db, {
+  String id = 'observation',
+  int runOrdinal = 1,
+  List<List<String>> clusters = const [
+    ['message-1'],
+  ],
+  List<String> retrievalKeys = const ['npc:Alice'],
+  double confidence = 0.5,
+  String status = 'active',
+  int firstSeenRun = 1,
+  int? lastConfirmedRun,
+  int updatedAt = 10,
+}) => CardEvolutionObservationRepo(db).insertObservation(
+  CardEvolutionObservation(
+    id: id,
+    sessionId: 'session',
+    characterId: 'character',
+    runOrdinal: runOrdinal,
+    semanticScopeKey: 'character.personality.trust',
+    observedChange: 'Alice increasingly trusts the protagonist.',
+    canonicalClaim: 'Alice trusts the protagonist.',
+    evidenceClusters: clusters,
+    retrievalKeys: retrievalKeys,
+    targetKind: 'main_character_card',
+    cardFieldPath: 'personality',
+    confidence: confidence,
+    status: status,
+    firstSeenRun: firstSeenRun,
+    repeatCount: clusters.length,
+    lastConfirmedRun: lastConfirmedRun,
+    createdAt: 10,
+    updatedAt: updatedAt,
+  ),
+);
+
+Future<void> _insertCompletedClaim(
+  AppDatabase db,
+  CardEvolutionCollectorRunRow collector,
+) => db
+    .into(db.cardEvolutionClaims)
+    .insert(
+      CardEvolutionClaimsCompanion.insert(
+        id: 'completed-claim',
+        sessionId: 'session',
+        characterId: 'character',
+        ownerId: 'owner',
+        status: 'completed',
+        leaseExpiresAt: 0,
+        chatHistoryHash: 'history',
+        effectiveCanonIdentity: 'canon',
+        predecessorCursorHash: collector.reconciliationChainHash,
+        predecessorRunOrdinal: collector.collectorOrdinal,
+        inputHash: 'claim-input',
+        rewriteJobId: const Value('rewrite-job'),
+        createdAt: 12,
+        completedAt: const Value(13),
+      ),
+    );
+
+const _openingContent = 'Welcome to the story.';
+const _messages = [
+  {
+    'id': 'opening-assistant',
+    'role': 'assistant',
+    'content': _openingContent,
+    'swipes': [_openingContent],
+    'agentSwipes': <Object>[],
+  },
+  {'id': 'user-1', 'role': 'user', 'content': 'Begin.'},
+  {
+    'id': 'assistant-1',
+    'role': 'assistant',
+    'content': 'Assistant 1',
+    'swipes': ['Assistant 1'],
+    'agentSwipes': <Object>[],
+  },
+  {'id': 'user-2', 'role': 'user', 'content': 'Continue.'},
+  {
+    'id': 'assistant-2',
+    'role': 'assistant',
+    'content': 'Assistant 2',
+    'swipes': ['Assistant 2'],
+    'agentSwipes': <Object>[],
+  },
+  {'id': 'user-3', 'role': 'user', 'content': 'Continue again.'},
+  {
+    'id': 'assistant-3',
+    'role': 'assistant',
+    'content': 'Assistant 3',
+    'swipes': ['Assistant 3'],
+    'agentSwipes': <Object>[],
+  },
+];
+
+final _openingAnchor = ReconciliationAnchor(
+  messageId: 'opening-assistant',
+  swipeId: 0,
+  agentSwipeId: 0,
+  role: 'assistant',
+  contentHash: computeHash(_openingContent),
+);
+
+ReconciliationAnchor _progressAnchor(int ordinal) => ReconciliationAnchor(
+  messageId: 'assistant-$ordinal',
+  swipeId: 0,
+  agentSwipeId: 0,
+  role: 'assistant',
+  contentHash: computeHash('Assistant $ordinal'),
+);

--- a/test/reconciliation_state_sync_store_test.dart
+++ b/test/reconciliation_state_sync_store_test.dart
@@ -209,6 +209,44 @@ void main() {
     },
   );
 
+  test('malformed cloud evidence is discarded without failing sync', () async {
+    await _appendChain(
+      sourceDb,
+      1,
+      resultPrefix: 'cloud',
+      progressingEndpoints: true,
+    );
+    await _replaceMessages(sourceDb, [
+      _messages[0],
+      _messages[1],
+      {
+        ..._messages[2],
+        'content': 'Edited assistant response',
+        'swipes': ['Edited assistant response'],
+      },
+    ]);
+    await _replaceMessages(targetDb, [
+      _messages[0],
+      _messages[1],
+      {
+        ..._messages[2],
+        'content': 'Edited assistant response',
+        'swipes': ['Edited assistant response'],
+      },
+    ]);
+
+    final merged = await targetStore.mergeBySessionId(
+      'session',
+      (await sourceStore.getBySessionId('session'))!,
+    );
+
+    expect(merged['runs'], isEmpty);
+    expect(
+      await LedgerReconciliationRunRepo(targetDb).getHead('session'),
+      equals(null),
+    );
+  });
+
   test('completed collector round-trip consumes its valid pair', () async {
     final runs = await _appendChain(sourceDb, 2);
     final collectorRepo = CardEvolutionCollectorRunRepo(sourceDb);

--- a/test/studio_config_sync_store_test.dart
+++ b/test/studio_config_sync_store_test.dart
@@ -1,0 +1,29 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/studio_config_repo.dart';
+import 'package:glaze_flutter/core/models/studio_config.dart';
+import 'package:glaze_flutter/features/cloud_sync/services/sync_serialization.dart';
+
+void main() {
+  test('sync import preserves Studio config timestamps and hash', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final store = StudioConfigRepo(db);
+    const cloudConfig = StudioConfig(
+      sessionId: 'session-1',
+      enabled: true,
+      createdAt: 100,
+      updatedAt: 200,
+    );
+
+    await store.put(cloudConfig);
+
+    final imported = await store.getById(cloudConfig.sessionId);
+    expect(imported, cloudConfig);
+    expect(
+      SyncSerialization.computeStudioConfigHash(imported!.toJson()),
+      SyncSerialization.computeStudioConfigHash(cloudConfig.toJson()),
+    );
+  });
+}

--- a/test/sync_lifecycle_test.dart
+++ b/test/sync_lifecycle_test.dart
@@ -392,6 +392,7 @@ class FakeImageStore implements SyncImageStore {
 class FakeReconciliationStateStore implements SyncReconciliationStateStore {
   final Map<String, Map<String, dynamic>> data = {};
   bool discardCollectors = false;
+  bool discardAll = false;
 
   @override
   Future<List<String>> getAllSessionIds() async => data.keys.toList();
@@ -405,6 +406,10 @@ class FakeReconciliationStateStore implements SyncReconciliationStateStore {
     String sessionId,
     Map<String, dynamic> incoming,
   ) async {
+    if (discardAll) {
+      data.remove(sessionId);
+      return {};
+    }
     final merged = {...?data[sessionId], ...incoming};
     if (discardCollectors) merged['collectors'] = <dynamic>[];
     data[sessionId] = merged;
@@ -901,6 +906,55 @@ void main() {
 
       expect(progress.any((item) => item.message == 'Nothing to pull'), isTrue);
       expect(reconciliationStates.data[sessionId]!['collectors'], isEmpty);
+    },
+  );
+
+  test(
+    'reconciliation state normalized to empty does not repeat on next pull',
+    () async {
+      final reconciliationStates = FakeReconciliationStateStore()
+        ..discardAll = true;
+      final world = SyncWorld(reconciliationStateStore: reconciliationStates);
+      const sessionId = 'discarded-session';
+      const chat = ChatSession(
+        id: sessionId,
+        characterId: 'character',
+        sessionIndex: 0,
+        updatedAt: 1000,
+      );
+      await world.chats.put(chat);
+      final payload = <String, dynamic>{
+        'runs': [
+          {'id': 'malformed-cloud-run', 'ordinal': 1},
+        ],
+      };
+      final entry = SyncManifestEntry(
+        type: 'reconciliation_state',
+        id: sessionId,
+        path: cloudPath('reconciliation_state', sessionId),
+        updatedAt: 1000,
+        hash: SyncSerialization.computeSyncHash(payload),
+      );
+      final cloudManifest = SyncManifest(
+        deviceId: 'cloud-device',
+        createdAt: 1,
+        lastSync: 1000,
+        entries: {entry.key: entry},
+      );
+      world.cloud.files[entry.path] = jsonEncode(payload);
+      world.cloud.files[cloudPath('manifest', 'manifest')] = jsonEncode(
+        cloudManifest.toJson(),
+      );
+
+      await world.engine.pullEntities(onProgress: (_) {}, onConflict: (_) {});
+      final progress = <SyncProgress>[];
+      await world.engine.pullEntities(
+        onProgress: progress.add,
+        onConflict: (_) {},
+      );
+
+      expect(progress.any((item) => item.message == 'Nothing to pull'), isTrue);
+      expect(reconciliationStates.data[sessionId], isNull);
     },
   );
 

--- a/test/sync_lifecycle_test.dart
+++ b/test/sync_lifecycle_test.dart
@@ -2611,7 +2611,9 @@ void main() {
 
   test('resolve all cloud pulls data and rebuilds manifest', () async {
     final deviceA = SyncWorld();
-    await deviceA.characters.put(makeChar('c1', name: 'Cloud'));
+    for (var i = 0; i < 27; i++) {
+      await deviceA.characters.put(makeChar('c$i', name: 'Cloud $i'));
+    }
     final aManifest = await deviceA.manifestProvider.buildLocalManifest();
     await deviceA.manifestProvider.writeLocalManifest(
       aManifest.copyWith(lastSync: 5000),
@@ -2620,13 +2622,18 @@ void main() {
 
     final deviceB = SyncWorld();
     deviceB.cloud.files.addAll(deviceA.cloud.files);
-    await deviceB.characters.put(makeChar('c1', name: 'Local'));
+    for (var i = 0; i < 27; i++) {
+      await deviceB.characters.put(makeChar('c$i', name: 'Local $i'));
+    }
 
     final yManifest = await deviceB.manifestProvider.buildLocalManifest();
     final patched = Map<String, SyncManifestEntry>.from(yManifest.entries);
-    patched['character:c1'] = patched['character:c1']!.copyWith(
-      updatedAt: DateTime.now().millisecondsSinceEpoch + 100000,
-    );
+    for (var i = 0; i < 27; i++) {
+      final key = 'character:c$i';
+      patched[key] = patched[key]!.copyWith(
+        updatedAt: DateTime.now().millisecondsSinceEpoch + 100000,
+      );
+    }
     await deviceB.manifestProvider.writeLocalManifest(
       yManifest.copyWith(lastSync: 8000, entries: patched),
     );
@@ -2636,19 +2643,17 @@ void main() {
       onProgress: (_) {},
       onConflict: (c) => conflicts.add(c),
     );
-    expect(conflicts, isNotEmpty);
+    expect(conflicts, hasLength(27));
 
-    final resolvedKeys = <String>[];
-    for (final conflict in conflicts) {
-      await deviceB.engine.resolveConflict(conflict, 'cloud');
-      resolvedKeys.add(conflict.key);
-    }
+    final resolvedKeys = conflicts.map((conflict) => conflict.key).toList();
     await deviceB.engine.applyPendingPull(
       onProgress: (_) {},
       resolvedAsCloud: resolvedKeys,
     );
 
-    expect(deviceB.characters.data['c1']?.name, equals('Cloud'));
+    for (var i = 0; i < 27; i++) {
+      expect(deviceB.characters.data['c$i']?.name, equals('Cloud $i'));
+    }
     final manifest = await deviceB.manifestProvider.readLocalManifest();
     expect(manifest.lastSync, greaterThan(0));
     final cloudManifest = SyncManifest.fromJson(

--- a/test/sync_lifecycle_test.dart
+++ b/test/sync_lifecycle_test.dart
@@ -3091,6 +3091,16 @@ void main() {
       expect(pulled, isNotNull);
       expect(pulled!.sessionId, 's1');
       expect(pulled.enabled, isTrue);
+
+      final repeatConflicts = <SyncConflict>[];
+      await target.engine.pullEntities(
+        onProgress: (_) {},
+        onConflict: repeatConflicts.add,
+      );
+      expect(
+        repeatConflicts.where((conflict) => conflict.type == 'studio_config'),
+        isEmpty,
+      );
     },
   );
 }

--- a/test/sync_lifecycle_test.dart
+++ b/test/sync_lifecycle_test.dart
@@ -391,6 +391,7 @@ class FakeImageStore implements SyncImageStore {
 
 class FakeReconciliationStateStore implements SyncReconciliationStateStore {
   final Map<String, Map<String, dynamic>> data = {};
+  bool discardCollectors = false;
 
   @override
   Future<List<String>> getAllSessionIds() async => data.keys.toList();
@@ -405,6 +406,7 @@ class FakeReconciliationStateStore implements SyncReconciliationStateStore {
     Map<String, dynamic> incoming,
   ) async {
     final merged = {...?data[sessionId], ...incoming};
+    if (discardCollectors) merged['collectors'] = <dynamic>[];
     data[sessionId] = merged;
     return merged;
   }
@@ -854,6 +856,51 @@ void main() {
             as Map<String, dynamic>,
       );
       expect(uploadedManifest.entries[entry.key]?.hash, entry.hash);
+    },
+  );
+
+  test(
+    'normalized reconciliation state does not repeat on the next pull',
+    () async {
+      final reconciliationStates = FakeReconciliationStateStore()
+        ..discardCollectors = true;
+      final world = SyncWorld(reconciliationStateStore: reconciliationStates);
+      const sessionId = 'normalized-session';
+      final payload = <String, dynamic>{
+        'runs': [
+          {'id': 'cloud-run', 'ordinal': 1},
+        ],
+        'collectors': [
+          {'id': 'stale-collector'},
+        ],
+      };
+      final entry = SyncManifestEntry(
+        type: 'reconciliation_state',
+        id: sessionId,
+        path: cloudPath('reconciliation_state', sessionId),
+        updatedAt: 1000,
+        hash: SyncSerialization.computeSyncHash(payload),
+      );
+      final cloudManifest = SyncManifest(
+        deviceId: 'cloud-device',
+        createdAt: 1,
+        lastSync: 1000,
+        entries: {entry.key: entry},
+      );
+      world.cloud.files[entry.path] = jsonEncode(payload);
+      world.cloud.files[cloudPath('manifest', 'manifest')] = jsonEncode(
+        cloudManifest.toJson(),
+      );
+
+      await world.engine.pullEntities(onProgress: (_) {}, onConflict: (_) {});
+      final progress = <SyncProgress>[];
+      await world.engine.pullEntities(
+        onProgress: progress.add,
+        onConflict: (_) {},
+      );
+
+      expect(progress.any((item) => item.message == 'Nothing to pull'), isTrue);
+      expect(reconciliationStates.data[sessionId]!['collectors'], isEmpty);
     },
   );
 

--- a/test/sync_lifecycle_test.dart
+++ b/test/sync_lifecycle_test.dart
@@ -2,8 +2,11 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/chat_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_run_repo.dart';
 import 'package:glaze_flutter/core/models/api_config.dart';
 import 'package:glaze_flutter/core/models/character.dart';
 import 'package:glaze_flutter/core/models/chat_message.dart';
@@ -12,9 +15,11 @@ import 'package:glaze_flutter/core/models/memory_book.dart';
 import 'package:glaze_flutter/core/models/persona.dart';
 import 'package:glaze_flutter/core/models/preset.dart';
 import 'package:glaze_flutter/core/models/studio_config.dart';
+import 'package:glaze_flutter/core/utils/cast_helpers.dart';
 import 'package:glaze_flutter/core/utils/sync_deletion_tracker.dart';
 import 'package:glaze_flutter/core/application/session_deletion_store.dart';
 import 'package:glaze_flutter/core/application/character_deletion_store.dart';
+import 'package:glaze_flutter/features/cloud_sync/adapters/ext_blocks_sync_stores.dart';
 import 'package:glaze_flutter/features/cloud_sync/sync_repo_interfaces.dart';
 import 'package:glaze_flutter/shared/theme/theme_preset.dart';
 import 'package:glaze_flutter/features/cloud_sync/cloud_adapter.dart';
@@ -27,6 +32,7 @@ import 'package:glaze_flutter/features/cloud_sync/sync_models.dart';
 import 'package:glaze_flutter/features/extensions/models/extension_preset.dart';
 import 'package:glaze_flutter/features/extensions/models/extensions_settings.dart';
 import 'package:glaze_flutter/features/extensions/models/info_block.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 // ─── In-memory fakes ────────────────────────────────────────────────
 
@@ -95,6 +101,13 @@ class FakeSessionDeletionStore implements SessionDeletionStore {
     deletedSessionIds.add(sessionId);
     await chats.delete(sessionId);
   }
+}
+
+class NoopSessionDeletionStore implements SessionDeletionStore {
+  const NoopSessionDeletionStore();
+
+  @override
+  Future<void> deleteSession(String sessionId) async {}
 }
 
 class FakeCharacterDeletionStore implements CharacterDeletionStore {
@@ -376,6 +389,32 @@ class FakeImageStore implements SyncImageStore {
   }
 }
 
+class FakeReconciliationStateStore implements SyncReconciliationStateStore {
+  final Map<String, Map<String, dynamic>> data = {};
+
+  @override
+  Future<List<String>> getAllSessionIds() async => data.keys.toList();
+
+  @override
+  Future<Map<String, dynamic>?> getBySessionId(String sessionId) async =>
+      data[sessionId];
+
+  @override
+  Future<Map<String, dynamic>> mergeBySessionId(
+    String sessionId,
+    Map<String, dynamic> incoming,
+  ) async {
+    final merged = {...?data[sessionId], ...incoming};
+    data[sessionId] = merged;
+    return merged;
+  }
+
+  @override
+  Future<void> deleteBySessionId(String sessionId) async {
+    data.remove(sessionId);
+  }
+}
+
 class FakeCloudAdapter implements CloudAdapter {
   final Map<String, String> files = {};
   final List<String> listFolderCalls = [];
@@ -501,6 +540,7 @@ class InMemoryManifestProvider implements SyncManifestProvider {
     SyncTrackerValueStore? trackerValueStore,
     SyncStudioConfigStore? studioConfigStore,
     SyncStudioPresetStore? studioPresetStore,
+    SyncReconciliationStateStore? reconciliationStateStore,
   }) : _builder = SyncManifestBuilder(
           characterRepo: characterRepo,
           chatRepo: chatRepo,
@@ -519,6 +559,7 @@ class InMemoryManifestProvider implements SyncManifestProvider {
           trackerValueStore: trackerValueStore ?? FakeTrackerValueStore(),
           studioConfigStore: studioConfigStore ?? FakeStudioConfigStore(),
           studioPresetStore: studioPresetStore,
+          reconciliationStateStore: reconciliationStateStore,
         );
 
   @override
@@ -558,6 +599,9 @@ class InMemoryManifestProvider implements SyncManifestProvider {
   Future<void> clearDeleted() async {}
 
   @override
+  Future<bool> isDeleted(String type, String id) async => false;
+
+  @override
   Future<String> getDeviceId() => _builder.getDeviceId();
 }
 
@@ -580,8 +624,9 @@ class SyncWorld {
   late final FakeStudioPresetStore studioPresets;
   late final FakeSessionDeletionStore sessionDeletions;
   late final FakeCharacterDeletionStore characterDeletions;
+  late final FakeReconciliationStateStore? reconciliationStates;
 
-  SyncWorld() {
+  SyncWorld({FakeReconciliationStateStore? reconciliationStateStore}) {
     characters = FakeCharacterStore();
     chats = FakeChatStore();
     personas = FakePersonaStore();
@@ -597,6 +642,7 @@ class SyncWorld {
     studioPresets = FakeStudioPresetStore();
     sessionDeletions = FakeSessionDeletionStore(chats);
     characterDeletions = FakeCharacterDeletionStore(characters);
+    reconciliationStates = reconciliationStateStore;
     manifestProvider = InMemoryManifestProvider(
       characterRepo: characters,
       chatRepo: chats,
@@ -608,6 +654,7 @@ class SyncWorld {
       themePresetRepo: uiThemes,
       studioConfigStore: studioConfigs,
       studioPresetStore: studioPresets,
+      reconciliationStateStore: reconciliationStates,
     );
   }
 
@@ -638,6 +685,65 @@ class SyncWorld {
     sessionDeletions,
     characterDeletions,
     (_) async {},
+    reconciliationStates,
+  );
+}
+
+SyncEngine _realStoreEngine({
+  required SyncChatStore chatStore,
+  required SyncReconciliationStateStore reconciliationStore,
+  required FakeCloudAdapter cloud,
+}) {
+  final characters = FakeCharacterStore();
+  final personas = FakePersonaStore();
+  final presets = FakePresetStore();
+  final apiConfigs = FakeApiConfigStore();
+  final memoryBooks = FakeMemoryBookStore();
+  final lorebooks = FakeLorebookStore();
+  final uiThemes = FakeThemePresetStore();
+  final studioConfigs = FakeStudioConfigStore();
+  final studioPresets = FakeStudioPresetStore();
+  final manifestProvider = InMemoryManifestProvider(
+    characterRepo: characters,
+    chatRepo: chatStore,
+    personaRepo: personas,
+    presetRepo: presets,
+    apiRepo: apiConfigs,
+    memoryBookRepo: memoryBooks,
+    lorebookRepo: lorebooks,
+    themePresetRepo: uiThemes,
+    studioConfigStore: studioConfigs,
+    studioPresetStore: studioPresets,
+    reconciliationStateStore: reconciliationStore,
+  );
+  return SyncEngine(
+    cloud,
+    manifestProvider,
+    characters,
+    chatStore,
+    personas,
+    presets,
+    apiConfigs,
+    memoryBooks,
+    lorebooks,
+    FakeEmbeddingStore(),
+    FakeImageStore(),
+    uiThemes,
+    FakeExtensionPresetStore(),
+    FakeExtensionsSettingsStore(),
+    FakeInfoBlockStore(),
+    FakeTrackerSnapshotStore(),
+    FakeTrackerValueStore(),
+    studioConfigs,
+    studioPresets,
+    null,
+    null,
+    null,
+    null,
+    const NoopSessionDeletionStore(),
+    FakeCharacterDeletionStore(characters),
+    (_) async {},
+    reconciliationStore,
   );
 }
 
@@ -679,6 +785,199 @@ void main() {
       progressList.firstWhere(
         (p) => p.total > 0 || p.message?.contains('Nothing to push') == true,
       );
+
+  test(
+    'Push pre-merges cloud-only reconciliation state before rebuilding manifest',
+    () async {
+      final reconciliationStates = FakeReconciliationStateStore();
+      final world = SyncWorld(reconciliationStateStore: reconciliationStates);
+      const sessionId = 'cloud-only-session';
+      const chat = ChatSession(
+        id: sessionId,
+        characterId: 'cloud-character',
+        sessionIndex: 0,
+        updatedAt: 1000,
+      );
+      final payload = <String, dynamic>{
+        'runs': [
+          {'id': 'cloud-run', 'ordinal': 1},
+        ],
+        'collectors': <dynamic>[],
+      };
+      final entry = SyncManifestEntry(
+        type: 'reconciliation_state',
+        id: sessionId,
+        path: cloudPath('reconciliation_state', sessionId),
+        updatedAt: 1000,
+        hash: SyncSerialization.computeSyncHash(payload),
+      );
+      final chatEntry = SyncManifestEntry(
+        type: 'chat',
+        id: sessionId,
+        path: cloudPath('chat', sessionId),
+        updatedAt: 1000,
+        hash: SyncSerialization.computeChatMetadataHash(
+          const SessionMetadata(
+            sessionId: sessionId,
+            characterId: 'cloud-character',
+            sessionIndex: 0,
+            updatedAt: 1000,
+            messageCount: 0,
+            lastMessageContent: '',
+            lastMessageTimestamp: 0,
+          ),
+        ),
+      );
+      final cloudManifest = SyncManifest(
+        deviceId: 'cloud-device',
+        createdAt: 1,
+        lastSync: 1000,
+        entries: {chatEntry.key: chatEntry, entry.key: entry},
+      );
+      world.cloud.files[chatEntry.path] = jsonEncode(chat.toJson());
+      world.cloud.files[entry.path] = jsonEncode(payload);
+      world.cloud.files[cloudPath('manifest', 'manifest')] = jsonEncode(
+        cloudManifest.toJson(),
+      );
+
+      expect(await reconciliationStates.getAllSessionIds(), isEmpty);
+
+      await world.engine.pushEntities(onProgress: (_) {});
+
+      expect(
+        await reconciliationStates.getBySessionId(sessionId),
+        equals(payload),
+      );
+      expect(jsonDecode(world.cloud.files[entry.path]!), equals(payload));
+      final uploadedManifest = SyncManifest.fromJson(
+        jsonDecode(world.cloud.files[cloudPath('manifest', 'manifest')]!)
+            as Map<String, dynamic>,
+      );
+      expect(uploadedManifest.entries[entry.key]?.hash, entry.hash);
+    },
+  );
+
+  test(
+    'push-first premerge materializes cloud chat before real reconciliation state',
+    () async {
+      final sourceDb = AppDatabase.forTesting(NativeDatabase.memory());
+      final targetDb = AppDatabase.forTesting(NativeDatabase.memory());
+      try {
+        const sessionId = 'fresh-device-session';
+        const openingContent = 'Welcome to the fresh device.';
+        const chat = ChatSession(
+          id: sessionId,
+          characterId: 'character',
+          sessionIndex: 0,
+          updatedAt: 1000,
+          messages: [
+            ChatMessage(
+              id: 'opening-assistant',
+              role: 'assistant',
+              content: openingContent,
+              swipes: [openingContent],
+            ),
+          ],
+        );
+        final sourceChats = ChatRepo(sourceDb);
+        await sourceChats.put(chat);
+        final run = LedgerReconciliationRun(
+          id: 'source-run',
+          sessionId: sessionId,
+          ordinal: 1,
+          anchors: [
+            ReconciliationAnchor(
+              messageId: 'opening-assistant',
+              swipeId: 0,
+              agentSwipeId: 0,
+              role: 'assistant',
+              contentHash: computeHash(openingContent),
+            ),
+          ],
+          acceptedManifestRefs: const [],
+          effectiveCanonStamp: 'source-stamp',
+          effectiveCanonRevision: 1,
+          effectiveCanonHash: 'source-canon',
+          canonicalResult: const {
+            'facts': ['fresh-device-fact'],
+          },
+          predecessorChainHash: '',
+          contractVersion: 1,
+          opsApplied: const [],
+          createdAt: 1,
+        );
+        expect(
+          await LedgerReconciliationRunRepo(sourceDb).append(run),
+          isA<ReconciliationRunAppended>(),
+        );
+        final sourceStore = ReconciliationStateSyncStore(sourceDb);
+        final payload = (await sourceStore.getBySessionId(sessionId))!;
+        final sourceChat = (await sourceChats.getById(sessionId))!;
+        final sourceMetadata =
+            (await sourceChats.getAllSessionMetadata()).single;
+
+        final cloud = FakeCloudAdapter();
+        final chatEntry = SyncManifestEntry(
+          type: 'chat',
+          id: sessionId,
+          path: cloudPath('chat', sessionId),
+          updatedAt: 1000,
+          hash: SyncSerialization.computeChatMetadataHash(sourceMetadata),
+        );
+        final stateEntry = SyncManifestEntry(
+          type: 'reconciliation_state',
+          id: sessionId,
+          path: cloudPath('reconciliation_state', sessionId),
+          updatedAt: 1000,
+          hash: SyncSerialization.computeSyncHash(payload),
+        );
+        final cloudManifest = SyncManifest(
+          deviceId: 'source-device',
+          createdAt: 1,
+          lastSync: 1000,
+          entries: {chatEntry.key: chatEntry, stateEntry.key: stateEntry},
+        );
+        cloud.files[chatEntry.path] = jsonEncode(sourceChat.toJson());
+        cloud.files[stateEntry.path] = jsonEncode(payload);
+        cloud.files[cloudPath('manifest', 'manifest')] = jsonEncode(
+          cloudManifest.toJson(),
+        );
+
+        final targetChats = ChatRepo(targetDb);
+        final targetStore = ReconciliationStateSyncStore(targetDb);
+        expect(await targetChats.getById(sessionId), isNull);
+        expect(
+          await LedgerReconciliationRunRepo(targetDb).getHead(sessionId),
+          isNull,
+        );
+
+        final engine = _realStoreEngine(
+          chatStore: targetChats,
+          reconciliationStore: targetStore,
+          cloud: cloud,
+        );
+        await engine.pushEntities(onProgress: (_) {});
+
+        expect(await targetChats.getById(sessionId), equals(sourceChat));
+        final importedHead = await LedgerReconciliationRunRepo(
+          targetDb,
+        ).getHead(sessionId);
+        expect(importedHead?.id, run.id);
+        expect(importedHead?.chainHash, run.chainHash);
+        expect(jsonDecode(cloud.files[stateEntry.path]!), equals(payload));
+
+        final uploadedManifest = SyncManifest.fromJson(
+          jsonDecode(cloud.files[cloudPath('manifest', 'manifest')]!)
+              as Map<String, dynamic>,
+        );
+        expect(uploadedManifest.entries[chatEntry.key]?.hash, chatEntry.hash);
+        expect(uploadedManifest.entries[stateEntry.key]?.hash, stateEntry.hash);
+      } finally {
+        await sourceDb.close();
+        await targetDb.close();
+      }
+    },
+  );
 
   test('Full sync lifecycle: push → pull → conflict → resolve', () async {
     // ── SCENE 1: Device A pushes to empty cloud ──
@@ -2750,7 +3049,7 @@ void main() {
         jsonDecode(
               world.cloud.files[cloudPath('manifest', 'manifest')]!,
             ) as
-                Map<String, dynamic>,
+            Map<String, dynamic>,
       );
       expect(
         cloudManifest.entries.containsKey(entryKey('studio_preset', 'doomed')),

--- a/test/sync_serialization_test.dart
+++ b/test/sync_serialization_test.dart
@@ -49,6 +49,26 @@ void main() {
     expect(StudioPreset.fromJson(wireJson as Map<String, dynamic>), preset);
   });
 
+  test('Studio config hash ignores sync timestamps', () {
+    const first = StudioConfig(
+      sessionId: 'session-1',
+      enabled: true,
+      createdAt: 100,
+      updatedAt: 200,
+    );
+    const second = StudioConfig(
+      sessionId: 'session-1',
+      enabled: true,
+      createdAt: 300,
+      updatedAt: 400,
+    );
+
+    expect(
+      SyncSerialization.computeStudioConfigHash(first.toJson()),
+      SyncSerialization.computeStudioConfigHash(second.toJson()),
+    );
+  });
+
   test('computeMemoryBookHash ignores device-local fields', () {
     final base = MemoryBook(
       id: 'memorybook_s1',


### PR DESCRIPTION
## Reconciliation provenance
- Add a merge-only per-session reconciliation state aggregate so devices share immutable reconciliation runs, invalidations, lorebook evidence, completed collectors, observations, and writer delivery boundaries.
- Resolve divergent legacy chains deterministically against the durable transcript, while discarding malformed or stale derived provenance without blocking sync.
- Preserve accepted empty-state markers so rejected legacy history does not download repeatedly.

## Sync convergence
- Batch conflict resolution and prevent overlapping sync operations from duplicating conflicts.
- Stabilize Studio config and chat summary timestamps and hashes so repeated pulls converge.
- Add reconciliation-state tombstones to session and character deletion flows.

## Verification
- Added real-DB and lifecycle regression coverage for fresh-device import, divergent chains, stale endpoints and collectors, observation convergence, active leases, repeated pulls, and bulk conflict resolution.
- lutter analyze (no issues).
- lutter test --reporter expanded (2863 tests passed).