### PR TITLE
fix(studio): record Ledger parse and repair diagnostics

### DIFF
--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -51,6 +51,7 @@ part 'app_db.g.dart';
     LedgerReconciliationSuccessfulRuns,
     LedgerReconciliationRunInvalidations,
     LedgerReconciliationCursors,
+    LedgerDebugRuns,
     CardEvolutionClaims,
     CardEvolutionProposalRuns,
     CardEvolutionDebugRuns,
@@ -75,7 +76,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 119;
+  int get schemaVersion => 120;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -2220,6 +2221,12 @@ class AppDatabase extends _$AppDatabase {
         // 'selection' diagnostic row. Rebuild the table so its CHECK accepts
         // that stage and stops requiring a model name for it.
         await m.alterTable(TableMigration(cardEvolutionDebugRuns));
+      }
+      if (from < 120) {
+        // Ledger parse rejections and the repair call they silently trigger
+        // were only ever visible in debug console output, so a failing turn
+        // left nothing behind to diagnose.
+        await m.createTable(ledgerDebugRuns);
       }
     },
   );

--- a/lib/core/db/repositories/ledger_debug_run_repo.dart
+++ b/lib/core/db/repositories/ledger_debug_run_repo.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../models/agent_operation_record.dart';
+import '../../utils/id_generator.dart';
+import '../../utils/time_helpers.dart';
+import '../app_db.dart';
+
+/// Which Ledger entry point produced a diagnostic row.
+enum LedgerDebugRunKind {
+  /// Per-turn Studio Ledger run over the final assistant message.
+  normal,
+
+  /// Range reconciliation run over accepted chunks.
+  reconciliation,
+}
+
+/// One recorded Studio Ledger model exchange.
+///
+/// Rows are written even when the run succeeds, because the interesting
+/// question is usually "why did this turn need two model calls" rather than
+/// "did it ultimately apply ops".
+class LedgerDebugRun {
+  const LedgerDebugRun({
+    required this.sessionId,
+    required this.kind,
+    required this.status,
+    this.messageId = '',
+    this.swipeId = 0,
+    this.agentSwipeId = 0,
+    this.model = '',
+    this.parseFailure = 'none',
+    this.rejectionReason,
+    this.rejectedOps = const [],
+    this.repairAttempted = false,
+    this.repairFailure,
+    this.responseText,
+    this.repairResponseText,
+    this.attempts = const [],
+    this.error,
+    this.opsApplied = 0,
+    this.elapsedMs = 0,
+    this.promptChars = 0,
+    this.responseChars = 0,
+  });
+
+  final String sessionId;
+  final LedgerDebugRunKind kind;
+  final String status;
+  final String messageId;
+  final int swipeId;
+  final int agentSwipeId;
+  final String model;
+  final String parseFailure;
+  final String? rejectionReason;
+  final List<String> rejectedOps;
+  final bool repairAttempted;
+  final String? repairFailure;
+  final String? responseText;
+  final String? repairResponseText;
+  final List<AgentOperationAttempt> attempts;
+  final String? error;
+  final int opsApplied;
+  final int elapsedMs;
+  final int promptChars;
+  final int responseChars;
+}
+
+/// Bounded journal of Studio Ledger model exchanges.
+///
+/// Diagnostics must never be able to break or slow a Ledger turn, so every
+/// write is best-effort: failures are logged and swallowed, stored text is
+/// truncated, and old rows are trimmed as new ones arrive.
+class LedgerDebugRunRepo {
+  const LedgerDebugRunRepo(this.db);
+
+  final AppDatabase db;
+
+  /// Retained rows per session. Enough to cover a debugging session without
+  /// letting a long chat accumulate megabytes of raw model output.
+  static const int maxRunsPerSession = 50;
+
+  /// Upper bound for each stored response payload.
+  static const int maxStoredTextChars = 200000;
+
+  /// Records [run], trimming the session's journal to [maxRunsPerSession].
+  ///
+  /// Never throws: a diagnostic failure must not surface as a Ledger failure.
+  Future<void> record(LedgerDebugRun run) async {
+    if (run.sessionId.isEmpty || run.status.isEmpty) return;
+    try {
+      await db.transaction(() async {
+        await db
+            .into(db.ledgerDebugRuns)
+            .insert(
+              LedgerDebugRunsCompanion.insert(
+                id: 'ledger-debug-${generateId()}',
+                sessionId: run.sessionId,
+                kind: run.kind.name,
+                status: run.status,
+                messageId: Value(run.messageId),
+                swipeId: Value(run.swipeId),
+                agentSwipeId: Value(run.agentSwipeId),
+                model: Value(run.model),
+                parseFailure: Value(run.parseFailure),
+                rejectionReason: Value(_bounded(run.rejectionReason)),
+                rejectedOpsJson: Value(
+                  jsonEncode([
+                    for (final op in run.rejectedOps) _bounded(op) ?? '',
+                  ]),
+                ),
+                repairAttempted: Value(run.repairAttempted),
+                repairFailure: Value(run.repairFailure),
+                responseText: Value(_bounded(run.responseText)),
+                repairResponseText: Value(_bounded(run.repairResponseText)),
+                attemptsJson: Value(
+                  jsonEncode([
+                    for (final attempt in run.attempts) attempt.toJson(),
+                  ]),
+                ),
+                error: Value(_bounded(run.error)),
+                opsApplied: Value(run.opsApplied),
+                elapsedMs: Value(run.elapsedMs),
+                promptChars: Value(run.promptChars),
+                responseChars: Value(run.responseChars),
+                createdAt: currentTimestampSeconds(),
+              ),
+            );
+        await _trim(run.sessionId);
+      });
+    } catch (e) {
+      debugPrint('[StudioLedger] debug run not recorded: $e');
+    }
+  }
+
+  /// Most recent rows for [sessionId], newest first.
+  Future<List<LedgerDebugRunRow>> recentForSession(
+    String sessionId, {
+    int limit = 20,
+  }) {
+    final query = db.select(db.ledgerDebugRuns)
+      ..where((table) => table.sessionId.equals(sessionId))
+      ..orderBy([
+        (table) => OrderingTerm(
+          expression: table.createdAt,
+          mode: OrderingMode.desc,
+        ),
+        (table) =>
+            OrderingTerm(expression: table.id, mode: OrderingMode.desc),
+      ])
+      ..limit(limit);
+    return query.get();
+  }
+
+  Future<void> deleteBySessionId(String sessionId) {
+    return (db.delete(
+      db.ledgerDebugRuns,
+    )..where((table) => table.sessionId.equals(sessionId))).go();
+  }
+
+  Future<void> _trim(String sessionId) async {
+    await db.customStatement(
+      'DELETE FROM ledger_debug_runs WHERE session_id = ? AND id NOT IN ('
+      'SELECT id FROM ledger_debug_runs WHERE session_id = ? '
+      'ORDER BY created_at DESC, id DESC LIMIT ?)',
+      [sessionId, sessionId, maxRunsPerSession],
+    );
+  }
+
+  static String? _bounded(String? text) {
+    if (text == null) return null;
+    if (text.length <= maxStoredTextChars) return text;
+    return '${text.substring(0, maxStoredTextChars)}…[truncated]';
+  }
+}

