### PR TITLE
Bug triage: make the DeepSeek calls actually work (prompted JSON, live logs, timeout)

### DIFF
--- a/.github/workflows/bug-triage-check.yml
+++ b/.github/workflows/bug-triage-check.yml
@@ -39,4 +39,4 @@ jobs:
           DISCORD_FORUM_CHANNEL_ID: ${{ vars.DISCORD_FORUM_CHANNEL_ID }}
           DISCORD_IGNORED_TAG_IDS: ${{ vars.DISCORD_IGNORED_TAG_IDS }}
           DISCORD_SKIP_ARCHIVED: ${{ vars.DISCORD_SKIP_ARCHIVED }}
-        run: python check_connections.py
+        run: python -u check_connections.py

--- a/.github/workflows/bug-triage.yml
+++ b/.github/workflows/bug-triage.yml
@@ -22,6 +22,9 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    # A thinking model auditing a dozen reports takes minutes, not seconds —
+    # but it must never sit on a runner for hours if a call hangs.
+    timeout-minutes: 45
     steps:
       - name: Checkout (agent needs the source to audit)
         uses: actions/checkout@v4
@@ -54,4 +57,6 @@ jobs:
           MAX_NEW_CARDS_PER_RUN: ${{ vars.MAX_NEW_CARDS_PER_RUN }}
           MAX_AUDITS_PER_RUN: ${{ vars.MAX_AUDITS_PER_RUN }}
           DRY_RUN: ${{ inputs.dry_run }}
-        run: python triage.py
+        # -u: unbuffered, so progress shows up in the Actions log live
+        # instead of arriving in one block when the process exits.
+        run: python -u triage.py

--- a/.github/workflows/bug-triage.yml
+++ b/.github/workflows/bug-triage.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     # A thinking model auditing a dozen reports takes minutes, not seconds —
     # but it must never sit on a runner for hours if a call hangs.
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout (agent needs the source to audit)
         uses: actions/checkout@v4

--- a/tools/bug_triage/auditor.py
+++ b/tools/bug_triage/auditor.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, Field
-from pydantic_ai import Agent
+from pydantic_ai import Agent, PromptedOutput
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
@@ -90,7 +90,12 @@ def build_agent(api_key: str, base_url: str, model_name: str) -> Agent[None, Bug
     )
     agent: Agent[None, BugAudit] = Agent(
         model,
-        output_type=BugAudit,
+        # PromptedOutput, not the default forced output tool: DeepSeek's
+        # thinking models reject `tool_choice` pinned to a specific tool
+        # ("Thinking mode does not support this tool_choice", HTTP 400). Asking
+        # for the JSON in the prompt keeps `search_code` / `read_file` as
+        # ordinary optional tools, which those models do accept.
+        output_type=PromptedOutput(BugAudit),
         system_prompt=_SYSTEM_PROMPT,
         retries=2,
     )

--- a/tools/bug_triage/matcher.py
+++ b/tools/bug_triage/matcher.py
@@ -24,7 +24,7 @@ import re
 import sys
 
 from pydantic import BaseModel, Field
-from pydantic_ai import Agent
+from pydantic_ai import Agent, PromptedOutput
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
@@ -81,7 +81,8 @@ def build_matcher(api_key: str, base_url: str, model_name: str) -> Agent[None, C
     )
     return Agent(
         model,
-        output_type=CardMatch,
+        # Prompted JSON rather than a forced output tool — see auditor.py.
+        output_type=PromptedOutput(CardMatch),
         system_prompt=_SYSTEM_PROMPT,
         retries=2,
     )


### PR DESCRIPTION
Follow-up to #282, cut fresh from `nightly` (replaces #284, whose branch predated the squash merge and could no longer be merged). The first real dispatch surfaced two failures that only a live run could show.

## Every model call returned HTTP 400

`Thinking mode does not support this tool_choice`. Pydantic AI's default structured output pins `tool_choice` to a synthetic output tool, and the thinking models (`deepseek-v4-flash` here) reject that outright — so all 13 audits and every duplicate lookup failed, and the run mirrored each thread without ever comparing it to the board.

- Both agents now use `PromptedOutput(...)`: the schema is asked for in the prompt and parsed from the reply, with no pinned `tool_choice`
- The auditor keeps `search_code` / `read_file` as ordinary optional tools, which those models do accept

## The log arrived only at the very end

Python block-buffers stdout when it is not a tty, so a 31-minute run looked like a run doing nothing.

- `python -u` in both triage workflows — progress streams into the Actions log as it happens
- `timeout-minutes: 60` on the triage job, so a hung model call fails the run instead of holding a runner for hours (a full run measures 31 minutes: 15 audits at one to three minutes each, plus a lookup per new thread)

## Verification

Dry run against the live Discord/Trello/DeepSeek setup ([run 32256270917](https://github.com/hydall/Glaze/actions/runs/32256270917)) — 31 minutes, exit 0, no failures:

- 38 open Discord threads, 48 closed ones skipped; 336 Trello cards, 25 already marker-linked
- 13 unlinked threads went through the duplicate check; the matcher answered "no match" for each, so each would get its own card
- 15 reports audited (the `MAX_AUDITS_PER_RUN` cap): 8 real audits with a verdict, severity and confidence — one of them `NOT clearly actionable` — and 7 `NEED MORE INFO`
- Nothing was written: it was a dry run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJNGpvkuLzDSd3mcuga4R6

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJNGpvkuLzDSd3mcuga4R6)_