### PR TITLE
chore(ci): put the bug-triage workflow on stable so its cron fires

### DIFF
--- a/.github/workflows/bug-triage-check.yml
+++ b/.github/workflows/bug-triage-check.yml
@@ -1,0 +1,40 @@
+name: Bug triage — connection check
+
+# Read-only smoke test: verifies Discord / Trello / DeepSeek creds + IDs work.
+# Creates nothing, comments nothing. Runs on pushes to the feature branch while
+# we're wiring it up, and can be dispatched manually once merged.
+on:
+  push:
+    branches: [feat/bug-triage-agent]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps (check only needs requests)
+        run: pip install requests
+
+      - name: Connection check
+        working-directory: tools/bug_triage
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
+          TRELLO_KEY: ${{ secrets.TRELLO_KEY }}
+          TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
+          TRELLO_BOARD_ID: ${{ vars.TRELLO_BOARD_ID }}
+          TRELLO_NEW_BUG_LIST_ID: ${{ vars.TRELLO_NEW_BUG_LIST_ID }}
+          TRELLO_AUDITED_LABEL_ID: ${{ vars.TRELLO_AUDITED_LABEL_ID }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
+          DISCORD_FORUM_CHANNEL_ID: ${{ vars.DISCORD_FORUM_CHANNEL_ID }}
+        run: python check_connections.py

--- a/.github/workflows/bug-triage.yml
+++ b/.github/workflows/bug-triage.yml
@@ -1,0 +1,51 @@
+name: Bug triage (Discord + Trello)
+
+on:
+  schedule:
+    # Once a day, 18:00 UTC. Cron is UTC-only.
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run without creating cards / posting comments"
+        type: boolean
+        default: false
+
+# Read-only on the repo: the agent physically cannot push code or open a PR.
+permissions:
+  contents: read
+
+concurrency:
+  group: bug-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (agent needs the source to audit)
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: pip install -r tools/bug_triage/requirements.txt
+
+      - name: Run triage
+        working-directory: tools/bug_triage
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
+          TRELLO_KEY: ${{ secrets.TRELLO_KEY }}
+          TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
+          TRELLO_BOARD_ID: ${{ vars.TRELLO_BOARD_ID }}
+          TRELLO_NEW_BUG_LIST_ID: ${{ vars.TRELLO_NEW_BUG_LIST_ID }}
+          TRELLO_AUDITED_LABEL_ID: ${{ vars.TRELLO_AUDITED_LABEL_ID }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+          DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
+          DISCORD_FORUM_CHANNEL_ID: ${{ vars.DISCORD_FORUM_CHANNEL_ID }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: python triage.py

--- a/tools/bug_triage/README.md
+++ b/tools/bug_triage/README.md
@@ -1,0 +1,96 @@
+# Bug-triage agent
+
+A daily, **read-only** agent that keeps the Trello board in sync with the Discord
+bug-report forum and drops an AI audit on each open bug. It **never** changes
+code or opens PRs — it only creates Trello cards and posts comments for a human
+to act on.
+
+## What it does (once per day)
+
+1. Fetches Discord forum posts (active + archived-public threads) via the REST
+   API — no persistent gateway connection. **Closed posts are skipped**: locked
+   threads, archived (closed) threads, and posts carrying an ignored forum tag.
+   Note Discord also auto-archives inactive posts, so a quiet-but-open report is
+   dropped too; set `DISCORD_SKIP_ARCHIVED=false` to triage those as well.
+2. Fetches all Trello cards from the main board.
+3. For any Discord post **not yet on the board**, creates a card in the "new
+   bugs" list, with a back-link to the Discord thread in the description.
+4. If nothing needs auditing, **exits before calling the LLM** (no token spend).
+5. For each card **in the audited list(s)** without the `audited` label, runs a
+   DeepSeek agent over that ONE report — title, original post and replies
+   together — that greps / reads the checked-out source, then posts a structured
+   audit as a comment and applies the `audited` label. Cards elsewhere on the
+   board are never touched.
+
+Reports that cannot be judged from text (screenshot-only posts, missing repro
+steps) get a **NEED MORE INFO** comment naming what to ask instead of a guess.
+A post with no readable text at all skips the LLM entirely.
+
+De-dup has no external database: each mirrored card carries a hidden
+`discord-thread:<id>` marker in its description, and that's the source of truth.
+
+## Architecture
+
+Only the **audit** step is agentic (DeepSeek + `search_code`/`read_file` tools,
+via Pydantic AI). Polling, card creation and de-dup are plain deterministic code
+— cheaper and more reliable than handing those to the model.
+
+```
+triage.py         orchestrator + early-exit
+config.py         env-var loading (fails fast on missing secrets)
+discord_client.py read-only forum access (REST)
+trello_client.py  cards / comments / labels (source of truth)
+auditor.py        Pydantic AI agent (DeepSeek) + structured BugAudit output
+```
+
+## Secrets & variables (GitHub → Settings)
+
+**Secrets** (`Settings → Secrets and variables → Actions → Secrets`):
+
+| Name | What |
+|------|------|
+| `DEEPSEEK_API_KEY` | DeepSeek API key |
+| `TRELLO_KEY` / `TRELLO_TOKEN` | Trello API key + token |
+| `DISCORD_BOT_TOKEN` | Bot token (scope `bot`, perms: Read Messages, Read Message History) |
+
+**Variables** (`… → Variables`) — non-secret IDs:
+
+| Name | What | Default |
+|------|------|---------|
+| `DEEPSEEK_MODEL` | model id | `deepseek-chat` |
+| `TRELLO_BOARD_ID` | main board id | — |
+| `TRELLO_NEW_BUG_LIST_ID` | list where new bugs land | — |
+| `TRELLO_AUDITED_LABEL_ID` | label id meaning "AI audited" | — |
+| `DISCORD_GUILD_ID` | your server id | — |
+| `DISCORD_FORUM_CHANNEL_ID` | the bug-report forum channel id | — |
+| `DISCORD_IGNORED_TAG_IDS` | forum tag ids meaning closed (comma-separated) | empty |
+| `DISCORD_SKIP_ARCHIVED` | treat archived threads as closed | `true` |
+| `TRELLO_AUDIT_LIST_IDS` | lists eligible for audit (comma-separated) | the new-bug list |
+| `MAX_NEW_CARDS_PER_RUN` | cap on cards created per run (0 = unlimited) | `25` |
+| `MAX_AUDITS_PER_RUN` | cap on DeepSeek audits per run (0 = unlimited) | `15` |
+
+The connection check prints the forum's tag names with their ids, so run it
+once and copy the closed/solved tag id into `DISCORD_IGNORED_TAG_IDS`.
+
+Finding IDs:
+- Trello: append `.json` to a board URL, or hit
+  `https://api.trello.com/1/members/me/boards?key=…&token=…`.
+- Discord: enable Developer Mode → right-click → "Copy ID".
+
+## Running locally
+
+```bash
+pip install -r requirements.txt
+# export all the env vars above, then:
+DRY_RUN=true python triage.py   # dry-run: fetches + logs, no writes
+```
+
+## Schedule
+
+Daily at 18:00 UTC (`.github/workflows/bug-triage.yml`). Trigger manually from
+the Actions tab ("Run workflow"), optionally with **dry run** checked.
+
+> **Scheduled runs only fire from the repository's default branch** (`stable`).
+> On `nightly` or a feature branch the cron is inert — only `workflow_dispatch`
+> works there. The daily 18:00 UTC run starts once this file reaches `stable`
+> through the normal `nightly` → `staging` → `stable` promotion.

--- a/tools/bug_triage/auditor.py
+++ b/tools/bug_triage/auditor.py
@@ -1,0 +1,157 @@
+"""The only agentic part of the pipeline.
+
+A DeepSeek-backed Pydantic AI agent gets two read-only tools to explore the
+checked-out repo (ripgrep search + file read) and must return a *structured*
+audit. It never edits code, never opens PRs — the orchestrator only posts its
+output as a Trello comment for a human to act on.
+
+One report is audited per agent run: title, original post and replies travel
+together, but threads are never mixed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+# Repo root = two levels up from this file (tools/bug_triage/auditor.py).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_MAX_FILE_BYTES = 40_000
+_MAX_RG_MATCHES = 60
+
+_SYSTEM_PROMPT = """\
+You are a bug-triage engineer for Glaze, a Flutter (Dart) LLM roleplay frontend.
+You receive ONE bug report at a time: its title, the original post, and any
+replies from the thread. Judge them together — a reply often carries the repro
+steps or the correction that the title alone is missing.
+
+Your job: investigate the CURRENT source code using the `search_code` and
+`read_file` tools, then produce a structured audit. Rules:
+- Only claim something is a bug if the code actually supports it. If you cannot
+  reproduce the cause from the code, say so and set confidence low.
+- Prefer concrete file:line references over vague statements.
+- Propose a fix as a description, NOT as a patch. Do not invent files.
+- Be concise. A human will read this in a Trello comment.
+
+You CANNOT see images. When a report leans on screenshots, or the text is too
+vague to tell what actually went wrong, set `needs_more_info` to true and put
+the specific questions a human should ask in `missing_info`. Never guess the
+contents of an attachment, and never invent repro steps that were not reported.
+"""
+
+
+class BugAudit(BaseModel):
+    is_actionable: bool = Field(
+        description="True if this is a real, reproducible bug worth fixing."
+    )
+    severity: Literal["low", "medium", "high", "critical", "unknown"]
+    summary: str = Field(description="One-paragraph restatement of the bug.")
+    root_cause: str = Field(
+        description="Suspected cause with file:line refs, or why it's unclear."
+    )
+    proposed_fix: str = Field(description="Fix direction in prose, no code patch.")
+    relevant_files: list[str] = Field(default_factory=list)
+    confidence: Literal["low", "medium", "high"]
+    needs_more_info: bool = Field(
+        default=False,
+        description=(
+            "True when the report cannot be judged from text alone — e.g. it "
+            "relies on screenshots you cannot see, or lacks repro steps."
+        ),
+    )
+    missing_info: str = Field(
+        default="",
+        description="What exactly to ask the reporter, when needs_more_info is true.",
+    )
+    notes: str = Field(default="", description="Anything a human should double-check.")
+
+
+def _safe_path(rel: str) -> Path | None:
+    """Resolve a user-supplied path and confine it inside the repo."""
+    p = (REPO_ROOT / rel).resolve()
+    try:
+        p.relative_to(REPO_ROOT)
+    except ValueError:
+        return None
+    return p
+
+
+def build_agent(api_key: str, base_url: str, model_name: str) -> Agent[None, BugAudit]:
+    model = OpenAIModel(
+        model_name,
+        provider=OpenAIProvider(base_url=base_url, api_key=api_key),
+    )
+    agent: Agent[None, BugAudit] = Agent(
+        model,
+        output_type=BugAudit,
+        system_prompt=_SYSTEM_PROMPT,
+        retries=2,
+    )
+
+    @agent.tool_plain
+    def search_code(pattern: str) -> str:
+        """Regex-search the repo (ripgrep). Returns matching `path:line: text`."""
+        try:
+            out = subprocess.run(
+                ["rg", "--line-number", "--no-heading", "--max-count", "20",
+                 "--glob", "!**/*.g.dart", "--glob", "!**/*.freezed.dart",
+                 pattern],
+                cwd=REPO_ROOT, capture_output=True, text=True, timeout=30,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+            return f"search unavailable: {e}"
+        lines = out.stdout.splitlines()
+        if not lines:
+            return "no matches"
+        return "\n".join(lines[:_MAX_RG_MATCHES])
+
+    @agent.tool_plain
+    def read_file(path: str) -> str:
+        """Read a repo file (relative path). Truncated to 40KB."""
+        p = _safe_path(path)
+        if p is None or not p.is_file():
+            return f"not found or outside repo: {path}"
+        data = p.read_text(encoding="utf-8", errors="replace")
+        if len(data) > _MAX_FILE_BYTES:
+            return data[:_MAX_FILE_BYTES] + "\n... [truncated]"
+        return data
+
+    return agent
+
+
+def format_comment(audit: BugAudit, source_url: str | None) -> str:
+    """Render the audit as a Trello comment (markdown-ish)."""
+    src = f"\nSource: {source_url}" if source_url else ""
+
+    if audit.needs_more_info:
+        asks = audit.missing_info.strip() or (
+            "The report relies on context that is not readable from text "
+            "(screenshots?). Ask the reporter for steps to reproduce."
+        )
+        return (
+            f"\u26a0\ufe0f **NEED MORE INFO** \u2014 automated triage could not "
+            f"judge this report.{src}\n\n"
+            f"**What was understood**\n{audit.summary}\n\n"
+            f"**What is missing**\n{asks}\n\n"
+            f"*(No audit was performed. Nothing was changed.)*"
+        )
+
+    files = "\n".join(f"- {f}" for f in audit.relevant_files) or "- (none identified)"
+    verdict = "actionable" if audit.is_actionable else "NOT clearly actionable"
+    notes = f"\n**Notes:** {audit.notes}" if audit.notes else ""
+    return (
+        f"\U0001f916 **Automated audit** (DeepSeek) \u2014 {verdict}, severity "
+        f"**{audit.severity}**, confidence **{audit.confidence}**{src}\n\n"
+        f"**Summary**\n{audit.summary}\n\n"
+        f"**Suspected root cause**\n{audit.root_cause}\n\n"
+        f"**Proposed fix (needs human approval \u2014 nothing was changed)**\n"
+        f"{audit.proposed_fix}\n\n"
+        f"**Relevant files**\n{files}{notes}"
+    )

--- a/tools/bug_triage/check_connections.py
+++ b/tools/bug_triage/check_connections.py
@@ -1,0 +1,176 @@
+"""Read-only smoke test. Verifies every credential/ID works BEFORE the real run.
+
+Creates nothing, comments nothing. For DeepSeek it sends one tiny 1-token
+request just to confirm the key + model are valid.
+
+Run:  python check_connections.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import requests
+
+from config import Config
+from discord_client import DiscordClient
+from trello_client import TrelloClient
+
+OK = "OK  "
+BAD = "FAIL"
+
+
+def _line(status: str, label: str, detail: str = "") -> None:
+    print(f"[{status}] {label}" + (f" — {detail}" if detail else ""))
+
+
+def check_discord(cfg: Config) -> bool:
+    h = {"Authorization": f"Bot {cfg.discord_bot_token}"}
+    try:
+        me = requests.get(
+            "https://discord.com/api/v10/users/@me", headers=h, timeout=20
+        )
+        me.raise_for_status()
+        _line(OK, "Discord token", f"bot = {me.json().get('username')}")
+
+        ch = requests.get(
+            f"https://discord.com/api/v10/channels/{cfg.discord_forum_channel_id}",
+            headers=h, timeout=20,
+        )
+        ch.raise_for_status()
+        c = ch.json()
+        kind = "forum" if c.get("type") == 15 else f"type={c.get('type')} (NOT a forum?)"
+        _line(OK, "Discord forum channel", f"{c.get('name')} [{kind}]")
+
+        dc = DiscordClient(
+            cfg.discord_bot_token,
+            cfg.discord_guild_id,
+            cfg.discord_forum_channel_id,
+            ignored_tag_ids=cfg.discord_ignored_tag_ids,
+            skip_archived=cfg.discord_skip_archived,
+        )
+
+        tags = dc.available_tags()
+        if tags:
+            listed = ", ".join(f"{t.get('name')}={t.get('id')}" for t in tags)
+            _line(OK, "Discord forum tags", listed)
+            _line(OK, "Ignored tag ids",
+                  ", ".join(cfg.discord_ignored_tag_ids) or
+                  "(none set — put closed/solved tag ids in DISCORD_IGNORED_TAG_IDS)")
+        else:
+            _line(OK, "Discord forum tags", "none configured on the channel")
+
+        threads = dc._threads()
+        closed = sum(1 for t in threads if dc.is_closed(t)[0])
+        _line(OK, "Discord closed filter",
+              f"{closed} of {len(threads)} thread(s) treated as closed "
+              f"(skip_archived={cfg.discord_skip_archived})")
+
+        posts = dc.fetch_posts()
+        empty = sum(1 for p in posts if not p.has_text)
+        _line(OK, "Discord forum read",
+              f"{len(posts)} open post(s), {empty} without readable text")
+        if posts and empty == len(posts):
+            _line(BAD, "Discord message content",
+                  "all bodies empty → enable MESSAGE CONTENT INTENT")
+            return False
+        return True
+    except requests.HTTPError as e:
+        _line(BAD, "Discord", f"{e.response.status_code} {e.response.text[:120]}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        _line(BAD, "Discord", str(e))
+        return False
+
+
+def check_trello(cfg: Config) -> bool:
+    auth = {"key": cfg.trello_key, "token": cfg.trello_token}
+    try:
+        b = requests.get(
+            f"https://api.trello.com/1/boards/{cfg.trello_board_id}",
+            params={**auth, "fields": "name"}, timeout=20,
+        )
+        b.raise_for_status()
+        _line(OK, "Trello board", b.json().get("name"))
+
+        cards = TrelloClient(
+            cfg.trello_key, cfg.trello_token, cfg.trello_board_id
+        ).fetch_cards()
+        linked = sum(1 for c in cards if c.discord_thread_id)
+        _line(OK, "Trello cards read", f"{len(cards)} card(s), {linked} discord-linked")
+
+        lst = requests.get(
+            f"https://api.trello.com/1/lists/{cfg.trello_new_bug_list_id}",
+            params={**auth, "fields": "name,idBoard"}, timeout=20,
+        )
+        lst.raise_for_status()
+        lj = lst.json()
+        on_board = lj.get("idBoard") == cfg.trello_board_id
+        _line(OK if on_board else BAD, "Trello new-bug list",
+              f"{lj.get('name')}" + ("" if on_board else " — list is NOT on this board!"))
+        if not on_board:
+            return False
+
+        lbls = requests.get(
+            f"https://api.trello.com/1/boards/{cfg.trello_board_id}/labels",
+            params={**auth, "fields": "name"}, timeout=20,
+        )
+        lbls.raise_for_status()
+        ids = {l["id"] for l in lbls.json()}
+        if cfg.trello_audited_label_id in ids:
+            _line(OK, "Trello audited label", "found on board")
+        else:
+            _line(BAD, "Trello audited label",
+                  "id not found on this board → wrong TRELLO_AUDITED_LABEL_ID")
+            return False
+        return True
+    except requests.HTTPError as e:
+        _line(BAD, "Trello", f"{e.response.status_code} {e.response.text[:120]}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        _line(BAD, "Trello", str(e))
+        return False
+
+
+def check_deepseek(cfg: Config) -> bool:
+    try:
+        r = requests.post(
+            f"{cfg.deepseek_base_url}/chat/completions",
+            headers={"Authorization": f"Bearer {cfg.deepseek_api_key}"},
+            json={
+                "model": cfg.deepseek_model,
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 1,
+            },
+            timeout=30,
+        )
+        r.raise_for_status()
+        _line(OK, "DeepSeek", f"model {cfg.deepseek_model} responded")
+        return True
+    except requests.HTTPError as e:
+        _line(BAD, "DeepSeek", f"{e.response.status_code} {e.response.text[:160]}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        _line(BAD, "DeepSeek", str(e))
+        return False
+
+
+def main() -> int:
+    try:
+        cfg = Config.load()
+    except SystemExit as e:
+        print(e)
+        return 2
+
+    print("=== bug-triage connection check (read-only) ===")
+    results = [check_discord(cfg), check_trello(cfg), check_deepseek(cfg)]
+    print("=" * 47)
+    if all(results):
+        print("ALL GOOD ✅  — safe to run triage.py (try DRY_RUN=true first).")
+        return 0
+    print("SOME CHECKS FAILED ❌ — fix the FAIL lines above.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/bug_triage/config.py
+++ b/tools/bug_triage/config.py
@@ -1,0 +1,96 @@
+"""Central config: everything comes from env vars (GitHub Secrets in CI).
+
+Nothing here has a real default for a secret — a missing secret raises loudly
+so a misconfigured workflow fails fast instead of silently doing nothing.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _require(name: str) -> str:
+    val = os.environ.get(name, "").strip()
+    if not val:
+        raise SystemExit(f"[config] missing required env var: {name}")
+    return val
+
+
+def _optional(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _csv(name: str) -> tuple[str, ...]:
+    raw = _optional(name)
+    return tuple(x.strip() for x in raw.split(",") if x.strip())
+
+
+def _audit_lists() -> tuple[str, ...]:
+    """Lists whose cards may be audited (comma-separated ids).
+
+    Falls back to the new-bug list alone, which is the intended scope: the AI
+    must never comment on unrelated cards elsewhere on the board.
+    """
+    raw = _optional("TRELLO_AUDIT_LIST_IDS")
+    if raw:
+        return tuple(x.strip() for x in raw.split(",") if x.strip())
+    return (_require("TRELLO_NEW_BUG_LIST_ID"),)
+
+
+@dataclass(frozen=True)
+class Config:
+    # --- DeepSeek (OpenAI-compatible) ---
+    deepseek_api_key: str
+    deepseek_base_url: str
+    deepseek_model: str
+
+    # --- Trello ---
+    trello_key: str
+    trello_token: str
+    trello_board_id: str
+    trello_new_bug_list_id: str  # where freshly-discovered bugs land
+    trello_audited_label_id: str  # label meaning "AI already audited this"
+    # Only cards in these lists are ever audited. Defaults to the new-bug list,
+    # so the rest of the board is never touched.
+    trello_audit_list_ids: tuple[str, ...]
+
+    # --- Discord ---
+    discord_bot_token: str
+    discord_guild_id: str
+    discord_forum_channel_id: str
+    # Forum tag ids that mean "closed" (e.g. Solved / Duplicate / Won't fix).
+    discord_ignored_tag_ids: tuple[str, ...]
+    # Closed forum posts show up as archived, so they are skipped like locked
+    # ones. Set DISCORD_SKIP_ARCHIVED=false to also triage auto-archived posts.
+    discord_skip_archived: bool
+
+    # --- Behaviour ---
+    dry_run: bool  # if true: don't create cards / post comments, just log
+    # Per-run ceilings so a first run over a long-lived forum can't flood the
+    # board or the token budget in one go. 0 = unlimited.
+    max_new_cards_per_run: int
+    max_audits_per_run: int
+
+    @staticmethod
+    def load() -> "Config":
+        return Config(
+            deepseek_api_key=_require("DEEPSEEK_API_KEY"),
+            deepseek_base_url=_optional("DEEPSEEK_BASE_URL", "https://api.deepseek.com"),
+            deepseek_model=_optional("DEEPSEEK_MODEL", "deepseek-chat"),
+            trello_key=_require("TRELLO_KEY"),
+            trello_token=_require("TRELLO_TOKEN"),
+            trello_board_id=_require("TRELLO_BOARD_ID"),
+            trello_new_bug_list_id=_require("TRELLO_NEW_BUG_LIST_ID"),
+            trello_audited_label_id=_require("TRELLO_AUDITED_LABEL_ID"),
+            trello_audit_list_ids=_audit_lists(),
+            discord_bot_token=_require("DISCORD_BOT_TOKEN"),
+            discord_guild_id=_require("DISCORD_GUILD_ID"),
+            discord_forum_channel_id=_require("DISCORD_FORUM_CHANNEL_ID"),
+            discord_ignored_tag_ids=_csv("DISCORD_IGNORED_TAG_IDS"),
+            discord_skip_archived=_optional("DISCORD_SKIP_ARCHIVED", "true").lower()
+            in ("1", "true", "yes"),
+            dry_run=_optional("DRY_RUN", "false").lower() in ("1", "true", "yes"),
+            max_new_cards_per_run=int(_optional("MAX_NEW_CARDS_PER_RUN", "25")),
+            max_audits_per_run=int(_optional("MAX_AUDITS_PER_RUN", "15")),
+        )

--- a/tools/bug_triage/discord_client.py
+++ b/tools/bug_triage/discord_client.py
@@ -1,0 +1,174 @@
+"""Read-only Discord forum access via the REST API (no gateway/socket needed).
+
+A forum channel's "posts" are threads. For every thread we collect the title,
+the starter message, and the replies — each thread is audited on its own, so
+the whole conversation travels together as one bug report.
+
+Closed posts are skipped. "Closed" is not one flag in Discord, so three cases
+are handled separately:
+  * locked      — a moderator closed the post. Always skipped.
+  * tagged      — forum tags like "Solved"/"Duplicate"; skipped when their ids
+                  are listed in DISCORD_IGNORED_TAG_IDS.
+  * archived    — how a closed forum post presents itself; skipped by default.
+                  Note Discord also auto-archives inactive posts, so this drops
+                  quiet-but-open reports too; DISCORD_SKIP_ARCHIVED=false keeps
+                  them.
+
+Attachments are counted but never downloaded: the auditor cannot see images, so
+a report that leans on screenshots is flagged for a human instead of guessed at.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+_API = "https://discord.com/api/v10"
+
+# How many messages of a thread to pull (newest page). Plenty for a bug report.
+_MSG_LIMIT = 100
+# Replies longer than this are trimmed so one rambling thread can't blow up the
+# prompt; the auditor gets the gist, a human still has the Discord link.
+_MAX_REPLY_CHARS = 1500
+
+
+@dataclass(frozen=True)
+class ForumPost:
+    thread_id: str
+    title: str
+    body: str
+    replies: tuple[str, ...]
+    attachment_count: int
+    url: str
+
+    @property
+    def has_text(self) -> bool:
+        return bool(self.body.strip() or any(r.strip() for r in self.replies))
+
+
+class DiscordClient:
+    def __init__(
+        self,
+        bot_token: str,
+        guild_id: str,
+        forum_channel_id: str,
+        ignored_tag_ids: tuple[str, ...] = (),
+        skip_archived: bool = True,
+    ):
+        self._guild_id = guild_id
+        self._forum_channel_id = forum_channel_id
+        self._ignored_tags = set(ignored_tag_ids)
+        self._skip_archived = skip_archived
+        self._s = requests.Session()
+        self._s.headers.update(
+            {
+                "Authorization": f"Bot {bot_token}",
+                "User-Agent": "GlazeBugTriage (https://github.com/hydall/Glaze, 1.0)",
+            }
+        )
+
+    def _get(self, path: str, **params) -> Any:
+        r = self._s.get(f"{_API}{path}", params=params or None, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+    def available_tags(self) -> list[dict]:
+        """Forum tags configured on the channel (id + name), for configuring
+        DISCORD_IGNORED_TAG_IDS."""
+        ch = self._get(f"/channels/{self._forum_channel_id}")
+        return ch.get("available_tags", []) or []
+
+    def _threads(self) -> list[dict]:
+        """Active + archived-public threads belonging to the forum channel."""
+        by_id: dict[str, dict] = {}
+
+        # Active threads are returned guild-wide; filter by parent channel.
+        active = self._get(f"/guilds/{self._guild_id}/threads/active")
+        for t in active.get("threads", []):
+            if str(t.get("parent_id")) == self._forum_channel_id:
+                by_id[str(t["id"])] = t
+
+        # Archived public threads live under the channel itself.
+        archived = self._get(
+            f"/channels/{self._forum_channel_id}/threads/archived/public"
+        )
+        for t in archived.get("threads", []):
+            by_id.setdefault(str(t["id"]), t)
+
+        return [by_id[k] for k in sorted(by_id)]
+
+    def is_closed(self, thread: dict) -> tuple[bool, str]:
+        """(closed?, reason) for one thread object."""
+        meta = thread.get("thread_metadata") or {}
+        if meta.get("locked"):
+            return True, "locked"
+        tags = {str(t) for t in (thread.get("applied_tags") or [])}
+        hit = tags & self._ignored_tags
+        if hit:
+            return True, f"tagged {sorted(hit)}"
+        if self._skip_archived and meta.get("archived"):
+            return True, "archived (closed)"
+        return False, ""
+
+    @staticmethod
+    def _attachment_count(msg: dict) -> int:
+        embeds = [e for e in msg.get("embeds", []) if e.get("type") == "image"]
+        return len(msg.get("attachments", [])) + len(embeds)
+
+    def _thread_content(self, thread_id: str) -> tuple[str, tuple[str, ...], int]:
+        """Return (starter_body, replies, attachment_count) for one thread."""
+        msgs: list[dict] = self._get(
+            f"/channels/{thread_id}/messages", limit=_MSG_LIMIT
+        )
+        msgs = list(reversed(msgs))  # API returns newest-first; read chronologically
+        if not msgs:
+            return "", (), 0
+
+        attachments = sum(self._attachment_count(m) for m in msgs)
+
+        # In a forum thread the starter message shares the thread's id.
+        starter = next((m for m in msgs if str(m.get("id")) == thread_id), msgs[0])
+        body = (starter.get("content") or "").strip()
+
+        replies: list[str] = []
+        for m in msgs:
+            if m is starter:
+                continue
+            text = (m.get("content") or "").strip()
+            if not text and not self._attachment_count(m):
+                continue  # join/system noise
+            author = (m.get("author") or {}).get("username", "unknown")
+            if len(text) > _MAX_REPLY_CHARS:
+                text = text[:_MAX_REPLY_CHARS] + " …[trimmed]"
+            if not text:
+                text = "(image/attachment only)"
+            replies.append(f"{author}: {text}")
+
+        return body, tuple(replies), attachments
+
+    def fetch_posts(self) -> list[ForumPost]:
+        posts: list[ForumPost] = []
+        skipped = 0
+        for thread in self._threads():
+            closed, reason = self.is_closed(thread)
+            if closed:
+                skipped += 1
+                print(f"[discord] skip closed thread {thread.get('id')} ({reason})")
+                continue
+            tid = str(thread["id"])
+            body, replies, attachments = self._thread_content(tid)
+            posts.append(
+                ForumPost(
+                    thread_id=tid,
+                    title=(thread.get("name") or "(untitled)").strip(),
+                    body=body,
+                    replies=replies,
+                    attachment_count=attachments,
+                    url=f"https://discord.com/channels/{self._guild_id}/{tid}",
+                )
+            )
+        if skipped:
+            print(f"[discord] {skipped} closed thread(s) ignored")
+        return posts

--- a/tools/bug_triage/requirements.txt
+++ b/tools/bug_triage/requirements.txt
@@ -1,0 +1,4 @@
+# Bug-triage agent dependencies (Python 3.11+)
+# Slim Pydantic AI + only the OpenAI-compatible backend (DeepSeek speaks it).
+pydantic-ai-slim[openai]==0.0.49
+requests==2.32.3

--- a/tools/bug_triage/trello_client.py
+++ b/tools/bug_triage/trello_client.py
@@ -1,0 +1,90 @@
+"""Trello REST access. The board is the source of truth; we never store state
+elsewhere.
+
+De-dup contract: every card created from a Discord post carries a hidden marker
+line in its description:
+
+    discord-thread:<thread_id>
+
+so "is this bug already on the board?" is just a substring scan over card
+descriptions — survives workflow restarts with no external DB.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import requests
+
+_API = "https://api.trello.com/1"
+_MARKER_RE = re.compile(r"discord-thread:(\d+)")
+
+
+def marker_for(thread_id: str) -> str:
+    return f"discord-thread:{thread_id}"
+
+
+@dataclass(frozen=True)
+class Card:
+    id: str
+    name: str
+    desc: str
+    list_id: str
+    label_ids: tuple[str, ...]
+
+    @property
+    def discord_thread_id(self) -> str | None:
+        m = _MARKER_RE.search(self.desc)
+        return m.group(1) if m else None
+
+
+class TrelloClient:
+    def __init__(self, key: str, token: str, board_id: str, dry_run: bool = False):
+        self._board_id = board_id
+        self._dry_run = dry_run
+        self._auth = {"key": key, "token": token}
+        self._s = requests.Session()
+
+    def _req(self, method: str, path: str, **params) -> dict | list:
+        r = self._s.request(
+            method, f"{_API}{path}", params={**self._auth, **params}, timeout=30
+        )
+        r.raise_for_status()
+        return r.json() if r.text else {}
+
+    def fetch_cards(self) -> list[Card]:
+        raw = self._req(
+            "GET",
+            f"/boards/{self._board_id}/cards",
+            fields="name,desc,idList,idLabels",
+        )
+        return [
+            Card(
+                id=c["id"],
+                name=c.get("name", ""),
+                desc=c.get("desc", ""),
+                list_id=c.get("idList", ""),
+                label_ids=tuple(c.get("idLabels", [])),
+            )
+            for c in raw  # type: ignore[union-attr]
+        ]
+
+    def create_card(self, list_id: str, name: str, desc: str) -> str:
+        if self._dry_run:
+            print(f"[dry-run] would create card: {name!r}")
+            return "dry-run-card-id"
+        card = self._req("POST", "/cards", idList=list_id, name=name, desc=desc)
+        return card["id"]  # type: ignore[index]
+
+    def add_comment(self, card_id: str, text: str) -> None:
+        if self._dry_run:
+            print(f"[dry-run] would comment on {card_id}: {text[:80]}...")
+            return
+        self._req("POST", f"/cards/{card_id}/actions/comments", text=text)
+
+    def add_label(self, card_id: str, label_id: str) -> None:
+        if self._dry_run:
+            print(f"[dry-run] would label {card_id} with {label_id}")
+            return
+        self._req("POST", f"/cards/{card_id}/idLabels", value=label_id)

--- a/tools/bug_triage/triage.py
+++ b/tools/bug_triage/triage.py
@@ -1,0 +1,171 @@
+"""Orchestrator. Runs once per invocation (the workflow schedules it daily).
+
+Flow (only the audit step touches the LLM):
+  1. Pull Discord forum posts + Trello cards.
+  2. Any Discord post with no matching card  -> create a card (with back-link).
+  3. Collect cards that are in an audited list and still lack the label.
+  4. EARLY EXIT: if nothing needs auditing, stop before calling DeepSeek.
+  5. For each such card: run the agent on that ONE report (title + post +
+     replies), post the result as a comment, then apply the "audited" label.
+
+Nothing here ever modifies source code or opens a PR.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from auditor import build_agent, format_comment
+from config import Config
+from discord_client import DiscordClient, ForumPost
+from trello_client import Card, TrelloClient, marker_for
+
+# Below this much readable text a report cannot be audited at all, so we skip
+# the LLM entirely and ask a human for details instead of burning tokens.
+_MIN_REPORT_CHARS = 15
+
+
+def _card_body(post: ForumPost) -> str:
+    """Title/body/replies of one thread, plus the de-dup marker footer."""
+    parts = [post.body.strip() or "(no text in the original post)"]
+
+    if post.replies:
+        parts.append("**Replies from the thread:**")
+        parts.extend(f"- {r}" for r in post.replies)
+
+    footer = ["---"]
+    if post.attachment_count:
+        footer.append(
+            f"Attachments: {post.attachment_count} — images are NOT readable by "
+            f"the triage agent."
+        )
+    footer.append(f"Reported on Discord: {post.url}")
+    footer.append(marker_for(post.thread_id))
+
+    return "\n\n".join(parts) + "\n\n" + "\n".join(footer)
+
+
+def _report_text(desc: str) -> str:
+    """The human-written part of a card description (footer stripped)."""
+    return desc.split("\n---\n", 1)[0].replace(
+        "(no text in the original post)", ""
+    ).strip()
+
+
+def _unreadable_comment(card: Card, source_url: str | None) -> str:
+    src = f"\nSource: {source_url}" if source_url else ""
+    return (
+        f"\u26a0\ufe0f **NEED MORE INFO** \u2014 this report carries no readable "
+        f"text.{src}\n\n"
+        f"It looks like screenshots or attachments only. Please add: what you "
+        f"did, what you expected, and what happened instead.\n\n"
+        f"*(No audit was performed. Nothing was changed.)*"
+    )
+
+
+def main() -> int:
+    cfg = Config.load()
+
+    discord = DiscordClient(
+        cfg.discord_bot_token,
+        cfg.discord_guild_id,
+        cfg.discord_forum_channel_id,
+        ignored_tag_ids=cfg.discord_ignored_tag_ids,
+        skip_archived=cfg.discord_skip_archived,
+    )
+    trello = TrelloClient(
+        cfg.trello_key, cfg.trello_token, cfg.trello_board_id, dry_run=cfg.dry_run
+    )
+
+    posts = discord.fetch_posts()
+    cards = trello.fetch_cards()
+    known_threads = {c.discord_thread_id for c in cards if c.discord_thread_id}
+    print(f"[triage] discord posts={len(posts)} trello cards={len(cards)} "
+          f"already-linked-threads={len(known_threads)}")
+
+    # --- Step 2: mirror new Discord posts into Trello -----------------------
+    new_posts = [p for p in posts if p.thread_id not in known_threads]
+    if cfg.max_new_cards_per_run and len(new_posts) > cfg.max_new_cards_per_run:
+        print(f"[triage] {len(new_posts)} new thread(s); capped to "
+              f"{cfg.max_new_cards_per_run} this run (MAX_NEW_CARDS_PER_RUN)")
+        new_posts = new_posts[: cfg.max_new_cards_per_run]
+
+    created: list[Card] = []
+    for post in new_posts:
+        body = _card_body(post)
+        new_id = trello.create_card(cfg.trello_new_bug_list_id, post.title, body)
+        print(f"[triage] created card for thread {post.thread_id}: {post.title!r}")
+        created.append(
+            Card(
+                id=new_id,
+                name=post.title,
+                desc=body,
+                list_id=cfg.trello_new_bug_list_id,
+                label_ids=(),
+            )
+        )
+
+    # --- Step 3: which cards may be audited? --------------------------------
+    # Scope is deliberately narrow: only the configured bug list(s), never the
+    # whole board, so the agent can't comment on unrelated cards.
+    to_audit = [
+        c for c in (cards + created)
+        if c.list_id in cfg.trello_audit_list_ids
+        and cfg.trello_audited_label_id not in c.label_ids
+    ]
+
+    # --- Step 4: early exit before spending any tokens ---------------------
+    if not to_audit:
+        print("[triage] nothing new to audit — exiting before LLM.")
+        return 0
+
+    if cfg.max_audits_per_run and len(to_audit) > cfg.max_audits_per_run:
+        print(f"[triage] {len(to_audit)} card(s) pending; auditing "
+              f"{cfg.max_audits_per_run} this run (MAX_AUDITS_PER_RUN)")
+        to_audit = to_audit[: cfg.max_audits_per_run]
+
+    agent = None  # built lazily: unreadable-only batches never need the LLM
+    failures = 0
+
+    for card in to_audit:
+        source_url = None
+        if card.discord_thread_id:
+            source_url = (
+                f"https://discord.com/channels/{cfg.discord_guild_id}/"
+                f"{card.discord_thread_id}"
+            )
+
+        # Cheap path: nothing to read -> ask a human, don't call DeepSeek.
+        if len(_report_text(card.desc)) < _MIN_REPORT_CHARS:
+            trello.add_comment(card.id, _unreadable_comment(card, source_url))
+            trello.add_label(card.id, cfg.trello_audited_label_id)
+            print(f"[triage] NEED MORE INFO (no text) for card {card.id}")
+            continue
+
+        if agent is None:
+            print(f"[triage] using model {cfg.deepseek_model}")
+            agent = build_agent(
+                cfg.deepseek_api_key, cfg.deepseek_base_url, cfg.deepseek_model
+            )
+
+        prompt = f"Bug title: {card.name}\n\nBug report:\n{card.desc}"
+        try:
+            result = agent.run_sync(prompt)
+        except Exception as e:  # noqa: BLE001 — one bad card must not sink the run
+            print(f"[triage] audit FAILED for card {card.id}: {e}", file=sys.stderr)
+            failures += 1
+            continue
+
+        trello.add_comment(card.id, format_comment(result.output, source_url))
+        trello.add_label(card.id, cfg.trello_audited_label_id)
+        flag = " [NEED MORE INFO]" if result.output.needs_more_info else ""
+        print(f"[triage] audited card {card.id}: {card.name!r}{flag}")
+
+    if failures:
+        print(f"[triage] completed with {failures} audit failure(s).", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Follow-up to #279, which landed the bug-triage agent on `nightly`.

## Why this targets `stable` directly

GitHub only fires `schedule` triggers from the repository default branch (`stable`), and the manual "Run workflow" button also requires the workflow file to exist there. While the agent lives only on `nightly`, the daily 18:00 UTC cron never runs.

The normal promotion path (`nightly` -> `staging` -> `stable`) would work, but it would also ship the 275 commits currently unreleased on `nightly` into the stable channel — a full app release, when the goal is only to start a cron.

## What this contains

- Cherry-pick of the squashed #279 commit, nothing else.
- 10 files, all CI-only tooling: `.github/workflows/bug-triage*.yml` and `tools/bug_triage/**` (Python).
- No Dart, no `pubspec`, no assets — nothing that ships in the app or changes a build.

## Risk

- The workflow runs with `permissions: contents: read`, so it cannot modify source or open PRs.
- It only creates Trello cards and posts comments; source is read-only to the agent.
- Card creation and audits are capped per run (`MAX_NEW_CARDS_PER_RUN`, `MAX_AUDITS_PER_RUN`), and the run exits before calling the LLM when there is nothing to audit.

## Verification

`check_connections.py` (read-only, writes nothing) is green on the feature branch:

- closed filter: 48 of 85 Discord threads treated as closed, 37 open posts remain, 3 without readable text
- Trello board, `Known Bugs` list and `audited` label resolved
- DeepSeek model responded

`Analyze + test` passed on #279 with the same tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)