--- a/lib/core/db/tables.dart
+++ b/lib/core/db/tables.dart
@@ -1103,6 +1103,68 @@ class CardEvolutionProposalRuns extends Table {
   ];
 }
 
+/// Rolling journal of Studio Ledger model exchanges kept for diagnosis.
+///
+/// A Ledger turn can silently spend a second model call: when the first
+/// response fails to parse in a repairable way the service issues a repair
+/// call. Nothing about that decision used to outlive the process, so a user
+/// seeing two provider requests had no way to learn why. Each row therefore
+/// records the raw response, the parser verdict that rejected it, whether a
+/// repair call followed, and the final outcome.
+///
+/// The journal is intentionally bounded: only recent rows are retained and
+/// stored payloads are truncated, because this is diagnostic state rather
+/// than canon provenance.
+@DataClassName('LedgerDebugRunRow')
+class LedgerDebugRuns extends Table {
+  @override
+  String get tableName => 'ledger_debug_runs';
+  TextColumn get id => text()();
+  TextColumn get sessionId => text()();
+
+  /// `normal` for the per-turn Ledger, `reconciliation` for range review.
+  TextColumn get kind => text()();
+  TextColumn get messageId => text().withDefault(const Constant(''))();
+  IntColumn get swipeId => integer().withDefault(const Constant(0))();
+  IntColumn get agentSwipeId => integer().withDefault(const Constant(0))();
+
+  /// Terminal [LedgerRunResult.status] for the run.
+  TextColumn get status => text()();
+  TextColumn get model => text().withDefault(const Constant(''))();
+
+  /// Parser failure class for the first response, e.g. `malformedJson`.
+  TextColumn get parseFailure => text().withDefault(const Constant('none'))();
+
+  /// Human-readable parser rejection text, when the response was rejected.
+  TextColumn get rejectionReason => text().nullable()();
+
+  /// Operations dropped by semantic validation, as a JSON array of strings.
+  TextColumn get rejectedOpsJson =>
+      text().withDefault(const Constant('[]'))();
+  BoolColumn get repairAttempted =>
+      boolean().withDefault(const Constant(false))();
+
+  /// Parser failure class after the repair response, when one was requested.
+  TextColumn get repairFailure => text().nullable()();
+  TextColumn get responseText => text().nullable()();
+  TextColumn get repairResponseText => text().nullable()();
+  TextColumn get attemptsJson => text().withDefault(const Constant('[]'))();
+  TextColumn get error => text().nullable()();
+  IntColumn get opsApplied => integer().withDefault(const Constant(0))();
+  IntColumn get elapsedMs => integer().withDefault(const Constant(0))();
+  IntColumn get promptChars => integer().withDefault(const Constant(0))();
+  IntColumn get responseChars => integer().withDefault(const Constant(0))();
+  IntColumn get createdAt => integer()();
+  @override
+  Set<Column> get primaryKey => {id};
+  @override
+  List<String> get customConstraints => [
+    "CHECK (id <> '' AND session_id <> '' "
+        "AND kind IN ('normal', 'reconciliation') "
+        "AND status <> '' AND attempts_json <> '' AND rejected_ops_json <> '')",
+  ];
+}
+
 /// Latest raw writer result retained per session and writer stage for Card
 /// Rewriter debugging. This is intentionally replaceable diagnostic state,
 /// unlike reviewable proposal provenance which remains immutable once

