### PR TITLE
Bug triage on stable: merge duplicate forum threads onto the first card, and audit nightly

### DIFF
--- a/.github/workflows/bug-triage.yml
+++ b/.github/workflows/bug-triage.yml
@@ -26,8 +26,20 @@ jobs:
     # but it must never sit on a runner for hours if a call hangs.
     timeout-minutes: 60
     steps:
-      - name: Checkout (agent needs the source to audit)
+      # The tooling comes from the branch this run was started on, so a fix
+      # can be dispatched from its own branch before it is merged.
+      - name: Checkout (triage tooling)
         uses: actions/checkout@v4
+
+      # The audited source is always nightly, whatever branch started the run.
+      # Scheduled runs only fire from the default branch (stable), which trails
+      # nightly by hundreds of commits — auditing that would judge reports
+      # against code the fix has long since left.
+      - name: Checkout nightly (the source the agent reads)
+        uses: actions/checkout@v4
+        with:
+          ref: nightly
+          path: audit-src
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -40,6 +52,7 @@ jobs:
       - name: Run triage
         working-directory: tools/bug_triage
         env:
+          AUDIT_REPO_ROOT: ${{ github.workspace }}/audit-src
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
           TRELLO_KEY: ${{ secrets.TRELLO_KEY }}

--- a/tools/bug_triage/README.md
+++ b/tools/bug_triage/README.md
@@ -19,23 +19,27 @@ act on.
    threads found in step 1 — it is never scanned for work of its own, so a card
    written by hand (in any list, anywhere on the board) is never commented on
    or labelled.
-3. For any Discord post **not yet linked to a card**, first checks whether a
-   human already wrote a card for that same bug: one DeepSeek call compares the
-   thread against the cards that carry no marker yet. On a match it writes the
-   hidden marker + Discord back-link into that card (appended — the human's
-   text is never overwritten) and **creates no duplicate**; otherwise it
-   creates a card in the "new bugs" list. The matcher is deliberately
-   conservative: below 0.7 confidence it answers "no match", because a missed
-   link only costs a duplicate a human can merge, while a wrong link puts a
-   Discord thread on someone else's card. Set `MATCH_EXISTING_CARDS=false` to
-   skip the check entirely.
+3. For any Discord post **not yet linked to a card**, checks whether the board
+   already tracks that same bug: one DeepSeek call compares the thread against
+   the existing cards — both the ones a human typed in and the ones earlier
+   forum threads produced, including cards created moments ago in the same run.
+   On a match it appends the hidden marker + Discord back-link to that card
+   (the existing text is never overwritten) and **creates no duplicate**;
+   otherwise it creates a card in the "new bugs" list. Candidates are shown to
+   the model oldest first and it is told to pick the smallest matching number,
+   so a second report always joins **the card that reported the bug first**.
+   The matcher is deliberately conservative: below 0.7 confidence it answers
+   "no match", because a missed link only costs a duplicate a human can merge,
+   while a wrong link hangs a thread on an unrelated card. Set
+   `MATCH_EXISTING_CARDS=false` to skip the check entirely.
 4. If every open thread already carries the `audited` label, **exits before
    calling the LLM** (no token spend).
 5. For each remaining thread, runs a DeepSeek agent over that ONE report —
    title, original post and replies, read live from Discord, so replies added
-   after the card was mirrored are included — that greps / reads the
-   checked-out source, then posts a structured audit as a comment on the
-   thread's card and applies the `audited` label.
+   after the card was mirrored are included — that greps / reads the source,
+   then posts a structured audit as a comment on the thread's card and applies
+   the `audited` label. A card that collected several duplicate threads is
+   audited once, on the first of them.
 
 Reports that cannot be judged from text (screenshot-only posts, missing repro
 steps) get a **NEED MORE INFO** comment naming what to ask instead of a guess.
@@ -43,9 +47,17 @@ A post with no readable text at all skips the LLM entirely.
 
 De-dup has no external database: each card that tracks a thread carries a hidden
 `discord-thread:<id>` marker in its description, and that's the source of truth.
