### PR TITLE
fix(image-gen): fix broken generated images and give each block its own variants

### DIFF
--- a/assets/chat_webview/bridge/interaction_dispatch.js
+++ b/assets/chat_webview/bridge/interaction_dispatch.js
@@ -179,6 +179,48 @@ export class InteractionDispatch {
     return { instr, messageId, imgIndex };
   }
 
+  // Pages one image block through the images it carries. The swap happens
+  // here — the pictures are already in the page — and Flutter is told only so
+  // the choice survives a reload. Like a message swipe, the ends are hard: the
+  // first image does not wrap around to the last.
+  _stepImageVariant(e, el, direction) {
+    const wrapper = e.composedPath().find(
+      (node) => node.classList?.contains('imggen-result-wrapper'),
+    );
+    if (!wrapper) return;
+    const variants = (wrapper.dataset.variants || '').split(';;').filter(Boolean);
+    if (variants.length < 2) return;
+
+    const current = parseInt(wrapper.dataset.variantIndex, 10);
+    const from = Number.isInteger(current) ? current : 0;
+    const next = from + direction;
+    if (next < 0 || next >= variants.length) return;
+
+    const img = wrapper.querySelector('img.imggen-result');
+    const src = variants[next];
+    if (img) {
+      img.src = src;
+      img.dataset.src = src;
+      // A retry counter from the previous image must not carry over.
+      delete img.dataset.retryAttempt;
+    }
+    const options = wrapper.querySelector('.imggen-options-btn');
+    if (options) options.dataset.src = src;
+    const count = wrapper.querySelector('.imggen-variant-count');
+    if (count) count.textContent = `${next + 1}/${variants.length}`;
+    wrapper.dataset.variantIndex = String(next);
+
+    const section = e.composedPath().find((node) => node.dataset?.messageId);
+    const messageId = section ? section.dataset.messageId : '';
+    const rawIndex = parseInt(el.dataset.imgIndex, 10);
+    if (!messageId || !Number.isInteger(rawIndex) || rawIndex < 0) return;
+    this.bridge._sendToFlutter('onImgVariant', [JSON.stringify({
+      messageId,
+      imgIndex: rawIndex,
+      variantIndex: next,
+    })]);
+  }
+
   get _actionMap() {
     const bridge = this.bridge;
     return {
@@ -290,6 +332,8 @@ export class InteractionDispatch {
         bridge._sendToFlutter('onImgRegen', [instr, messageId, imgIndex]);
       },
       'img-stop': (e, el) => bridge._sendToFlutter('onImgCancel', []),
+      'img-variant-prev': (e, el) => this._stepImageVariant(e, el, -1),
+      'img-variant-next': (e, el) => this._stepImageVariant(e, el, 1),
       'img-options': (e, el) => {
         const { instr, messageId, imgIndex } = this._extractImgInstruction(el, e.composedPath());
         bridge._sendToFlutter('onImgOptions', [JSON.stringify({

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -3,6 +3,39 @@ import { renderStyledSegment } from './text_format.js';
 
 // Vertical 3-dot "options" icon (ported from Glaze useMessageImageGen.js).
 const OPTIONS_SVG = '<svg viewBox="0 0 24 24"><path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>';
+const VARIANT_PREV_SVG = '<svg viewBox="0 0 24 24"><path d="M15.4 7.4 14 6l-6 6 6 6 1.4-1.4-4.6-4.6z"/></svg>';
+const VARIANT_NEXT_SVG = '<svg viewBox="0 0 24 24"><path d="M8.6 7.4 10 6l6 6-6 6-1.4-1.4 4.6-4.6z"/></svg>';
+
+/** Separator between the images one block carries, mirroring the Dart codec. */
+const IMG_VARIANT_SEPARATOR = ';;';
+
+/** Marks the image on screen inside a multi-image payload. */
+const IMG_VARIANT_ACTIVE_MARKER = '*';
+
+/**
+ * Splits an `[IMG:RESULT:…]` payload into its images, the one on screen and
+ * the instruction — the JS half of ImageBlockPayload in image_tag_markup.dart.
+ * A single-image block keeps the historical `path|instruction` spelling, so
+ * messages written before block variants existed parse unchanged.
+ */
+export function parseImageResultPayload(payload) {
+  const raw = String(payload == null ? '' : payload);
+  const pipeIdx = raw.indexOf('|');
+  const head = pipeIdx === -1 ? raw : raw.substring(0, pipeIdx);
+  const instruction = pipeIdx === -1 ? '' : raw.substring(pipeIdx + 1);
+  const paths = [];
+  let activeIndex = 0;
+  for (const entry of head.split(IMG_VARIANT_SEPARATOR)) {
+    if (!entry) continue;
+    if (entry.startsWith(IMG_VARIANT_ACTIVE_MARKER)) {
+      activeIndex = paths.length;
+      paths.push(entry.substring(IMG_VARIANT_ACTIVE_MARKER.length));
+    } else {
+      paths.push(entry);
+    }
+  }
+  return { paths, activeIndex, instruction };
+}
 
 export class Formatter {
   constructor() {
@@ -156,10 +189,14 @@ export class Formatter {
     });
     html = html.replace(/\[IMG:RESULT:(.*?)\]/g, (match, payload) => {
       const id = this._ph('IG_', imgBlocks.length, true);
-      const pipeIdx = payload.indexOf('|');
-      const path = pipeIdx !== -1 ? payload.substring(0, pipeIdx) : payload;
-      const instruction = pipeIdx !== -1 ? payload.substring(pipeIdx + 1) : '';
-      imgBlocks.push({ type: 'result', path, instruction });
+      const parsed = parseImageResultPayload(payload);
+      imgBlocks.push({
+        type: 'result',
+        path: parsed.paths[parsed.activeIndex] || parsed.paths[0] || '',
+        paths: parsed.paths,
+        activeIndex: parsed.activeIndex,
+        instruction: parsed.instruction,
+      });
       return '\n\n' + id + '\n\n';
     });
     html = html.replace(/\[IMG:ERROR:(.*?)\]/g, (match, data) => {
@@ -409,6 +446,18 @@ export class Formatter {
       if (block.type === 'result') {
         const src = this._imageSrc(block.path);
         const encInstr = encodeURIComponent(block.instruction || '');
+        const variants = (block.paths || []).map((p) => this._imageSrc(p));
+        const activeIndex = variants.length > 1 ? (block.activeIndex || 0) : 0;
+        // The switcher only exists once the block holds a second image, so a
+        // single-image block renders exactly as it always did.
+        const switcher = variants.length > 1
+          ? `<span class="imggen-variants"><button class="imggen-variant-btn" type="button" data-action="img-variant-prev" data-img-index="${at}" title="Previous image">${VARIANT_PREV_SVG}</button><span class="imggen-variant-count">${activeIndex + 1}/${variants.length}</span><button class="imggen-variant-btn" type="button" data-action="img-variant-next" data-img-index="${at}" title="Next image">${VARIANT_NEXT_SVG}</button></span>`
+          : '';
+        // The whole list rides along on the wrapper so paging through the
+        // block swaps the picture in place, with no round trip to Flutter.
+        const variantAttrs = variants.length > 1
+          ? ` data-variants="${this._escapeHtml(variants.join(IMG_VARIANT_SEPARATOR))}" data-variant-index="${activeIndex}"`
+          : '';
         // loading="eager" (not "lazy"): a just-generated image lands at the
         // bottom edge of the WebView, where Android/iOS keep resizing the
         // viewport around the input bar. A lazy image there can be evaluated
@@ -416,7 +465,7 @@ export class Formatter {
         // the picture the user just waited for shows as a broken tag. These
         // are local files, so eager loading costs nothing — same reasoning as
         // _renderExtBlockImageHtml in the bridge controller.
-        return `<span class="imggen-result-wrapper"><img src="${src}" class="imggen-result" loading="eager" decoding="async" data-action="image-click" data-src="${src}"><button class="imggen-options-btn" type="button" data-action="img-options" data-src="${src}" data-instruction="${encInstr}" data-img-index="${at}" title="Options">${OPTIONS_SVG}</button></span>`;
+        return `<span class="imggen-result-wrapper"${variantAttrs}><img src="${src}" class="imggen-result" loading="eager" decoding="async" data-action="image-click" data-src="${src}"><button class="imggen-options-btn" type="button" data-action="img-options" data-src="${src}" data-instruction="${encInstr}" data-img-index="${at}" title="Options">${OPTIONS_SVG}</button>${switcher}</span>`;
       }
       if (block.type === 'gen') {
         const start = Date.now();

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -409,7 +409,14 @@ export class Formatter {
       if (block.type === 'result') {
         const src = this._imageSrc(block.path);
         const encInstr = encodeURIComponent(block.instruction || '');
-        return `<span class="imggen-result-wrapper"><img src="${src}" class="imggen-result" loading="lazy" data-action="image-click" data-src="${src}"><button class="imggen-options-btn" type="button" data-action="img-options" data-src="${src}" data-instruction="${encInstr}" data-img-index="${at}" title="Options">${OPTIONS_SVG}</button></span>`;
+        // loading="eager" (not "lazy"): a just-generated image lands at the
+        // bottom edge of the WebView, where Android/iOS keep resizing the
+        // viewport around the input bar. A lazy image there can be evaluated
+        // while the row is still off-screen and never come back for it, and
+        // the picture the user just waited for shows as a broken tag. These
+        // are local files, so eager loading costs nothing — same reasoning as
+        // _renderExtBlockImageHtml in the bridge controller.
+        return `<span class="imggen-result-wrapper"><img src="${src}" class="imggen-result" loading="eager" decoding="async" data-action="image-click" data-src="${src}"><button class="imggen-options-btn" type="button" data-action="img-options" data-src="${src}" data-instruction="${encInstr}" data-img-index="${at}" title="Options">${OPTIONS_SVG}</button></span>`;
       }
       if (block.type === 'gen') {
         const start = Date.now();

--- a/assets/chat_webview/formatter/index.js
+++ b/assets/chat_webview/formatter/index.js
@@ -1,6 +1,7 @@
 import { Formatter } from './formatter.js';
 
 export { Formatter } from './formatter.js';
+export { parseImageResultPayload } from './formatter.js';
 export { renderStyledSegment } from './text_format.js';
 
 window.Formatter = Formatter;

--- a/assets/chat_webview/renderer/markdown.js
+++ b/assets/chat_webview/renderer/markdown.js
@@ -5,6 +5,12 @@ import { sanitizeMessageHtml } from '../bridge/html_sanitizer.js';
 /** Cheap pre-sanitize probe for an embedded `<script>` in formatted HTML. */
 const SCRIPT_TAG = /<script\b/i;
 
+/** How many times a generated image may re-request itself after a failure. */
+const LOCAL_IMAGE_RETRY_LIMIT = 2;
+
+/** Backoff before the first retry; later attempts scale with the attempt. */
+const LOCAL_IMAGE_RETRY_DELAY_MS = 350;
+
 /**
  * Tell Flutter that a message wanted to run JS while execution is off, so the
  * app can offer to turn it on. The check has to run on the *formatted* HTML:
@@ -51,9 +57,40 @@ export function writeShadowContent({
     syncCodeBlockMetadata(root);
     executeInlineScripts(root, allowMessageScripts);
     fixDetailsSummaryArrows(root);
+    retryFailedLocalImages(root);
   } catch (e) {
     root.textContent = text || '';
     console.error('Formatter error:', e);
+  }
+}
+
+/**
+ * Re-requests a generated image that failed to load.
+ *
+ * Generated images are served by the app's own loopback file server, and that
+ * fetch can lose a race the picture itself is not to blame for — the file
+ * server is still answering an aborted request from the render this one
+ * replaced, or the app is mid-resize as the reply settles. The browser never
+ * retries a failed <img>, so a message keeps the broken tag until something
+ * re-renders it. A couple of delayed attempts with a fresh query string (the
+ * file server reads only `path`, and a new URL sidesteps a cached failure)
+ * turn that into a picture that simply arrives a moment later.
+ */
+export function retryFailedLocalImages(root) {
+  for (const img of root.querySelectorAll('img.imggen-result')) {
+    if (img.dataset.retryWired) continue;
+    img.dataset.retryWired = '1';
+    img.addEventListener('error', () => {
+      const source = img.dataset.src || '';
+      if (!source) return;
+      const attempt = Number(img.dataset.retryAttempt || '0') + 1;
+      if (attempt > LOCAL_IMAGE_RETRY_LIMIT) return;
+      img.dataset.retryAttempt = String(attempt);
+      setTimeout(() => {
+        const separator = source.includes('?') ? '&' : '?';
+        img.src = `${source}${separator}__glaze_retry=${attempt}`;
+      }, LOCAL_IMAGE_RETRY_DELAY_MS * attempt);
+    });
   }
 }
 

--- a/assets/chat_webview/renderer/shadow_style.js
+++ b/assets/chat_webview/renderer/shadow_style.js
@@ -246,6 +246,53 @@ export const SHADOW_STYLE = `
     margin: 6px 0;
     max-width: 100%;
   }
+  /* Block-level image switcher: the message switcher, shrunk and made
+     see-through so it sits on the picture without covering it. Only rendered
+     when the block holds more than one image. */
+  .glaze-message .imggen-variants {
+    position: absolute;
+    left: 8px;
+    bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 1px;
+    height: 18px;
+    padding: 0 2px;
+    border-radius: 9px;
+    background: rgba(0, 0, 0, 0.38);
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    color: rgba(255, 255, 255, 0.92);
+    font-size: 10px;
+    line-height: 1;
+    opacity: 0.45;
+    transition: opacity 0.15s;
+  }
+  .glaze-message .imggen-result-wrapper:hover .imggen-variants { opacity: 1; }
+  .glaze-message .imggen-variant-btn {
+    width: 16px;
+    height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background: none;
+    color: inherit;
+    cursor: pointer;
+  }
+  .glaze-message .imggen-variant-btn svg {
+    width: 12px;
+    height: 12px;
+    fill: currentColor;
+    pointer-events: none;
+  }
+  .glaze-message .imggen-variant-btn:active { opacity: 0.6; }
+  .glaze-message .imggen-variant-count {
+    min-width: 20px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+  }
+
   .glaze-message .imggen-result {
     max-width: 100%;
     border-radius: 10px;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1153,7 +1153,7 @@ feature-local adapters to `SyncService`.
 - `image_prompt_builder.dart` — `[STYLE: …]` block, reference descriptions, reference instruction
 - `reference_matcher.dart` — alias / word-boundary matching of the reference library against a prompt
 - `image_reference_collector.dart` — avatars + matched references + context images, clipped per model
-- `image_tag_markup.dart` — pure `[IMG:GEN]`/`[IMG:RESULT]`/`[IMG:ERROR]` tag text transforms (extracted from ImageGenService)
+- `image_tag_markup.dart` — pure `[IMG:GEN]`/`[IMG:RESULT]`/`[IMG:ERROR]` tag text transforms (extracted from ImageGenService), including `ImageBlockPayload`: the images one block carries, which of them is visible, and the instruction that produced them (INV-IG8)
 - `image_gen_provider.dart` — manages settings + generation state
 - `image_gen_models.dart` — Freezed data models for image generation
 - `image_gen_constants.dart` — per-provider model / ratio / resolution tables (re-exported by the models file)
@@ -1165,6 +1165,16 @@ feature-local adapters to `SyncService`.
   `gemini_image_provider.dart`, `naistera_image_provider.dart`, `openrouter_image_provider.dart`,
   `a1111_image_provider.dart`
 - UI: `widgets/image_gen_sheet.dart`, `widgets/image_content_renderer.dart`
+
+### Image variants
+
+Regenerating a picture appends to its block instead of replacing it: the block
+keeps every image it has produced and the message shows one of them. The chat
+formatter renders a small translucent `‹ n/N ›` switcher on the picture once a
+block holds a second image; paging swaps the `<img>` in the page (every variant
+is resolved to a servable URL up front) and reports the choice back through
+`onImgVariant`, which rewrites the active swipe in place — no message swipe is
+created for it (INV-IG7, INV-IG8).
 
 ### Reference handling
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -116,6 +116,15 @@ regenerates the tapped image only and leaves the other images of the message
 untouched. A missing index (markdown images) disables the generation actions
 rather than falling back to the whole message.
 
+### INV-IG7: Regenerating an image never adds a message swipe
+
+`ImageRecoveryService` resets the retried blocks through
+`ImageGenProcessor.resetImageContentInPlace()`, which rewrites the swipe the
+user is looking at (content, `swipes[swipeId]`, its agent swipe and metadata)
+and clears the error flag left by the failed block. Rerolling a picture must
+not grow the reply's swipe count or duplicate the text around the image — only
+a text generation creates swipes.
+
 ---
 
 ## 3. Summary Generation Invariants

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -116,6 +116,19 @@ regenerates the tapped image only and leaves the other images of the message
 untouched. A missing index (markdown images) disables the generation actions
 rather than falling back to the whole message.
 
+### INV-IG8: A block keeps every image it generates
+
+`ImageBlockPayload` (image_tag_markup.dart) is the single codec for the tag
+payload: `[IMG:RESULT:/a.png;;*/b.png|<instruction>]` lists the images of one
+block oldest first and marks the visible one with `*`; a pending block carries
+them through a regeneration behind `@`, and an error card behind its
+`variants` string. A block with one image keeps the historical
+`path|instruction` spelling, so older messages parse unchanged. Only the
+visible image counts as context for the next generation
+(`extractImageResultPaths`), the WebView formatter parses the same format
+(`parseImageResultPayload`), and `rewriteResultPaths` resolves every variant so
+the switcher can page through them without a round trip to Dart.
+
 ### INV-IG7: Regenerating an image never adds a message swipe
 
 `ImageRecoveryService` resets the retried blocks through

--- a/lib/features/chat/bridge/bridge_handlers.dart
+++ b/lib/features/chat/bridge/bridge_handlers.dart
@@ -90,6 +90,7 @@ const Map<String, HandlerSpec> bridgeHandlers = {
     debugPrint: '[BRIDGE] onImgCancel called',
   ),
   'onImgOptions': HandlerSpec(HandlerKind.jsonObject),
+  'onImgVariant': HandlerSpec(HandlerKind.jsonObject),
   // Stop
   'onStop': HandlerSpec(HandlerKind.noArgs),
   // Ext blocks

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -11,6 +11,7 @@ import '../../../core/models/chat_message.dart';
 import '../../../core/models/persona.dart';
 import '../../../core/models/preset.dart';
 import '../../extensions/services/js_bridge_service.dart';
+import '../../image_gen/services/image_tag_markup.dart';
 import 'chat_webview_environment.dart';
 import 'chat_message_mapper.dart';
 import 'bridge_handlers.dart';
@@ -185,15 +186,7 @@ class ChatBridgeController {
   // private state of the host.
 
   Future<String> resolveImgResults(String text) async {
-    return text.replaceAllMapped(
-      RegExp(r'\[IMG:RESULT:([^\]|]+)(\|[^\]]*)?\]'),
-      (match) {
-        final path = match.group(1) ?? '';
-        final suffix = match.group(2) ?? '';
-        final resolved = resolveLocalFileUrl(path);
-        return resolved == null ? '' : '[IMG:RESULT:$resolved$suffix]';
-      },
-    );
+    return ImageTagMarkup.rewriteResultPaths(text, resolveLocalFileUrl);
   }
 
   String? resolveLocalFileUrl(String? source) {

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -299,6 +299,8 @@ class ChatBridgeController {
     int? blockIndex,
   )?
   onImgOptions;
+  void Function(String messageId, int blockIndex, int variantIndex)?
+  onImgVariant;
   void Function()? onImgCancel;
   void Function()? onStop;
   void Function(String messageId)? onExtBlocksRunAll;
@@ -467,6 +469,14 @@ class ChatBridgeController {
             data['messageId'] as String? ?? '',
             _blockIndex(data['imgIndex']),
           );
+        case 'onImgVariant':
+          final messageId = data['messageId'] as String? ?? '';
+          final blockIndex = _blockIndex(data['imgIndex']);
+          final variantIndex = _blockIndex(data['variantIndex']);
+          if (messageId.isEmpty || blockIndex == null || variantIndex == null) {
+            return;
+          }
+          onImgVariant?.call(messageId, blockIndex, variantIndex);
         case 'onPanelEvent':
           final panelId = data['panelId'] as String? ?? '';
           final event = data['event'] as String? ?? 'action';

--- a/lib/features/chat/bridge/chat_webview_environment.dart
+++ b/lib/features/chat/bridge/chat_webview_environment.dart
@@ -232,50 +232,80 @@ Future<void> _startChatWebViewBundleServer() async {
 
 Future<void> _serveChatWebViewBundleAssets(HttpServer server) async {
   await for (final request in server) {
-    try {
-      final path = _safeAssetPath(request.uri.path);
-      if (path == null) {
-        request.response.statusCode = HttpStatus.forbidden;
-        await request.response.close();
-        continue;
-      }
-
-      // Asset keys always use forward slashes regardless of platform.
-      final assetKey =
-          'assets/chat_webview/${path.replaceAll(Platform.pathSeparator, '/')}';
-      ByteData data;
-      try {
-        data = await rootBundle.load(assetKey);
-      } catch (_) {
-        request.response.statusCode = HttpStatus.notFound;
-        await request.response.close();
-        continue;
-      }
-
-      request.response.headers.contentType = _contentTypeFor(path);
-      request.response.add(
-        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
-      );
-      await request.response.close();
-    } catch (_) {
-      request.response.statusCode = HttpStatus.internalServerError;
-      await request.response.close();
-    }
+    unawaited(_handleServerRequest(request, _serveBundleAsset));
   }
+}
+
+Future<void> _serveBundleAsset(HttpRequest request) async {
+  final path = _safeAssetPath(request.uri.path);
+  if (path == null) {
+    request.response.statusCode = HttpStatus.forbidden;
+    await request.response.close();
+    return;
+  }
+
+  // Asset keys always use forward slashes regardless of platform.
+  final assetKey =
+      'assets/chat_webview/${path.replaceAll(Platform.pathSeparator, '/')}';
+  ByteData data;
+  try {
+    data = await rootBundle.load(assetKey);
+  } catch (_) {
+    request.response.statusCode = HttpStatus.notFound;
+    await request.response.close();
+    return;
+  }
+
+  request.response.headers.contentType = _contentTypeFor(path);
+  request.response.add(
+    data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+  );
+  await request.response.close();
 }
 
 Future<void> _serveChatWebViewLocalFiles(HttpServer server) async {
   await for (final request in server) {
+    unawaited(_handleServerRequest(request, _serveLocalFile));
+  }
+}
+
+Future<void> _serveLocalFile(HttpRequest request) async {
+  if (request.uri.path != '/__glaze_file__') {
+    request.response.statusCode = HttpStatus.notFound;
+    await request.response.close();
+    return;
+  }
+  await _serveGlazeDataFile(request);
+}
+
+/// Runs one request handler in isolation.
+///
+/// Two reasons this is not inlined in the `await for` loops. Awaiting the
+/// handler there served the page one file at a time, so a single slow or
+/// half-abandoned response (the chat re-renders a message body while its image
+/// is still downloading) held back every other avatar and generated image
+/// behind it — long enough for a freshly generated image to render as a broken
+/// tag. And a failure raised after the headers were already on the wire made
+/// the recovery path throw again, which escaped the loop and tore the whole
+/// server down, so every later request failed too. Handlers now run
+/// concurrently, and a late failure is answered as far as the response still
+/// allows and then dropped.
+Future<void> _handleServerRequest(
+  HttpRequest request,
+  Future<void> Function(HttpRequest request) handler,
+) async {
+  try {
+    await handler(request);
+  } catch (_) {
     try {
-      if (request.uri.path != '/__glaze_file__') {
-        request.response.statusCode = HttpStatus.notFound;
-        await request.response.close();
-        continue;
-      }
-      await _serveGlazeDataFile(request);
-    } catch (_) {
       request.response.statusCode = HttpStatus.internalServerError;
+    } catch (_) {
+      // Headers already sent — the status can no longer be changed.
+    }
+    try {
       await request.response.close();
+    } catch (_) {
+      // Connection already gone.
     }
   }
 }
@@ -296,29 +326,28 @@ Directory _chatWebViewAssetDirectory() {
 
 Future<void> _serveChatWebViewAssets(HttpServer server, Directory root) async {
   await for (final request in server) {
-    try {
-      final path = _safeAssetPath(request.uri.path);
-      if (path == null) {
-        request.response.statusCode = HttpStatus.forbidden;
-        await request.response.close();
-        continue;
-      }
-
-      final file = File('${root.path}${Platform.pathSeparator}$path');
-      if (!file.existsSync()) {
-        request.response.statusCode = HttpStatus.notFound;
-        await request.response.close();
-        continue;
-      }
-
-      request.response.headers.contentType = _contentTypeFor(path);
-      await request.response.addStream(file.openRead());
-      await request.response.close();
-    } catch (_) {
-      request.response.statusCode = HttpStatus.internalServerError;
-      await request.response.close();
-    }
+    unawaited(_handleServerRequest(request, (r) => _serveAssetFile(r, root)));
   }
+}
+
+Future<void> _serveAssetFile(HttpRequest request, Directory root) async {
+  final path = _safeAssetPath(request.uri.path);
+  if (path == null) {
+    request.response.statusCode = HttpStatus.forbidden;
+    await request.response.close();
+    return;
+  }
+
+  final file = File('${root.path}${Platform.pathSeparator}$path');
+  if (!file.existsSync()) {
+    request.response.statusCode = HttpStatus.notFound;
+    await request.response.close();
+    return;
+  }
+
+  request.response.headers.contentType = _contentTypeFor(path);
+  await request.response.addStream(file.openRead());
+  await request.response.close();
 }
 
 Future<void> _serveGlazeDataFile(HttpRequest request) async {

--- a/lib/features/chat/chat_provider.dart
+++ b/lib/features/chat/chat_provider.dart
@@ -199,6 +199,15 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     instruction,
     blockIndex: blockIndex,
   );
+  Future<void> selectImageVariant(
+    String messageId,
+    int blockIndex,
+    int variantIndex,
+  ) async => _imageRecoverySvc.selectImageVariant(
+    messageId,
+    blockIndex,
+    variantIndex,
+  );
   final Set<String> _queuedImageRetries = <String>{};
   Future<void> retryImageGenerationForMessage(
     String messageId, {

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -1608,6 +1608,15 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                 .cancelImageGeneration();
                           },
                           onImgDownload: _downloadImage,
+                          onImgVariant: (messageId, blockIndex, variantIndex) {
+                            ref
+                                .read(chatProvider(widget.charId).notifier)
+                                .selectImageVariant(
+                                  messageId,
+                                  blockIndex,
+                                  variantIndex,
+                                );
+                          },
                           onImgOptions: _showImageOptionsSheet,
                         ),
                         scrollActions: ScrollCallbacks(

--- a/lib/features/chat/image_recovery_service.dart
+++ b/lib/features/chat/image_recovery_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as p;
@@ -201,33 +202,64 @@ class ImageRecoveryService {
   /// Turns only the failed blocks back into pending tags, leaving the images
   /// that did arrive in place. This is what the error card's regenerate button
   /// runs: retrying one block must not throw away its finished siblings.
-  static String resetImgErrorTagsToGen(String text) {
-    return text.replaceAllMapped(ImgGenPatterns.imgErrorRegex, (m) {
-      final data = m.group(1) ?? '';
-      String instruction = '';
-      try {
-        final parsed = jsonDecode(data);
-        instruction = (parsed['instruction'] ?? '') as String;
-      } catch (_) {}
-      if (instruction.isNotEmpty) {
-        return '[IMG:GEN:$instruction]';
-      }
-      return '[IMG:GEN]';
-    });
-  }
+  /// Only the failed blocks go back to pending; finished images stay.
+  static String resetImgErrorTagsToGen(String text) =>
+      ImageTagMarkup.resetImageErrorTags(text);
 
-  static String resetImgTagsToGen(String text) {
-    var result = resetImgErrorTagsToGen(text);
-    result = result.replaceAllMapped(ImgGenPatterns.imgResultRegex, (m) {
-      final raw = m.group(1) ?? '';
-      final pipeIdx = raw.indexOf('|');
-      final instr = pipeIdx != -1 ? raw.substring(pipeIdx + 1) : '';
-      if (instr.isNotEmpty) {
-        return '[IMG:GEN:$instr]';
-      }
-      return '[IMG:GEN]';
-    });
-    return result;
+  /// Every block of the message goes back to pending, keeping its prompt and
+  /// the images it already holds.
+  static String resetImgTagsToGen(String text) =>
+      ImageTagMarkup.resetErrorTags(text);
+
+  /// Puts another image of one block on screen — the block-level counterpart
+  /// of a message swipe.
+  ///
+  /// The page has already swapped the picture when this arrives, so the write
+  /// only has to make the choice durable: the active swipe of the message is
+  /// rewritten in place, exactly like a regeneration does, and no swipe is
+  /// added for it.
+  Future<void> selectImageVariant(
+    String messageId,
+    int blockIndex,
+    int variantIndex,
+  ) async {
+    final current = _getState().value;
+    final session = current?.session;
+    if (current == null || session == null) return;
+
+    final message = session.messages.firstWhereOrNull((m) => m.id == messageId);
+    if (message == null || message.role != 'assistant') return;
+    if (ImageTagMarkup.setImageBlockVariant(
+          message.content,
+          blockIndex,
+          variantIndex,
+        ) ==
+        message.content) {
+      return;
+    }
+
+    final updated = await _ref
+        .read(chatRepoProvider)
+        .mutateMessage(
+          sessionId: session.id,
+          messageId: messageId,
+          updatedAt: currentTimestampSeconds(),
+          mutate: (stored) {
+            if (stored.role != 'assistant') return null;
+            final content = ImageTagMarkup.setImageBlockVariant(
+              stored.content,
+              blockIndex,
+              variantIndex,
+            );
+            if (content == stored.content) return null;
+            return ImageGenProcessor.replaceActiveImageContent(stored, content);
+          },
+        );
+    if (updated == null) return;
+    ChatSessionService.updateCache(updated);
+    final liveState = _getState().value;
+    if (liveState == null || liveState.session?.id != updated.id) return;
+    _setState(AsyncData(liveState.copyWith(session: updated)));
   }
 
   Future<void> retryImageGeneration() async {

--- a/lib/features/chat/image_recovery_service.dart
+++ b/lib/features/chat/image_recovery_service.dart
@@ -271,7 +271,7 @@ class ImageRecoveryService {
                 !ImageTagMarkup.hasImageGenTags(content)) {
               return null;
             }
-            return ImageGenProcessor.appendImageRegenerationSwipe(
+            return ImageGenProcessor.resetImageContentInPlace(
               message,
               content,
             );
@@ -392,7 +392,7 @@ class ImageRecoveryService {
             if (message.role != 'assistant') return null;
             final content = reset(message.content);
             if (content == message.content) return null;
-            return ImageGenProcessor.appendImageRegenerationSwipe(
+            return ImageGenProcessor.resetImageContentInPlace(
               message,
               content,
             );

--- a/lib/features/chat/services/image_gen_processor.dart
+++ b/lib/features/chat/services/image_gen_processor.dart
@@ -315,64 +315,26 @@ class ImageGenProcessor {
         );
   }
 
-  static ChatMessage appendImageRegenerationSwipe(
+  /// Rewrites the image blocks of the swipe the user is looking at.
+  ///
+  /// Regenerating a picture used to append a message swipe, so "regenerate
+  /// this image" read as a whole new reply: the swipe counter grew and the
+  /// text around the image was duplicated into the new variant. The retried
+  /// blocks are reset inside the active swipe instead, which leaves the reply
+  /// itself — and its swipe count — alone. An error flag left over from the
+  /// failed block is cleared with them, the way the appending path did.
+  static ChatMessage resetImageContentInPlace(
     ChatMessage message,
     String pendingContent,
   ) {
-    final swipes = message.swipes.isEmpty
-        ? <String>[message.content]
-        : List<String>.from(message.swipes);
-    final activeSwipeId = message.swipeId.clamp(0, swipes.length - 1);
-    final meta = List<Map<String, dynamic>>.generate(
-      swipes.length,
-      (index) => index < message.swipesMeta.length
-          ? Map<String, dynamic>.from(message.swipesMeta[index])
-          : <String, dynamic>{},
-    );
-    final activeAgentSwipes = message.agentSwipes.isEmpty
-        ? <AgentSwipe>[
-            AgentSwipe(
-              content: message.content,
-              reasoning: message.reasoning,
-              genTime: message.genTime,
-              tokens: message.tokens,
-              studioOutputs: message.studioOutputs,
-            ),
-          ]
-        : List<AgentSwipe>.from(message.agentSwipes);
-    final activeAgentSwipeId = message.agentSwipeId.clamp(
-      0,
-      activeAgentSwipes.length - 1,
-    );
-    meta[activeSwipeId] = {
-      ...meta[activeSwipeId],
-      'agentSwipes': activeAgentSwipes.map((swipe) => swipe.toJson()).toList(),
-      'agentSwipeId': activeAgentSwipeId,
-    };
-
-    final candidateAgentSwipes = List<AgentSwipe>.from(activeAgentSwipes);
-    candidateAgentSwipes[activeAgentSwipeId] =
-        candidateAgentSwipes[activeAgentSwipeId].copyWith(
-          content: pendingContent,
-        );
-    final candidateMeta = Map<String, dynamic>.from(meta[activeSwipeId])
-      ..remove('isError')
-      ..['agentSwipes'] = candidateAgentSwipes
-          .map((swipe) => swipe.toJson())
-          .toList()
-      ..['agentSwipeId'] = activeAgentSwipeId;
-    swipes.add(pendingContent);
-    meta.add(candidateMeta);
-
-    return message.copyWith(
-      content: pendingContent,
-      swipes: swipes,
-      swipeId: swipes.length - 1,
-      swipesMeta: meta,
-      agentSwipes: candidateAgentSwipes,
-      agentSwipeId: activeAgentSwipeId,
-      isError: false,
-    );
+    final updated = replaceActiveImageContent(message, pendingContent);
+    final meta = List<Map<String, dynamic>>.from(updated.swipesMeta);
+    final swipeId = updated.swipeId;
+    if (swipeId >= 0 && swipeId < meta.length) {
+      meta[swipeId] = Map<String, dynamic>.from(meta[swipeId])
+        ..remove('isError');
+    }
+    return updated.copyWith(swipesMeta: meta, isError: false);
   }
 
   static ChatMessage replaceActiveImageContent(

--- a/lib/features/chat/widgets/chat_webview_callbacks.dart
+++ b/lib/features/chat/widgets/chat_webview_callbacks.dart
@@ -144,6 +144,10 @@ class ChatWebViewCallbacks {
     imageGenActions.onImgOptions?.call(src, instruction, messageId, blockIndex);
   }
 
+  void onImgVariant(String messageId, int blockIndex, int variantIndex) {
+    imageGenActions.onImgVariant?.call(messageId, blockIndex, variantIndex);
+  }
+
   void onImgCancel() {
     imageGenActions.onImgCancel?.call();
   }

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -200,6 +200,7 @@ class _ChatWebViewSurfaceState extends ConsumerState<ChatWebViewSurface> {
     bridge.onImgFind = callbacks.onImgFind;
     bridge.onImgRegen = callbacks.onImgRegen;
     bridge.onImgOptions = callbacks.onImgOptions;
+    bridge.onImgVariant = callbacks.onImgVariant;
     bridge.onImgCancel = callbacks.onImgCancel;
     bridge.onStop = callbacks.onStop;
     bridge.onLinkClick = callbacks.onLinkClick;

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -626,6 +626,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     bridge.onImgFind = callbacks.onImgFind;
     bridge.onImgRegen = callbacks.onImgRegen;
     bridge.onImgOptions = callbacks.onImgOptions;
+    bridge.onImgVariant = callbacks.onImgVariant;
     bridge.onImgCancel = callbacks.onImgCancel;
     bridge.onStop = callbacks.onStop;
     bridge.onLinkClick = callbacks.onLinkClick;

--- a/lib/features/chat/widgets/webview_callbacks.dart
+++ b/lib/features/chat/widgets/webview_callbacks.dart
@@ -22,6 +22,8 @@ typedef EditFocusCallback = void Function(String id, bool focused);
 /// handler then falls back to acting on the whole message.
 typedef ImgActionCallback =
     void Function(String instruction, String messageId, int? blockIndex);
+typedef ImgVariantCallback =
+    void Function(String messageId, int blockIndex, int variantIndex);
 typedef ImgOptionsCallback =
     void Function(
       String src,
@@ -82,6 +84,7 @@ class ImageGenCallbacks {
   final ImgActionCallback? onImgFind;
   final ImgActionCallback? onImgRegen;
   final ImgOptionsCallback? onImgOptions;
+  final ImgVariantCallback? onImgVariant;
   final ImgVoidCallback? onImgCancel;
   final ImageClickCallback? onImgDownload;
 
@@ -91,6 +94,7 @@ class ImageGenCallbacks {
     this.onImgFind,
     this.onImgRegen,
     this.onImgOptions,
+    this.onImgVariant,
     this.onImgCancel,
     this.onImgDownload,
   });

--- a/lib/features/image_gen/services/image_tag_markup.dart
+++ b/lib/features/image_gen/services/image_tag_markup.dart
@@ -279,6 +279,30 @@ class ImageTagMarkup {
         .toList();
   }
 
+  /// Rewrites the file path inside every `[IMG:RESULT:…]` tag with [resolve],
+  /// dropping the whole tag when it returns null.
+  ///
+  /// The payload is split exactly like the WebView formatter does — the tag
+  /// ends at the first `]`, the path ends at the first `|` — so an instruction
+  /// JSON carrying a `]` cannot leave the two sides disagreeing about which
+  /// substring is the path. A stricter pattern skipped such a tag, and the raw
+  /// filesystem path then reached the page as `file://…`, which the chat
+  /// WebView (an https / loopback origin) cannot load at all: the message
+  /// rendered a broken image.
+  static String rewriteResultPaths(
+    String text,
+    String? Function(String path) resolve,
+  ) {
+    return text.replaceAllMapped(ImgGenPatterns.imgResultRegex, (match) {
+      final payload = match.group(1) ?? '';
+      final pipeIdx = payload.indexOf('|');
+      final path = pipeIdx == -1 ? payload : payload.substring(0, pipeIdx);
+      final suffix = pipeIdx == -1 ? '' : payload.substring(pipeIdx);
+      final resolved = resolve(path);
+      return resolved == null ? '' : '[IMG:RESULT:$resolved$suffix]';
+    });
+  }
+
   /// Strips optional `|instructionJson` suffix from [IMG:RESULT:…] payloads.
   static String normalizeImageResultPayload(String payload) {
     final pipeIdx = payload.indexOf('|');

--- a/lib/features/image_gen/services/image_tag_markup.dart
+++ b/lib/features/image_gen/services/image_tag_markup.dart
@@ -2,6 +2,149 @@ import 'dart:convert';
 
 import '../../../core/constants/image_gen_patterns.dart';
 
+/// The images one image block carries, which of them is on screen, and the
+/// instruction that produced them.
+///
+/// A block keeps every image it has generated so the reader can page back
+/// through them, so the tag payload is a list rather than a single path:
+///
+///     [IMG:RESULT:/a.png;;*/b.png|{"prompt":"…"}]
+///     [IMG:GEN:@/a.png;;/b.png|{"prompt":"…"}]
+///
+/// Rules that keep older messages readable and newer ones unambiguous:
+///
+/// * the instruction is always the last segment, so a `|` inside a prompt is
+///   never mistaken for a separator;
+/// * a result block with one image keeps the historical `path|instruction`
+///   spelling, and gains `;;` separators only once it holds a second image;
+/// * `*` marks the visible image, and is only written when there is more than
+///   one — without it the first image is the visible one;
+/// * a pending block introduces its carried images with `@`, because its
+///   payload is otherwise a bare instruction (JSON or plain prompt text) that
+///   must keep parsing exactly as before.
+class ImageBlockPayload {
+  const ImageBlockPayload({
+    this.paths = const [],
+    this.activeIndex = 0,
+    this.instruction = '',
+  });
+
+  /// Every image generated for this block, oldest first.
+  final List<String> paths;
+
+  /// Position in [paths] of the image the message shows.
+  final int activeIndex;
+
+  /// Instruction JSON (or raw prompt text) carried by the block.
+  final String instruction;
+
+  static const String _separator = ';;';
+  static const String _activeMarker = '*';
+  static const String _pendingMarker = '@';
+
+  /// The image on screen, or empty when the block has none yet.
+  String get activePath => paths.isEmpty
+      ? ''
+      : paths[activeIndex.clamp(0, paths.length - 1)];
+
+  bool get hasVariants => paths.length > 1;
+
+  /// Reads a `[IMG:RESULT:…]` payload, whose leading segment is the path list.
+  static ImageBlockPayload parseResult(String payload) {
+    final pipeIdx = payload.indexOf('|');
+    final head = pipeIdx == -1 ? payload : payload.substring(0, pipeIdx);
+    final instruction = pipeIdx == -1 ? '' : payload.substring(pipeIdx + 1);
+    return _fromPathList(head, instruction);
+  }
+
+  /// Reads a `[IMG:GEN:…]` payload: a bare instruction, or images carried
+  /// through the regeneration behind the `@` marker.
+  static ImageBlockPayload parsePending(String payload) {
+    if (!payload.startsWith(_pendingMarker)) {
+      return ImageBlockPayload(instruction: payload);
+    }
+    final rest = payload.substring(_pendingMarker.length);
+    final pipeIdx = rest.indexOf('|');
+    final head = pipeIdx == -1 ? rest : rest.substring(0, pipeIdx);
+    final instruction = pipeIdx == -1 ? '' : rest.substring(pipeIdx + 1);
+    return _fromPathList(head, instruction);
+  }
+
+  static ImageBlockPayload _fromPathList(String head, String instruction) {
+    final paths = <String>[];
+    var active = 0;
+    for (final entry in head.split(_separator)) {
+      if (entry.isEmpty) continue;
+      if (entry.startsWith(_activeMarker)) {
+        active = paths.length;
+        paths.add(entry.substring(_activeMarker.length));
+      } else {
+        paths.add(entry);
+      }
+    }
+    return ImageBlockPayload(
+      paths: paths,
+      activeIndex: paths.isEmpty ? 0 : active.clamp(0, paths.length - 1),
+      instruction: instruction,
+    );
+  }
+
+  String encodeResult() {
+    final head = _encodePathList();
+    return instruction.isEmpty ? head : '$head|$instruction';
+  }
+
+  String encodePending() {
+    if (paths.isEmpty) return instruction;
+    final head = '$_pendingMarker${_encodePathList()}';
+    return instruction.isEmpty ? head : '$head|$instruction';
+  }
+
+  String _encodePathList() {
+    if (paths.length < 2) return paths.isEmpty ? '' : paths.first;
+    final active = activeIndex.clamp(0, paths.length - 1);
+    return [
+      for (var i = 0; i < paths.length; i++)
+        i == active ? '$_activeMarker${paths[i]}' : paths[i],
+    ].join(_separator);
+  }
+
+  /// Appends [path] and puts it on screen — what a finished (re)generation
+  /// does, so the previous images stay reachable through the block switcher.
+  ImageBlockPayload withNewImage(String path) => ImageBlockPayload(
+    paths: [...paths, path],
+    activeIndex: paths.length,
+    instruction: instruction,
+  );
+
+  ImageBlockPayload withActiveIndex(int index) => ImageBlockPayload(
+    paths: paths,
+    activeIndex: paths.isEmpty ? 0 : index.clamp(0, paths.length - 1),
+    instruction: instruction,
+  );
+
+  ImageBlockPayload withPaths(List<String> newPaths, {int? activeIndex}) =>
+      ImageBlockPayload(
+        paths: newPaths,
+        activeIndex: newPaths.isEmpty
+            ? 0
+            : (activeIndex ?? this.activeIndex).clamp(0, newPaths.length - 1),
+        instruction: instruction,
+      );
+
+  ImageBlockPayload withInstruction(String value) => ImageBlockPayload(
+    paths: paths,
+    activeIndex: activeIndex,
+    instruction: value,
+  );
+
+  /// The path list on its own, as carried through an error card.
+  String encodePathList() => _encodePathList();
+
+  static List<String> decodePathList(String value) =>
+      _fromPathList(value, '').paths;
+}
+
 /// One pending image tag located in a message: the span it occupies and the
 /// raw instruction payload it carries.
 class PendingImageTag {
@@ -40,6 +183,8 @@ class ImageBlock {
     required this.kind,
     required this.instruction,
     this.imagePath = '',
+    this.paths = const [],
+    this.activeIndex = 0,
   });
 
   final int start;
@@ -49,13 +194,27 @@ class ImageBlock {
   /// Instruction JSON carried by the block, or empty when it has none.
   final String instruction;
 
-  /// Saved file of a finished block; empty for the other kinds.
+  /// Visible image of a finished block; empty for the other kinds.
   final String imagePath;
 
-  /// The block written back as a pending tag, prompt included, so a
-  /// regeneration does not have to ask the model for the prompt again.
-  String get asPendingTag =>
-      instruction.isEmpty ? '[IMG:GEN]' : '[IMG:GEN:$instruction]';
+  /// Every image this block has generated, oldest first. A pending or failed
+  /// block carries the images of its earlier attempts here.
+  final List<String> paths;
+
+  /// Position of [imagePath] inside [paths].
+  final int activeIndex;
+
+  /// The block written back as a pending tag, prompt and earlier images
+  /// included, so a regeneration neither asks the model for the prompt again
+  /// nor loses the images the block already holds.
+  String get asPendingTag {
+    final payload = ImageBlockPayload(
+      paths: paths,
+      activeIndex: activeIndex,
+      instruction: instruction,
+    ).encodePending();
+    return payload.isEmpty ? '[IMG:GEN]' : '[IMG:GEN:$payload]';
+  }
 }
 
 /// Pure text transformations for `[IMG:GEN]` / `[IMG:RESULT:]` / `[IMG:ERROR]`
@@ -117,12 +276,13 @@ class ImageTagMarkup {
       scanPendingTags(text).map(_decodeInstruction).toList();
 
   static Map<String, dynamic> _decodeInstruction(PendingImageTag tag) {
-    if (tag.payload.isEmpty) return <String, dynamic>{'prompt': ''};
+    final instruction = ImageBlockPayload.parsePending(tag.payload).instruction;
+    if (instruction.isEmpty) return <String, dynamic>{'prompt': ''};
     try {
-      final decoded = jsonDecode(tag.payload);
+      final decoded = jsonDecode(instruction);
       if (decoded is Map<String, dynamic>) return decoded;
     } catch (_) {}
-    return <String, dynamic>{'prompt': tag.payload};
+    return <String, dynamic>{'prompt': instruction};
   }
 
   static String replaceTagWithResult(String text, int index, String imagePath) {
@@ -131,7 +291,10 @@ class ImageTagMarkup {
     final tag = tags[index];
     final instruction = _decodeInstruction(tag);
     final instrJson = instruction.isNotEmpty ? jsonEncode(instruction) : '';
-    final payload = instrJson.isNotEmpty ? '$imagePath|$instrJson' : imagePath;
+    final payload = ImageBlockPayload.parsePending(tag.payload)
+        .withInstruction(instrJson)
+        .withNewImage(imagePath)
+        .encodeResult();
     return text.replaceRange(tag.start, tag.end, '[IMG:RESULT:$payload]');
   }
 
@@ -140,9 +303,13 @@ class ImageTagMarkup {
     if (index < 0 || index >= tags.length) return text;
     final tag = tags[index];
     final instructionJson = jsonEncode(_decodeInstruction(tag));
+    // The path list rides along as a plain string: the error payload is JSON,
+    // and a JSON array would close the tag on its own `]`.
+    final carried = ImageBlockPayload.parsePending(tag.payload).encodePathList();
     final encoded = jsonEncode({
       'error': error,
       if (instructionJson.isNotEmpty) 'instruction': instructionJson,
+      if (carried.isNotEmpty) 'variants': carried,
     });
     return text.replaceRange(tag.start, tag.end, '[IMG:ERROR:$encoded]');
   }
@@ -164,27 +331,39 @@ class ImageTagMarkup {
     return result;
   }
 
-  static String resetErrorTags(String text) {
-    var result = text.replaceAllMapped(ImgGenPatterns.imgErrorRegex, (m) {
+  static String resetErrorTags(String text) =>
+      resetResultTags(resetImageErrorTags(text));
+
+  /// Sends every `[IMG:ERROR:…]` card back to pending, keeping its prompt and
+  /// the images its earlier attempts produced.
+  static String resetImageErrorTags(String text) {
+    return text.replaceAllMapped(ImgGenPatterns.imgErrorRegex, (m) {
       try {
         final json = jsonDecode(m.group(1)!) as Map<String, dynamic>;
-        final instruction = json['instruction'] as String?;
-        if (instruction != null && instruction.isNotEmpty) {
-          return '[IMG:GEN:$instruction]';
-        }
+        return _pendingTag(
+          ImageBlockPayload(
+            paths: ImageBlockPayload.decodePathList(
+              json['variants'] as String? ?? '',
+            ),
+            instruction: json['instruction'] as String? ?? '',
+          ),
+        );
       } catch (_) {}
       return '[IMG:GEN]';
     });
-    result = result.replaceAllMapped(ImgGenPatterns.imgResultRegex, (m) {
-      final raw = m.group(1) ?? '';
-      final pipeIdx = raw.indexOf('|');
-      final instr = pipeIdx != -1 ? raw.substring(pipeIdx + 1) : null;
-      if (instr != null && instr.isNotEmpty) {
-        return '[IMG:GEN:$instr]';
-      }
-      return '[IMG:GEN]';
+  }
+
+  /// Sends every finished `[IMG:RESULT:…]` block back to pending, keeping its
+  /// prompt and the images it already holds.
+  static String resetResultTags(String text) {
+    return text.replaceAllMapped(ImgGenPatterns.imgResultRegex, (m) {
+      return _pendingTag(ImageBlockPayload.parseResult(m.group(1) ?? ''));
     });
-    return result;
+  }
+
+  static String _pendingTag(ImageBlockPayload payload) {
+    final encoded = payload.encodePending();
+    return encoded.isEmpty ? '[IMG:GEN]' : '[IMG:GEN:$encoded]';
   }
 
   /// Every image block of [text] in document order, whatever state it is in.
@@ -194,12 +373,7 @@ class ImageTagMarkup {
   static List<ImageBlock> scanImageBlocks(String text) {
     final blocks = <ImageBlock>[
       for (final tag in scanPendingTags(text))
-        ImageBlock(
-          start: tag.start,
-          end: tag.end,
-          kind: ImageBlockKind.pending,
-          instruction: tag.payload,
-        ),
+        _pendingBlock(tag),
     ];
 
     // A resolved token can never sit inside a pending tag; the guard just keeps
@@ -210,15 +384,16 @@ class ImageTagMarkup {
 
     for (final match in ImgGenPatterns.imgResultRegex.allMatches(text)) {
       if (insidePendingTag(match)) continue;
-      final raw = match.group(1) ?? '';
-      final pipeIdx = raw.indexOf('|');
+      final payload = ImageBlockPayload.parseResult(match.group(1) ?? '');
       blocks.add(
         ImageBlock(
           start: match.start,
           end: match.end,
           kind: ImageBlockKind.result,
-          instruction: pipeIdx != -1 ? raw.substring(pipeIdx + 1) : '',
-          imagePath: normalizeImageResultPayload(raw),
+          instruction: payload.instruction,
+          imagePath: payload.activePath,
+          paths: payload.paths,
+          activeIndex: payload.activeIndex,
         ),
       );
     }
@@ -226,9 +401,15 @@ class ImageTagMarkup {
     for (final match in ImgGenPatterns.imgErrorRegex.allMatches(text)) {
       if (insidePendingTag(match)) continue;
       var instruction = '';
+      var carried = const <String>[];
       try {
         final parsed = jsonDecode(match.group(1) ?? '');
-        if (parsed is Map) instruction = parsed['instruction'] as String? ?? '';
+        if (parsed is Map) {
+          instruction = parsed['instruction'] as String? ?? '';
+          carried = ImageBlockPayload.decodePathList(
+            parsed['variants'] as String? ?? '',
+          );
+        }
       } catch (_) {}
       blocks.add(
         ImageBlock(
@@ -236,12 +417,25 @@ class ImageTagMarkup {
           end: match.end,
           kind: ImageBlockKind.error,
           instruction: instruction,
+          paths: carried,
         ),
       );
     }
 
     blocks.sort((a, b) => a.start.compareTo(b.start));
     return blocks;
+  }
+
+  static ImageBlock _pendingBlock(PendingImageTag tag) {
+    final payload = ImageBlockPayload.parsePending(tag.payload);
+    return ImageBlock(
+      start: tag.start,
+      end: tag.end,
+      kind: ImageBlockKind.pending,
+      instruction: payload.instruction,
+      paths: payload.paths,
+      activeIndex: payload.activeIndex,
+    );
   }
 
   /// Sends the [index]-th image block back to pending, keeping its prompt.
@@ -265,9 +459,34 @@ class ImageTagMarkup {
     final blocks = scanImageBlocks(text);
     if (index < 0 || index >= blocks.length) return text;
     final block = blocks[index];
-    final payload = block.instruction.isEmpty
-        ? imagePath
-        : '$imagePath|${block.instruction}';
+    final payload = ImageBlockPayload(
+      paths: block.paths,
+      activeIndex: block.activeIndex,
+      instruction: block.instruction,
+    ).withNewImage(imagePath).encodeResult();
+    return text.replaceRange(block.start, block.end, '[IMG:RESULT:$payload]');
+  }
+
+  /// Puts the [variantIndex]-th image of the [blockIndex]-th block on screen.
+  ///
+  /// Returns [text] unchanged when either index addresses nothing or the block
+  /// already shows that image, which the caller reads as "nothing to do".
+  static String setImageBlockVariant(
+    String text,
+    int blockIndex,
+    int variantIndex,
+  ) {
+    final blocks = scanImageBlocks(text);
+    if (blockIndex < 0 || blockIndex >= blocks.length) return text;
+    final block = blocks[blockIndex];
+    if (block.kind != ImageBlockKind.result) return text;
+    if (variantIndex < 0 || variantIndex >= block.paths.length) return text;
+    if (variantIndex == block.activeIndex) return text;
+    final payload = ImageBlockPayload(
+      paths: block.paths,
+      activeIndex: variantIndex,
+      instruction: block.instruction,
+    ).encodeResult();
     return text.replaceRange(block.start, block.end, '[IMG:RESULT:$payload]');
   }
 
@@ -294,20 +513,31 @@ class ImageTagMarkup {
     String? Function(String path) resolve,
   ) {
     return text.replaceAllMapped(ImgGenPatterns.imgResultRegex, (match) {
-      final payload = match.group(1) ?? '';
-      final pipeIdx = payload.indexOf('|');
-      final path = pipeIdx == -1 ? payload : payload.substring(0, pipeIdx);
-      final suffix = pipeIdx == -1 ? '' : payload.substring(pipeIdx);
-      final resolved = resolve(path);
-      return resolved == null ? '' : '[IMG:RESULT:$resolved$suffix]';
+      final payload = ImageBlockPayload.parseResult(match.group(1) ?? '');
+      // Every variant is resolved, not just the visible one: the switcher
+      // swaps the image in the page, and a variant it cannot address would
+      // read as a picture that vanished. A variant that cannot be served is
+      // dropped from the block instead.
+      final resolved = <String>[];
+      var active = 0;
+      for (var i = 0; i < payload.paths.length; i++) {
+        final url = resolve(payload.paths[i]);
+        if (url == null) continue;
+        if (i == payload.activeIndex) active = resolved.length;
+        resolved.add(url);
+      }
+      if (resolved.isEmpty) return '';
+      final rewritten = payload
+          .withPaths(resolved, activeIndex: active)
+          .encodeResult();
+      return '[IMG:RESULT:$rewritten]';
     });
   }
 
-  /// Strips optional `|instructionJson` suffix from [IMG:RESULT:…] payloads.
-  static String normalizeImageResultPayload(String payload) {
-    final pipeIdx = payload.indexOf('|');
-    return pipeIdx != -1 ? payload.substring(0, pipeIdx) : payload;
-  }
+  /// The image an `[IMG:RESULT:…]` payload shows — instruction suffix and the
+  /// block's other variants stripped.
+  static String normalizeImageResultPayload(String payload) =>
+      ImageBlockPayload.parseResult(payload).activePath;
 
   /// [contentsNewestFirst] — text blobs ordered newest → oldest (e.g. ext-block bodies).
   static List<String> collectRecentImageResultPaths(
@@ -356,10 +586,10 @@ class ImageTagMarkup {
     var count = 0;
     return text.replaceAllMapped(ImgGenPatterns.imgResultRegex, (match) {
       if (count++ != index) return match.group(0)!;
-      final raw = match.group(1)!;
-      final pipeIdx = raw.indexOf('|');
-      final suffix = pipeIdx != -1 ? raw.substring(pipeIdx) : '';
-      return '[IMG:RESULT:$newPath$suffix]';
+      final payload = ImageBlockPayload.parseResult(match.group(1)!)
+          .withNewImage(newPath)
+          .encodeResult();
+      return '[IMG:RESULT:$payload]';
     });
   }
 }

--- a/test/chat_webview_security_test.dart
+++ b/test/chat_webview_security_test.dart
@@ -177,5 +177,19 @@ void main() {
       expect(source, contains("request.method != 'HEAD'"));
       expect(source, contains("HttpHeaders.allowHeader, 'GET, HEAD'"));
     });
+
+    test('every server dispatches its requests concurrently and guarded', () {
+      // Awaiting a handler inside the accept loop served the page one file at
+      // a time, and a failure after the headers were sent used to escape the
+      // loop and kill the server for the rest of the session.
+      expect(
+        RegExp(
+          r'await for \(final request in server\) \{\s*'
+          r'unawaited\(_handleServerRequest\(',
+        ).allMatches(source).length,
+        3,
+      );
+      expect(source, contains('Future<void> _handleServerRequest('));
+    });
   });
 }

--- a/test/image_block_variants_test.dart
+++ b/test/image_block_variants_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/image_gen/services/image_tag_markup.dart';
+
+void main() {
+  group('ImageBlockPayload', () {
+    test('reads a legacy single-image result payload', () {
+      final payload = ImageBlockPayload.parseResult('/a.png|{"prompt":"cat"}');
+      expect(payload.paths, ['/a.png']);
+      expect(payload.activeIndex, 0);
+      expect(payload.activePath, '/a.png');
+      expect(payload.instruction, '{"prompt":"cat"}');
+      expect(payload.hasVariants, isFalse);
+    });
+
+    test('a single image keeps the legacy spelling when encoded', () {
+      expect(
+        const ImageBlockPayload(
+          paths: ['/a.png'],
+          instruction: '{"prompt":"cat"}',
+        ).encodeResult(),
+        '/a.png|{"prompt":"cat"}',
+      );
+    });
+
+    test('marks the visible image once a block holds more than one', () {
+      const payload = ImageBlockPayload(
+        paths: ['/a.png', '/b.png', '/c.png'],
+        activeIndex: 1,
+        instruction: '{"prompt":"cat"}',
+      );
+      expect(payload.encodeResult(), '/a.png;;*/b.png;;/c.png|{"prompt":"cat"}');
+      final round = ImageBlockPayload.parseResult(payload.encodeResult());
+      expect(round.paths, payload.paths);
+      expect(round.activeIndex, 1);
+      expect(round.activePath, '/b.png');
+    });
+
+    test('a pending payload without the marker is a bare instruction', () {
+      final payload = ImageBlockPayload.parsePending('{"prompt":"a|b"}');
+      expect(payload.paths, isEmpty);
+      expect(payload.instruction, '{"prompt":"a|b"}');
+      expect(payload.encodePending(), '{"prompt":"a|b"}');
+    });
+
+    test('a pending payload carries earlier images behind the marker', () {
+      const payload = ImageBlockPayload(
+        paths: ['/a.png', '/b.png'],
+        activeIndex: 1,
+        instruction: '{"prompt":"cat"}',
+      );
+      expect(payload.encodePending(), '@/a.png;;*/b.png|{"prompt":"cat"}');
+      final round = ImageBlockPayload.parsePending(payload.encodePending());
+      expect(round.paths, ['/a.png', '/b.png']);
+      expect(round.instruction, '{"prompt":"cat"}');
+    });
+  });
+
+  group('block variants through a regeneration', () {
+    test('a finished image is appended and put on screen', () {
+      const text = 'x [IMG:GEN:@/a.png|{"prompt":"cat"}] y';
+      final out = ImageTagMarkup.replaceTagWithResult(text, 0, '/b.png');
+      expect(out, 'x [IMG:RESULT:/a.png;;*/b.png|{"prompt":"cat"}] y');
+
+      final block = ImageTagMarkup.scanImageBlocks(out).single;
+      expect(block.paths, ['/a.png', '/b.png']);
+      expect(block.activeIndex, 1);
+      expect(block.imagePath, '/b.png');
+    });
+
+    test('a reset carries the images the block already holds', () {
+      const text = '[IMG:RESULT:/a.png;;*/b.png|{"prompt":"cat"}]';
+      final pending = ImageTagMarkup.resetImageBlockAt(text, 0);
+      expect(pending, '[IMG:GEN:@/a.png;;*/b.png|{"prompt":"cat"}]');
+
+      final finished = ImageTagMarkup.replaceTagWithResult(pending, 0, '/c.png');
+      expect(
+        finished,
+        '[IMG:RESULT:/a.png;;/b.png;;*/c.png|{"prompt":"cat"}]',
+      );
+    });
+
+    test('a failed regeneration keeps the images in the error card', () {
+      const text = '[IMG:GEN:@/a.png|{"prompt":"cat"}]';
+      final failed = ImageTagMarkup.replaceTagWithError(text, 0, 'boom');
+      expect(failed, contains('"variants":"/a.png"'));
+
+      final retried = ImageTagMarkup.resetImageErrorTags(failed);
+      expect(ImageTagMarkup.scanImageBlocks(retried).single.paths, ['/a.png']);
+
+      final finished = ImageTagMarkup.replaceTagWithResult(retried, 0, '/b.png');
+      expect(
+        ImageTagMarkup.scanImageBlocks(finished).single.paths,
+        ['/a.png', '/b.png'],
+      );
+    });
+
+    test('only the addressed block is reset', () {
+      const text =
+          '[IMG:RESULT:/a.png|{"prompt":"one"}] [IMG:RESULT:/b.png|{"prompt":"two"}]';
+      final out = ImageTagMarkup.resetImageBlockAt(text, 1);
+      expect(out, '[IMG:RESULT:/a.png|{"prompt":"one"}] [IMG:GEN:@/b.png|{"prompt":"two"}]');
+    });
+  });
+
+  group('setImageBlockVariant', () {
+    const text = 'a [IMG:RESULT:/a.png;;*/b.png;;/c.png|{"prompt":"cat"}] b';
+
+    test('puts another image of the block on screen', () {
+      final out = ImageTagMarkup.setImageBlockVariant(text, 0, 2);
+      expect(out, 'a [IMG:RESULT:/a.png;;/b.png;;*/c.png|{"prompt":"cat"}] b');
+      expect(ImageTagMarkup.scanImageBlocks(out).single.imagePath, '/c.png');
+    });
+
+    test('returns the text unchanged for a no-op or a bad index', () {
+      expect(ImageTagMarkup.setImageBlockVariant(text, 0, 1), text);
+      expect(ImageTagMarkup.setImageBlockVariant(text, 0, 7), text);
+      expect(ImageTagMarkup.setImageBlockVariant(text, 3, 0), text);
+      expect(
+        ImageTagMarkup.setImageBlockVariant('[IMG:GEN:{"prompt":"x"}]', 0, 0),
+        '[IMG:GEN:{"prompt":"x"}]',
+      );
+    });
+  });
+
+  group('rewriteResultPaths with variants', () {
+    test('resolves every image of the block', () {
+      final out = ImageTagMarkup.rewriteResultPaths(
+        '[IMG:RESULT:/a.png;;*/b.png|{"prompt":"cat"}]',
+        (path) => 'served:$path',
+      );
+      expect(
+        out,
+        '[IMG:RESULT:served:/a.png;;*served:/b.png|{"prompt":"cat"}]',
+      );
+    });
+
+    test('drops an image that cannot be served and keeps the rest', () {
+      final out = ImageTagMarkup.rewriteResultPaths(
+        '[IMG:RESULT:/blocked.png;;*/b.png|{}]',
+        (path) => path == '/blocked.png' ? null : 'served:$path',
+      );
+      expect(out, '[IMG:RESULT:served:/b.png|{}]');
+    });
+
+    test('drops the tag when nothing can be served', () {
+      expect(
+        ImageTagMarkup.rewriteResultPaths(
+          'x [IMG:RESULT:/a.png;;*/b.png|{}] y',
+          (_) => null,
+        ),
+        'x  y',
+      );
+    });
+  });
+
+  group('context images', () {
+    test('only the visible image of a block is offered as context', () {
+      expect(
+        ImageTagMarkup.extractImageResultPaths(
+          '[IMG:RESULT:/a.png;;*/b.png|{}] [IMG:RESULT:/c.png]',
+        ),
+        ['/b.png', '/c.png'],
+      );
+    });
+  });
+}

--- a/test/image_gen_lifecycle_test.dart
+++ b/test/image_gen_lifecycle_test.dart
@@ -201,7 +201,9 @@ void main() {
       final result = ImageRecoveryService.resetImgTagsToGen(text);
 
       expect(result, isNot(contains('[IMG:RESULT:')));
-      expect(result, contains('[IMG:GEN:{"prompt":"kept"}]'));
+      // The finished image rides along in the pending tag, so the retry adds a
+      // variant to that block instead of replacing its only picture.
+      expect(result, contains('[IMG:GEN:@/kept.png|{"prompt":"kept"}]'));
       expect(result, contains('[IMG:GEN:{"prompt":"lost"}]'));
     });
   });

--- a/test/image_gen_lifecycle_test.dart
+++ b/test/image_gen_lifecycle_test.dart
@@ -105,43 +105,46 @@ void main() {
   });
 
   group('Imagen green swipes', () {
-    test('regeneration appends a selected swipe and preserves old image', () {
+    test('regeneration rewrites the active swipe instead of adding one', () {
       final message = ChatMessage(
         id: 'assistant',
         role: 'assistant',
-        content: '[IMG:RESULT:/old.png|{"prompt":"scene"}]',
-        swipes: const ['[IMG:RESULT:/old.png|{"prompt":"scene"}]'],
+        content: 'She smiles. [IMG:RESULT:/old.png|{"prompt":"scene"}]',
+        isError: true,
+        swipes: const ['She smiles. [IMG:RESULT:/old.png|{"prompt":"scene"}]'],
         swipesMeta: [
           <String, dynamic>{
+            'isError': true,
             'agentSwipes': [
               const AgentSwipe(
-                content: '[IMG:RESULT:/old.png|{"prompt":"scene"}]',
+                content: 'She smiles. [IMG:RESULT:/old.png|{"prompt":"scene"}]',
               ).toJson(),
             ],
             'agentSwipeId': 0,
           },
         ],
         agentSwipes: const [
-          AgentSwipe(content: '[IMG:RESULT:/old.png|{"prompt":"scene"}]'),
+          AgentSwipe(
+            content: 'She smiles. [IMG:RESULT:/old.png|{"prompt":"scene"}]',
+          ),
         ],
       );
 
-      final result = ImageGenProcessor.appendImageRegenerationSwipe(
+      final result = ImageGenProcessor.resetImageContentInPlace(
         message,
-        '[IMG:GEN:{"prompt":"scene"}]',
+        'She smiles. [IMG:GEN:{"prompt":"scene"}]',
       );
 
-      expect(result.swipes, [
-        '[IMG:RESULT:/old.png|{"prompt":"scene"}]',
-        '[IMG:GEN:{"prompt":"scene"}]',
-      ]);
-      expect(result.swipeId, 1);
-      expect(result.swipesMeta, hasLength(2));
+      expect(result.swipes, ['She smiles. [IMG:GEN:{"prompt":"scene"}]']);
+      expect(result.swipeId, 0);
+      expect(result.content, 'She smiles. [IMG:GEN:{"prompt":"scene"}]');
       expect(result.agentSwipes.single.content, contains('[IMG:GEN:'));
+      expect(result.isError, isFalse);
+      expect(result.swipesMeta.single.containsKey('isError'), isFalse);
       expect(
         AgentSwipe.fromJson(
           Map<String, dynamic>.from(
-            (result.swipesMeta[1]['agentSwipes'] as List).single as Map,
+            (result.swipesMeta[0]['agentSwipes'] as List).single as Map,
           ),
         ).content,
         contains('[IMG:GEN:'),

--- a/test/image_gen_service_test.dart
+++ b/test/image_gen_service_test.dart
@@ -312,19 +312,21 @@ void main() {
       expect(result, isNot(contains('[IMG:ERROR')));
     });
 
+    // The pending tag carries the image the block already produced, so the
+    // regeneration adds a variant to the block instead of dropping the old one.
     test('converts [IMG:RESULT:] with instruction back to [IMG:GEN:]', () {
       final result = ImageTagMarkup.resetErrorTags(
         '[IMG:RESULT:/path/to/img.png|{"prompt":"scene"}]',
       );
-      expect(result, contains('[IMG:GEN:{"prompt":"scene"}]'));
+      expect(result, contains('[IMG:GEN:@/path/to/img.png|{"prompt":"scene"}]'));
       expect(result, isNot(contains('[IMG:RESULT')));
     });
 
-    test('converts [IMG:RESULT:] without instruction to bare [IMG:GEN]', () {
+    test('converts [IMG:RESULT:] without instruction to [IMG:GEN]', () {
       final result = ImageTagMarkup.resetErrorTags(
         '[IMG:RESULT:/path/to/img.png]',
       );
-      expect(result, contains('[IMG:GEN]'));
+      expect(result, contains('[IMG:GEN:@/path/to/img.png]'));
       expect(result, isNot(contains('[IMG:RESULT')));
     });
 
@@ -337,7 +339,7 @@ void main() {
           '[IMG:ERROR:$errorJson] and [IMG:RESULT:/img.png|{"prompt":"second"}]';
       final result = ImageTagMarkup.resetErrorTags(text);
       expect(result, contains('[IMG:GEN:{"prompt":"first"}]'));
-      expect(result, contains('[IMG:GEN:{"prompt":"second"}]'));
+      expect(result, contains('[IMG:GEN:@/img.png|{"prompt":"second"}]'));
       expect(result, isNot(contains('[IMG:ERROR')));
       expect(result, isNot(contains('[IMG:RESULT')));
     });
@@ -448,7 +450,7 @@ void main() {
     test('rerolling a finished image only touches that image', () {
       final result = ImageTagMarkup.resetImageBlockAt(message, 0);
 
-      expect(result, startsWith('[IMG:GEN:{"prompt":"one"}]'));
+      expect(result, startsWith('[IMG:GEN:@/one.png|{"prompt":"one"}]'));
       expect(result, contains('[IMG:ERROR:'));
       expect(ImageTagMarkup.pendingImageGenTagCount(result), 2);
     });

--- a/test/image_result_path_rewrite_test.dart
+++ b/test/image_result_path_rewrite_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/image_gen/services/image_tag_markup.dart';
+
+void main() {
+  group('ImageTagMarkup.rewriteResultPaths', () {
+    test('rewrites the path and keeps the instruction suffix', () {
+      final out = ImageTagMarkup.rewriteResultPaths(
+        'before [IMG:RESULT:/data/Glaze/generated/a.png|{"prompt":"cat"}] after',
+        (path) => 'http://127.0.0.1:1/__glaze_file__?path=$path',
+      );
+      expect(
+        out,
+        'before [IMG:RESULT:http://127.0.0.1:1/__glaze_file__'
+        '?path=/data/Glaze/generated/a.png|{"prompt":"cat"}] after',
+      );
+    });
+
+    test('rewrites a payload without an instruction', () {
+      final out = ImageTagMarkup.rewriteResultPaths(
+        '[IMG:RESULT:/data/Glaze/generated/a.png]',
+        (path) => 'served:$path',
+      );
+      expect(out, '[IMG:RESULT:served:/data/Glaze/generated/a.png]');
+    });
+
+    // A `]` in the prompt used to make the tag unmatchable, and the raw
+    // filesystem path reached the WebView as `file://…` — a broken image.
+    test('resolves the path when the instruction contains a bracket', () {
+      final out = ImageTagMarkup.rewriteResultPaths(
+        '[IMG:RESULT:/data/Glaze/generated/a.png|{"prompt":"a [tag] girl"}]',
+        (path) => 'served:$path',
+      );
+      expect(out, startsWith('[IMG:RESULT:served:/data/Glaze/generated/a.png|'));
+      expect(out, isNot(contains('[IMG:RESULT:/data')));
+    });
+
+    test('drops the tag when the path cannot be served', () {
+      final out = ImageTagMarkup.rewriteResultPaths(
+        'x [IMG:RESULT:/etc/passwd|{"prompt":"cat"}] y',
+        (_) => null,
+      );
+      expect(out, 'x  y');
+    });
+
+    test('rewrites every tag in a message', () {
+      final out = ImageTagMarkup.rewriteResultPaths(
+        '[IMG:RESULT:/a.png] mid [IMG:RESULT:/b.png|{}]',
+        (path) => 'served:$path',
+      );
+      expect(out, '[IMG:RESULT:served:/a.png] mid [IMG:RESULT:served:/b.png|{}]');
+    });
+
+    test('leaves pending and error tags alone', () {
+      const text = '[IMG:GEN:{"prompt":"cat"}] [IMG:ERROR:{"error":"nope"}]';
+      expect(
+        ImageTagMarkup.rewriteResultPaths(text, (path) => 'served:$path'),
+        text,
+      );
+    });
+  });
+}

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -603,6 +603,30 @@ void main() {
   });
 
   // ─── markdown image options button ────────────────────────────────────────
+  group('generated image (formatter/formatter.js, renderer/markdown.js)', () {
+    test('the result image loads eagerly', () {
+      // A lazy image at the bottom edge of the WebView can be evaluated while
+      // the row is still off-screen and never fetched, leaving the picture the
+      // user waited for as a broken tag.
+      final imgIdx = formatterFormatterJs.indexOf('class="imggen-result"');
+      expect(imgIdx, isNot(-1));
+      final chunk = formatterFormatterJs.substring(
+        formatterFormatterJs.lastIndexOf('<img', imgIdx),
+        formatterFormatterJs.indexOf('>', imgIdx),
+      );
+      expect(chunk, contains('loading="eager"'));
+      expect(chunk, isNot(contains('loading="lazy"')));
+    });
+
+    test('a failed generated image re-requests itself', () {
+      expect(rendererJs, contains('export function retryFailedLocalImages('));
+      expect(rendererJs, contains('retryFailedLocalImages(root)'));
+      expect(rendererJs, contains("querySelectorAll('img.imggen-result')"));
+      // A fresh query string keeps a cached failure from being replayed.
+      expect(rendererJs, contains('__glaze_retry='));
+    });
+  });
+
   group('markdown image card (formatter/formatter.js)', () {
     test('the card is stashed whole, not emitted as raw HTML mid-pipeline', () {
       // Raw HTML emitted before the tag extraction gets torn apart: <img>,

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -618,6 +618,52 @@ void main() {
       expect(chunk, isNot(contains('loading="lazy"')));
     });
 
+    test('the block switcher renders only for more than one image', () {
+      // The count is `variants.length > 1` on both the switcher and the data
+      // attributes, so a single-image block keeps its historical markup.
+      expect(formatterFormatterJs, contains('imggen-variants'));
+      expect(formatterFormatterJs, contains("data-action=\"img-variant-prev\""));
+      expect(formatterFormatterJs, contains("data-action=\"img-variant-next\""));
+      expect(
+        RegExp(r'variants\.length > 1').allMatches(formatterFormatterJs).length,
+        greaterThanOrEqualTo(3),
+      );
+      expect(formatterFormatterJs, contains('data-variants='));
+      expect(formatterFormatterJs, contains('data-variant-index='));
+    });
+
+    test('the payload parser mirrors the Dart codec', () {
+      expect(
+        formatterFormatterJs,
+        contains('export function parseImageResultPayload('),
+      );
+      expect(formatterFormatterJs, contains("IMG_VARIANT_SEPARATOR = ';;'"));
+      expect(formatterFormatterJs, contains("IMG_VARIANT_ACTIVE_MARKER = '*'"));
+    });
+
+    test('paging a block swaps the picture in the page', () {
+      expect(interactionDispatchJs, contains('_stepImageVariant('));
+      expect(interactionDispatchJs, contains("'img-variant-prev'"));
+      expect(interactionDispatchJs, contains("'img-variant-next'"));
+      // The lightbox and the download button read data-src, so it moves too.
+      expect(interactionDispatchJs, contains('img.dataset.src = src'));
+      expect(
+        interactionDispatchJs,
+        contains("_sendToFlutter('onImgVariant'"),
+      );
+    });
+
+    test('the switcher is small and see-through', () {
+      final css = rendererJs;
+      final start = css.indexOf('.imggen-variants {');
+      expect(start, isNot(-1));
+      final rule = css.substring(start, css.indexOf('}', start));
+      expect(rule, contains('position: absolute'));
+      expect(rule, contains('height: 18px'));
+      expect(rule, contains('opacity: 0.45'));
+      expect(rule, contains('rgba(0, 0, 0, 0.38)'));
+    });
+
     test('a failed generated image re-requests itself', () {
       expect(rendererJs, contains('export function retryFailedLocalImages('));
       expect(rendererJs, contains('retryFailedLocalImages(root)'));


### PR DESCRIPTION
Three fixes to how a generated picture reaches the message and how rerolling it behaves.

## A freshly generated image rendered as a broken tag

The chat page serves local files from a loopback origin, so an image whose fetch is lost has no way back on screen until something re-renders it.

- `chat_webview_environment.dart` — every chat WebView request is handled concurrently and in isolation. Awaiting the handler inside the accept loop served the page one file at a time, so an aborted image response (the body re-renders while its picture is still downloading) held back the file queued behind it, and a failure raised after the headers were sent escaped the loop and killed the server for the rest of the session
- `ImageTagMarkup.rewriteResultPaths` parses `[IMG:RESULT:…]` the way the WebView formatter does when resolving its path: the stricter pattern skipped a tag whose instruction JSON carried a `]`, and the raw filesystem path then reached the page as an unloadable `file://` URL
- The generated image loads eagerly, matching the ExtBlock panel — a lazy image at the bottom edge of the WebView can be evaluated while its row is still off-screen and never fetched
- `renderer/markdown.js` re-requests a generated image that failed to load, twice, with a fresh query string so a cached failure is not replayed

## Rerolling a picture created a whole message swipe

- `ImageRecoveryService` resets the retried blocks through the new `ImageGenProcessor.resetImageContentInPlace()`, which rewrites the swipe the user is looking at and clears the error flag left by the failed block. `appendImageRegenerationSwipe` grew the reply's swipe count and duplicated the text around the image into the new variant; it is gone (INV-IG7)

## A block now keeps every image it generates

- `ImageBlockPayload` is the single codec for the tag payload: a result block lists its images oldest first and marks the visible one (`/a.png;;*/b.png|<instruction>`), a pending block carries them through the regeneration behind `@`, and an error card carries them as a plain string — a JSON array would close the tag on its own bracket. A block with one image keeps the historical `path|instruction` spelling, so older messages parse unchanged (INV-IG8)
- A finished generation appends its image and puts it on screen, so a reroll adds to the block instead of overwriting it — a failed reroll no longer costs the picture that was there
- The formatter renders a small translucent `‹ n/N ›` switcher on the picture, and only once the block holds a second image. Paging swaps the image in the page (every variant is resolved to a servable URL up front) and moves `data-src` with it, so the full-screen viewer and the download button follow the visible image
- The choice comes back through the new `onImgVariant` handler and rewrites the active swipe in place, adding no message swipe
- Only the visible image of a block is offered as context to the next generation

## Verification

- `flutter analyze --no-fatal-infos --no-fatal-warnings` — no issues found
- `flutter test` — 3029 passed
- New suites: `test/image_block_variants_test.dart` (payload codec, the regeneration round trip, carrying images through an error, switching, URL resolution, context) and `test/image_result_path_rewrite_test.dart` (path rewrite, including a `]` inside the instruction); added coverage in `chat_webview_security_test.dart` (concurrent, guarded dispatch) and `webview_assets_test.dart` (eager loading, retry, switcher markup and CSS)
- Three existing expectations were updated to the new tag spelling, where a pending tag now carries the block's images
- Not verified on a device — the sandbox has no Android/iOS runtime, and naistera.org is unreachable from it, so the runtime behaviour of the switcher needs a look on the nightly build


---
_Generated by [Claude Code](https://claude.ai/code/session_01U5spbDyoXxTQbdB7Vuj4jQ)_