--- a/lib/core/llm/studio_ledger_export_parser.dart
+++ b/lib/core/llm/studio_ledger_export_parser.dart
@@ -67,11 +67,17 @@ class LedgerParseResult {
   /// single formatting repair is safe. Semantic rejections are never retried.
   final LedgerParseFailure failure;
 
+  /// Operations dropped by validation, as `key: reason` entries. Populated
+  /// even when the surviving export is returned, so a partially discarded
+  /// response can be diagnosed after the fact.
+  final List<String> rejectedOps;
+
   const LedgerParseResult({
     this.export,
     required this.visibleLedger,
     this.rejectionReason,
     this.failure = LedgerParseFailure.none,
+    this.rejectedOps = const [],
   });
 
   bool get hasExport => export != null;
@@ -167,7 +173,9 @@ class StudioLedgerExportParser {
     for (final op in export.ops) {
       final reason = _validateOp(op, focalUserName: focalUserName);
       if (reason != null) {
-        rejectedOps.add('${op.key}: $reason');
+        // Keep the verb: the same key can be legal for `set` and illegal for
+        // `append_unique`, so the key alone does not identify the mistake.
+        rejectedOps.add('${op.op} ${op.key}: $reason');
         debugPrint('[StudioLedger] rejected op ${op.op} ${op.key}: $reason');
       } else {
         validatedOps.add(op);
@@ -197,6 +205,7 @@ class StudioLedgerExportParser {
         failure: rejectedOps.isNotEmpty
             ? LedgerParseFailure.semanticSchema
             : LedgerParseFailure.emptyExport,
+        rejectedOps: rejectedOps,
       );
     }
 
@@ -207,6 +216,7 @@ class StudioLedgerExportParser {
     return LedgerParseResult(
       export: validatedExport,
       visibleLedger: visibleLedger,
+      rejectedOps: rejectedOps,
     );
   }
 

--- a/lib/core/llm/studio_ledger_service.dart
+++ b/lib/core/llm/studio_ledger_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import '../db/repositories/character_knowledge_fact_repo.dart';
 import '../db/repositories/character_repo.dart';
 import '../db/repositories/chat_repo.dart';
+import '../db/repositories/ledger_debug_run_repo.dart';
 import '../db/repositories/ledger_reconciliation_checkpoint_repo.dart';
 import '../db/repositories/ledger_reconciliation_run_repo.dart';
 import '../db/repositories/memory_book_repo.dart';
@@ -135,6 +136,7 @@ class StudioLedgerService {
   final StudioLedgerExportParser _parser;
   final StudioLedgerPrompt _promptBuilder;
   final LedgerOpApplier _opApplier;
+  final LedgerDebugRunRepo _debugRunRepo;
 
   StudioLedgerService({
     required this._llm,
@@ -147,9 +149,11 @@ class StudioLedgerService {
     required this._characterRepo,
     required this._chatRepo,
     required this._canonContextLoader,
+    LedgerDebugRunRepo? debugRunRepo,
   }) : _parser = const StudioLedgerExportParser(),
        _promptBuilder = const StudioLedgerPrompt(),
-       _opApplier = const LedgerOpApplier();
+       _opApplier = const LedgerOpApplier(),
+       _debugRunRepo = debugRunRepo ?? LedgerDebugRunRepo(_trackerRepo.db);
 
   Future<LedgerRunResult> reconcile({
     required String sessionId,
@@ -204,6 +208,39 @@ class StudioLedgerService {
   }
 
   Future<LedgerRunResult> _reconcileUnshared({
+    required String sessionId,
+    required PipelineSettings settings,
+    required AuxApiConfig config,
+    required LedgerReconciliationPlan plan,
+    List<StudioPresetBlock> ledgerBlocks = const [],
+    MacroContext? macroCtx,
+    FutureOr<bool> Function()? isStillCurrent,
+    CancelToken? cancelToken,
+  }) async {
+    final trace = _LedgerRunTrace(
+      sessionId: sessionId,
+      kind: LedgerDebugRunKind.reconciliation,
+      messageId: plan.endMessage.id,
+      swipeId: plan.endMessage.swipeId,
+      agentSwipeId: plan.endMessage.agentSwipeId,
+    );
+    final result = await _reconcileTraced(
+      trace: trace,
+      sessionId: sessionId,
+      settings: settings,
+      config: config,
+      plan: plan,
+      ledgerBlocks: ledgerBlocks,
+      macroCtx: macroCtx,
+      isStillCurrent: isStillCurrent,
+      cancelToken: cancelToken,
+    );
+    await _recordDebugRun(trace, result);
+    return result;
+  }
+
+  Future<LedgerRunResult> _reconcileTraced({
+    required _LedgerRunTrace trace,
     required String sessionId,
     required PipelineSettings settings,
     required AuxApiConfig config,
@@ -317,6 +354,11 @@ class StudioLedgerService {
         responseText,
         focalUserName: macroCtx?.userName ?? '',
       );
+      trace.recordFirstResponse(
+        model: config.model,
+        responseText: responseText,
+        parsed: parsed,
+      );
       final originalFailure = parsed.failure;
       final originalVisibleLedger = parsed.visibleLedger;
       var attempts = outcome.attempts;
@@ -336,6 +378,9 @@ class StudioLedgerService {
           return LedgerRunResult.aborted;
         }
         repairAttempted = true;
+        trace.recordRepairRequested(
+          exportRepair: needsExportRepair,
+        );
         if (_isOversizedRepairInput(responseText)) {
           return LedgerRunResult(
             status: 'error',
@@ -389,6 +434,10 @@ class StudioLedgerService {
             repairedText,
             focalUserName: macroCtx?.userName ?? '',
           );
+          trace.recordRepairResponse(
+            responseText: repairedText,
+            parsed: repaired,
+          );
           if (repaired.export != null &&
               !_repairPreservesStructuredEvidence(
                 responseText,
@@ -438,6 +487,7 @@ class StudioLedgerService {
           // The export was already valid. A cleanup-only repair must never
           // replace or reinterpret the authoritative tracker export.
           cleanupResponseText = repair.text!;
+          trace.recordRepairResponse(responseText: cleanupResponseText);
           final repairedCleanup = cleanupParser.parse(
             output: cleanupResponseText,
             offeredFacts: offeredFacts,
@@ -837,6 +887,53 @@ class StudioLedgerService {
     bool commitSnapshot = false,
     StudioLedgerEngine engine = StudioLedgerEngine.currentReconciled,
   }) async {
+    final trace = _LedgerRunTrace(
+      sessionId: sessionId,
+      kind: LedgerDebugRunKind.normal,
+      messageId: messageId,
+      swipeId: swipeId,
+      agentSwipeId: agentSwipeId,
+    );
+    final result = await _runTraced(
+      trace: trace,
+      sessionId: sessionId,
+      settings: settings,
+      config: config,
+      finalAssistantText: finalAssistantText,
+      recentHistoryText: recentHistoryText,
+      messageId: messageId,
+      swipeId: swipeId,
+      agentSwipeId: agentSwipeId,
+      forceEnabled: forceEnabled,
+      isStillCurrent: isStillCurrent,
+      cancelToken: cancelToken,
+      ledgerBlocks: ledgerBlocks,
+      macroCtx: macroCtx,
+      commitSnapshot: commitSnapshot,
+      engine: engine,
+    );
+    await _recordDebugRun(trace, result);
+    return result;
+  }
+
+  Future<LedgerRunResult> _runTraced({
+    required _LedgerRunTrace trace,
+    required String sessionId,
+    required PipelineSettings settings,
+    required AuxApiConfig config,
+    required String finalAssistantText,
+    required String recentHistoryText,
+    required String messageId,
+    required int swipeId,
+    required int agentSwipeId,
+    bool forceEnabled = false,
+    FutureOr<bool> Function()? isStillCurrent,
+    CancelToken? cancelToken,
+    List<StudioPresetBlock> ledgerBlocks = const [],
+    MacroContext? macroCtx,
+    bool commitSnapshot = false,
+    StudioLedgerEngine engine = StudioLedgerEngine.currentReconciled,
+  }) async {
     // Studio Ledger is always-on when Studio is enabled. forceEnabled is
     // still respected for manual triggers.
 
@@ -957,6 +1054,11 @@ class StudioLedgerService {
         effectiveResponse,
         focalUserName: macroCtx?.userName ?? '',
       );
+      trace.recordFirstResponse(
+        model: config.model,
+        responseText: rawResponse,
+        parsed: parseResult,
+      );
       final originalFailure = parseResult.failure;
       final originalVisibleLedger = parseResult.visibleLedger;
       var attempts = outcome.attempts;
@@ -986,6 +1088,7 @@ class StudioLedgerService {
           );
         }
         repairAttempted = true;
+        trace.recordRepairRequested(exportRepair: true);
         final repairPrompt = _buildRepairPrompt(effectiveResponse);
         totalPromptChars += repairPrompt.length;
         final repair = await _llm.callOnceWithLog(
@@ -1023,6 +1126,10 @@ class StudioLedgerService {
         parseResult = _parser.parse(
           effectiveResponse,
           focalUserName: macroCtx?.userName ?? '',
+        );
+        trace.recordRepairResponse(
+          responseText: effectiveResponse,
+          parsed: parseResult,
         );
         if (parseResult.export != null &&
             !_repairPreservesStructuredEvidence(
@@ -1515,6 +1622,43 @@ UNTRUSTED_INPUT_BASE64_END''';
     return true;
   }
 
+  /// Persists what the model returned and how the parser judged it.
+  ///
+  /// Skipped for runs that never reached the model (disabled, empty text) so
+  /// the journal stays a record of actual model exchanges. Recording a
+  /// successful run is deliberate: a silent second provider call is only
+  /// explainable when the healthy case is visible for comparison.
+  Future<void> _recordDebugRun(
+    _LedgerRunTrace trace,
+    LedgerRunResult result,
+  ) async {
+    if (!trace.reachedModel) return;
+    await _debugRunRepo.record(
+      LedgerDebugRun(
+        sessionId: trace.sessionId,
+        kind: trace.kind,
+        status: result.status,
+        messageId: trace.messageId,
+        swipeId: trace.swipeId,
+        agentSwipeId: trace.agentSwipeId,
+        model: result.model ?? trace.model,
+        parseFailure: trace.parseFailure,
+        rejectionReason: trace.rejectionReason,
+        rejectedOps: trace.rejectedOps,
+        repairAttempted: trace.repairAttempted || result.repairAttempted,
+        repairFailure: trace.repairFailure,
+        responseText: trace.responseText,
+        repairResponseText: trace.repairResponseText,
+        attempts: result.attempts,
+        error: result.error,
+        opsApplied: result.opsApplied,
+        elapsedMs: result.elapsedMs,
+        promptChars: result.promptChars,
+        responseChars: result.responseChars,
+      ),
+    );
+  }
+
   List<AgentOperationAttempt> _combineAttempts(
     List<AgentOperationAttempt> first,
     List<AgentOperationAttempt> second,
@@ -1701,6 +1845,68 @@ UNTRUSTED_INPUT_BASE64_END''';
     KnowledgeCleanupOpType.renameEntity =>
       'cleanup:rename:${op.fromKey}:${op.toKey}:${op.canonicalName}',
   };
+}
+
+/// Mutable notes gathered while a Ledger run executes.
+///
+/// The run itself has many early returns; collecting the diagnostic facts as
+/// they become known keeps a single write site at the end instead of one per
+/// exit path.
+class _LedgerRunTrace {
+  _LedgerRunTrace({
+    required this.sessionId,
+    required this.kind,
+    required this.messageId,
+    required this.swipeId,
+    required this.agentSwipeId,
+  });
+
+  final String sessionId;
+  final LedgerDebugRunKind kind;
+  final String messageId;
+  final int swipeId;
+  final int agentSwipeId;
+
+  bool reachedModel = false;
+  String model = '';
+  String parseFailure = 'none';
+  String? rejectionReason;
+  List<String> rejectedOps = const [];
+  bool repairAttempted = false;
+  String? repairFailure;
+  String? responseText;
+  String? repairResponseText;
+
+  void recordFirstResponse({
+    required String model,
+    required String responseText,
+    required LedgerParseResult parsed,
+  }) {
+    reachedModel = true;
+    this.model = model;
+    this.responseText = responseText;
+    parseFailure = parsed.failure.name;
+    rejectionReason = parsed.rejectionReason;
+    rejectedOps = parsed.rejectedOps;
+  }
+
+  void recordRepairRequested({required bool exportRepair}) {
+    repairAttempted = true;
+    if (!exportRepair) {
+      // The export parsed cleanly; only the cleanup block needed another pass.
+      repairFailure = 'cleanupBlockMissing';
+    }
+  }
+
+  void recordRepairResponse({
+    required String responseText,
+    LedgerParseResult? parsed,
+  }) {
+    repairResponseText = responseText;
+    if (parsed == null) return;
+    repairFailure = parsed.failure.name;
+    if (parsed.rejectedOps.isNotEmpty) rejectedOps = parsed.rejectedOps;
+  }
 }
 
 class _LedgerCanonContext {

--- a/lib/features/chat/widgets/post_gen_status_card.dart
+++ b/lib/features/chat/widgets/post_gen_status_card.dart
@@ -1,13 +1,24 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../state/post_gen_status_provider.dart';
 import 'chat_status_card_shell.dart';
 
+/// Longest a post-generation task may advertise itself as running.
+///
+/// Every stage clears its own status, but each of those paths needs a mounted
+/// ref. When the owning ref goes away mid-run nobody is left to write the
+/// terminal state and the card would spin forever. The bound is generous on
+/// purpose: an aux call may retry three times against a three-minute timeout,
+/// so anything past this window is a stranded indicator, not slow work.
+const Duration kPostGenRunningWatchdog = Duration(minutes: 12);
+
 /// Floating card shown at the top of the chat while post-generation tasks
 /// (Ledger, Card Rewriter, and extension blocks) are running. Auto-dismisses
-/// 2.5s after
-/// the last task completes.
+/// 2.5s after the last task completes, and can always be dismissed by hand
+/// while running so a stranded indicator never blocks the chat header.
 class PostGenStatusCard extends ConsumerStatefulWidget {
   const PostGenStatusCard({super.key, required this.sessionId});
 
@@ -20,6 +31,13 @@ class PostGenStatusCard extends ConsumerStatefulWidget {
 class _PostGenStatusCardState extends ConsumerState<PostGenStatusCard> {
   PostGenTaskPhase? _lastSeenPhase;
   PostGenTask? _lastSeenTask;
+  Timer? _watchdog;
+
+  @override
+  void dispose() {
+    _watchdog?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +49,8 @@ class _PostGenStatusCardState extends ConsumerState<PostGenStatusCard> {
         state.sessionId != widget.sessionId) {
       _lastSeenPhase = null;
       _lastSeenTask = null;
+      _watchdog?.cancel();
+      _watchdog = null;
       return const SizedBox.shrink();
     }
 
@@ -45,6 +65,8 @@ class _PostGenStatusCardState extends ConsumerState<PostGenStatusCard> {
       if (state.phase == PostGenTaskPhase.done ||
           state.phase == PostGenTaskPhase.error) {
         _scheduleAutoDismiss(state);
+      } else if (state.phase == PostGenTaskPhase.running) {
+        _scheduleWatchdog(state);
       }
     }
 
@@ -148,10 +170,25 @@ class _PostGenStatusCardState extends ConsumerState<PostGenStatusCard> {
       icon: icon,
       accent: accent,
       showSpinner: showSpinner,
+      action: showSpinner
+          ? IconButton(
+              icon: const Icon(Icons.close, size: 16),
+              tooltip: 'Hide status',
+              visualDensity: VisualDensity.compact,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+              // Hides the indicator only. The underlying task keeps running and
+              // is cancelled from its own control, so this can never leave the
+              // pipeline in a half-stopped state.
+              onPressed: _dismissRunning,
+            )
+          : null,
     );
   }
 
   void _scheduleAutoDismiss(PostGenStatusState expected) {
+    _watchdog?.cancel();
+    _watchdog = null;
     Future<void>.delayed(const Duration(milliseconds: 2500), () {
       if (!mounted) return;
       final current = ref.read(postGenStatusProvider);
@@ -160,5 +197,36 @@ class _PostGenStatusCardState extends ConsumerState<PostGenStatusCard> {
             const PostGenStatusState.idle();
       }
     });
+  }
+
+  /// Clears a running status that nobody is left to finish.
+  ///
+  /// Compares logically rather than by identity: the stranded state is the very
+  /// object we saw, but an equal-valued replacement is just as stuck, and the
+  /// point of the watchdog is that its owner is already gone.
+  void _scheduleWatchdog(PostGenStatusState expected) {
+    _watchdog?.cancel();
+    _watchdog = Timer(kPostGenRunningWatchdog, () {
+      if (!mounted) return;
+      final current = ref.read(postGenStatusProvider);
+      if (current.phase != PostGenTaskPhase.running ||
+          current.sessionId != expected.sessionId ||
+          current.task != expected.task) {
+        return;
+      }
+      debugPrint(
+        '[PostGenStatus] watchdog cleared stranded ${expected.task.name} '
+        'session=${expected.sessionId}',
+      );
+      ref.read(postGenStatusProvider.notifier).state =
+          const PostGenStatusState.idle();
+    });
+  }
+
+  void _dismissRunning() {
+    _watchdog?.cancel();
+    _watchdog = null;
+    ref.read(postGenStatusProvider.notifier).state =
+        const PostGenStatusState.idle();
   }
 }

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -1,4 +1,4 @@
-﻿import 'dart:convert';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -78,7 +78,7 @@ void main() {
 
       // user_version matches the Drift schema version (app_db.dart schemaVersion).
       // Update this constant whenever a new migration step is added.
-      expect(version, 119);
+      expect(version, 120);
     });
 
     test(
@@ -232,7 +232,7 @@ void main() {
         final version = await upgraded
             .customSelect('PRAGMA user_version')
             .get();
-        expect(version.first.read<int>('user_version'), 119);
+        expect(version.first.read<int>('user_version'), 120);
         expect(names, contains('variant_group_id'));
         expect(names, contains('hidden'));
       },
@@ -262,7 +262,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
     });
 
     test(
@@ -611,7 +611,7 @@ void main() {
 
     test('current schema includes atomic character fact tables', () async {
       final version = await db.customSelect('PRAGMA user_version').getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
 
       final factColumns = await db
           .customSelect("PRAGMA table_info('character_knowledge_fact_rows')")
@@ -723,7 +723,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
     });
 
     test(
@@ -833,7 +833,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
     });
 
     test('v80 adds Responses API toggle defaulting to off', () async {
@@ -873,7 +873,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
     });
 
     test('v81 adds composite embedding source index', () async {
@@ -907,7 +907,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
     });
 
     test('v82 creates rewrite persistence schema and provenance columns', () async {
@@ -981,7 +981,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
     });
 
     test('v83 rebuilds interim text revision columns without losing rows', () async {
@@ -1433,7 +1433,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
 
       // Rows and payloads survive; legacy statuses pass through or are
       // normalized fail-closed, and new columns carry neutral defaults.
@@ -1638,7 +1638,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
       final row = await upgraded
           .customSelect(
             'SELECT blocks_json FROM studio_preset_rows WHERE preset_id = ?',
@@ -1754,7 +1754,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
       final check = await upgraded.customSelect('PRAGMA integrity_check').get();
       expect(check.single.read<String>('integrity_check'), 'ok');
     });
@@ -2418,7 +2418,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
     });
 
     test(
@@ -2515,7 +2515,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
     });
 
     test('v118 adds prompt post-processing with none for every config', () async {
@@ -2707,7 +2707,93 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 119);
+      expect(version.read<int>('user_version'), 120);
+    });
+
+    test('v120 adds the ledger debug journal to an older database', () async {
+      final file = File(
+        '${Directory.systemTemp.path}/glaze_mig_ledger_debug_${DateTime.now().microsecondsSinceEpoch}.db',
+      );
+      addTearDown(() async {
+        if (file.existsSync()) await file.delete();
+      });
+
+      final seeded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      await seeded.customSelect('SELECT 1').get();
+      // A v119 database predates the journal entirely.
+      await seeded.customStatement('DROP TABLE ledger_debug_runs');
+      await seeded.customStatement('PRAGMA user_version = 119');
+      await seeded.close();
+
+      final upgraded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      addTearDown(() async => upgraded.close());
+
+      await upgraded.customStatement(
+        'INSERT INTO ledger_debug_runs (id, session_id, kind, message_id, '
+        'swipe_id, agent_swipe_id, status, model, parse_failure, '
+        'rejection_reason, rejected_ops_json, repair_attempted, '
+        'repair_failure, response_text, repair_response_text, attempts_json, '
+        'error, ops_applied, elapsed_ms, prompt_chars, response_chars, '
+        'created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '
+        '?, ?, ?, ?, ?, ?)',
+        [
+          'ledger-debug-1',
+          'session',
+          'normal',
+          'message',
+          0,
+          0,
+          'error',
+          'model-a',
+          'malformedJson',
+          'malformed JSON: unexpected end of input',
+          '["op[0] rejected"]',
+          1,
+          'none',
+          'raw',
+          'repaired',
+          '[]',
+          'parse failed',
+          0,
+          1200,
+          900,
+          400,
+          10,
+        ],
+      );
+      final rows = await upgraded
+          .customSelect(
+            'SELECT kind, parse_failure, repair_attempted, rejected_ops_json '
+            'FROM ledger_debug_runs',
+          )
+          .get();
+      expect(rows, hasLength(1));
+      expect(rows.single.read<String>('kind'), 'normal');
+      expect(rows.single.read<String>('parse_failure'), 'malformedJson');
+      expect(rows.single.read<int>('repair_attempted'), 1);
+      expect(
+        rows.single.read<String>('rejected_ops_json'),
+        '["op[0] rejected"]',
+      );
+
+      // Only the two real Ledger call sites may write to the journal.
+      await expectLater(
+        upgraded.customStatement(
+          'INSERT INTO ledger_debug_runs (id, session_id, kind, status, '
+          'created_at) VALUES (?, ?, ?, ?, ?)',
+          ['ledger-debug-2', 'session', 'bogus', 'ok', 20],
+        ),
+        throwsA(anything),
+      );
+
+      final version = await upgraded
+          .customSelect('PRAGMA user_version')
+          .getSingle();
+      expect(version.read<int>('user_version'), 120);
     });
 
     test('v111 resolves the retired session_id_mode default', () async {

--- a/test/ledger_debug_run_repo_test.dart
+++ b/test/ledger_debug_run_repo_test.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/ledger_debug_run_repo.dart';
+import 'package:glaze_flutter/core/models/agent_operation_record.dart';
+
+void main() {
+  late AppDatabase db;
+  late LedgerDebugRunRepo repo;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    repo = LedgerDebugRunRepo(db);
+  });
+  tearDown(() => db.close());
+
+  test('records a rejected response with the reason and repair payload', () async {
+    await repo.record(
+      LedgerDebugRun(
+        sessionId: 'session',
+        kind: LedgerDebugRunKind.normal,
+        status: 'error',
+        messageId: 'message',
+        swipeId: 2,
+        agentSwipeId: 1,
+        model: 'google/gemini-3.7-flash',
+        parseFailure: 'malformedJson',
+        rejectionReason: 'malformed JSON: unexpected end of input',
+        rejectedOps: const ['op[0] set: missing key'],
+        repairAttempted: true,
+        repairFailure: 'emptyExport',
+        responseText: 'first response',
+        repairResponseText: 'repair response',
+        attempts: const [
+          AgentOperationAttempt(
+            attempt: 1,
+            statusCode: 200,
+            status: 'ok',
+            startedAtMs: 5,
+            elapsedMs: 30,
+          ),
+        ],
+        error: 'export rejected',
+        elapsedMs: 1200,
+        promptChars: 900,
+        responseChars: 400,
+      ),
+    );
+
+    final rows = await repo.recentForSession('session');
+    expect(rows, hasLength(1));
+    final row = rows.single;
+    expect(row.kind, 'normal');
+    expect(row.messageId, 'message');
+    expect(row.swipeId, 2);
+    expect(row.agentSwipeId, 1);
+    expect(row.parseFailure, 'malformedJson');
+    expect(row.rejectionReason, 'malformed JSON: unexpected end of input');
+    expect(jsonDecode(row.rejectedOpsJson), ['op[0] set: missing key']);
+    // The silent second call is the whole point of the journal.
+    expect(row.repairAttempted, isTrue);
+    expect(row.repairFailure, 'emptyExport');
+    expect(row.responseText, 'first response');
+    expect(row.repairResponseText, 'repair response');
+    expect(jsonDecode(row.attemptsJson), hasLength(1));
+    expect(row.error, 'export rejected');
+  });
+
+  test('truncates oversized payloads instead of storing them whole', () async {
+    final huge = 'x' * (LedgerDebugRunRepo.maxStoredTextChars + 500);
+    await repo.record(
+      LedgerDebugRun(
+        sessionId: 'session',
+        kind: LedgerDebugRunKind.reconciliation,
+        status: 'ok',
+        responseText: huge,
+      ),
+    );
+
+    final row = (await repo.recentForSession('session')).single;
+    expect(row.responseText, isNotNull);
+    expect(
+      row.responseText!.length,
+      lessThan(LedgerDebugRunRepo.maxStoredTextChars + 100),
+    );
+    expect(row.responseText, endsWith('[truncated]'));
+  });
+
+  test('keeps the journal bounded per session', () async {
+    for (var i = 0; i < LedgerDebugRunRepo.maxRunsPerSession + 5; i++) {
+      await repo.record(
+        LedgerDebugRun(
+          sessionId: 'session',
+          kind: LedgerDebugRunKind.normal,
+          status: 'ok',
+          messageId: 'message-$i',
+        ),
+      );
+    }
+    await repo.record(
+      const LedgerDebugRun(
+        sessionId: 'other',
+        kind: LedgerDebugRunKind.normal,
+        status: 'ok',
+      ),
+    );
+
+    final kept = await db
+        .customSelect(
+          "SELECT COUNT(*) AS c FROM ledger_debug_runs "
+          "WHERE session_id = 'session'",
+        )
+        .getSingle();
+    expect(kept.read<int>('c'), LedgerDebugRunRepo.maxRunsPerSession);
+    // Trimming is scoped to the session that just wrote.
+    final others = await repo.recentForSession('other');
+    expect(others, hasLength(1));
+  });
+
+  test('a rejected write never surfaces as a Ledger failure', () async {
+    // An empty status violates the table CHECK; the repo must swallow it.
+    await repo.record(
+      const LedgerDebugRun(
+        sessionId: 'session',
+        kind: LedgerDebugRunKind.normal,
+        status: '',
+      ),
+    );
+    expect(await repo.recentForSession('session'), isEmpty);
+  });
+
+  test('deletes a session journal', () async {
+    await repo.record(
+      const LedgerDebugRun(
+        sessionId: 'session',
+        kind: LedgerDebugRunKind.normal,
+        status: 'ok',
+      ),
+    );
+    await repo.deleteBySessionId('session');
+    expect(await repo.recentForSession('session'), isEmpty);
+  });
+}

--- a/test/post_gen_status_card_test.dart
+++ b/test/post_gen_status_card_test.dart
@@ -77,4 +77,105 @@ void main() {
     expect(find.text('Card Rewriter running...'), findsOneWidget);
     expect(find.byType(GlazeSpinner), findsOneWidget);
   });
+
+  testWidgets('a running badge can always be dismissed by hand', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container
+        .read(postGenStatusProvider.notifier)
+        .state = const PostGenStatusState.running(
+      sessionId: 'session-1',
+      task: PostGenTask.ledger,
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: PostGenStatusCard(sessionId: 'session-1')),
+        ),
+      ),
+    );
+    expect(find.text('Ledger running...'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pump();
+
+    // A stage whose ref went away can no longer clear the badge, so the user
+    // must be able to. The pipeline keeps running; only the indicator goes.
+    expect(container.read(postGenStatusProvider).phase, PostGenTaskPhase.idle);
+    expect(find.text('Ledger running...'), findsNothing);
+  });
+
+  testWidgets('a stranded running badge is cleared by the watchdog', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container
+        .read(postGenStatusProvider.notifier)
+        .state = const PostGenStatusState.running(
+      sessionId: 'session-1',
+      task: PostGenTask.ledger,
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: PostGenStatusCard(sessionId: 'session-1')),
+        ),
+      ),
+    );
+    expect(find.text('Ledger running...'), findsOneWidget);
+
+    await tester.pump(kPostGenRunningWatchdog + const Duration(seconds: 1));
+    await tester.pump();
+
+    expect(container.read(postGenStatusProvider).phase, PostGenTaskPhase.idle);
+    expect(find.text('Ledger running...'), findsNothing);
+  });
+
+  testWidgets('the watchdog leaves a newer running task alone', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container
+        .read(postGenStatusProvider.notifier)
+        .state = const PostGenStatusState.running(
+      sessionId: 'session-1',
+      task: PostGenTask.ledger,
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(body: PostGenStatusCard(sessionId: 'session-1')),
+        ),
+      ),
+    );
+
+    // A later task takes over the slot just before the first watchdog fires.
+    await tester.pump(kPostGenRunningWatchdog - const Duration(seconds: 1));
+    container
+        .read(postGenStatusProvider.notifier)
+        .state = const PostGenStatusState.running(
+      sessionId: 'session-1',
+      task: PostGenTask.cardRewriter,
+    );
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 5));
+
+    // The first task's deadline must not cut short the task that replaced it.
+    expect(
+      container.read(postGenStatusProvider).task,
+      PostGenTask.cardRewriter,
+    );
+    expect(find.text('Card Rewriter running...'), findsOneWidget);
+
+    // Drain the rescheduled timer so the test does not end with one pending.
+    await tester.pump(kPostGenRunningWatchdog);
+  });
 }

--- a/test/studio_ledger_test.dart
+++ b/test/studio_ledger_test.dart
@@ -193,6 +193,11 @@ void main() {
       final result = parser.parse(raw);
       expect(result.export, isNull);
       expect(result.rejectionReason, contains('all ops rejected'));
+      // Which ops were dropped is the only way to tell a prompt-shape problem
+      // from a model regression, so the reasons must survive the parse.
+      expect(result.rejectedOps, hasLength(2));
+      expect(result.rejectedOps.join('\n'), contains('append_unique'));
+      expect(result.rejectedOps.join('\n'), contains('npc:Lucy.knowledge'));
     });
 
     test('legacy per-turn compatibility profile is parser-compatible', () {

--- a/test/studio_ledger_transaction_test.dart
+++ b/test/studio_ledger_transaction_test.dart
@@ -14,6 +14,7 @@ import 'package:glaze_flutter/core/db/repositories/character_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/character_revision_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/character_session_baseline_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/chat_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/ledger_debug_run_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_checkpoint_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_run_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/memory_book_repo.dart';
@@ -904,6 +905,64 @@ void main() {
       expect(result.status, 'aborted');
       expect(endpoint.requests(), 1);
       expect(await trackers.get('session', 'world:time'), isNull);
+    });
+
+    test('a silent repair call is recorded with both responses', () async {
+      final endpoint = await _serveSequence([malformed, _repairResponse]);
+      addTearDown(endpoint.close);
+
+      expect((await run(endpoint.url)).status, 'ok');
+
+      final journal = await LedgerDebugRunRepo(
+        db,
+      ).recentForSession('session');
+      expect(journal, hasLength(1));
+      final row = journal.single;
+      expect(row.kind, 'normal');
+      expect(row.messageId, 'a1');
+      expect(row.status, 'ok');
+      // The whole point: a healthy-looking turn that silently cost two calls.
+      expect(row.repairAttempted, isTrue);
+      expect(row.parseFailure, 'incompleteJson');
+      expect(row.rejectionReason, isNotNull);
+      expect(row.responseText, contains('"ops"'));
+      expect(row.repairResponseText, contains('01:00'));
+      expect(jsonDecode(row.attemptsJson), hasLength(2));
+    });
+
+    test('a rejected export keeps the raw response for inspection', () async {
+      final endpoint = await _serveSequence([semanticInvalid]);
+      addTearDown(endpoint.close);
+
+      expect((await run(endpoint.url)).status, 'error');
+
+      final row = (await LedgerDebugRunRepo(
+        db,
+      ).recentForSession('session')).single;
+      expect(row.status, 'error');
+      expect(row.repairAttempted, isFalse);
+      expect(row.parseFailure, 'semanticSchema');
+      // Without the rejected op text there is no way to tell whether the model
+      // regressed or the prompt drifted.
+      expect(jsonDecode(row.rejectedOpsJson), hasLength(1));
+      expect(row.rejectedOpsJson, contains('world:time'));
+      expect(row.responseText, contains('explode'));
+    });
+
+    test('a run that never reaches the model writes no journal row', () async {
+      final result = await service.run(
+        sessionId: 'session',
+        settings: const PipelineSettings(),
+        config: _config('http://127.0.0.1:1'),
+        finalAssistantText: '   ',
+        recentHistoryText: 'Start',
+        messageId: 'a1',
+        swipeId: 0,
+        agentSwipeId: 0,
+      );
+
+      expect(result.status, 'skipped');
+      expect(await LedgerDebugRunRepo(db).recentForSession('session'), isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Problem

Studio Ledger fires a second, silent repair call whenever the export parser
judges the first response repairable (`studio_ledger_service.dart` in both the
per-turn and reconciliation paths). None of that exchange is persisted, so after
the fact a turn that quietly cost two provider calls looks identical to a healthy
one. Rejected ops were only ever `debugPrint`ed.

Separately, a post-generation status badge could stay on `running` forever:
every path that writes a terminal state in `ledger_stage.dart` requires a
mounted ref, and the card only auto-dismisses the `done`/`error` phases.

## Changes

- Add `ledger_debug_runs`: a bounded per-session journal (50 rows, payloads
  truncated at 200k chars) recording the raw response, parse failure, rejection
  reason, rejected ops, repair payload, attempts, model, sizes, and outcome for
  both Ledger entry points. Schema 119 -> 120.
- Write the journal from a run-scoped trace so the many early returns in
  `StudioLedgerService` share one write site. Runs that never reach the model
  are not recorded.
- Surface rejected ops on `LedgerParseResult` instead of only logging them, and
  include the op verb so the same key is attributable to the right operation.
- Make the diagnostic write best-effort: a rejected or failing insert is logged
  and swallowed, never turning into a Ledger failure.
- Clear a stranded `running` badge with a 12-minute watchdog and give the
  running card a manual dismiss button. Dismissing hides the indicator only; the
  underlying task keeps running and is cancelled from its own control.

## Verification

- `dart run build_runner build --delete-conflicting-outputs`
- `flutter analyze` — no issues found
- `flutter test` — 2941 passed
- New coverage: journal repo (record, truncation, per-session trimming, swallowed
  failure, delete), v120 migration against a v119-shaped database, service-level
  assertions that a silent repair and a rejected export are both recorded while a
  skipped run is not, parser rejected-op reasons, and widget tests for the
  watchdog and manual dismiss.