-Cards written by hand get that marker the first time the matcher recognises
-their bug in the forum, and behave like mirrored ones from then on — including
-getting audited, if they don't already carry the `audited` label.
+A card can carry **several** markers — that is what a duplicate looks like on the
+board. Cards written by hand get their first marker when the matcher recognises
+their bug in the forum, and behave like mirrored ones from then on, including
+getting audited if they don't already carry the `audited` label.
+
+**The audited source is always `nightly`.** The workflow checks the triage code
+out from the branch the run was started on, and `nightly` separately into
+`audit-src/`, which is what the agent greps and reads (`AUDIT_REPO_ROOT`).
+Scheduled runs fire only from the default branch (`stable`), which trails
+nightly by hundreds of commits — auditing that tree would judge reports against
+code the fix has long since left.
 
 ## Architecture
 

--- a/tools/bug_triage/auditor.py
+++ b/tools/bug_triage/auditor.py
@@ -11,6 +11,7 @@ together, but threads are never mixed.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 from typing import Literal
@@ -20,8 +21,13 @@ from pydantic_ai import Agent, PromptedOutput
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
-# Repo root = two levels up from this file (tools/bug_triage/auditor.py).
-REPO_ROOT = Path(__file__).resolve().parents[2]
+# The tree the agent is allowed to grep and read. Defaults to this checkout
+# (two levels up from tools/bug_triage/auditor.py); CI points AUDIT_REPO_ROOT at
+# a separate nightly checkout, so a scheduled run started from stable still
+# judges reports against current code rather than a months-old tree.
+REPO_ROOT = Path(
+    os.environ.get("AUDIT_REPO_ROOT") or Path(__file__).resolve().parents[2]
+).resolve()
 
 _MAX_FILE_BYTES = 40_000
 _MAX_RG_MATCHES = 60

--- a/tools/bug_triage/check_connections.py
+++ b/tools/bug_triage/check_connections.py
@@ -96,7 +96,7 @@ def check_trello(cfg: Config) -> bool:
         cards = TrelloClient(
             cfg.trello_key, cfg.trello_token, cfg.trello_board_id
         ).fetch_cards()
-        linked = sum(1 for c in cards if c.discord_thread_id)
+        linked = sum(1 for c in cards if c.discord_thread_ids)
         _line(OK, "Trello cards read",
               f"{len(cards)} card(s), {linked} discord-linked "
               f"(only discord-linked cards are ever touched)")

--- a/tools/bug_triage/matcher.py
+++ b/tools/bug_triage/matcher.py
@@ -1,18 +1,19 @@
 """Duplicate check: is this Discord thread already a card on the board?
 
 New threads are not blindly mirrored. Before creating a card, the thread is
-compared against the cards that carry no `discord-thread:` marker yet — the
-ones a human typed in by hand — and a DeepSeek call decides whether any of them
-reports the SAME bug. On a match the orchestrator writes the marker and the
-back-link into that card instead of opening a duplicate.
+compared against the cards already on the board — the ones a human typed in by
+hand and the ones earlier forum threads produced alike — and a DeepSeek call
+decides whether any of them reports the SAME bug. On a match the orchestrator
+writes the marker and the back-link into that card instead of opening a
+duplicate, so two people reporting one bug in two threads land on one card.
 
 Two guards keep this cheap and quiet:
   * candidates are pre-ranked by shared words and cut to the top N, so the
     prompt stays small on a busy board;
   * the model must answer with a card number and a confidence, and anything
     below _MIN_CONFIDENCE is treated as "no match" — a missed link costs one
-    duplicate card, a wrong link corrupts a human's card, so we bias to the
-    cheap mistake.
+    duplicate card, a wrong link puts a thread on the wrong card, so we bias to
+    the cheap mistake.
 
 This agent gets NO tools: it only compares text. Source-code investigation is
 the auditor's job.
@@ -42,7 +43,10 @@ You decide whether a bug reported on Discord is ALREADY tracked by one of the
 existing Trello cards you are shown.
 
 Answer with the number of the single card that reports the SAME bug, or 0 if
-none of them does.
+none of them does. The cards are listed oldest first, and some of them were
+themselves written from an earlier Discord thread — that is fine: a second
+thread about the same bug belongs on the card that reported it first. If more
+than one card reports this bug, answer with the SMALLEST matching number.
 
 The same bug means the same faulty behaviour: same symptom in the same feature,
 even when the wording, language or level of detail differs. It is NOT enough
@@ -50,11 +54,16 @@ that two reports touch the same screen, the same feature area, or are both
 crashes. Two different bugs in the same widget are two different bugs.
 
 Be conservative. A missed match only costs a duplicate card that a human can
-merge; a wrong match writes a Discord link into an unrelated card. If you are
+merge; a wrong match hangs a Discord thread on an unrelated card. If you are
 unsure, answer 0. Set `confidence` to how sure you are that the card you picked
 is the same bug (0.0-1.0); when you answer 0, confidence is ignored.
 """
 
