### PR TITLE
fix(studio): attribute silent Card Rewriter bails

### DIFF
--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -75,7 +75,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 118;
+  int get schemaVersion => 119;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2214,6 +2214,12 @@ class AppDatabase extends _$AppDatabase {
         if (!names.contains('prompt_post_processing')) {
           await m.addColumn(apiConfigs, apiConfigs.promptPostProcessing);
         }
+      }
+      if (from < 119) {
+        // Card Rewriter runs that bail before resolving a model now record a
+        // 'selection' diagnostic row. Rebuild the table so its CHECK accepts
+        // that stage and stops requiring a model name for it.
+        await m.alterTable(TableMigration(cardEvolutionDebugRuns));
       }
     },
   );

--- a/lib/core/db/repositories/card_evolution_repo.dart
+++ b/lib/core/db/repositories/card_evolution_repo.dart
@@ -22,6 +22,41 @@ const _maxCanonValueCharacters = 2000;
 const _maxLorebookEntryCharacters = 20000;
 const _maxLorebookTotalCharacters = 40000;
 
+/// Why the canonical writer/collector input could not be selected. Every bail
+/// point in [CardEvolutionRepo._selectInput] maps to exactly one value so a
+/// silent `notEligible` can be attributed without re-deriving the state.
+enum CardEvolutionSelectionFailure {
+  sessionMissing,
+  messagesMalformed,
+  canonUnavailable,
+  baselineDecisionRequired,
+  reconciliationRunsMissing,
+  historyUnresolved,
+  historyTooShort,
+  historyRolesIncomplete,
+  lorebookEvidenceUnavailable,
+  collectorRunsUnresolved,
+  inputHashMismatch,
+  claimEvidenceMismatch,
+  unexpectedError,
+}
+
+/// Either the canonical selected input or the reason it is unavailable.
+final class CardEvolutionSelection {
+  const CardEvolutionSelection.selected(String this.json) : failure = null;
+  const CardEvolutionSelection.failed(
+    CardEvolutionSelectionFailure this.failure,
+  ) : json = null;
+
+  final String? json;
+  final CardEvolutionSelectionFailure? failure;
+
+  bool get isSelected => json != null;
+
+  /// Stable diagnostic label; empty when the selection succeeded.
+  String get failureName => failure?.name ?? '';
+}
+
 final class CardEvolutionClaim {
   const CardEvolutionClaim({
     required this.row,
@@ -32,9 +67,14 @@ final class CardEvolutionClaim {
 }
 
 final class CardEvolutionClaimOutcome {
-  const CardEvolutionClaimOutcome(this.kind, [this.claim]);
+  const CardEvolutionClaimOutcome(this.kind, [this.claim, this.detail]);
   final String kind;
   final CardEvolutionClaim? claim;
+
+  /// Diagnostic attribution for the non-claiming kinds. Never user-facing
+  /// copy: it carries a [CardEvolutionSelectionFailure] name when the claim
+  /// failed while selecting evidence.
+  final String? detail;
   bool get isClaimed => kind == 'claimed' || kind == 'existing';
 }
 
@@ -48,6 +88,20 @@ final class CardEvolutionPromptSnapshot {
   final CardEvolutionClaimRow claim;
   final Character character;
   final String selectedInputJson;
+}
+
+/// Either the prompt snapshot for a live lease or the reason it is
+/// unavailable. The reason is diagnostic only and is never shown verbatim to
+/// the user.
+final class CardEvolutionPromptSnapshotOutcome {
+  const CardEvolutionPromptSnapshotOutcome.ready(
+    CardEvolutionPromptSnapshot this.snapshot,
+  ) : reason = null;
+  const CardEvolutionPromptSnapshotOutcome.unavailable(String this.reason)
+    : snapshot = null;
+
+  final CardEvolutionPromptSnapshot? snapshot;
+  final String? reason;
 }
 
 final class CardEvolutionFinalizeOutcome {
@@ -92,8 +146,17 @@ class CardEvolutionRepo {
   final SessionLorebookEvolutionRepo lorebookEvolutionRepo;
   final Future<void> Function()? beforeCursorInsert;
 
-  Future<bool> isEligible(String sessionId) =>
-      db.transaction<bool>(() async => (await _selectInput(sessionId)) != null);
+  Future<bool> isEligible(String sessionId) => db.transaction<bool>(
+    () async => (await _selectInput(sessionId)).isSelected,
+  );
+
+  /// Diagnostic variant of [isEligible]: reports why the session cannot be
+  /// selected instead of collapsing every cause into `false`.
+  @visibleForTesting
+  Future<CardEvolutionSelectionFailure?> selectionFailure(String sessionId) =>
+      db.transaction<CardEvolutionSelectionFailure?>(
+        () async => (await _selectInput(sessionId)).failure,
+      );
 
   Future<CardEvolutionClaimOutcome> claim({
     required String sessionId,
@@ -116,9 +179,10 @@ class CardEvolutionRepo {
       if (existing.ownerId != ownerId) {
         return const CardEvolutionClaimOutcome('busy');
       }
-      final selected = await _selectedInputForClaim(existing);
+      final selection = await _selectedInputForClaim(existing);
+      final selected = selection.json;
       return selected == null
-          ? const CardEvolutionClaimOutcome('stale')
+          ? CardEvolutionClaimOutcome('stale', null, selection.failureName)
           : CardEvolutionClaimOutcome(
               'existing',
               CardEvolutionClaim(row: existing, selectedInputJson: selected),
@@ -138,12 +202,17 @@ class CardEvolutionRepo {
         return const CardEvolutionClaimOutcome('busy');
       }
     }
-    final selected = await _selectInput(
+    final selection = await _selectInput(
       sessionId,
       reconciliationRunIds: reconciliationRunIds,
     );
+    final selected = selection.json;
     if (selected == null) {
-      return const CardEvolutionClaimOutcome('notEligible');
+      return CardEvolutionClaimOutcome(
+        'notEligible',
+        null,
+        selection.failureName,
+      );
     }
     final session = await (db.select(
       db.chatSessions,
@@ -194,29 +263,68 @@ class CardEvolutionRepo {
     required String claimId,
     required String ownerId,
     required int now,
+  }) async => (await readPromptSnapshotOutcome(
+    claimId: claimId,
+    ownerId: ownerId,
+    now: now,
+  )).snapshot;
+
+  /// Same contract as [readPromptSnapshot] but keeps the reason the snapshot
+  /// could not be produced, so an early writer bail stays attributable.
+  Future<CardEvolutionPromptSnapshotOutcome> readPromptSnapshotOutcome({
+    required String claimId,
+    required String ownerId,
+    required int now,
   }) => db.transaction(() async {
     final claim = await (db.select(
       db.cardEvolutionClaims,
     )..where((row) => row.id.equals(claimId))).getSingleOrNull();
-    if (claim == null ||
-        claim.status != 'claimed' ||
-        claim.ownerId != ownerId ||
-        claim.leaseExpiresAt <= now) {
-      return null;
+    if (claim == null) {
+      return const CardEvolutionPromptSnapshotOutcome.unavailable(
+        'claimMissing',
+      );
     }
-    final selected = await _selectedInputForClaim(claim);
-    if (selected == null || computeHash(selected) != claim.inputHash) {
-      return null;
+    if (claim.status != 'claimed') {
+      return const CardEvolutionPromptSnapshotOutcome.unavailable(
+        'claimNotClaimed',
+      );
+    }
+    if (claim.ownerId != ownerId) {
+      return const CardEvolutionPromptSnapshotOutcome.unavailable('claimOwner');
+    }
+    if (claim.leaseExpiresAt <= now) {
+      return const CardEvolutionPromptSnapshotOutcome.unavailable('leaseLost');
+    }
+    final selection = await _selectedInputForClaim(claim);
+    final selected = selection.json;
+    if (selected == null) {
+      return CardEvolutionPromptSnapshotOutcome.unavailable(
+        selection.failureName,
+      );
+    }
+    if (computeHash(selected) != claim.inputHash) {
+      return const CardEvolutionPromptSnapshotOutcome.unavailable(
+        'inputHashMismatch',
+      );
     }
     final assembled = await _assemble(claim.sessionId, claim.characterId);
-    if (assembled == null || assembled.$2.requiresBaselineDecision) {
-      return null;
+    if (assembled == null) {
+      return const CardEvolutionPromptSnapshotOutcome.unavailable(
+        'canonUnavailable',
+      );
+    }
+    if (assembled.$2.requiresBaselineDecision) {
+      return const CardEvolutionPromptSnapshotOutcome.unavailable(
+        'baselineDecisionRequired',
+      );
     }
     final assembly = assembled.$2;
-    return CardEvolutionPromptSnapshot(
-      claim: claim,
-      character: assembly.character,
-      selectedInputJson: selected,
+    return CardEvolutionPromptSnapshotOutcome.ready(
+      CardEvolutionPromptSnapshot(
+        claim: claim,
+        character: assembly.character,
+        selectedInputJson: selected,
+      ),
     );
   });
 
@@ -244,9 +352,21 @@ class CardEvolutionRepo {
     if (claim.ownerId != ownerId || claim.leaseExpiresAt <= now) {
       return const CardEvolutionFinalizeOutcome('leaseLost');
     }
-    final selected = await _selectedInputForClaim(claim);
-    if (selected == null || computeHash(selected) != claim.inputHash) {
-      return const CardEvolutionFinalizeOutcome('staleEvidence');
+    final selection = await _selectedInputForClaim(claim);
+    final selected = selection.json;
+    if (selected == null) {
+      return CardEvolutionFinalizeOutcome(
+        'staleEvidence',
+        null,
+        selection.failureName,
+      );
+    }
+    if (computeHash(selected) != claim.inputHash) {
+      return const CardEvolutionFinalizeOutcome(
+        'staleEvidence',
+        null,
+        'inputHashMismatch',
+      );
     }
     final assembled = await _assemble(claim.sessionId, claim.characterId);
     if (assembled == null || assembled.$2.requiresBaselineDecision) {
@@ -489,7 +609,7 @@ class CardEvolutionRepo {
   Future<CardEvolutionObservationSnapshot?> buildObservationSnapshot(
     String sessionId,
   ) => db.transaction(() async {
-    final selected = await _selectInput(sessionId);
+    final selected = (await _selectInput(sessionId)).json;
     if (selected == null) return null;
     final session = await (db.select(
       db.chatSessions,
@@ -511,7 +631,8 @@ class CardEvolutionRepo {
   Future<CardEvolutionObservationSnapshot?> buildObservationSnapshotForRun(
     LedgerReconciliationSuccessfulRunRow run,
   ) => db.transaction(() async {
-    final selected = await _selectInput(run.sessionId, reconciliationRun: run);
+    final selected =
+        (await _selectInput(run.sessionId, reconciliationRun: run)).json;
     if (selected == null) return null;
     final session = await (db.select(
       db.chatSessions,
@@ -532,10 +653,10 @@ class CardEvolutionRepo {
   ) => db.transaction(() async {
     if (runs.length != 2 || runs[0].sessionId != runs[1].sessionId) return null;
     final sessionId = runs.first.sessionId;
-    final selected = await _selectInput(
+    final selected = (await _selectInput(
       sessionId,
       reconciliationRunIds: [for (final run in runs) run.id],
-    );
+    )).json;
     if (selected == null) return null;
     final session = await (db.select(
       db.chatSessions,
@@ -579,27 +700,37 @@ class CardEvolutionRepo {
             ),
           );
 
-  Future<String?> _selectedInputForClaim(CardEvolutionClaimRow claim) async {
+  Future<CardEvolutionSelection> _selectedInputForClaim(
+    CardEvolutionClaimRow claim,
+  ) async {
     final runIds = await _reconciliationRunIdsForClaim(claim);
     if (claim.predecessorRunOrdinal > 0 &&
         runIds.length != _writerReconciliationRunCount) {
-      return null;
+      return const CardEvolutionSelection.failed(
+        CardEvolutionSelectionFailure.collectorRunsUnresolved,
+      );
     }
-    final selected = await _selectInput(
+    final selection = await _selectInput(
       claim.sessionId,
       reconciliationRunIds: runIds,
     );
-    if (selected == null || computeHash(selected) != claim.inputHash) {
-      return null;
+    final selected = selection.json;
+    if (selected == null) return selection;
+    if (computeHash(selected) != claim.inputHash) {
+      return const CardEvolutionSelection.failed(
+        CardEvolutionSelectionFailure.inputHashMismatch,
+      );
     }
     final snapshot = jsonDecode(selected) as Map<String, dynamic>;
     return snapshot['chatHistoryHash'] == claim.chatHistoryHash &&
             snapshot['effectiveCanonIdentity'] == claim.effectiveCanonIdentity
-        ? selected
-        : null;
+        ? selection
+        : const CardEvolutionSelection.failed(
+            CardEvolutionSelectionFailure.claimEvidenceMismatch,
+          );
   }
 
-  Future<String?> _selectInput(
+  Future<CardEvolutionSelection> _selectInput(
     String sessionId, {
     LedgerReconciliationSuccessfulRunRow? reconciliationRun,
     List<String> reconciliationRunIds = const [],
@@ -608,19 +739,38 @@ class CardEvolutionRepo {
       final session = await (db.select(
         db.chatSessions,
       )..where((row) => row.sessionId.equals(sessionId))).getSingleOrNull();
-      if (session == null) return null;
+      if (session == null) {
+        return const CardEvolutionSelection.failed(
+          CardEvolutionSelectionFailure.sessionMissing,
+        );
+      }
       final messages = jsonDecode(session.messagesJson);
-      if (messages is! List) return null;
+      if (messages is! List) {
+        return const CardEvolutionSelection.failed(
+          CardEvolutionSelectionFailure.messagesMalformed,
+        );
+      }
       final assembled = await _assemble(sessionId, session.characterId);
-      if (assembled == null || assembled.$2.requiresBaselineDecision) {
-        return null;
+      if (assembled == null) {
+        return const CardEvolutionSelection.failed(
+          CardEvolutionSelectionFailure.canonUnavailable,
+        );
+      }
+      if (assembled.$2.requiresBaselineDecision) {
+        return const CardEvolutionSelection.failed(
+          CardEvolutionSelectionFailure.baselineDecisionRequired,
+        );
       }
       final boundaryRuns = reconciliationRunIds.isEmpty
           ? <LedgerReconciliationSuccessfulRunRow>[]
           : await (db.select(
               db.ledgerReconciliationSuccessfulRuns,
             )..where((row) => row.id.isIn(reconciliationRunIds))).get();
-      if (boundaryRuns.length != reconciliationRunIds.length) return null;
+      if (boundaryRuns.length != reconciliationRunIds.length) {
+        return const CardEvolutionSelection.failed(
+          CardEvolutionSelectionFailure.reconciliationRunsMissing,
+        );
+      }
       boundaryRuns.sort(
         (a, b) => reconciliationRunIds
             .indexOf(a.id)
@@ -637,8 +787,15 @@ class CardEvolutionRepo {
               runs: boundaryRuns,
             )
           : _selectChatHistory(messages: messages);
-      if (history == null || history.length < 2) {
-        return null;
+      if (history == null) {
+        return const CardEvolutionSelection.failed(
+          CardEvolutionSelectionFailure.historyUnresolved,
+        );
+      }
+      if (history.length < 2) {
+        return const CardEvolutionSelection.failed(
+          CardEvolutionSelectionFailure.historyTooShort,
+        );
       }
       final hasUser = history.any(
         (message) => message is Map && message['role'] == 'user',
@@ -647,13 +804,19 @@ class CardEvolutionRepo {
         (message) => message is Map && message['role'] == 'assistant',
       );
       if (!hasUser || !hasAssistant) {
-        return null;
+        return const CardEvolutionSelection.failed(
+          CardEvolutionSelectionFailure.historyRolesIncomplete,
+        );
       }
       final lorebookEntries = await _selectInjectedLorebookEntries(
         sessionId: sessionId,
         history: history,
       );
-      if (lorebookEntries == null) return null;
+      if (lorebookEntries == null) {
+        return const CardEvolutionSelection.failed(
+          CardEvolutionSelectionFailure.lorebookEvidenceUnavailable,
+        );
+      }
       final historyJson = _canonicalJson(history);
       final canonEvidence = _canonEvidence(assembled.$1, assembled.$2, history);
       final writableFields = CardRewritePolicy.nonEmptyEvolutionFields(
@@ -718,9 +881,11 @@ class CardEvolutionRepo {
         'availableObservationRetrievalTargets': availableRetrievalTargets,
         'accumulatedObservations': compactObservations,
       });
-      return selected;
+      return CardEvolutionSelection.selected(selected);
     } catch (_) {
-      return null;
+      return const CardEvolutionSelection.failed(
+        CardEvolutionSelectionFailure.unexpectedError,
+      );
     }
   }
 

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -1107,6 +1107,10 @@ class CardEvolutionProposalRuns extends Table {
 /// Rewriter debugging. This is intentionally replaceable diagnostic state,
 /// unlike reviewable proposal provenance which remains immutable once
 /// persisted.
+///
+/// The `selection` stage records writer runs that bailed before a model was
+/// resolved (claim refused, prompt snapshot unavailable). It therefore has no
+/// model name, which is why the model check is scoped to the model stages.
 @DataClassName('CardEvolutionDebugRunRow')
 class CardEvolutionDebugRuns extends Table {
   @override
@@ -1122,8 +1126,9 @@ class CardEvolutionDebugRuns extends Table {
   Set<Column> get primaryKey => {sessionId, stage};
   @override
   List<String> get customConstraints => [
-    "CHECK (session_id <> '' AND stage IN ('card', 'lorebook') "
-        "AND status <> '' AND model <> '' AND attempts_json <> '')",
+    "CHECK (session_id <> '' AND stage IN ('card', 'lorebook', 'selection') "
+        "AND status <> '' AND attempts_json <> '' "
+        "AND (stage = 'selection' OR model <> ''))",
   ];
 }
 

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 
 import '../../db/repositories/card_evolution_observation_repo.dart';
 import '../../db/repositories/card_evolution_collector_run_repo.dart';
@@ -208,17 +209,44 @@ class AutomatedCardEvolutionService {
           [for (final run in collectorBoundaryRuns) run.reconciliationRunId],
     );
     final claim = claimed.claim;
-    if (claim == null) return CardEvolutionFinalizeOutcome(claimed.kind);
+    if (claim == null) {
+      await _saveSelectionBail(
+        sessionId: sessionId,
+        outcome: claimed.kind,
+        reason: claimed.detail,
+        throughCollectorOrdinal: throughCollectorOrdinal,
+        reconciliationRunIds:
+            reconciliationRunIds ??
+            [for (final run in collectorBoundaryRuns) run.reconciliationRunId],
+      );
+      return CardEvolutionFinalizeOutcome(claimed.kind, null, claimed.detail);
+    }
     CancelToken? token;
     var finalized = false;
     try {
-      final snapshot = await repo.readPromptSnapshot(
+      final snapshotOutcome = await repo.readPromptSnapshotOutcome(
         claimId: claim.row.id,
         ownerId: owner,
         now: currentTimestampSeconds(),
       );
+      final snapshot = snapshotOutcome.snapshot;
       if (snapshot == null) {
-        return const CardEvolutionFinalizeOutcome('snapshotUnavailable');
+        await _saveSelectionBail(
+          sessionId: sessionId,
+          outcome: 'snapshotUnavailable',
+          reason: snapshotOutcome.reason,
+          throughCollectorOrdinal: throughCollectorOrdinal,
+          reconciliationRunIds:
+              reconciliationRunIds ??
+              [
+                for (final run in collectorBoundaryRuns) run.reconciliationRunId,
+              ],
+        );
+        return CardEvolutionFinalizeOutcome(
+          'snapshotUnavailable',
+          null,
+          snapshotOutcome.reason,
+        );
       }
       final config = await resolveModel();
       token = CancelToken();
@@ -982,6 +1010,47 @@ class AutomatedCardEvolutionService {
     ]),
     updatedAt: currentTimestampSeconds(),
   );
+
+  /// Records a writer run that ended before any model call. Without this the
+  /// only trace of a refused claim or an unavailable prompt snapshot is a
+  /// transient toast, which makes the cause unrecoverable after the fact.
+  Future<void> _saveSelectionBail({
+    required String sessionId,
+    required String outcome,
+    required String? reason,
+    required int throughCollectorOrdinal,
+    required List<String> reconciliationRunIds,
+  }) async {
+    final detail = reason == null || reason.isEmpty ? 'unattributed' : reason;
+    debugPrint(
+      '[CardRewriter] writer bailed before model session=$sessionId '
+      'outcome=$outcome reason=$detail '
+      'collectorBoundary=$throughCollectorOrdinal '
+      'runs=${reconciliationRunIds.length}',
+    );
+    try {
+      await repo.saveDebugRun(
+        sessionId: sessionId,
+        stage: 'selection',
+        status: outcome,
+        model: '',
+        output: null,
+        attemptsJson: jsonEncode([
+          {
+            'outcome': outcome,
+            'reason': detail,
+            'collectorBoundary': throughCollectorOrdinal,
+            'reconciliationRunIds': reconciliationRunIds,
+            'at': currentTimestampSeconds(),
+          },
+        ]),
+        updatedAt: currentTimestampSeconds(),
+      );
+    } catch (error) {
+      // Diagnostics must never break the pipeline.
+      debugPrint('[CardRewriter] failed to persist selection bail: $error');
+    }
+  }
 }
 
 final class _PreparedWriterContext {

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -313,6 +313,11 @@ class LedgerStage {
                       );
                     },
                   );
+              debugPrint(
+                '[StudioLedger] card rewriter session=$sessionId '
+                'kind=${rewriteOutcome.kind} '
+                'detail=${rewriteOutcome.detail ?? '-'}',
+              );
               emitAutomaticRewriteReviewIntent(
                 ctx.ref,
                 outcome: rewriteOutcome,

--- a/test/card_evolution_repo_test.dart
+++ b/test/card_evolution_repo_test.dart
@@ -107,6 +107,14 @@ void main() {
       ],
     );
 
+    final outcome = await evolution.readPromptSnapshotOutcome(
+      claimId: claim.row.id,
+      ownerId: 'owner',
+      now: 11,
+    );
+
+    expect(outcome.snapshot, isNull);
+    expect(outcome.reason, 'inputHashMismatch');
     expect(
       await evolution.readPromptSnapshot(
         claimId: claim.row.id,
@@ -115,6 +123,76 @@ void main() {
       ),
       isNull,
     );
+  });
+
+  test('an unknown session is attributed instead of silently ignored', () async {
+    expect(
+      await evolution.selectionFailure('missing'),
+      CardEvolutionSelectionFailure.sessionMissing,
+    );
+
+    final claim = await evolution.claim(
+      sessionId: 'missing',
+      ownerId: 'owner',
+      now: 10,
+      leaseSeconds: 30,
+    );
+
+    expect(claim.kind, 'notEligible');
+    expect(claim.detail, 'sessionMissing');
+  });
+
+  test('a malformed message list is attributed', () async {
+    await db.customStatement(
+      'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
+      ['{}', 'session'],
+    );
+
+    expect(
+      await evolution.selectionFailure('session'),
+      CardEvolutionSelectionFailure.messagesMalformed,
+    );
+  });
+
+  test('a single-turn history is attributed as too short', () async {
+    await db.customStatement(
+      'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
+      [
+        jsonEncode([_messages.first]),
+        'session',
+      ],
+    );
+
+    expect(
+      await evolution.selectionFailure('session'),
+      CardEvolutionSelectionFailure.historyTooShort,
+    );
+    expect(await evolution.isEligible('session'), isFalse);
+  });
+
+  test('a character without revisions is attributed as canon unavailable', () async {
+    await db.customStatement(
+      'DELETE FROM character_revision_rows WHERE character_id = ?',
+      ['character'],
+    );
+
+    expect(
+      await evolution.selectionFailure('session'),
+      CardEvolutionSelectionFailure.canonUnavailable,
+    );
+  });
+
+  test('a claim asking for unknown reconciliation runs is attributed', () async {
+    final claim = await evolution.claim(
+      sessionId: 'session',
+      ownerId: 'owner',
+      now: 10,
+      leaseSeconds: 30,
+      reconciliationRunIds: const ['missing-run'],
+    );
+
+    expect(claim.kind, 'notEligible');
+    expect(claim.detail, 'reconciliationRunsMissing');
   });
 
   test('expired claim is replaced using a fresh chat snapshot', () async {

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -1,4 +1,4 @@
-import 'dart:convert';
+﻿import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -78,7 +78,7 @@ void main() {
 
       // user_version matches the Drift schema version (app_db.dart schemaVersion).
       // Update this constant whenever a new migration step is added.
-      expect(version, 118);
+      expect(version, 119);
     });
 
     test(
@@ -232,7 +232,7 @@ void main() {
         final version = await upgraded
             .customSelect('PRAGMA user_version')
             .get();
-        expect(version.first.read<int>('user_version'), 118);
+        expect(version.first.read<int>('user_version'), 119);
         expect(names, contains('variant_group_id'));
         expect(names, contains('hidden'));
       },
@@ -262,7 +262,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
     });
 
     test(
@@ -611,7 +611,7 @@ void main() {
 
     test('current schema includes atomic character fact tables', () async {
       final version = await db.customSelect('PRAGMA user_version').getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
 
       final factColumns = await db
           .customSelect("PRAGMA table_info('character_knowledge_fact_rows')")
@@ -723,7 +723,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
     });
 
     test(
@@ -833,7 +833,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
     });
 
     test('v80 adds Responses API toggle defaulting to off', () async {
@@ -873,7 +873,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
     });
 
     test('v81 adds composite embedding source index', () async {
@@ -907,7 +907,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
     });
 
     test('v82 creates rewrite persistence schema and provenance columns', () async {
@@ -981,7 +981,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
     });
 
     test('v83 rebuilds interim text revision columns without losing rows', () async {
@@ -1433,7 +1433,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
 
       // Rows and payloads survive; legacy statuses pass through or are
       // normalized fail-closed, and new columns carry neutral defaults.
@@ -1638,7 +1638,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
       final row = await upgraded
           .customSelect(
             'SELECT blocks_json FROM studio_preset_rows WHERE preset_id = ?',
@@ -1754,7 +1754,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
       final check = await upgraded.customSelect('PRAGMA integrity_check').get();
       expect(check.single.read<String>('integrity_check'), 'ok');
     });
@@ -2418,7 +2418,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
     });
 
     test(
@@ -2515,7 +2515,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 118);
+      expect(version.read<int>('user_version'), 119);
     });
 
     test('v118 adds prompt post-processing with none for every config', () async {
@@ -2617,6 +2617,97 @@ void main() {
         'custom': 'single',
         'anthropic': 'none',
       });
+    });
+
+    test('v119 lets card rewriter debug runs record a selection bail', () async {
+      final file = File(
+        '${Directory.systemTemp.path}/glaze_mig_selection_${DateTime.now().microsecondsSinceEpoch}.db',
+      );
+      addTearDown(() async {
+        if (file.existsSync()) await file.delete();
+      });
+
+      final seeded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      await seeded.customSelect('SELECT 1').get();
+      await seeded.customStatement('DROP TABLE card_evolution_debug_runs');
+      // v118-shaped table: only model-backed stages, model always required.
+      await seeded.customStatement('''
+        CREATE TABLE card_evolution_debug_runs (
+          session_id TEXT NOT NULL, stage TEXT NOT NULL,
+          status TEXT NOT NULL, model TEXT NOT NULL, output TEXT NULL,
+          attempts_json TEXT NOT NULL, updated_at INTEGER NOT NULL,
+          PRIMARY KEY (session_id, stage),
+          CHECK (session_id <> '' AND stage IN ('card', 'lorebook')
+            AND status <> '' AND model <> '' AND attempts_json <> ''))
+      ''');
+      await seeded.customStatement(
+        'INSERT INTO card_evolution_debug_runs (session_id, stage, status, '
+        'model, output, attempts_json, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        ['session', 'card', 'ok', 'model-a', 'out', '[]', 10],
+      );
+      await expectLater(
+        seeded.customStatement(
+          'INSERT INTO card_evolution_debug_runs (session_id, stage, status, '
+          'model, output, attempts_json, updated_at) '
+          'VALUES (?, ?, ?, ?, ?, ?, ?)',
+          ['session', 'selection', 'notEligible', '', null, '[]', 20],
+        ),
+        throwsA(anything),
+      );
+      await seeded.customStatement('PRAGMA user_version = 118');
+      await seeded.close();
+
+      final upgraded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      addTearDown(() async => upgraded.close());
+
+      // A writer that bails before resolving a model has no model name.
+      await upgraded.customStatement(
+        'INSERT INTO card_evolution_debug_runs (session_id, stage, status, '
+        'model, output, attempts_json, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        ['session', 'selection', 'notEligible', '', null, '[{"a":1}]', 20],
+      );
+      final rows = await upgraded
+          .customSelect(
+            'SELECT stage, status, model FROM card_evolution_debug_runs '
+            'ORDER BY stage',
+          )
+          .get();
+      expect(rows.map((row) => row.read<String>('stage')).toList(), [
+        'card',
+        'selection',
+      ]);
+      // The pre-existing model diagnostic survives the table rebuild.
+      expect(rows.first.read<String>('model'), 'model-a');
+      expect(rows.last.read<String>('status'), 'notEligible');
+
+      // Model stages still require a model name, and unknown stages stay out.
+      await expectLater(
+        upgraded.customStatement(
+          'INSERT INTO card_evolution_debug_runs (session_id, stage, status, '
+          'model, output, attempts_json, updated_at) '
+          'VALUES (?, ?, ?, ?, ?, ?, ?)',
+          ['other', 'lorebook', 'ok', '', null, '[]', 30],
+        ),
+        throwsA(anything),
+      );
+      await expectLater(
+        upgraded.customStatement(
+          'INSERT INTO card_evolution_debug_runs (session_id, stage, status, '
+          'model, output, attempts_json, updated_at) '
+          'VALUES (?, ?, ?, ?, ?, ?, ?)',
+          ['other', 'bogus', 'ok', 'model-a', null, '[]', 30],
+        ),
+        throwsA(anything),
+      );
+
+      final version = await upgraded
+          .customSelect('PRAGMA user_version')
+          .getSingle();
+      expect(version.read<int>('user_version'), 119);
     });
 
     test('v111 resolves the retired session_id_mode default', () async {


### PR DESCRIPTION
## Problem

On a synced session the Card Rewriter showed `Card Rewriter running...`, disappeared about a second later without ever reaching the provider, and the Ledger toast took over. Nothing was written anywhere, so the cause could not be recovered afterwards:

- `CardEvolutionRepo._selectInput` collapsed nine distinct bail points (and every thrown exception) into a bare `null`, which the claim path reported as a single opaque `notEligible`.
- `notEligible`, `busy`, `stale` and friends are not in the Ledger stage failure set, so they render as a green "done" status that `startStatus(PostGenTask.ledger)` overwrites on the next line.
- `card_evolution_debug_runs` is only written after a model call, so a writer that bails earlier leaves no row.

## Changes

- `_selectInput` and `_selectedInputForClaim` now return `CardEvolutionSelection`, carrying a `CardEvolutionSelectionFailure` enum value for every bail point instead of `null`.
- `claim` reports that reason as `CardEvolutionClaimOutcome.detail`; `finalize` does the same for `staleEvidence`.
- New `readPromptSnapshotOutcome` returns the reason a live lease could not produce a snapshot; `readPromptSnapshot` stays as a thin nullable wrapper for existing callers.
- `AutomatedCardEvolutionService._runWriter` records a `selection` stage debug run (plus a `debugPrint`) when it bails before resolving a model, and forwards the reason in the finalize outcome. Failing to record the diagnostic never breaks the pipeline.
- `card_evolution_debug_runs` accepts the new `selection` stage and only requires a model name for the model-backed stages; schema bumped 118 -> 119 with a table rebuild.
- The Ledger stage logs the rewriter outcome next to the existing reconciliation log.

No behaviour change for the successful path: the same evidence is selected, the same claims are taken, and the same proposals are produced.

## Verification

- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze` — no issues found
- `flutter test` — 2929 tests passed, including a new v119 migration test and six new `CardEvolutionRepo` attribution tests