### PR TITLE
fix(sync): recover conflicting reconciliation identities

### DIFF
--- a/lib/core/db/repositories/ledger_reconciliation_run_repo.dart
+++ b/lib/core/db/repositories/ledger_reconciliation_run_repo.dart
@@ -163,6 +163,18 @@ class LedgerReconciliationRunRepo {
   Future<bool> anchorsMatchSession(LedgerReconciliationRun run) =>
       _anchorsMatchSession(run);
 
+  /// Content hashes bind a run to its session, but legacy branch copies could
+  /// move the content-derived global id to another session. Keep the compact
+  /// historical id when available and deterministically namespace collisions.
+  Future<String> allocateId(String sessionId, String contentHash) async {
+    final contentId = 'reconciliation-$contentHash';
+    final occupied = await (_db.select(
+      _db.ledgerReconciliationSuccessfulRuns,
+    )..where((row) => row.id.equals(contentId))).getSingleOrNull();
+    if (occupied == null || occupied.sessionId == sessionId) return contentId;
+    return 'reconciliation-${computeHash('$sessionId\u001f$contentHash')}';
+  }
+
   /// Caller owns the transaction. This method never opens a nested transaction.
   Future<ReconciliationRunIntegrity> append(LedgerReconciliationRun run) async {
     final valid = await _validate(run);
@@ -240,7 +252,9 @@ class LedgerReconciliationRunRepo {
     final head = existing ?? await _physicalHead(candidate.sessionId);
     final replay = existing != null;
     final allocated = LedgerReconciliationRun(
-      id: candidate.id,
+      id: replay
+          ? existing.id
+          : await allocateId(candidate.sessionId, candidate.contentHash),
       sessionId: candidate.sessionId,
       ordinal: replay ? head!.ordinal : (head == null ? 1 : head.ordinal + 1),
       anchors: candidate.anchors,
@@ -404,57 +418,68 @@ class LedgerReconciliationRunRepo {
     return affectedIds.toList(growable: false);
   }
 
-  /// Copies all reconciliation runs from [fromSessionId] to [toSessionId],
-  /// preserving the ordinal chain. Only runs whose endpoint message falls
-  /// within the branched slice ([messageIds]) are copied. The chain hashes
-  /// remain valid because ordinals are preserved and the physical order is
-  /// unchanged. Used by `branchSession` so the cadence gate continues from
-  /// the parent's reconciliation count instead of resetting to zero.
+  /// Rebuilds the transferable reconciliation prefix for a branched session.
+  /// Run identities and hashes bind the session id, so source rows must never
+  /// be copied directly. Runs with accepted lorebook refs remain fail-closed
+  /// until their complete source provenance can be re-keyed for the branch.
   Future<void> copyForSessionBranch({
     required String fromSessionId,
     required String toSessionId,
     required Set<String> messageIds,
   }) async {
     if (messageIds.isEmpty) return;
-    final rows =
-        await (_db.select(_db.ledgerReconciliationSuccessfulRuns)
-              ..where((r) => r.sessionId.equals(fromSessionId))
-              ..where((r) => r.endMessageId.isIn(messageIds))
-              ..orderBy([(r) => OrderingTerm.asc(r.ordinal)]))
-            .get();
+    final rows = await readSession(fromSessionId);
     if (rows.isEmpty) return;
-    await _db.batch((batch) {
-      for (final row in rows) {
-        batch.insert(
-          _db.ledgerReconciliationSuccessfulRuns,
-          LedgerReconciliationSuccessfulRunsCompanion.insert(
-            id: row.id,
-            sessionId: toSessionId,
-            ordinal: row.ordinal,
-            startMessageId: row.startMessageId,
-            startSwipeId: row.startSwipeId,
-            startAgentSwipeId: row.startAgentSwipeId,
-            endMessageId: row.endMessageId,
-            endSwipeId: row.endSwipeId,
-            endAgentSwipeId: row.endAgentSwipeId,
-            anchorsJson: row.anchorsJson,
-            rangeHash: row.rangeHash,
-            acceptedManifestRefsJson: row.acceptedManifestRefsJson,
-            effectiveCanonStamp: row.effectiveCanonStamp,
-            effectiveCanonRevision: row.effectiveCanonRevision,
-            effectiveCanonHash: row.effectiveCanonHash,
-            canonicalResultJson: row.canonicalResultJson,
-            contentHash: row.contentHash,
-            predecessorChainHash: row.predecessorChainHash,
-            chainHash: row.chainHash,
-            contractVersion: row.contractVersion,
-            opsAppliedJson: row.opsAppliedJson,
-            createdAt: row.createdAt,
-          ),
-          mode: InsertMode.insertOrReplace,
-        );
+    var predecessor = '';
+    var ordinal = 1;
+    for (final row in rows) {
+      final anchors = _decodeAnchors(row.anchorsJson);
+      final refs = _decodeRefs(row.acceptedManifestRefsJson);
+      if (!anchors.every((anchor) => messageIds.contains(anchor.messageId)) ||
+          refs.isNotEmpty) {
+        break;
       }
-    });
+      final result = jsonDecode(row.canonicalResultJson);
+      final ops = jsonDecode(row.opsAppliedJson);
+      if (result is! Map<Object?, Object?> || ops is! List) break;
+      var run = LedgerReconciliationRun(
+        id: '',
+        sessionId: toSessionId,
+        ordinal: ordinal,
+        anchors: anchors,
+        acceptedManifestRefs: const [],
+        effectiveCanonStamp: row.effectiveCanonStamp,
+        effectiveCanonRevision: row.effectiveCanonRevision,
+        effectiveCanonHash: row.effectiveCanonHash,
+        canonicalResult: Map<String, dynamic>.from(result),
+        predecessorChainHash: predecessor,
+        contractVersion: row.contractVersion,
+        opsApplied: List<String>.from(ops),
+        createdAt: row.createdAt,
+      );
+      run = LedgerReconciliationRun(
+        id: await allocateId(toSessionId, run.contentHash),
+        sessionId: run.sessionId,
+        ordinal: run.ordinal,
+        anchors: run.anchors,
+        acceptedManifestRefs: run.acceptedManifestRefs,
+        effectiveCanonStamp: run.effectiveCanonStamp,
+        effectiveCanonRevision: run.effectiveCanonRevision,
+        effectiveCanonHash: run.effectiveCanonHash,
+        canonicalResult: run.canonicalResult,
+        predecessorChainHash: run.predecessorChainHash,
+        contractVersion: run.contractVersion,
+        opsApplied: run.opsApplied,
+        createdAt: run.createdAt,
+      );
+      final appended = await append(run);
+      if (appended is! ReconciliationRunAppended &&
+          appended is! ReconciliationRunIdempotent) {
+        break;
+      }
+      predecessor = run.chainHash;
+      ordinal++;
+    }
   }
 
   /// A head is authoritative only if the whole durable chain is canonical and

--- a/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
+++ b/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
@@ -633,23 +633,30 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
       throw const FormatException('Invalid reconciliation sync payload');
     }
     await _db.transaction(() async {
-      final runDecision = await _resolveRunMerge(
+      final normalized = await _normalizeIncomingRuns(
         sessionId,
         _maps(data['runs']),
         _maps(data['invalidations']),
+      );
+      final runDecision = await _resolveRunMerge(
+        sessionId,
+        normalized.runs,
+        normalized.invalidations,
       );
       if (runDecision == _RunMergeDecision.keepLocal) return;
       if (runDecision == _RunMergeDecision.replaceLocal) {
         await _clearReconciliationLane(sessionId);
       }
       await _mergeSourceRows(sessionId, data);
-      final importedComplete = await _mergeRuns(sessionId, _maps(data['runs']));
+      final importedComplete = await _mergeRuns(sessionId, normalized.runs);
       await _mergeInvalidations(
         sessionId,
-        _maps(data['invalidations']),
+        normalized.invalidations,
         ignoreUnknown: !importedComplete,
       );
-      final collectors = _maps(data['collectors']);
+      final collectors = normalized.identitiesChanged
+          ? <Map<String, dynamic>>[]
+          : _maps(data['collectors']);
       final resetDerivedLane = await _resetDerivedLaneForInvalidations(
         sessionId,
         collectors,
@@ -657,15 +664,111 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
       if (importedComplete && !resetDerivedLane) {
         final collectorsValid = await _mergeCollectors(sessionId, collectors);
         if (collectorsValid) {
-          await _mergeObservations(sessionId, _maps(data['observations']));
-          await _mergeCompletedClaims(
-            sessionId,
-            _maps(data['completedClaims']),
-          );
+          if (!normalized.identitiesChanged) {
+            await _mergeObservations(sessionId, _maps(data['observations']));
+            await _mergeCompletedClaims(
+              sessionId,
+              _maps(data['completedClaims']),
+            );
+          }
         }
       }
     });
     return await getBySessionId(sessionId) ?? _emptyPayload(sessionId);
+  }
+
+  Future<_NormalizedReconciliationPayload> _normalizeIncomingRuns(
+    String sessionId,
+    List<Map<String, dynamic>> incoming,
+    List<Map<String, dynamic>> invalidations,
+  ) async {
+    incoming.sort(
+      (a, b) => (a['ordinal'] as int).compareTo(b['ordinal'] as int),
+    );
+    final normalized = <Map<String, dynamic>>[];
+    final idMap = <String, String>{};
+    var predecessor = '';
+    var changed = false;
+    for (var index = 0; index < incoming.length; index++) {
+      final row = LedgerReconciliationSuccessfulRunRow.fromJson(
+        incoming[index],
+      );
+      _requireSession(sessionId, row.sessionId);
+      final decoded = _runFromRow(row);
+      final occupied = await (_db.select(
+        _db.ledgerReconciliationSuccessfulRuns,
+      )..where((item) => item.id.equals(row.id))).getSingleOrNull();
+      final canonical = LedgerReconciliationRun(
+        id: '',
+        sessionId: sessionId,
+        ordinal: index + 1,
+        anchors: decoded.anchors,
+        acceptedManifestRefs: decoded.acceptedManifestRefs,
+        effectiveCanonStamp: decoded.effectiveCanonStamp,
+        effectiveCanonRevision: decoded.effectiveCanonRevision,
+        effectiveCanonHash: decoded.effectiveCanonHash,
+        canonicalResult: decoded.canonicalResult,
+        predecessorChainHash: predecessor,
+        contractVersion: decoded.contractVersion,
+        opsApplied: decoded.opsApplied,
+        createdAt: decoded.createdAt,
+      );
+      final canonicalId = await LedgerReconciliationRunRepo(
+        _db,
+      ).allocateId(sessionId, canonical.contentHash);
+      final storedCanonical =
+          row.ordinal != canonical.ordinal ||
+          row.contentHash != canonical.contentHash ||
+          row.predecessorChainHash != canonical.predecessorChainHash ||
+          row.chainHash != canonical.chainHash;
+      final foreignIdentity =
+          occupied != null && occupied.sessionId != sessionId;
+      final legacyBranchCopy =
+          foreignIdentity &&
+          row.contentHash == occupied.contentHash &&
+          row.predecessorChainHash == occupied.predecessorChainHash &&
+          row.chainHash == occupied.chainHash;
+      if (storedCanonical && !legacyBranchCopy) {
+        changed = true;
+        break;
+      }
+      final needsNormalization = storedCanonical || foreignIdentity;
+      final outputId = needsNormalization ? canonicalId : row.id;
+      if (needsNormalization && canonical.acceptedManifestRefs.isNotEmpty) {
+        changed = true;
+        break;
+      }
+      final output = needsNormalization
+          ? {
+              ...row.toJson(),
+              'id': outputId,
+              'ordinal': canonical.ordinal,
+              'contentHash': canonical.contentHash,
+              'predecessorChainHash': canonical.predecessorChainHash,
+              'chainHash': canonical.chainHash,
+            }
+          : row.toJson();
+      normalized.add(output);
+      idMap[row.id] = output['id'] as String;
+      predecessor = output['chainHash'] as String;
+      changed = changed || needsNormalization;
+    }
+    final remappedInvalidations = <Map<String, dynamic>>[];
+    for (final invalidation in invalidations) {
+      final oldId = invalidation['runId'] as String;
+      final newId = idMap[oldId];
+      if (newId == null) {
+        changed = true;
+        continue;
+      }
+      remappedInvalidations.add({...invalidation, 'runId': newId});
+      changed = changed || newId != oldId;
+    }
+    return _NormalizedReconciliationPayload(
+      runs: normalized,
+      invalidations: remappedInvalidations,
+      identitiesChanged: changed,
+    );
   }
 
   Future<_RunMergeDecision> _resolveRunMerge(
@@ -1291,3 +1394,15 @@ String _integrityReason(ReconciliationRunIntegrity integrity) =>
     };
 
 enum _RunMergeDecision { merge, keepLocal, replaceLocal }
+
+final class _NormalizedReconciliationPayload {
+  const _NormalizedReconciliationPayload({
+    required this.runs,
+    required this.invalidations,
+    required this.identitiesChanged,
+  });
+
+  final List<Map<String, dynamic>> runs;
+  final List<Map<String, dynamic>> invalidations;
+  final bool identitiesChanged;
+}

--- a/test/ledger_reconciliation_run_repo_test.dart
+++ b/test/ledger_reconciliation_run_repo_test.dart
@@ -34,6 +34,49 @@ void main() {
     expect((await repo.getHead('session'))!.id, 'run-2');
   });
 
+  test('candidate replay keeps the stored legacy identity', () async {
+    await _seedSession(db);
+    final stored = _run(id: 'legacy-id');
+    expect(await repo.append(stored), isA<ReconciliationRunAppended>());
+
+    expect(
+      await repo.appendCandidate(_run(id: 'new-draft-id')),
+      isA<ReconciliationRunIdempotent>(),
+    );
+    expect((await repo.getHead('session'))!.id, 'legacy-id');
+  });
+
+  test(
+    'branch copy rebuilds session-bound identities without replacing source',
+    () async {
+      await _seedSession(db);
+      await db.customStatement(
+        "INSERT INTO chat_sessions (session_id, character_id, session_index, messages_json) "
+        "SELECT 'branch', character_id, 1, messages_json FROM chat_sessions WHERE session_id = 'session'",
+      );
+      final source = _run();
+      expect(await repo.append(source), isA<ReconciliationRunAppended>());
+
+      await repo.copyForSessionBranch(
+        fromSessionId: 'session',
+        toSessionId: 'branch',
+        messageIds: {'message', 'user'},
+      );
+
+      final sourceRows = await repo.readSession('session');
+      final branchRows = await repo.readSession('branch');
+      expect(sourceRows.single.id, source.id);
+      expect(branchRows, hasLength(1));
+      expect(branchRows.single.id, isNot(source.id));
+      expect(
+        branchRows.single.id,
+        'reconciliation-${branchRows.single.contentHash}',
+      );
+      expect(branchRows.single.sessionId, 'branch');
+      expect(await repo.validateChain('branch'), isA<ReconciliationRunValid>());
+    },
+  );
+
   test(
     'rejects anchor mutations and immutable content-hash collisions',
     () async {
@@ -307,7 +350,9 @@ void main() {
         isA<ReconciliationRunAppended>(),
       );
       final rows = await db.select(db.ledgerReconciliationSuccessfulRuns).get();
-      final second = rows.singleWhere((row) => row.id == 'run-2');
+      final second = rows.singleWhere(
+        (row) => row.contentHash == candidate.contentHash,
+      );
       expect(second.ordinal, 2);
       expect(second.predecessorChainHash, first.chainHash);
     },

--- a/test/reconciliation_state_sync_store_test.dart
+++ b/test/reconciliation_state_sync_store_test.dart
@@ -43,6 +43,134 @@ void main() {
   });
 
   test(
+    'legacy global run id collision is re-keyed without replacing parent',
+    () async {
+      final incoming = (await _appendChain(sourceDb, 1)).single;
+      await targetDb.customStatement(
+        'INSERT INTO chat_sessions '
+        '(session_id, character_id, session_index, messages_json) '
+        'VALUES (?, ?, 1, ?)',
+        ['parent', 'character', jsonEncode(_messages)],
+      );
+      var parent = LedgerReconciliationRun(
+        id: '',
+        sessionId: 'parent',
+        ordinal: 1,
+        anchors: incoming.anchors,
+        acceptedManifestRefs: const [],
+        effectiveCanonStamp: incoming.effectiveCanonStamp,
+        effectiveCanonRevision: incoming.effectiveCanonRevision,
+        effectiveCanonHash: incoming.effectiveCanonHash,
+        canonicalResult: incoming.canonicalResult,
+        predecessorChainHash: '',
+        contractVersion: incoming.contractVersion,
+        opsApplied: incoming.opsApplied,
+        createdAt: incoming.createdAt,
+      );
+      parent = LedgerReconciliationRun(
+        id: 'reconciliation-${parent.contentHash}',
+        sessionId: parent.sessionId,
+        ordinal: parent.ordinal,
+        anchors: parent.anchors,
+        acceptedManifestRefs: parent.acceptedManifestRefs,
+        effectiveCanonStamp: parent.effectiveCanonStamp,
+        effectiveCanonRevision: parent.effectiveCanonRevision,
+        effectiveCanonHash: parent.effectiveCanonHash,
+        canonicalResult: parent.canonicalResult,
+        predecessorChainHash: parent.predecessorChainHash,
+        contractVersion: parent.contractVersion,
+        opsApplied: parent.opsApplied,
+        createdAt: parent.createdAt,
+      );
+      expect(
+        await LedgerReconciliationRunRepo(targetDb).append(parent),
+        isA<ReconciliationRunAppended>(),
+      );
+
+      final payload = (await sourceStore.getBySessionId('session'))!;
+      final legacyRun = Map<String, dynamic>.from(
+        (payload['runs'] as List).single as Map,
+      );
+      legacyRun
+        ..['id'] = parent.id
+        ..['contentHash'] = parent.contentHash
+        ..['predecessorChainHash'] = parent.predecessorChainHash
+        ..['chainHash'] = parent.chainHash;
+      final legacyPayload = {
+        ...payload,
+        'runs': [legacyRun],
+      };
+      final firstMerge = await targetStore.mergeBySessionId(
+        'session',
+        legacyPayload,
+      );
+      final secondMerge = await targetStore.mergeBySessionId(
+        'session',
+        legacyPayload,
+      );
+
+      final parentRows = await LedgerReconciliationRunRepo(
+        targetDb,
+      ).readSession('parent');
+      final importedRows = await LedgerReconciliationRunRepo(
+        targetDb,
+      ).readSession('session');
+      expect(parentRows.single.id, parent.id);
+      expect(importedRows, hasLength(1));
+      expect(importedRows.single.id, isNot(parent.id));
+      expect(
+        importedRows.single.id,
+        'reconciliation-${importedRows.single.contentHash}',
+      );
+      expect(secondMerge, firstMerge);
+    },
+  );
+
+  test(
+    'canonical cloud id is namespaced when a legacy foreign row occupies it',
+    () async {
+      await _appendChain(sourceDb, 1);
+      final payload = (await sourceStore.getBySessionId('session'))!;
+      final cloudJson = Map<String, dynamic>.from(
+        (payload['runs'] as List).single as Map,
+      );
+      final canonicalId = 'reconciliation-${cloudJson['contentHash']}';
+      cloudJson['id'] = canonicalId;
+      payload['runs'] = [cloudJson];
+
+      await targetDb.customStatement(
+        'INSERT INTO chat_sessions '
+        '(session_id, character_id, session_index, messages_json) '
+        'VALUES (?, ?, 1, ?)',
+        ['legacy-owner', 'character', jsonEncode(_messages)],
+      );
+      await targetDb
+          .into(targetDb.ledgerReconciliationSuccessfulRuns)
+          .insert(
+            LedgerReconciliationSuccessfulRunRow.fromJson({
+              ...cloudJson,
+              'sessionId': 'legacy-owner',
+            }),
+          );
+
+      await targetStore.mergeBySessionId('session', payload);
+
+      final imported = await LedgerReconciliationRunRepo(
+        targetDb,
+      ).readSession('session');
+      expect(imported, hasLength(1));
+      expect(
+        imported.single.id,
+        'reconciliation-${computeHash('session\u001f${imported.single.contentHash}')}',
+      );
+      final occupied = await (targetDb.select(
+        targetDb.ledgerReconciliationSuccessfulRuns,
+      )..where((row) => row.id.equals(canonicalId))).getSingle();
+      expect(occupied.sessionId, 'legacy-owner');
+    },
+  );
+
+  test(
     'a stale shorter incoming chain never truncates local history',
     () async {
       await _appendChain(sourceDb, 2);


### PR DESCRIPTION
## Summary
- rebuild reconciliation provenance when branching instead of reusing globally keyed source rows
- normalize recoverable legacy cloud chains and deterministically namespace occupied run identities
- preserve idempotent legacy replays while preventing future cross-session primary-key collisions

## Verification
- replayed all 14 current Dropbox reconciliation payloads against a copy of the active database
- lutter analyze`n- lutter test --reporter expanded (2922 passed)
- focused reconciliation, sync, branch, and deletion suites (93 passed)