+_MARKER_LINE_RE = re.compile(
+    r"^(?:---|discord-thread:\d+|(?:Also )?[Rr]eported on Discord:.*|"
+    r"Attachments:.*)$\n?",
+    re.MULTILINE,
+)
 _WORD_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
 _STOP = {
     "when", "with", "that", "this", "from", "have", "does", "doesn", "there",
@@ -100,17 +109,30 @@ def shortlist(post: ForumPost, cards: list[Card], limit: int) -> list[Card]:
 
     Pure lexical pre-ranking — it only decides what the model gets to look at
     when a board has more cards than fit in one prompt, never whether something
-    is a match.
+    is a match. Whatever survives the cut is handed over oldest first, so
+    "answer with the smallest matching number" means "the card that reported
+    this bug first".
     """
-    if limit and len(cards) > limit:
+    picked = list(cards)
+    if limit and len(picked) > limit:
         wanted = _tokens(f"{post.title}\n{post.body}")
         ranked = sorted(
-            cards,
+            picked,
             key=lambda c: len(wanted & _tokens(f"{c.name}\n{c.desc}")),
             reverse=True,
         )
-        return ranked[:limit]
-    return list(cards)
+        picked = ranked[:limit]
+    return sorted(picked, key=lambda c: c.created_at)
+
+
+def _strip_markers(desc: str) -> str:
+    """Card text without the bookkeeping footer.
+
+    The `discord-thread:` markers and back-links say nothing about what the bug
+    is, and on a card that already collected several reports they would crowd
+    out the part the model has to judge.
+    """
+    return _MARKER_LINE_RE.sub("", desc).strip()
 
 
 def _trim(text: str, limit: int) -> str:
@@ -129,7 +151,7 @@ def _prompt(post: ForumPost, candidates: list[Card]) -> str:
     ]
     for i, c in enumerate(candidates, start=1):
         lines.append(f"{i}. {c.name}")
-        desc = _trim(c.desc, _MAX_CARD_DESC_CHARS)
+        desc = _trim(_strip_markers(c.desc), _MAX_CARD_DESC_CHARS)
         if desc:
             lines.append(f"   {desc}")
     lines.append("")

--- a/tools/bug_triage/trello_client.py
+++ b/tools/bug_triage/trello_client.py
@@ -3,13 +3,15 @@ already has a card, and whether it was audited); we never store state elsewhere.
 It is not a work queue — the agent only ever acts on cards that carry a Discord
 marker, and finds them by walking the forum, not the board.
 
-De-dup contract: every card created from a Discord post carries a hidden marker
+De-dup contract: every card that tracks a Discord post carries a hidden marker
 line in its description:
 
     discord-thread:<thread_id>
 
-so "is this bug already on the board?" is just a substring scan over card
-descriptions — survives workflow restarts with no external DB.
+so "is this bug already on the board?" is just a scan over card descriptions —
+survives workflow restarts with no external DB. A card can carry SEVERAL such
+markers: when two forum threads turn out to report the same bug, the later ones
+are appended to the card that reported it first instead of opening duplicates.
 """
 
 from __future__ import annotations
@@ -36,9 +38,22 @@ class Card:
     label_ids: tuple[str, ...]
 
     @property
-    def discord_thread_id(self) -> str | None:
-        m = _MARKER_RE.search(self.desc)
-        return m.group(1) if m else None
+    def discord_thread_ids(self) -> tuple[str, ...]:
+        """Every Discord thread this card tracks, in the order they were linked."""
+        return tuple(m.group(1) for m in _MARKER_RE.finditer(self.desc))
+
+    @property
+    def created_at(self) -> int:
+        """Creation time as a unix timestamp.
+
+        Trello ids are Mongo ObjectIds: the first four bytes are the creation
+        time. That is what makes "the card that reported it first" answerable
+        without another API call.
+        """
+        try:
+            return int(self.id[:8], 16)
+        except ValueError:
+            return 0
 
 
 class TrelloClient:

--- a/tools/bug_triage/triage.py
+++ b/tools/bug_triage/triage.py
@@ -8,18 +8,21 @@ picked up, commented on or labelled by this agent.
 Flow (only the audit step touches the LLM):
   1. Pull the open Discord forum posts.
   2. Pull Trello cards ONCE, to index them by their `discord-thread:<id>`
-     marker. That index answers two questions per thread and nothing else:
+     markers. That index answers two questions per thread and nothing else:
      does it already have a card, and was that card already audited?
-  3. Any thread with no matching card -> check whether a human already wrote
-     a card for that same bug (matcher.py, one DeepSeek call over the cards
-     that carry no marker yet). On a hit, write the marker + back-link into
-     that card; otherwise create a new card.
+  3. Any thread with no card of its own -> check whether one of the board's
+     cards already reports that same bug (matcher.py, one DeepSeek call).
+     Candidates include cards a human typed in AND cards earlier threads
+     produced, so a second thread about a known bug lands on the card that
+     reported it first instead of opening a duplicate. On a hit, append the
+     marker + back-link to that card; otherwise create a new card.
   4. EARLY EXIT: if every thread already carries the audited label, stop
      before the (far more expensive) audit agent is ever built. A run with no
      new threads and nothing to audit spends zero tokens.
   5. For each remaining thread: run the agent on that ONE report (title +
      post + replies, read live from Discord), post the result as a comment on
-     its card, then apply the "audited" label.
+     its card, then apply the "audited" label. A card that collected several
+     threads is audited once, on the first of them.
 
 Nothing here ever modifies source code or opens a PR.
 """
@@ -106,7 +109,7 @@ def main() -> int:
     posts = discord.fetch_posts()
     cards = trello.fetch_cards()
     by_thread: dict[str, Card] = {
-        c.discord_thread_id: c for c in cards if c.discord_thread_id
+        tid: c for c in cards for tid in c.discord_thread_ids
     }
     print(f"[triage] discord posts={len(posts)} trello cards={len(cards)} "
           f"already-linked-threads={len(by_thread)}")
@@ -118,52 +121,66 @@ def main() -> int:
               f"{cfg.max_new_cards_per_run} this run (MAX_NEW_CARDS_PER_RUN)")
         new_posts = new_posts[: cfg.max_new_cards_per_run]
 
-    # Cards a human wrote by hand: candidates for "this bug is already on the
-    # board". A card claimed by one thread drops out for the rest of the run.
-    unlinked = [c for c in cards if not c.discord_thread_id]
+    # Every card on the board is a candidate for "this bug is already tracked" —
+    # one a human typed in, or one an earlier thread produced. Cards created
+    # during this run join the pool too, so two duplicate threads in the same
+    # batch also end up on one card.
+    candidates = list(cards)
     matcher = None  # built lazily: no new threads -> no lookup, no tokens
 
     for post in new_posts:
         hit = None
-        if cfg.match_existing_cards and unlinked:
+        if cfg.match_existing_cards and candidates:
             if matcher is None:
                 matcher = build_matcher(
                     cfg.deepseek_api_key, cfg.deepseek_base_url, cfg.deepseek_model
                 )
             hit = find_existing_card(
-                matcher, post, unlinked, cfg.max_match_candidates
+                matcher, post, candidates, cfg.max_match_candidates
             )
 
         if hit is not None:
             desc = _linked_desc(hit, post)
             trello.set_desc(hit.id, desc)
+            also = f" (now tracks {len(hit.discord_thread_ids) + 1} threads)"
             print(f"[triage] linked thread {post.thread_id} to existing card "
-                  f"{hit.id}: {hit.name!r} (no duplicate created)")
-            by_thread[post.thread_id] = replace(hit, desc=desc)
-            unlinked.remove(hit)
+                  f"{hit.id}: {hit.name!r}{also}")
+            linked = replace(hit, desc=desc)
+            by_thread[post.thread_id] = linked
+            candidates[candidates.index(hit)] = linked
             continue
 
         body = _card_body(post)
         new_id = trello.create_card(cfg.trello_new_bug_list_id, post.title, body)
         print(f"[triage] created card for thread {post.thread_id}: {post.title!r}")
-        by_thread[post.thread_id] = Card(
+        fresh = Card(
             id=new_id,
             name=post.title,
             desc=body,
             list_id=cfg.trello_new_bug_list_id,
             label_ids=(),
         )
+        by_thread[post.thread_id] = fresh
+        candidates.append(fresh)
 
     # --- Step 4: which threads still need an audit? -------------------------
     # Driven by the forum, never by the board: a thread is a candidate only if
-    # its own card is missing the audited label. Threads whose card creation was
-    # capped above simply wait for the next run.
-    to_audit: list[tuple[ForumPost, Card]] = [
-        (p, by_thread[p.thread_id])
-        for p in posts
-        if p.thread_id in by_thread
-        and cfg.trello_audited_label_id not in by_thread[p.thread_id].label_ids
-    ]
+    # its card is missing the audited label. Threads whose card creation was
+    # capped above simply wait for the next run. Duplicates share a card, and a
+    # card is audited once — the later threads add their link, not a second
+    # audit of the same bug.
+    to_audit: list[tuple[ForumPost, Card]] = []
+    claimed: set[str] = set()
+    for p in posts:
+        card = by_thread.get(p.thread_id)
+        if card is None or cfg.trello_audited_label_id in card.label_ids:
+            continue
+        if card.id in claimed:
+            print(f"[triage] thread {p.thread_id} shares card {card.id} with an "
+                  f"earlier thread — no second audit")
+            continue
+        claimed.add(card.id)
+        to_audit.append((p, card))
 
     # --- Step 5: early exit before spending any tokens ---------------------
     if not to_audit:


### PR DESCRIPTION
Same change as the nightly-side PR, cut against `stable` so the daily cron runs it. `tools/bug_triage/` and the triage workflow only — no Dart code.

## Duplicate threads land on the card that reported the bug first

Two people reporting one bug in two Discord threads produced two cards: the duplicate check only ever looked at cards carrying no `discord-thread:` marker, so anything an earlier thread had already mirrored was invisible to it.

- Candidates are now every card on the board — hand-written and thread-mirrored alike — plus the cards created earlier in the same run, so duplicates inside one batch also collapse onto one card
- Candidates are listed oldest first (Trello ids are ObjectIds and carry their creation time) and the model is told to answer with the smallest matching number, so a second report joins **the card that reported the bug first**
- A card can carry several markers now: `Card.discord_thread_ids` replaces the single-marker accessor, and the thread index maps every marker to its card
- A card shared by several threads is audited **once**, on the first of them — the later ones add their back-link, not a second audit of the same bug
- Bookkeeping lines (markers, back-links, attachment counts) are stripped from the candidate text sent to the model; they say nothing about the bug and would crowd out what it has to judge

## The agent was reading the wrong tree

This matters most here: scheduled runs fire only from this branch, hundreds of commits behind `nightly` — so reports were judged against code the fix had long since left, and the agent could "confirm" a bug that no longer exists.

- The workflow checks the triage tooling out from the branch that started the run (so a fix can still be dispatched from its own branch before merging) and `nightly` separately into `audit-src/`
- `AUDIT_REPO_ROOT` points the auditor's `search_code` / `read_file` at that tree; without the variable the agent falls back to its own checkout exactly as before

## Verification

Offline orchestrator tests against stubbed Discord/Trello clients and a stubbed model:

- two duplicate threads share one card and one audit, with both markers appended to that card
- a card created moments earlier in the same run is itself a duplicate candidate
- the earliest card is candidate number 1 after the lexical shortlist
- markers and back-links are stripped from the text the model sees
- unchanged behaviours still hold: low confidence rejected, "no match" and out-of-range answers create a card, a lookup failure falls back to creating a card, marker-linked threads never reach the matcher, `MATCH_EXISTING_CARDS=false` skips it

The live path was exercised by the previous run on `nightly` ([32261982770](https://github.com/hydall/Glaze/actions/runs/32261982770)) — 29 minutes, exit 0, audits and labels written to the board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJNGpvkuLzDSd3mcuga4R6

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJNGpvkuLzDSd3mcuga4R6)_