### PR TITLE
fix(image-gen): move Naistera onto the current /api/generate route

### DIFF
--- a/lib/features/image_gen/image_gen_capabilities.dart
+++ b/lib/features/image_gen/image_gen_capabilities.dart
@@ -246,9 +246,9 @@ int providerMaxReferences(ImageGenSettings settings) {
     case ImageGenApiType.openrouter:
       return openRouterCapabilities(settings.openrouter.model).maxReferences;
     case ImageGenApiType.naistera:
-      return NaisteraConstants.noRefModels.contains(settings.naisteraModel)
-          ? 0
-          : maxGenerationReferenceImages;
+      return NaisteraConstants.supportsReferences(settings.naisteraModel)
+          ? maxGenerationReferenceImages
+          : 0;
     case ImageGenApiType.routmy:
     case ImageGenApiType.ruRoutmy:
       return routmyMaxInjectedReferenceImages;

--- a/lib/features/image_gen/image_gen_constants.dart
+++ b/lib/features/image_gen/image_gen_constants.dart
@@ -72,16 +72,48 @@ class RuRoutMyConstants {
 }
 
 class NaisteraConstants {
+  /// Base of the public API. The generation route is `/api/generate`; the
+  /// legacy `/prompt/api/img` route answers 405 Method Not Allowed.
+  static const String baseUrl = 'https://naistera.org';
+
   static const models = [
     ('grok', 'Grok'),
     ('grok-pro', 'Grok Pro'),
-    ('nano banana', 'Nano Banana'),
+    ('nano banana 2', 'Nano Banana 2'),
     ('novelai', 'NovelAI'),
   ];
 
   static const aspectRatios = ['1:1', '16:9', '9:16', '3:2', '2:3'];
 
   static const noRefModels = {'grok-pro', 'novelai'};
+
+  /// Maps stored and retired model labels onto the ids the API accepts today,
+  /// so a settings blob written by an older build keeps generating.
+  static String normalizeModel(String? model) {
+    final raw = (model ?? '').trim().toLowerCase();
+    if (raw.isEmpty) return 'grok';
+    switch (raw) {
+      case 'grok pro':
+      case 'grok-pro':
+      case 'grok-imagine-pro':
+      case 'imagine-pro':
+        return 'grok-pro';
+      case 'nano-banana':
+      case 'nano banana':
+      case 'nano banana pro':
+      case 'nano-banana-pro':
+      case 'nano-banana-2':
+      case 'nano banana 2':
+        return 'nano banana 2';
+      case 'novel ai':
+      case 'novelai':
+        return 'novelai';
+    }
+    return models.any((m) => m.$1 == raw) ? raw : 'grok';
+  }
+
+  static bool supportsReferences(String? model) =>
+      !noRefModels.contains(normalizeModel(model));
 }
 
 class OpenAIConstants {

--- a/lib/features/image_gen/services/image_gen_connection_service.dart
+++ b/lib/features/image_gen/services/image_gen_connection_service.dart
@@ -43,7 +43,7 @@ class ImageGenConnectionService {
         if (settings.naisteraApiKey.trim().isEmpty) {
           throw StateError('Naistera API key not configured');
         }
-        await _get('https://naistera.org', null);
+        await _get(NaisteraConstants.baseUrl, null);
       case ImageGenApiType.routmy:
         if (settings.routmyApiKey.trim().isEmpty) {
           throw StateError('rout.my API key not configured');

--- a/lib/features/image_gen/services/image_gen_dispatcher.dart
+++ b/lib/features/image_gen/services/image_gen_dispatcher.dart
@@ -79,7 +79,7 @@ class ImageGenDispatcher {
             NaisteraConstants.aspectRatios,
             settings.naisteraAspectRatio,
           ),
-          references: _naisteraRefs(references),
+          references: references.isEmpty ? null : references,
           cancelToken: cancelToken,
         );
       case ImageGenApiType.routmy:
@@ -284,24 +284,6 @@ class ImageGenDispatcher {
       return null;
     }
     return openAiAspectRatioToSize(aspect, classifyOpenAiImageModel(model));
-  }
-
-  /// Naistera's payload only knows `name`, `image` and `description` — the
-  /// collector's bookkeeping keys must not leak into the request body.
-  static List<Map<String, String>>? _naisteraRefs(
-    List<Map<String, String>> references,
-  ) {
-    if (references.isEmpty) return null;
-    return references
-        .map(
-          (ref) => {
-            'name': ref['name'] ?? '',
-            'image': ref['image'] ?? '',
-            if ((ref['description'] ?? '').isNotEmpty)
-              'description': ref['description']!,
-          },
-        )
-        .toList();
   }
 
   static List<String>? _imagesOf(List<Map<String, String>> references) {

--- a/lib/features/image_gen/services/image_gen_http.dart
+++ b/lib/features/image_gen/services/image_gen_http.dart
@@ -79,6 +79,27 @@ class ImageGenHttp {
     return await extract(json);
   }
 
+  /// Plain JSON GET (job polling, model listings).
+  Future<Map<String, dynamic>> getJson({
+    required String url,
+    String? apiKey,
+    Map<String, String>? extraHeaders,
+    CancelToken? cancelToken,
+  }) async {
+    final headers = <String, String>{
+      'Accept': 'application/json',
+      if (apiKey != null && apiKey.isNotEmpty)
+        'Authorization': 'Bearer $apiKey',
+      ...?extraHeaders,
+    };
+    final response = await _dio.get<Map<String, dynamic>>(
+      url,
+      options: Options(headers: headers),
+      cancelToken: cancelToken,
+    );
+    return response.data ?? {};
+  }
+
   /// Downloads raw bytes from a URL (for endpoints that return `url` instead
   /// of `b64_json`).
   static Future<Uint8List> downloadImage(

--- a/lib/features/image_gen/services/naistera_image_provider.dart
+++ b/lib/features/image_gen/services/naistera_image_provider.dart
@@ -2,11 +2,28 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 
+import '../image_gen_constants.dart';
 import 'image_gen_http.dart';
-import '../image_gen_models.dart';
 
+/// Naistera image client.
+///
+/// Mirrors the reference extension (https://github.com/0xl0cal/sillyimages,
+/// `NaisteraProvider`): `POST {base}/api/generate` with a JSON body, answered
+/// either synchronously with `data_url` or with a `job_id` that is polled on
+/// `GET {base}/api/generate/jobs/{id}`. The route Glaze used before
+/// (`/prompt/api/img`, `images: [base64]`) is retired and answers
+/// 405 Method Not Allowed.
 class NaisteraImageProvider {
+  NaisteraImageProvider({
+    this.baseUrl = NaisteraConstants.baseUrl,
+    this.pollInterval = const Duration(seconds: 3),
+    this.pollTimeout = const Duration(minutes: 10),
+  });
+
   final ImageGenHttp _http = ImageGenHttp();
+  final String baseUrl;
+  final Duration pollInterval;
+  final Duration pollTimeout;
 
   Future<Uint8List> generate({
     required String apiKey,
@@ -16,26 +33,110 @@ class NaisteraImageProvider {
     List<Map<String, String>>? references,
     CancelToken? cancelToken,
   }) async {
+    final normalizedModel = NaisteraConstants.normalizeModel(model);
     final body = <String, dynamic>{
-      'model': model,
       'prompt': prompt,
       'aspect_ratio': aspectRatio,
+      'model': normalizedModel,
     };
-    if (references != null && references.isNotEmpty && !NaisteraConstants.noRefModels.contains(model)) {
-      body['references'] = references;
+    final referenceObjects = _referenceObjects(references, normalizedModel);
+    if (referenceObjects.isNotEmpty) {
+      body['reference_objects'] = referenceObjects;
     }
 
-    final b64 = await _http.postAndExtractBase64(
-      url: 'https://naistera.org/prompt/api/img',
+    var json = await _http.post(
+      url: _generateUrl,
       apiKey: apiKey,
       body: body,
       cancelToken: cancelToken,
-      extractBase64: (json) {
-        final images = json['images'] as List?;
-        if (images == null || images.isEmpty) throw Exception('No images in response');
-        return images.first as String;
-      },
     );
-    return ImageGenHttp.base64ToBytes(b64);
+
+    final rawJobId = json['job_id'];
+    final jobId = rawJobId is String ? rawJobId : '';
+    if (json['data_url'] is! String && jobId.isNotEmpty) {
+      json = await _pollJob(jobId, apiKey: apiKey, cancelToken: cancelToken);
+    }
+
+    return _bytesFrom(json, cancelToken: cancelToken);
+  }
+
+  String get _generateUrl {
+    final base = baseUrl.replaceAll(RegExp(r'/+$'), '');
+    return base.endsWith('/api/generate') ? base : '$base/api/generate';
+  }
+
+  /// Naistera takes references as `{image, description}` pairs where `image`
+  /// is a full data URL — the collector hands over bare base64 plus its mime.
+  static List<Map<String, String>> _referenceObjects(
+    List<Map<String, String>>? references,
+    String normalizedModel,
+  ) {
+    if (references == null ||
+        references.isEmpty ||
+        !NaisteraConstants.supportsReferences(normalizedModel)) {
+      return const [];
+    }
+    final objects = <Map<String, String>>[];
+    for (final ref in references) {
+      final image = ref['image'] ?? '';
+      if (image.isEmpty) continue;
+      final mime = ref['mime'] ?? 'image/png';
+      objects.add({
+        'image': image.startsWith('data:')
+            ? image
+            : 'data:$mime;base64,$image',
+        'description': ref['description'] ?? '',
+      });
+    }
+    return objects;
+  }
+
+  Future<Map<String, dynamic>> _pollJob(
+    String jobId, {
+    required String apiKey,
+    CancelToken? cancelToken,
+  }) async {
+    final base = _generateUrl;
+    final url = '$base/jobs/${Uri.encodeComponent(jobId)}';
+    final deadline = DateTime.now().add(pollTimeout);
+
+    while (DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(pollInterval);
+      if (cancelToken?.isCancelled ?? false) {
+        throw Exception('Naistera generation cancelled');
+      }
+      final json = await _http.getJson(
+        url: url,
+        apiKey: apiKey,
+        cancelToken: cancelToken,
+      );
+      final rawStatus = json['status'];
+      final status = (rawStatus is String ? rawStatus : '').toLowerCase();
+      if (json['data_url'] is String || status == 'completed') return json;
+      if (status == 'failed' || json['error'] != null) {
+        final detail = json['detail'] ?? json['error'] ?? 'Unknown error';
+        throw Exception('Naistera generation failed: $detail');
+      }
+    }
+    throw Exception(
+      'Naistera polling timed out after ${pollTimeout.inSeconds}s',
+    );
+  }
+
+  Future<Uint8List> _bytesFrom(
+    Map<String, dynamic> json, {
+    CancelToken? cancelToken,
+  }) async {
+    final raw = json['data_url'];
+    final dataUrl = raw is String ? raw : '';
+    if (dataUrl.isEmpty) {
+      throw Exception('No data_url in Naistera response');
+    }
+    if (dataUrl.startsWith('http://') || dataUrl.startsWith('https://')) {
+      return ImageGenHttp.downloadImage(dataUrl, cancelToken: cancelToken);
+    }
+    return ImageGenHttp.base64ToBytes(
+      ImageGenHttp.stripBase64Prefix(dataUrl),
+    );
   }
 }

--- a/lib/features/image_gen/widgets/image_gen_sheet.dart
+++ b/lib/features/image_gen/widgets/image_gen_sheet.dart
@@ -256,7 +256,7 @@ class _ImageGenSheetState extends ConsumerState<ImageGenSheet> {
               ],
             ),
             if (s.apiType == ImageGenApiType.naistera &&
-                NaisteraConstants.noRefModels.contains(s.naisteraModel))
+                !NaisteraConstants.supportsReferences(s.naisteraModel))
               Container(
                 margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                 padding: const EdgeInsets.all(12),

--- a/lib/features/image_gen/widgets/model_fields.dart
+++ b/lib/features/image_gen/widgets/model_fields.dart
@@ -22,21 +22,21 @@ List<Widget> buildNaisteraModelFields(
   ValueChanged<ImageGenSettings> onUpdate,
   ShowOptionsCallback showOptions,
 ) {
+  // Settings written by older builds can still hold a retired model label
+  // ('nano banana'), so the selector matches on the normalized id.
+  final model = NaisteraConstants.normalizeModel(s.naisteraModel);
   return [
     MenuSelectorItem(
       label: 'Model',
       currentValue: NaisteraConstants.models
-          .firstWhere(
-            (e) => e.$1 == s.naisteraModel,
-            orElse: () => (s.naisteraModel, s.naisteraModel),
-          )
+          .firstWhere((e) => e.$1 == model, orElse: () => (model, model))
           .$2,
       onTap: () => showOptions<String>(
         title: 'Model',
         items: NaisteraConstants.models.map((e) => e.$1).toList(),
         labelBuilder: (v) =>
             NaisteraConstants.models.firstWhere((e) => e.$1 == v).$2,
-        isSelected: (v) => s.naisteraModel == v,
+        isSelected: (v) => model == v,
         onSelected: (v) => onUpdate(s.copyWith(naisteraModel: v)),
       ),
     ),

--- a/test/naistera_image_provider_test.dart
+++ b/test/naistera_image_provider_test.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/image_gen/services/naistera_image_provider.dart';
+
+void main() {
+  /// Serves canned JSON and records every request, so the tests can assert on
+  /// the path/method the client actually used.
+  Future<
+    ({
+      String baseUrl,
+      List<({String method, String path, Map<String, dynamic>? body})> requests,
+    })
+  >
+  startServer(List<Map<String, dynamic>> responses) async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    final requests =
+        <({String method, String path, Map<String, dynamic>? body})>[];
+    var index = 0;
+    server.listen((request) async {
+      final raw = await utf8.decoder.bind(request).join();
+      requests.add((
+        method: request.method,
+        path: request.uri.path,
+        body: raw.isEmpty ? null : jsonDecode(raw) as Map<String, dynamic>,
+      ));
+      final response = responses[index.clamp(0, responses.length - 1)];
+      index++;
+      request.response.headers.contentType = ContentType.json;
+      request.response.write(jsonEncode(response));
+      await request.response.close();
+    });
+    return (
+      baseUrl: 'http://${server.address.host}:${server.port}',
+      requests: requests,
+    );
+  }
+
+  group('NaisteraImageProvider', () {
+    test('posts to /api/generate and decodes data_url', () async {
+      final server = await startServer([
+        {'data_url': 'data:image/png;base64,AQI=', 'content_type': 'image/png'},
+      ]);
+
+      final bytes = await NaisteraImageProvider(
+        baseUrl: server.baseUrl,
+      ).generate(
+        apiKey: 'key',
+        model: 'grok',
+        prompt: 'a cat',
+        aspectRatio: '16:9',
+      );
+
+      expect(bytes, [1, 2]);
+      expect(server.requests.single.method, 'POST');
+      expect(server.requests.single.path, '/api/generate');
+      expect(server.requests.single.body, {
+        'prompt': 'a cat',
+        'aspect_ratio': '16:9',
+        'model': 'grok',
+      });
+    });
+
+    test('sends references as data URLs in reference_objects', () async {
+      final server = await startServer([
+        {'data_url': 'data:image/png;base64,AQI='},
+      ]);
+
+      await NaisteraImageProvider(baseUrl: server.baseUrl).generate(
+        apiKey: 'key',
+        model: 'nano banana 2',
+        prompt: 'a cat',
+        aspectRatio: '1:1',
+        references: [
+          {
+            'name': 'Mia',
+            'image': 'AQI=',
+            'mime': 'image/jpeg',
+            'description': 'Mia',
+            'source': 'char',
+          },
+          {
+            'name': 'ctx',
+            'image': 'data:image/png;base64,AQI=',
+            'mime': 'image/png',
+            'description': '',
+            'source': 'context',
+          },
+        ],
+      );
+
+      expect(server.requests.single.body!['reference_objects'], [
+        {'image': 'data:image/jpeg;base64,AQI=', 'description': 'Mia'},
+        {'image': 'data:image/png;base64,AQI=', 'description': ''},
+      ]);
+    });
+
+    test('drops references for models that do not accept them', () async {
+      final server = await startServer([
+        {'data_url': 'data:image/png;base64,AQI='},
+      ]);
+
+      await NaisteraImageProvider(baseUrl: server.baseUrl).generate(
+        apiKey: 'key',
+        model: 'novelai',
+        prompt: 'a cat',
+        aspectRatio: '1:1',
+        references: [
+          {'image': 'AQI=', 'mime': 'image/png', 'description': 'Mia'},
+        ],
+      );
+
+      expect(
+        server.requests.single.body!.containsKey('reference_objects'),
+        isFalse,
+      );
+    });
+
+    test('normalizes a retired model label', () async {
+      final server = await startServer([
+        {'data_url': 'data:image/png;base64,AQI='},
+      ]);
+
+      await NaisteraImageProvider(baseUrl: server.baseUrl).generate(
+        apiKey: 'key',
+        model: 'nano banana',
+        prompt: 'a cat',
+        aspectRatio: '1:1',
+      );
+
+      expect(server.requests.single.body!['model'], 'nano banana 2');
+    });
+
+    test('polls the job endpoint when the response is async', () async {
+      final server = await startServer([
+        {'job_id': 'job1'},
+        {'status': 'pending'},
+        {'status': 'completed', 'data_url': 'data:image/png;base64,AQI='},
+      ]);
+
+      final bytes = await NaisteraImageProvider(
+        baseUrl: server.baseUrl,
+        pollInterval: const Duration(milliseconds: 10),
+      ).generate(
+        apiKey: 'key',
+        model: 'grok',
+        prompt: 'a cat',
+        aspectRatio: '1:1',
+      );
+
+      expect(bytes, [1, 2]);
+      expect(server.requests.map((r) => r.method).toList(), [
+        'POST',
+        'GET',
+        'GET',
+      ]);
+      expect(server.requests.last.path, '/api/generate/jobs/job1');
+    });
+
+    test('reports a failed job instead of hanging', () async {
+      final server = await startServer([
+        {'job_id': 'job1'},
+        {'status': 'failed', 'detail': 'moderation'},
+      ]);
+
+      await expectLater(
+        NaisteraImageProvider(
+          baseUrl: server.baseUrl,
+          pollInterval: const Duration(milliseconds: 10),
+        ).generate(
+          apiKey: 'key',
+          model: 'grok',
+          prompt: 'a cat',
+          aspectRatio: '1:1',
+        ),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('moderation'),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Naistera generation fails with `405 Method Not Allowed`: `NaisteraImageProvider` calls `POST https://naistera.org/prompt/api/img`, a route naistera.org has retired. The provider file is unchanged between `stable` and `nightly`, and `git log -S "prompt/api/img"` shows that URL has been there since the provider was first added — the break is on the service side, not in the nightly image-gen refactor.

The reference extension ([0xl0cal/sillyimages](https://github.com/0xl0cal/sillyimages), `src/providers.js` → `NaisteraProvider`) has always talked to `/api/generate`, so the client is realigned with it.

## Changes

- `naistera_image_provider.dart` — `POST {base}/api/generate` with `{prompt, aspect_ratio, model}` instead of `POST /prompt/api/img`
- References go out as `reference_objects: [{image: <data URL>, description}]` (the shape sillyimages switched to) instead of `references: [{name, image: <bare base64>, description}]`; the collector hands over bare base64 plus its mime, so the provider composes the data URL
- The image is read from `data_url` — data URL, bare base64 or an `http(s)` URL — instead of `images[0]`
- Async answers are followed: a `job_id` without a `data_url` is polled on `GET {base}/api/generate/jobs/{id}` every 3 s until `completed`/`failed`, capped at 10 min and abortable through the `CancelToken`
- `NaisteraConstants` — model id `nano banana` → `nano banana 2` (the label the API takes today), plus `normalizeModel` mapping stored and retired labels so settings written by older builds keep generating, and `supportsReferences` replacing the raw `noRefModels` lookups in `providerMaxReferences`, `ImageGenSheet` and `buildNaisteraModelFields`
- `ImageGenDispatcher` passes the collector entries through untouched (the `mime` key is needed now), dropping `_naisteraRefs`
- `ImageGenHttp.getJson` — plain JSON GET used by the job polling
- `ImageGenConnectionService` uses `NaisteraConstants.baseUrl` instead of a second hardcoded host

## Verification

- `flutter analyze --no-fatal-infos --no-fatal-warnings` — no issues found
- `flutter test` over the image-gen suites (`naistera_image_provider`, `image_gen_capabilities`, `image_gen_settings_codec`, `routmy_image_provider`, `image_gen_connection_service`, `image_gen_service`) — 93 passed
- New `test/naistera_image_provider_test.dart` drives the provider against a local `HttpServer` through an injectable `baseUrl`: request path and body, data-URL references, references dropped for `novelai`, `nano banana` normalization, job polling and a failed job
- Not verified against the live API — naistera.org is unreachable from the agent sandbox, so the request shape is matched against the reference extension's code rather than a real 200


---
_Generated by [Claude Code](https://claude.ai/code/session_01U5spbDyoXxTQbdB7Vuj4jQ)_