### PR TITLE
fix(prompt): make empty block emission explicit

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1838,6 +1838,7 @@
   "regex_only_format_prompt": "Only Format Prompt (promptOnly)",
   "regex_substitute_regex_header": "Substitute Regex (find pattern)",
   "block_append_to_last_user": "Appended to last user message",
+  "label_send_empty_block": "Send empty block",
   "label_append_last_user": "Append to last user message",
   "block_append_badge": "↩ Last User",
   "imggen_ref_keyword": "keyword",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -1781,6 +1781,7 @@
   "about_telegram": "Telegram",
   "block_append_badge": "↩ Посл. пользователь",
   "block_append_to_last_user": "Добавляется к последнему сообщению пользователя",
+  "label_send_empty_block": "Отправлять пустой блок",
   "label_append_last_user": "Добавлять к последнему сообщению пользователя",
   "catalog_importing": "Импорт...",
   "dev_mode_disabled": "Режим разработчика отключён",

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -691,21 +691,23 @@ Rules (enforced in `lib/core/llm/prompt_builder.dart:_assembleMessages` via `app
 5. The block is still subject to the standard `enabled` and `isStashed` gates — disabled or stashed blocks are ignored.
 6. The append happens in `_assembleMessages` **after** `HistoryAssembler.assemble(history)` and **before** `interleaveDepthWithHistory`, so depth blocks are still positioned by history depth and regex pipeline sees a single merged user message.
 
-### INV-PS10: A block is empty only when nothing at all is left of it
+### INV-PS10: Empty block emission is explicit
 
-Emptiness is measured the way SillyTavern measures it (`openai.js` `getChat`, which keeps any string a JS truthiness check accepts): **a block is empty only when its content has zero length.** Spaces and newlines are content the preset author typed on purpose, so a whitespace-only block survives every gate and is sent to the model.
+After macro expansion, content that is empty or whitespace-only is not sent as
+an API message by default. `PresetBlock.sendEmptyBlock = true` is the explicit
+per-block opt-in for emitting that blank message.
 
-Enforced at four points, all on the untrimmed string:
+Enforced at four points:
 
-1. `resolveBlockContent()` — `rawContent.isEmpty` before macros, `macroResult.text.isEmpty` after them (`lib/core/llm/prompt_block_resolver.dart`).
-2. `_assembleMessages` — `content.isEmpty` decides whether a block becomes a message (`lib/core/llm/prompt_builder.dart`).
+1. `resolveBlockContent()` checks trimmed content before and after macros (`lib/core/llm/prompt_block_resolver.dart`). Variable mutations still run even when their block is not emitted.
+2. `_assembleMessages` carries the block opt-in into the built message (`lib/core/llm/prompt_builder.dart`).
 3. The final message filter in `buildPrompt`, same file.
-4. `buildApiMessages()` — `content.isNotEmpty || hasImage` (`lib/core/llm/history_assembler.dart`), mirrored by `buildPreviewMessages()` so the inspector shows what the request carries.
+4. `buildApiMessages()` retains whitespace only when `sendEmptyBlock` is true (images remain independently sufficient), mirrored by `buildPreviewMessages()`.
 
 Consequences:
 
-- Block content is **never trimmed** on the way out. Leading and trailing newlines an author typed reach the provider verbatim. Authors who want trimming have the explicit `{{trim}}` macro — see INV-PS7 step 5, which is opt-in and not applied automatically.
-- A block that expands down to whitespace (e.g. `{{setvar::flag::1}}\n`) is a real message carrying that whitespace. Only an expansion down to a zero-length string takes the setvar accounting-only path described in INV-PS5.
+- Non-empty block content is not rewritten or trimmed on the way out. The trim is only an emptiness test.
+- A block containing only `{{setvar::...}}`, `{{memory}}`, or another macro that resolves empty does not create an accidental blank message. Setvar accounting remains as described in INV-PS5.
 - Two places stay trim-based on purpose, because neither emits a block as its own message: `applyAppendToLastMessage` (INV-PS9) joins block text into an existing user message, where whitespace would only add blank lines; and lorebook attribution reporting, which maps rendered entries back to snapshots.
 
 ---

--- a/lib/core/import/silly_tavern_preset_parser.dart
+++ b/lib/core/import/silly_tavern_preset_parser.dart
@@ -194,6 +194,7 @@ Preset parseSillyTavernPreset(Map<String, dynamic> json, String fileName) {
           insertionMode: insertionMode,
           depth: depth,
           appendToLastMessage: pm['appendToLastMessage'] as bool? ?? false,
+          sendEmptyBlock: pm['sendEmptyBlock'] as bool? ?? false,
         ),
       );
     }
@@ -287,6 +288,7 @@ Preset parseSillyTavernPreset(Map<String, dynamic> json, String fileName) {
           isStatic: _staticBlockIds.contains(normalizedId),
           insertionMode: insertionMode,
           depth: depth,
+          sendEmptyBlock: p['sendEmptyBlock'] as bool? ?? false,
         ),
       );
     }

--- a/lib/core/llm/agent_runner.dart
+++ b/lib/core/llm/agent_runner.dart
@@ -335,8 +335,9 @@ class AgentRunner {
   }
 
   /// Max tokens override. Two tiers:
-  /// - Final generator: [PipelineSettings.studioAgent.studioFinalMaxTokens] (>0)
-  ///   overrides the per-agent default (8000).
+  /// - Final generator: `studioFinalMaxTokensOverride` decides whether
+  ///   `studioFinalMaxTokens` replaces the per-agent default. Zero is valid and
+  ///   causes OpenAI-compatible transports to omit the token-limit field.
   /// - Trackers: [PipelineSettings.studioAgent.studioControllerMaxTokens] (>0) overrides the
   ///   per-agent default (1600). Lets the user tighten/loosen the compact JSON
   ///   brief budget for all 7 pre-gen agents at once from the Studio menu.
@@ -349,9 +350,10 @@ class AgentRunner {
   ]) {
     final pipeline = turnConfig?.pipelineSettings ?? _readPipelineSettings();
     if (isFinalResponse) {
-      final global = pipeline.studioAgent.studioFinalMaxTokens;
-      if (global > 0) return global;
-      return null;
+      final studio = pipeline.studioAgent;
+      return studio.studioFinalMaxTokensOverride
+          ? studio.studioFinalMaxTokens
+          : null;
     }
     if (agent.phase == 'post_processing') {
       final cleanerGlobal = pipeline.cleaner.postCleanerMaxTokens;

--- a/lib/core/llm/history_assembler.dart
+++ b/lib/core/llm/history_assembler.dart
@@ -75,6 +75,7 @@ class PromptMessage {
   final String? sourceMessageId;
   final String? reasoningContent;
   final String? imagePath;
+  final bool sendEmptyBlock;
 
   const PromptMessage({
     required this.role,
@@ -89,6 +90,7 @@ class PromptMessage {
     this.sourceMessageId,
     this.reasoningContent,
     this.imagePath,
+    this.sendEmptyBlock = false,
   });
 
   bool get hasImage => imagePath?.isNotEmpty == true;
@@ -120,6 +122,7 @@ class PromptMessage {
     'sourceMessageId': sourceMessageId,
     'reasoningContent': reasoningContent,
     'imagePath': imagePath,
+    'sendEmptyBlock': sendEmptyBlock,
   };
 
   factory PromptMessage.fromJson(Map<String, dynamic> json) => PromptMessage(
@@ -135,6 +138,7 @@ class PromptMessage {
     sourceMessageId: json['sourceMessageId'] as String?,
     reasoningContent: json['reasoningContent'] as String?,
     imagePath: json['imagePath'] as String?,
+    sendEmptyBlock: json['sendEmptyBlock'] as bool? ?? false,
   );
 }
 
@@ -142,10 +146,13 @@ List<Map<String, dynamic>> buildApiMessages(
   List<PromptMessage> messages, {
   int reasoningHistoryCount = 0,
 }) {
-  // Same emptiness rule as the block resolver: only a zero-length string counts
-  // as empty. Spaces and newlines are content and go out to the provider.
   final included = messages
-      .where((message) => message.content.isNotEmpty || message.hasImage)
+      .where(
+        (message) =>
+            message.content.trim().isNotEmpty ||
+            message.hasImage ||
+            message.sendEmptyBlock,
+      )
       .toList();
   final result = included.map((message) => message.toApiMap()).toList();
   if (reasoningHistoryCount == 0 || reasoningHistoryCount < -1) return result;

--- a/lib/core/llm/prompt/resolved_block.dart
+++ b/lib/core/llm/prompt/resolved_block.dart
@@ -4,12 +4,14 @@ class ResolvedDepthBlock {
   final String content;
   final int depth;
   final bool isSummary;
+  final bool sendEmptyBlock;
   const ResolvedDepthBlock({
     required this.id,
     required this.role,
     required this.content,
     required this.depth,
     this.isSummary = false,
+    this.sendEmptyBlock = false,
   });
 }
 
@@ -29,6 +31,7 @@ class ResolvedRelativeBlock {
   final String contentForAccounting;
   final bool isSummary;
   final bool appendToLastMessage;
+  final bool sendEmptyBlock;
   const ResolvedRelativeBlock({
     required this.id,
     required this.name,
@@ -37,5 +40,6 @@ class ResolvedRelativeBlock {
     required this.contentForAccounting,
     this.isSummary = false,
     this.appendToLastMessage = false,
+    this.sendEmptyBlock = false,
   });
 }

--- a/lib/core/llm/prompt_block_resolver.dart
+++ b/lib/core/llm/prompt_block_resolver.dart
@@ -12,9 +12,11 @@ class NotifyObj {
 
 class ResolvedContent {
   final String role;
+
   /// Fully expanded content — this is what actually gets sent to the LLM
   /// (all macros resolved: {{summary}}, {{memory}}, {{lorebooks}}, etc.).
   final String content;
+
   /// Preset-only content for token accounting: external injections (character,
   /// persona, memory, lorebooks, summary, guidance) are blanked; in-preset
   /// setvar/getvar/globalvars still count. See docs/INVARIANTS.md INV-PS5.
@@ -39,6 +41,7 @@ ResolvedContent? resolveBlockContent({
   required String? summaryContent,
   required String? summaryPrefix,
   AuthorsNote? authorsNote,
+  bool sendEmptyBlock = false,
 }) {
   String content;
   String resolvedRole = role;
@@ -55,26 +58,38 @@ ResolvedContent? resolveBlockContent({
     case 'user_persona':
       content = _userPersonaContent(persona);
     case 'chat_history':
-      return ResolvedContent(role: resolvedRole, content: '', contentForAccounting: '');
+      return ResolvedContent(
+        role: resolvedRole,
+        content: '',
+        contentForAccounting: '',
+      );
     case 'summary':
       if (summaryContent != null && summaryContent.isNotEmpty) {
         final prefix = summaryPrefix ?? 'Summary: ';
         content = '[$prefix$summaryContent]';
       } else {
-        return null;
+        if (!sendEmptyBlock) return null;
+        content = '';
       }
     case 'guided_generation':
-      if (macroCtx.guidanceText == null || macroCtx.guidanceText!.trim().isEmpty) {
-        return null;
+      if (macroCtx.guidanceText == null ||
+          macroCtx.guidanceText!.trim().isEmpty) {
+        if (!sendEmptyBlock) return null;
+        content = '';
+      } else {
+        content = rawContent;
       }
-      content = rawContent;
     case 'authors_note':
-      if (authorsNote == null || !authorsNote.enabled || authorsNote.content.isEmpty) {
-        return null;
+      if (authorsNote == null ||
+          !authorsNote.enabled ||
+          authorsNote.content.isEmpty) {
+        if (!sendEmptyBlock) return null;
+        content = '';
+      } else {
+        content = authorsNote.content;
       }
-      // Only content + enabled are session-scoped. Role/depth/insertion mode
-      // belong to the preset block, so keep [resolvedRole] = the block's role.
-      content = authorsNote.content;
+    // Only content + enabled are session-scoped. Role/depth/insertion mode
+    // belong to the preset block, so keep [resolvedRole] = the block's role.
     case 'memory':
       // Dedicated Memory Book hard block. Acts as the sink for memory content
       // exactly like the {{memory}} macro: macroCtx.memoryContent is the
@@ -82,13 +97,17 @@ ResolvedContent? resolveBlockContent({
       // cutoff, then PromptBuilder swaps in the real packed memory. When no
       // memory is selected the content is null and the block is skipped.
       final memory = macroCtx.memoryContent;
-      if (memory == null || memory.isEmpty) return null;
-      content = memory;
+      if (memory == null || memory.isEmpty) {
+        if (!sendEmptyBlock) return null;
+        content = '';
+      } else {
+        content = memory;
+      }
     default:
       content = rawContent;
   }
 
-  if (content.isEmpty) return null;
+  if (content.trim().isEmpty && !sendEmptyBlock) return null;
 
   // Fully-expanded content (everything resolved, what the LLM actually sees).
   final macroResult = replaceMacros(content, macroCtx);
@@ -98,14 +117,9 @@ ResolvedContent? resolveBlockContent({
     notifyObj.varsChanged = true;
   }
 
-  // Emptiness is measured the way SillyTavern measures it: a block is empty
-  // only when nothing at all is left, not when nothing *printable* is left.
-  // A block holding just spaces or newlines is content the author put there on
-  // purpose, so it survives and reaches the model (ST: `openai.js` `getChat`,
-  // which keeps any string a JS truthiness check accepts).
-  if (macroResult.text.isEmpty) {
+  if (macroResult.text.trim().isEmpty) {
     final setvarPayload = setvarDefinitionsForAccounting(content);
-    if (setvarPayload.isEmpty) return null;
+    if (setvarPayload.isEmpty && !sendEmptyBlock) return null;
     return ResolvedContent(
       role: resolvedRole,
       content: macroResult.text,
@@ -114,10 +128,13 @@ ResolvedContent? resolveBlockContent({
   }
 
   // Preset-only accounting: blank external injections; keep in-preset vars.
-  final accountingSource =
-      isPresetExternalInjectionBlock(id) ? rawContent : content;
-  final accountingResult =
-      replaceMacros(accountingSource, macroCtx.forPresetAccounting());
+  final accountingSource = isPresetExternalInjectionBlock(id)
+      ? rawContent
+      : content;
+  final accountingResult = replaceMacros(
+    accountingSource,
+    macroCtx.forPresetAccounting(),
+  );
 
   return ResolvedContent(
     role: resolvedRole,

--- a/lib/core/llm/prompt_builder.dart
+++ b/lib/core/llm/prompt_builder.dart
@@ -302,6 +302,7 @@ PromptResult _buildPromptOnce(PromptPayload payload) {
       // runtime payload value, then the resolver default).
       summaryPrefix: rawBlock.prefix ?? payload.summaryPrefix,
       authorsNote: payload.authorsNote,
+      sendEmptyBlock: rawBlock.sendEmptyBlock,
     );
 
     if (notifyObj.varsChanged) {
@@ -331,6 +332,7 @@ PromptResult _buildPromptOnce(PromptPayload payload) {
           content: resolved.content,
           depth: rawBlock.depth ?? 0,
           isSummary: blockIsSummary,
+          sendEmptyBlock: rawBlock.sendEmptyBlock,
         ),
       );
     } else {
@@ -343,6 +345,7 @@ PromptResult _buildPromptOnce(PromptPayload payload) {
           contentForAccounting: resolved.contentForAccounting,
           isSummary: blockIsSummary,
           appendToLastMessage: rawBlock.appendToLastMessage,
+          sendEmptyBlock: rawBlock.sendEmptyBlock,
         ),
       );
     }
@@ -539,6 +542,7 @@ PromptResult _assembleMessages({
             depth: b.depth,
             isDepth: true,
             isSummary: b.isSummary,
+            sendEmptyBlock: b.sendEmptyBlock,
           ),
           classifications: blockLoreClassifications[b.id] ?? const <String>{},
         ),
@@ -676,14 +680,11 @@ PromptResult _assembleMessages({
         );
       }
     } else {
-      // Content goes out as the author wrote it — no trimming. Trimming here
-      // would collapse a spaces-and-newlines block back to empty and drop it
-      // one line below, which is exactly what SillyTavern does not do.
       final content = block.content;
       final accountingContent = block.contentForAccounting;
 
       // setvar-only blocks: no LLM-visible text, but definitions count toward preset.
-      if (content.isEmpty) {
+      if (content.trim().isEmpty && !block.sendEmptyBlock) {
         if (accountingContent.isNotEmpty) {
           attributionBlocks.add(
             StaticBlock(id: block.id, content: accountingContent),
@@ -719,6 +720,7 @@ PromptResult _assembleMessages({
           blockName: block.name,
           content: content,
           isSummary: block.isSummary,
+          sendEmptyBlock: block.sendEmptyBlock,
         ),
       );
 
@@ -892,7 +894,7 @@ PromptResult _assembleMessages({
         }
       }
       historySeen++;
-    } else if (msg.content.isNotEmpty) {
+    } else if (msg.content.trim().isNotEmpty || msg.sendEmptyBlock) {
       finalMessages.add(msg);
     }
   }

--- a/lib/core/llm/prompt_regex_applicator.dart
+++ b/lib/core/llm/prompt_regex_applicator.dart
@@ -63,6 +63,7 @@ List<PromptMessage> applyPromptRegexes({
           sourceMessageId: msg.sourceMessageId,
           reasoningContent: msg.reasoningContent,
           imagePath: msg.imagePath,
+          sendEmptyBlock: msg.sendEmptyBlock,
         ),
       );
       historySeen++;
@@ -88,6 +89,7 @@ List<PromptMessage> applyPromptRegexes({
           sourceMessageId: msg.sourceMessageId,
           reasoningContent: msg.reasoningContent,
           imagePath: msg.imagePath,
+          sendEmptyBlock: msg.sendEmptyBlock,
         ),
       );
     }

--- a/lib/core/models/preset.dart
+++ b/lib/core/models/preset.dart
@@ -15,12 +15,17 @@ abstract class PresetBlock with _$PresetBlock {
     @Default('relative') String insertionMode,
     int? depth,
     String? prefix,
+
     /// When true, this block's content is appended (after macro expansion) to
     /// the last user-role message in the chat history at prompt-assembly time.
     /// The block's own `role` is ignored in this mode — content is always
     /// merged into the last user message. If no user message exists in
     /// history, the block is silently dropped. See docs/INVARIANTS.md.
     @Default(false) bool appendToLastMessage,
+
+    /// Emits this block as an API message even when macro expansion leaves no
+    /// visible content. Disabled by default to avoid accidental blank turns.
+    @Default(false) bool sendEmptyBlock,
   }) = _PresetBlock;
 
   factory PresetBlock.fromJson(Map<String, dynamic> json) =>
@@ -104,6 +109,7 @@ Map<String, dynamic> _normalizeBlock(Map<String, dynamic> json) {
   final alreadyStatic = _coerceBool(n['isStatic'], false);
   n['isStatic'] = alreadyStatic || (id != null && _staticBlockIds.contains(id));
   n['appendToLastMessage'] = _coerceBool(n['appendToLastMessage'], false);
+  n['sendEmptyBlock'] = _coerceBool(n['sendEmptyBlock'], false);
   n['depth'] = _coerceInt(n['depth']);
   // Bring the guided-generation wrapper to parity with hydall/Glaze. Presets
   // still carrying the legacy '[System Note: {{guidance}}]' default (i.e.
@@ -121,19 +127,23 @@ Map<String, dynamic> _normalizeRegex(Map<String, dynamic> json) {
   final n = Map<String, dynamic>.from(json);
 
   // ST key mappings → canonical Glaze keys (defensive for direct fromJson calls)
-  if (!n.containsKey('name') || (n['name'] is String && (n['name'] as String).isEmpty)) {
+  if (!n.containsKey('name') ||
+      (n['name'] is String && (n['name'] as String).isEmpty)) {
     final stName = n['scriptName'];
     if (stName is String && stName.isNotEmpty) n['name'] = stName;
   }
-  if (!n.containsKey('regex') || (n['regex'] is String && (n['regex'] as String).isEmpty)) {
+  if (!n.containsKey('regex') ||
+      (n['regex'] is String && (n['regex'] as String).isEmpty)) {
     final stRegex = n['findRegex'];
     if (stRegex is String && stRegex.isNotEmpty) n['regex'] = stRegex;
   }
-  if (!n.containsKey('replacement') || (n['replacement'] is String && (n['replacement'] as String).isEmpty)) {
+  if (!n.containsKey('replacement') ||
+      (n['replacement'] is String && (n['replacement'] as String).isEmpty)) {
     final stRepl = n['replaceString'];
     if (stRepl is String) n['replacement'] = stRepl;
   }
-  if (!n.containsKey('trimOut') || (n['trimOut'] is String && (n['trimOut'] as String).isEmpty)) {
+  if (!n.containsKey('trimOut') ||
+      (n['trimOut'] is String && (n['trimOut'] as String).isEmpty)) {
     n['trimOut'] = _joinTrimForNormalize(n['trimStrings']);
   }
 
@@ -147,7 +157,9 @@ Map<String, dynamic> _normalizeRegex(Map<String, dynamic> json) {
   n['substituteRegex'] = _coerceInt(n['substituteRegex']) ?? 0;
   if (n['placement'] is List) {
     n['placement'] = _migrateGlazePlacementIds(
-      (n['placement'] as List).map((e) => e is int ? e : int.tryParse(e.toString()) ?? 1).toList(),
+      (n['placement'] as List)
+          .map((e) => e is int ? e : int.tryParse(e.toString()) ?? 1)
+          .toList(),
     );
   }
   return n;

--- a/lib/core/models/studio_agent_settings.dart
+++ b/lib/core/models/studio_agent_settings.dart
@@ -28,9 +28,9 @@ part 'studio_agent_settings.g.dart';
 /// the preset). They default to `true` so an existing install keeps
 /// applying exactly the values it applied before the flags existed.
 ///
-/// Temperature, max tokens and the idle timeout have no flag: they already
-/// encode "not overridden" as a sentinel (negative temperature, `0` tokens,
-/// `0` ms) and fall back to the per-agent spec rather than to the preset.
+/// Temperature and the idle timeout use sentinels (negative temperature and
+/// `0` ms). Final-generator max tokens has an explicit flag because `0` is a
+/// meaningful override: it tells the transport to omit the token-limit field.
 @freezed
 abstract class StudioAgentSettings with _$StudioAgentSettings {
   const factory StudioAgentSettings({
@@ -44,10 +44,10 @@ abstract class StudioAgentSettings with _$StudioAgentSettings {
     // ── Final generator (Main Writer) ──────────────────────────────────
     // Final-generator idle timeout (ms). 0 = use agent/global fallback.
     @Default(0) int studioFinalTimeoutMs,
-    // Max tokens for the Studio final generator. When > 0, overrides the
-    // per-agent default (8000). Useful for reasoning models (e.g. Gemini)
-    // that spend most of the budget on thinking. 0 = use agent's maxTokens.
+    // Max tokens for the Studio final generator. When the override is enabled,
+    // 0 deliberately omits the transport's token-limit field.
     @Default(0) int studioFinalMaxTokens,
+    @Default(false) bool studioFinalMaxTokensOverride,
     @Default(0.9) double studioFinalTopP,
     @Default(0) int studioFinalTopK,
     @Default(0.0) double studioFinalFrequencyPenalty,
@@ -173,5 +173,9 @@ Map<String, dynamic> _normalizeStudioAgentSettingsJson(
     'studioFinalReasoningHistoryCount',
     () => n['studioFinalIncludeLastReasoning'] == true ? 1 : 0,
   );
+  n.putIfAbsent('studioFinalMaxTokensOverride', () {
+    final value = n['studioFinalMaxTokens'];
+    return value is num && value.toInt() > 0;
+  });
   return n;
 }

--- a/lib/features/chat/services/prompt_preview_post_processor.dart
+++ b/lib/features/chat/services/prompt_preview_post_processor.dart
@@ -57,10 +57,8 @@ const String _tokenSuffix = '\u0000';
 /// Applies [mode] to [messages] and returns the resulting rows.
 ///
 /// With [PromptPostProcessing.none] every message passes through untouched,
-/// one row each — including blocks with empty content, which the inspector has
-/// always listed even though the request omits them. Any other mode reproduces
-/// the request faithfully instead, so empty blocks are dropped first exactly
-/// as `buildApiMessages` drops them.
+/// one row each. Any other mode reproduces the request faithfully, so empty
+/// blocks are dropped unless their per-block opt-in keeps them.
 List<PreviewMessage> buildPreviewMessages(
   List<PromptMessage> messages,
   String mode, {
@@ -76,7 +74,12 @@ List<PreviewMessage> buildPreviewMessages(
   }
 
   final included = messages
-      .where((message) => message.content.isNotEmpty || message.hasImage)
+      .where(
+        (message) =>
+            message.content.trim().isNotEmpty ||
+            message.hasImage ||
+            message.sendEmptyBlock,
+      )
       .toList();
 
   final tagged = [
@@ -188,6 +191,7 @@ PromptMessage _synthesize(
       sourceMessageId: source.sourceMessageId,
       reasoningContent: source.reasoningContent,
       imagePath: source.imagePath,
+      sendEmptyBlock: source.sendEmptyBlock,
     );
   }
 

--- a/lib/features/presets/preset_editor_screen.dart
+++ b/lib/features/presets/preset_editor_screen.dart
@@ -1019,6 +1019,12 @@ class _BlockEditorInline extends StatelessWidget {
             ],
           ),
           GenericEditorField(
+            key: 'sendEmptyBlock',
+            label: 'label_send_empty_block'.tr(),
+            type: 'switch',
+            showIf: (item) => item['appendToLastMessage'] != true,
+          ),
+          GenericEditorField(
             key: 'content',
             label: 'section_content'.tr(),
             type: 'textarea',

--- a/lib/features/presets/preset_export.dart
+++ b/lib/features/presets/preset_export.dart
@@ -30,36 +30,38 @@ Future<String> savePresetJson(Preset preset) async {
     if (preset.author != null && preset.author!.isNotEmpty)
       'author': preset.author,
     'prompts': preset.blocks
-        .map((b) => <String, dynamic>{
-              'name': b.name,
-              'role': b.role,
-              'content': b.content,
-              'enabled': b.enabled,
-              'insertion_mode': b.insertionMode,
-              if (b.depth != null) 'depth': b.depth,
-              if (b.appendToLastMessage) 'appendToLastMessage': true,
-            })
+        .map(
+          (b) => <String, dynamic>{
+            'name': b.name,
+            'role': b.role,
+            'content': b.content,
+            'enabled': b.enabled,
+            'insertion_mode': b.insertionMode,
+            if (b.depth != null) 'depth': b.depth,
+            if (b.appendToLastMessage) 'appendToLastMessage': true,
+            if (b.sendEmptyBlock) 'sendEmptyBlock': true,
+          },
+        )
         .toList(),
     'regexes': preset.regexes
-        .map((r) => <String, dynamic>{
-              'scriptName': r.name,
-              'findRegex': r.regex,
-              'replaceString': r.replacement,
-              'trimStrings': r.trimOut.isEmpty
-                  ? <String>[]
-                  : r.trimOut
-                      .split('\n')
-                      .where((t) => t.isNotEmpty)
-                      .toList(),
-              'placement': r.placement,
-              'isEnabled': !r.disabled,
-              'markdownOnly': r.markdownOnly,
-              'promptOnly': r.promptOnly,
-              'runOnEdit': r.runOnEdit,
-              'substituteRegex': r.substituteRegex,
-              if (r.minDepth != null) 'minDepth': r.minDepth,
-              if (r.maxDepth != null) 'maxDepth': r.maxDepth,
-            })
+        .map(
+          (r) => <String, dynamic>{
+            'scriptName': r.name,
+            'findRegex': r.regex,
+            'replaceString': r.replacement,
+            'trimStrings': r.trimOut.isEmpty
+                ? <String>[]
+                : r.trimOut.split('\n').where((t) => t.isNotEmpty).toList(),
+            'placement': r.placement,
+            'isEnabled': !r.disabled,
+            'markdownOnly': r.markdownOnly,
+            'promptOnly': r.promptOnly,
+            'runOnEdit': r.runOnEdit,
+            'substituteRegex': r.substituteRegex,
+            if (r.minDepth != null) 'minDepth': r.minDepth,
+            if (r.maxDepth != null) 'maxDepth': r.maxDepth,
+          },
+        )
         .toList(),
     'reasoning': preset.reasoningEnabled,
   };

--- a/lib/features/studio/widgets/studio_slot_settings_dialog.dart
+++ b/lib/features/studio/widgets/studio_slot_settings_dialog.dart
@@ -21,8 +21,8 @@ enum StudioSlot { finalGenerator, controller, cleaner, ledger }
 /// Every parameter carries an `*Override` flag. When it is false the parameter
 /// is not written into the request at all, so the API preset selected for the
 /// slot supplies the value. Temperature, max tokens and the timeout have no
-/// flag of their own in [PipelineSettings] — they encode "not overridden" as a
-/// sentinel, so [applyTo] writes `-1` / `0` for them.
+/// flag of their own in [PipelineSettings] — except final-generator max tokens,
+/// where `0` is a meaningful override that omits the request field.
 ///
 /// The ledger only exposes temperature / max tokens / timeout — it has no
 /// sampling or reasoning overrides in [LedgerSettings] — so the ledger dialog
@@ -53,6 +53,7 @@ class StudioSlotSettings {
   final int reasoningHistoryCount;
   final bool excludeReasoningFromContextBudget;
   final int maxTokens;
+  final bool maxTokensOverride;
   final int timeoutMs;
   final List<ExtraRequestParameter> extraRequestParameters;
 
@@ -82,6 +83,7 @@ class StudioSlotSettings {
     this.reasoningHistoryCount = 0,
     this.excludeReasoningFromContextBudget = false,
     required this.maxTokens,
+    required this.maxTokensOverride,
     required this.timeoutMs,
     required this.extraRequestParameters,
   });
@@ -120,6 +122,7 @@ class StudioSlotSettings {
             studioFinalExcludeReasoningFromContextBudget:
                 excludeReasoningFromContextBudget,
             studioFinalMaxTokens: maxTokens,
+            studioFinalMaxTokensOverride: maxTokensOverride,
             studioFinalTimeoutMs: timeoutMs,
             studioFinalExtraRequestParameters: extraRequestParameters,
           ),
@@ -299,7 +302,11 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         _reasoningHistoryCountCtrl = TextEditingController(
           text: '${a.studioFinalReasoningHistoryCount}',
         );
-        _initTokensAndTimeout(a.studioFinalMaxTokens, a.studioFinalTimeoutMs);
+        _initTokensAndTimeout(
+          a.studioFinalMaxTokens,
+          a.studioFinalTimeoutMs,
+          maxTokensOverride: a.studioFinalMaxTokensOverride,
+        );
         _extraRequestParameters = a.studioFinalExtraRequestParameters;
       case StudioSlot.controller:
         final a = p.studioAgent;
@@ -346,8 +353,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         _requestReasoning = c.postCleanerRequestReasoning;
         _requestReasoningOverride = c.postCleanerRequestReasoningOverride;
         _showNativeReasoning = c.postCleanerShowNativeReasoning;
-        _showNativeReasoningOverride =
-            c.postCleanerShowNativeReasoningOverride;
+        _showNativeReasoningOverride = c.postCleanerShowNativeReasoningOverride;
         _useResponsesApi = c.postCleanerUseResponsesApi;
         _useResponsesApiOverride = c.postCleanerUseResponsesApiOverride;
         _reasoningEffort = c.postCleanerReasoningEffort;
@@ -358,10 +364,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         _omitReasoningEffort = c.postCleanerOmitReasoningEffort;
         _excludeReasoningFromContextBudget = false;
         _reasoningHistoryCountCtrl = TextEditingController(text: '0');
-        _initTokensAndTimeout(
-          c.postCleanerMaxTokens,
-          c.postCleanerTimeoutMs,
-        );
+        _initTokensAndTimeout(c.postCleanerMaxTokens, c.postCleanerTimeoutMs);
         _extraRequestParameters = c.postCleanerExtraRequestParameters;
       case StudioSlot.ledger:
         final l = p.ledger;
@@ -388,10 +391,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         _omitReasoningEffort = true;
         _excludeReasoningFromContextBudget = false;
         _reasoningHistoryCountCtrl = TextEditingController(text: '0');
-        _initTokensAndTimeout(
-          l.studioLedgerMaxTokens,
-          l.studioLedgerTimeoutMs,
-        );
+        _initTokensAndTimeout(l.studioLedgerMaxTokens, l.studioLedgerTimeoutMs);
         _extraRequestParameters = const [];
     }
   }
@@ -402,11 +402,16 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
     _temperature = stored >= 0 ? stored.clamp(0.0, 2.0) : _temperatureFallback;
   }
 
-  /// `0` is the "inherit" sentinel for both, so an empty field reads as off.
-  void _initTokensAndTimeout(int maxTokens, int timeoutMs) {
-    _maxTokensOverride = maxTokens > 0;
+  /// Other slots retain the legacy `0 = inherit` sentinel. The final generator
+  /// supplies an explicit flag so `0` can mean "omit the request field".
+  void _initTokensAndTimeout(
+    int maxTokens,
+    int timeoutMs, {
+    bool? maxTokensOverride,
+  }) {
+    _maxTokensOverride = maxTokensOverride ?? maxTokens > 0;
     _maxTokensCtrl = TextEditingController(
-      text: maxTokens > 0 ? '$maxTokens' : '',
+      text: _maxTokensOverride ? '$maxTokens' : '',
     );
     _timeoutOverride = timeoutMs > 0;
     _timeoutCtrl = TextEditingController(
@@ -500,6 +505,7 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
             : reasoningHistoryCount,
         excludeReasoningFromContextBudget: _excludeReasoningFromContextBudget,
         maxTokens: maxTokens,
+        maxTokensOverride: _maxTokensOverride,
         timeoutMs: seconds > 0 ? seconds * 1000 : 0,
         extraRequestParameters: _extraRequestParameters,
       ),
@@ -682,7 +688,8 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         ...studioSlotOverrideBlock(
           label: 'label_use_responses_api'.tr(),
           overridden: _useResponsesApiOverride,
-          onOverrideChanged: (v) => setState(() => _useResponsesApiOverride = v),
+          onOverrideChanged: (v) =>
+              setState(() => _useResponsesApiOverride = v),
           inheritedValue: _inherited.useResponsesApi,
           editor: MenuSwitchItem(
             label: 'label_use_responses_api'.tr(),
@@ -723,14 +730,14 @@ class _StudioSlotSettingsDialogState extends State<StudioSlotSettingsDialog> {
         ...studioSlotOverrideBlock(
           label: 'label_reasoning_effort'.tr(),
           overridden: _reasoningEffortOverride,
-          onOverrideChanged: (v) => setState(() => _reasoningEffortOverride = v),
+          onOverrideChanged: (v) =>
+              setState(() => _reasoningEffortOverride = v),
           inheritedValue: _inherited.reasoningEffort,
           editor: MenuSelectorItem(
             label: 'label_reasoning_effort'.tr(),
             currentValue: _reasoningEffortLabel(_reasoningEffort),
             included: !_omitReasoningEffort,
-            onIncludedChanged: (v) =>
-                setState(() => _omitReasoningEffort = !v),
+            onIncludedChanged: (v) => setState(() => _omitReasoningEffort = !v),
             onTap: _openReasoningEffortSelector,
           ),
         ),

--- a/lib/shared/widgets/generic_editor.dart
+++ b/lib/shared/widgets/generic_editor.dart
@@ -14,7 +14,7 @@ class GenericEditorField {
   final String key;
   final String label;
   final String
-  type; // 'text', 'number', 'tags', 'textarea', 'greeting_list', 'select', 'info'
+  type; // 'text', 'number', 'tags', 'textarea', 'greeting_list', 'select', 'switch', 'info'
   final bool expandable;
   final String? helpTerm;
   final String? placeholder;
@@ -50,6 +50,7 @@ class GenericEditor extends StatefulWidget {
   final List<GenericEditorSection> config;
   final bool showAvatar;
   final String avatarField;
+
   /// Defaults to the localized `hint_change_avatar` when not supplied — it
   /// cannot be a constructor default because `.tr()` is not a constant.
   final String? avatarHint;
@@ -421,6 +422,16 @@ class _GenericEditorState extends State<GenericEditor> {
           label: field.label,
           currentValue: _getSelectedLabel(field),
           onTap: () => _openSelectSelector(field),
+        );
+      case 'switch':
+        return MenuSwitchItem(
+          label: field.label,
+          value: _localItem[field.key] as bool? ?? false,
+          onChanged: (value) {
+            setState(() => _localItem[field.key] = value);
+            widget.onChanged(_localItem);
+            _scheduleSave();
+          },
         );
       case 'greeting_list':
         return _buildGreetingItems();

--- a/test/llm/transport/openai_chat_transport_test.dart
+++ b/test/llm/transport/openai_chat_transport_test.dart
@@ -14,6 +14,7 @@ ChatTransportRequest _req({
   String endpoint = 'https://api.openai.com',
   String sessionIdMode = 'openrouter',
   int? receiveTimeoutMs,
+  int maxTokens = 100,
   int topK = 0,
   double frequencyPenalty = 0,
   double presencePenalty = 0,
@@ -32,7 +33,7 @@ ChatTransportRequest _req({
     apiKey: 'sk-test',
     model: 'gpt-test',
     messages: messages,
-    maxTokens: 100,
+    maxTokens: maxTokens,
     temperature: 0.7,
     topP: 0.9,
     topK: topK,
@@ -74,6 +75,20 @@ class _RecordingAdapter implements HttpClientAdapter {
 }
 
 void main() {
+  test('zero max tokens leaves only an explicit completion limit', () {
+    final body = OpenAiChatTransport.buildBody(
+      _req(
+        maxTokens: 0,
+        extraRequestParameters: const [
+          ExtraRequestParameter(key: 'max_completion_tokens', value: '8000'),
+        ],
+      ),
+    );
+
+    expect(body.containsKey('max_tokens'), isFalse);
+    expect(body['max_completion_tokens'], 8000);
+  });
+
   test('per-request zero disables the default receive timeout', () async {
     final adapter = _RecordingAdapter();
     final dio = Dio(BaseOptions(receiveTimeout: const Duration(seconds: 120)))

--- a/test/prompt_block_empty_check_test.dart
+++ b/test/prompt_block_empty_check_test.dart
@@ -5,11 +5,8 @@ import 'package:glaze_flutter/core/llm/macro_engine.dart';
 import 'package:glaze_flutter/core/llm/prompt_block_resolver.dart';
 import 'package:glaze_flutter/core/models/character.dart';
 
-/// A preset block counts as empty only when nothing at all is left of it —
-/// the same rule SillyTavern applies in `openai.js` (`getChat` keeps every
-/// string a JS truthiness check accepts). A block holding just spaces or
-/// newlines is content the author typed on purpose, so it survives and is
-/// sent, and the text it carries is never trimmed on the way out.
+/// Empty expanded blocks are dropped unless the preset block explicitly opts
+/// in to emitting an empty API message.
 void main() {
   Character makeChar() => Character(
     id: 'c1',
@@ -22,43 +19,41 @@ void main() {
   MacroContext makeCtx() =>
       const MacroContext(charName: 'Alice', charId: 'c1', sessionId: 's1');
 
-  ResolvedContent? resolve(String rawContent) => resolveBlockContent(
-    id: 'custom',
-    rawContent: rawContent,
-    role: 'system',
-    char: makeChar(),
-    persona: null,
-    macroCtx: makeCtx(),
-    sessionVars: const {},
-    globalVars: const {},
-    summaryContent: null,
-    summaryPrefix: null,
-    notifyObj: NotifyObj(),
-  );
+  ResolvedContent? resolve(String rawContent, {bool sendEmptyBlock = false}) =>
+      resolveBlockContent(
+        id: 'custom',
+        rawContent: rawContent,
+        role: 'system',
+        char: makeChar(),
+        persona: null,
+        macroCtx: makeCtx(),
+        sessionVars: const {},
+        globalVars: const {},
+        summaryContent: null,
+        summaryPrefix: null,
+        notifyObj: NotifyObj(),
+        sendEmptyBlock: sendEmptyBlock,
+      );
 
   group('block emptiness', () {
     test('a zero-length block is dropped', () {
       expect(resolve(''), isNull);
     });
 
-    test('a spaces-only block survives', () {
-      final result = resolve('   ');
-      expect(result, isNotNull);
-      expect(result!.content, '   ');
+    test('a spaces-only block is dropped by default', () {
+      expect(resolve('   '), isNull);
     });
 
-    test('a newlines-only block survives', () {
-      final result = resolve('\n\n');
+    test('a whitespace-only block survives with the opt-in', () {
+      final result = resolve('\n\n', sendEmptyBlock: true);
       expect(result, isNotNull);
       expect(result!.content, '\n\n');
     });
 
-    test('a block that macros expand down to whitespace survives', () {
+    test('a block that macros expand down to whitespace is dropped', () {
       // {{summary}} resolves to nothing here, leaving only the newline the
       // author typed around it.
-      final result = resolve('{{summary}}\n');
-      expect(result, isNotNull);
-      expect(result!.content, '\n');
+      expect(resolve('{{summary}}\n'), isNull);
     });
 
     test('a block that macros expand down to nothing is dropped', () {
@@ -71,8 +66,15 @@ void main() {
       expect(result!.content, '\n  You are a helpful assistant.  \n');
     });
 
-    test('a setvar-only block still resolves to accounting content only', () {
+    test('a setvar-only block resolves for accounting but is not sent', () {
       final result = resolve('{{setvar::flag::1}}');
+      expect(result, isNotNull);
+      expect(result!.content, isEmpty);
+      expect(result.contentForAccounting, isNotEmpty);
+    });
+
+    test('a setvar-only block can explicitly emit an empty message', () {
+      final result = resolve('{{setvar::flag::1}}', sendEmptyBlock: true);
       expect(result, isNotNull);
       expect(result!.content, isEmpty);
       expect(result.contentForAccounting, isNotEmpty);
@@ -80,16 +82,17 @@ void main() {
   });
 
   group('buildApiMessages', () {
-    test('drops zero-length messages and keeps whitespace ones', () {
+    test('drops empty messages unless explicitly enabled', () {
       final messages = buildApiMessages(const [
         PromptMessage(role: 'system', content: 'kept'),
         PromptMessage(role: 'system', content: ''),
         PromptMessage(role: 'system', content: '   '),
+        PromptMessage(role: 'system', content: '', sendEmptyBlock: true),
       ]);
 
       expect(messages, hasLength(2));
       expect(messages[0]['content'], 'kept');
-      expect(messages[1]['content'], '   ');
+      expect(messages[1]['content'], '');
     });
 
     test('does not trim the content it sends', () {

--- a/test/prompt_preview_post_processing_test.dart
+++ b/test/prompt_preview_post_processing_test.dart
@@ -70,14 +70,24 @@ void main() {
     expect(rows.single.sources, hasLength(1));
   });
 
-  test('merge keeps a whitespace-only block, matching the request', () {
+  test('merge drops a whitespace-only block by default', () {
     final rows = buildPreviewMessages(const [
       PromptMessage(role: 'system', content: 'kept'),
       PromptMessage(role: 'system', content: '   '),
     ], PromptPostProcessing.merge);
 
     expect(rows, hasLength(1));
-    expect(rows.single.message.content, 'kept\n\n   ');
+    expect(rows.single.message.content, 'kept');
+    expect(rows.single.sources, hasLength(1));
+  });
+
+  test('merge keeps an explicitly enabled empty block', () {
+    final rows = buildPreviewMessages(const [
+      PromptMessage(role: 'system', content: 'kept'),
+      PromptMessage(role: 'system', content: '', sendEmptyBlock: true),
+    ], PromptPostProcessing.merge);
+
+    expect(rows, hasLength(1));
     expect(rows.single.sources, hasLength(2));
   });
 

--- a/test/studio_3config_resolution_test.dart
+++ b/test/studio_3config_resolution_test.dart
@@ -235,6 +235,31 @@ void main() {
   });
 
   group('AgentRunner Studio final routing', () {
+    test('final max tokens supports an explicit zero override', () {
+      const settings = PipelineSettings(
+        studioAgent: StudioAgentSettings(
+          studioFinalMaxTokens: 0,
+          studioFinalMaxTokensOverride: true,
+        ),
+      );
+      final runner = AgentRunner(
+        configResolver: AgentConfigResolver(
+          loadApiConfigs: () async => const [],
+          readActiveApiConfig: () => null,
+          readPipelineSettings: () => settings,
+        ),
+        readPipelineSettings: () => settings,
+      );
+
+      expect(
+        runner.effectiveMaxTokens(
+          const StudioAgent(id: 'final', name: 'Final'),
+          true,
+        ),
+        0,
+      );
+    });
+
     test('final timeout is not capped at 120 seconds', () {
       const settings = PipelineSettings(
         studioAgent: StudioAgentSettings(studioFinalTimeoutMs: 180000),
@@ -292,10 +317,7 @@ void main() {
         await container
             .read(studioPresetRepoProvider)
             .upsert(
-              StudioPreset(
-                id: 'default',
-                expensiveApiConfigId: expensive.id,
-              ),
+              StudioPreset(id: 'default', expensiveApiConfigId: expensive.id),
             );
         await container
             .read(pipelineSettingsProvider.notifier)
@@ -356,10 +378,7 @@ void main() {
         await container
             .read(studioPresetRepoProvider)
             .upsert(
-              StudioPreset(
-                id: 'default',
-                expensiveApiConfigId: expensive.id,
-              ),
+              StudioPreset(id: 'default', expensiveApiConfigId: expensive.id),
             );
         await container
             .read(pipelineSettingsProvider.notifier)

--- a/test/studio_agent_settings_test.dart
+++ b/test/studio_agent_settings_test.dart
@@ -51,4 +51,32 @@ void main() {
 
     expect(settings.studioFinalReasoningHistoryCount, 3);
   });
+
+  test('final max tokens zero round-trips as an explicit override', () {
+    final restored = StudioAgentSettings.fromJson(
+      const StudioAgentSettings(
+        studioFinalMaxTokens: 0,
+        studioFinalMaxTokensOverride: true,
+      ).toJson(),
+    );
+
+    expect(restored.studioFinalMaxTokens, 0);
+    expect(restored.studioFinalMaxTokensOverride, isTrue);
+  });
+
+  test('legacy positive final max tokens enables its override', () {
+    final restored = StudioAgentSettings.fromJson(const {
+      'studioFinalMaxTokens': 8000,
+    });
+
+    expect(restored.studioFinalMaxTokensOverride, isTrue);
+  });
+
+  test('legacy zero final max tokens keeps inheritance', () {
+    final restored = StudioAgentSettings.fromJson(const {
+      'studioFinalMaxTokens': 0,
+    });
+
+    expect(restored.studioFinalMaxTokensOverride, isFalse);
+  });
 }


### PR DESCRIPTION
## Summary
- add an opt-in `Send empty block` setting for ordinary preset blocks instead of automatically emitting macro-expanded blanks
- preserve the setting through prompt resolution, worker serialization, API filtering, preview, and preset import/export
- allow the Studio final generator to explicitly set max tokens to zero, omitting the deprecated `max_tokens` field while retaining provider-specific completion limits

## Compatibility
- existing preset blocks default to not sending empty messages
- legacy positive Studio final token limits automatically enable the new override flag
- legacy zero values continue to inherit the configured agent limit

## Verification
- `flutter analyze` (no issues)
- 51 prompt/preset tests passed
- 36 Studio settings/transport tests passed
- `git diff --check`