### PR TITLE
fix(image-gen): store an image block as an &lt;img&gt; with a relative src

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -10,6 +10,7 @@ import { TrackpadScroll } from './trackpad_scroll.js';
 import { InteractionDispatch } from './interaction_dispatch.js';
 import { PanelHost } from './panel_host.js';
 import { sanitizeExtBlockHtml } from './html_sanitizer.js';
+import { parseImageResultElement } from '../formatter/formatter.js';
 import { ICON } from '../renderer/icon_library.js';
 
 export class Bridge {
@@ -1694,6 +1695,26 @@ export class Bridge {
     return `<span class="ext-block-image-wrapper img-result-wrapper"><img src="${src}" class="ext-block-image" loading="eager" decoding="sync" data-action="image-click" data-src="${src}"><button class="img-download-btn" data-action="img-download" data-src="${src}" title="Save image">⤓</button></span>`;
   }
 
+  /**
+   * Rewrites the stored `<img data-iig-…>` form of a finished image block into
+   * the `[IMG:RESULT:…]` token this panel already renders — with the download
+   * button and the viewer action the bare element would not carry. Purely a
+   * render-time normalization; the block's stored content is untouched.
+   */
+  _extBlockLegacyImageTokens(content) {
+    const text = String(content == null ? '' : content);
+    if (text.indexOf('data-iig-instruction') === -1) return text;
+    return text.replace(
+      /<img\s[^>]*?data-iig-instruction\s*=\s*(?:"[^"]*"|'[^']*')[^>]*>/gi,
+      (tag) => {
+        const parsed = parseImageResultElement(tag);
+        if (!parsed) return tag;
+        const src = parsed.paths[parsed.activeIndex] || parsed.paths[0] || '';
+        return src ? `[IMG:RESULT:${src}]` : tag;
+      },
+    );
+  }
+
   _fillExtBlockBody(body, block) {
     const hasContent = block.content && block.content.trim().length > 0;
     if (!hasContent && block.status !== 'pending') {
@@ -1705,12 +1726,13 @@ export class Bridge {
     }
     if (!hasContent) return;
 
+    const content = this._extBlockLegacyImageTokens(block.content);
     const imgResultRegex = /\[IMG:RESULT:([^\]]+)\]/;
-    const hasImgResult = imgResultRegex.test(block.content);
-    const hasHtmlMarkup = /<[a-z][\s\S]*>/i.test(block.content);
+    const hasImgResult = imgResultRegex.test(content);
+    const hasHtmlMarkup = /<[a-z][\s\S]*>/i.test(content);
 
     if (hasImgResult && hasHtmlMarkup) {
-      let html = block.content.replace(
+      let html = content.replace(
         /\[IMG:RESULT:([^\]]+)\]/g,
         (match, payload) => this._renderExtBlockImageHtml(payload),
       );
@@ -1719,14 +1741,14 @@ export class Bridge {
       htmlEl.innerHTML = sanitizeExtBlockHtml(html);
       body.appendChild(htmlEl);
     } else if (hasImgResult) {
-      const imgMatch = block.content.match(imgResultRegex);
+      const imgMatch = content.match(imgResultRegex);
       const wrapper = document.createElement('span');
       wrapper.innerHTML = sanitizeExtBlockHtml(this._renderExtBlockImageHtml(imgMatch[1]));
       body.appendChild(wrapper.firstElementChild);
     } else {
       const html = document.createElement('div');
       html.className = 'ext-block-content';
-      html.innerHTML = sanitizeExtBlockHtml(block.content);
+      html.innerHTML = sanitizeExtBlockHtml(content);
       body.appendChild(html);
     }
   }

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -37,6 +37,73 @@ export function parseImageResultPayload(payload) {
   return { paths, activeIndex, instruction };
 }
 
+/**
+ * Matches one `<img …data-iig-instruction…>` element, the stored form of an
+ * image block. Whether it is finished or still waiting is decided by its
+ * `src` (see `parseImageResultElement`), not by the pattern.
+ */
+const IIG_ELEMENT_REGEX = /<img\s[^>]*?data-iig-instruction\s*=\s*(?:"[^"]*"|'[^']*')[^>]*>/gi;
+
+const ATTRIBUTE_PAIR_REGEX = /([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]*))/g;
+
+/** Attributes of one `<img …>` element, lower-cased names to raw values. */
+function imgAttributes(tag) {
+  const body = String(tag == null ? '' : tag).replace(/^<\s*[A-Za-z][-A-Za-z0-9]*/i, '');
+  // Null-prototype: an attribute called `constructor` or `toString` must not
+  // read as already present, and must not reach an inherited value.
+  const attributes = Object.create(null);
+  ATTRIBUTE_PAIR_REGEX.lastIndex = 0;
+  let match;
+  while ((match = ATTRIBUTE_PAIR_REGEX.exec(body)) !== null) {
+    const name = match[1].toLowerCase();
+    if (name in attributes) continue;
+    const value = match[2] !== undefined ? match[2]
+      : match[3] !== undefined ? match[3]
+      : match[4] !== undefined ? match[4] : '';
+    attributes[name] = value;
+  }
+  return attributes;
+}
+
+function unescapeAttribute(value) {
+  const raw = String(value == null ? '' : value);
+  if (raw.indexOf('&') === -1) return raw;
+  return raw
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * Reads the stored `<img data-iig-…>` form of a finished image block — the JS
+ * half of ImageTagMarkup.encodeResultElement in image_tag_markup.dart. The
+ * visible image is the element's `src`, the block's other images ride along in
+ * `data-iig-variants`. Returns null while the block is still waiting for its
+ * picture (no `src`, or the `[IMG:GEN…]` placeholder in it), which the caller
+ * reads as "not a result".
+ */
+export function parseImageResultElement(tag) {
+  const attributes = imgAttributes(tag);
+  const src = unescapeAttribute(attributes.src || '').trim();
+  if (!src || src.startsWith('[IMG:GEN')) return null;
+  const instruction = unescapeAttribute(attributes['data-iig-instruction'] || '');
+  const variants = unescapeAttribute(attributes['data-iig-variants'] || '');
+  const paths = [];
+  for (const entry of variants.split(IMG_VARIANT_SEPARATOR)) {
+    if (entry) paths.push(entry);
+  }
+  if (!paths.length) paths.push(src);
+  const declared = parseInt(attributes['data-iig-index'], 10);
+  const fallback = paths.indexOf(src);
+  let activeIndex = Number.isNaN(declared) ? fallback : declared;
+  if (!(activeIndex >= 0)) activeIndex = 0;
+  if (activeIndex > paths.length - 1) activeIndex = paths.length - 1;
+  return { paths, activeIndex, instruction };
+}
+
 export class Formatter {
   constructor() {
     this.cache = new Map();
@@ -181,7 +248,25 @@ export class Formatter {
     });
 
     // 5c. Glaze image gen tags
+    //
+    // The stored `<img data-iig-…>` element comes first: it is the form every
+    // finished block is written in, and pulling it out here (rather than
+    // letting step 6 treat it as an ordinary HTML tag) is what gives it the
+    // options button, the variant switcher and its `data-img-index`.
     const imgBlocks = [];
+    html = html.replace(IIG_ELEMENT_REGEX, (match) => {
+      const parsed = parseImageResultElement(match);
+      if (!parsed) return match;
+      const id = this._ph('IG_', imgBlocks.length, true);
+      imgBlocks.push({
+        type: 'result',
+        path: parsed.paths[parsed.activeIndex] || parsed.paths[0] || '',
+        paths: parsed.paths,
+        activeIndex: parsed.activeIndex,
+        instruction: parsed.instruction,
+      });
+      return '\n\n' + id + '\n\n';
+    });
     html = html.replace(/\[IMG:GEN(?::(.*?))?\]/g, (match, instruction) => {
       const id = this._ph('IG_', imgBlocks.length, true);
       imgBlocks.push({ type: 'gen', instruction: instruction || '' });

--- a/assets/chat_webview/formatter/index.js
+++ b/assets/chat_webview/formatter/index.js
@@ -2,6 +2,7 @@ import { Formatter } from './formatter.js';
 
 export { Formatter } from './formatter.js';
 export { parseImageResultPayload } from './formatter.js';
+export { parseImageResultElement } from './formatter.js';
 export { renderStyledSegment } from './text_format.js';
 
 window.Formatter = Formatter;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1153,7 +1153,7 @@ feature-local adapters to `SyncService`.
 - `image_prompt_builder.dart` — `[STYLE: …]` block, reference descriptions, reference instruction
 - `reference_matcher.dart` — alias / word-boundary matching of the reference library against a prompt
 - `image_reference_collector.dart` — avatars + matched references + context images, clipped per model
-- `image_tag_markup.dart` — pure `[IMG:GEN]`/`[IMG:RESULT]`/`[IMG:ERROR]` tag text transforms (extracted from ImageGenService), including `ImageBlockPayload`: the images one block carries, which of them is visible, and the instruction that produced them (INV-IG8)
+- `image_tag_markup.dart` — pure image-block text transforms (extracted from ImageGenService): the stored `<img data-iig-…>` element of a finished block (INV-IG9), the `[IMG:GEN]`/`[IMG:ERROR]` tags of one that has no picture yet, the `[IMG:RESULT]` of older messages, and `ImageBlockPayload`: the images one block carries, which of them is visible, and the instruction that produced them (INV-IG8)
 - `image_gen_provider.dart` — manages settings + generation state
 - `image_gen_models.dart` — Freezed data models for image generation
 - `image_gen_constants.dart` — per-provider model / ratio / resolution tables (re-exported by the models file)
@@ -1227,7 +1227,7 @@ per block via `InfoBlocksRepository.updateStatus()`.
 | `BlockType` | Handler | Notes |
 |---|---|---|
 | `infoblock` | `blocks/infoblock_handler.dart` | Calls `InfoBlockService`; injects last N results into prompt context |
-| `imageGen` | `blocks/image_gen_block_handler.dart` | Reads `[img gen:…]` tag, calls `ImageGenService`, saves via `ImageStorageService`; result stored as `[IMG:RESULT:<path>]` |
+| `imageGen` | `blocks/image_gen_block_handler.dart` | Reads `[img gen:…]` tag, calls `ImageGenService`, saves via `ImageStorageService`; result stored as an `<img data-iig-…>` element whose `src` is relative to the data root (INV-IG9) |
 | `jsRunner` | `blocks/js_runner_block_handler.dart` | Runs JS through the Chat WebView via `JsBlockExecutor`; absent bridges produce a bounded unavailable error. |
 | `interactive` | `blocks/interactive_block_handler.dart` | LLM → strip code-fence → sandboxed iframe island under the assistant message. JS inside the panel has access to `window.glaze.*` |
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -118,16 +118,46 @@ rather than falling back to the whole message.
 
 ### INV-IG8: A block keeps every image it generates
 
-`ImageBlockPayload` (image_tag_markup.dart) is the single codec for the tag
-payload: `[IMG:RESULT:/a.png;;*/b.png|<instruction>]` lists the images of one
-block oldest first and marks the visible one with `*`; a pending block carries
-them through a regeneration behind `@`, and an error card behind its
-`variants` string. A block with one image keeps the historical
-`path|instruction` spelling, so older messages parse unchanged. Only the
-visible image counts as context for the next generation
-(`extractImageResultPaths`), the WebView formatter parses the same format
-(`parseImageResultPayload`), and `rewriteResultPaths` resolves every variant so
-the switcher can page through them without a round trip to Dart.
+`ImageBlockPayload` (image_tag_markup.dart) is the single codec for a block's
+images: they are listed oldest first and the visible one is marked, so a
+regeneration appends rather than overwrites. A pending block carries them
+through behind `@` (`[IMG:GEN:@/a.png;;/b.png|<instruction>]`) and an error
+card behind its `variants` string. Only the visible image counts as context for
+the next generation (`extractImageResultPaths`), and `rewriteResultPaths`
+resolves every variant so the switcher can page through them without a round
+trip to Dart.
+
+### INV-IG9: An image block is stored as an `<img>` element with a relative src
+
+A finished block is written by `ImageTagMarkup.encodeResultElement()` only:
+
+```html
+<img data-iig-instruction='{"prompt":"…"}'
+     data-iig-variants='generated/a.jpg;;generated/b.jpg'
+     data-iig-index='1' src="generated/b.jpg">
+```
+
+* `src` is the visible image and is always **relative to the Glaze data root**
+  (`_saveGeneratedImage`, `findImageOnDisk`, `restoreChatWebViewLocalFilePath`
+  all store it that way, `resolveGlazeFilePath` joins it back onto the current
+  root). An absolute path stops resolving when that root moves — a new iOS
+  container UUID, a database copied between desktop build channels — and a
+  loopback `/__glaze_file__` URL, whose port only exists for one app launch,
+  breaks the picture permanently. Neither may reach storage: every text the
+  WebView hands back (`onEditSave`, `onMessageContext`, `onSelectionAction`)
+  goes through `ChatBridgeController.restoreImgResults()` first, and
+  `chatWebViewResolveLocalFileUrl` unwraps a URL that was stored by an older
+  build instead of requiring a migration.
+* the block's other images ride along in `data-iig-variants` so `src` stays one
+  plain path, readable by anything that renders HTML.
+* `[IMG:RESULT:…]` is still **read** everywhere a block is read — older
+  messages keep rendering, resetting and regenerating unchanged — but it is
+  never written any more. The same `<img data-iig-instruction…>` element with
+  no image in its `src` is a *pending* block, which is what keeps
+  `scanPendingTags()` and `scanResultElements()` from ever claiming the same
+  element (`ImgGenPatterns.isPendingIigElement`).
+* the WebView formatter parses the element with `parseImageResultElement()`,
+  the mirror of the Dart writer.
 
 ### INV-IG7: Regenerating an image never adds a message swipe
 
@@ -902,9 +932,11 @@ builder. Blocks with `dependsOnPrevious = false` (default) are launched without
 ### INV-EG7: Image-gen block results are stored via `ImageStorageService`; content holds the path token
 
 After `ImageGenService.generateImage()` succeeds, the image bytes are saved to disk
-through `ImageStorageService`. `InfoBlock.content` is set to `[IMG:RESULT:<path>]`
-(same format as inline img-gen). The WebView bridge renders this token as an `<img>`
-element inside the ext-blocks panel.
+through `ImageStorageService`. `InfoBlock.content` is set to the stored image
+block — an `<img data-iig-…>` element whose `src` is relative to the Glaze data
+root, same format as inline img-gen (INV-IG9). The WebView bridge renders it
+with the panel's own image controls inside the ext-blocks panel, and still
+reads the `[IMG:RESULT:<path>]` of blocks written before that form.
 
 ### INV-EG8: JS Runner / interactive panel code runs in a sandboxed iframe with null origin ✅ ENFORCED
 
@@ -1065,7 +1097,7 @@ Before merging any structural PR:
   - [ ] Block chain does not start on aborted or errored generation (INV-EG4)
   - [ ] Extension cancel token is separate from chat cancel token (INV-EG5)
   - [ ] `dependsOnPrevious` blocks await the preceding block; output is chained (INV-EG6)
-  - [ ] Image-gen block results stored via ImageStorageService; content = `[IMG:RESULT:<path>]` (INV-EG7)
+  - [ ] Image-gen block results stored via ImageStorageService; content = the `<img data-iig-…>` element (INV-EG7, INV-IG9)
   - [ ] JS Runner / interactive panel code runs in null-origin iframe (INV-EG8)
   - [ ] Bridge `glaze.*` calls gated by preset capabilities (INV-JS1)
   - [ ] Variable writes are atomic + JSON-validated + ≤ 64 KiB (INV-JS2)

--- a/docs/rules/generation.md
+++ b/docs/rules/generation.md
@@ -298,7 +298,7 @@ for block in blocks:
 | `BlockType` | Engine | Notes |
 |---|---|---|
 | `infoblock` | `InfoBlockService` (LLM) | Result stored in `InfoBlock.content` |
-| `imageGen` | `ImageGenService` (LLM agent → image API) | `[IMG:RESULT:<path>]` token in `InfoBlock.content` |
+| `imageGen` | `ImageGenService` (LLM agent → image API) | `<img data-iig-…>` element with a data-root-relative `src` in `InfoBlock.content` (INV-IG9) |
 | `jsRunner` | `JsEngineService` (preferred) → `ChatBridgeController.runJsBlock` (fallback) | Script output becomes the block content; null origin iframe (INV-EG8) |
 | `interactive` | `PanelHostService` (LLM agent → sandboxed iframe panel) | HTML persisted to `InfoBlock.content`; panel is rendered as a live iframe island |
 

--- a/lib/core/constants/image_gen_patterns.dart
+++ b/lib/core/constants/image_gen_patterns.dart
@@ -35,6 +35,45 @@ class ImgGenPatterns {
     dotAll: true,
   );
 
+  /// Reads the attributes off one matched `<img …>` element, lower-cased names
+  /// to their raw (still entity-encoded) values.
+  ///
+  /// Walking the pairs left to right consumes each quoted value whole, so a
+  /// `src=` written inside an instruction prompt is never mistaken for the
+  /// element's own `src` — which is the attribute that tells a finished image
+  /// block apart from one still waiting for its picture.
+  static Map<String, String> imgAttributes(String tag) {
+    final body = tag.replaceFirst(
+      RegExp(r'^<\s*[A-Za-z][-A-Za-z0-9]*', caseSensitive: false),
+      '',
+    );
+    final attributes = <String, String>{};
+    for (final match in _attributePairRegex.allMatches(body)) {
+      final name = match.group(1)!.toLowerCase();
+      attributes.putIfAbsent(
+        name,
+        () => match.group(2) ?? match.group(3) ?? match.group(4) ?? '',
+      );
+    }
+    return attributes;
+  }
+
+  static final _attributePairRegex = RegExp(
+    '([A-Za-z_:][-A-Za-z0-9_:.]*)'
+    r'\s*=\s*'
+    '(?:"([^"]*)"'
+    "|'([^']*)'"
+    r'''|([^\s"'>]*))''',
+  );
+
+  /// Whether an `<img …data-iig-instruction…>` element is still waiting for its
+  /// image: it has no `src`, or only the `[IMG:GEN…]` placeholder in it. The
+  /// same element with a stored image path in its `src` is the finished form.
+  static bool isPendingIigElement(String tag) {
+    final src = (imgAttributes(tag)['src'] ?? '').trim();
+    return src.isEmpty || src.startsWith('[IMG:GEN');
+  }
+
   static final base64DataUrlRegex = RegExp(
     r'data:image/[^;]+;base64,[A-Za-z0-9+/=]{256,}',
   );

--- a/lib/core/utils/html_to_markdown.dart
+++ b/lib/core/utils/html_to_markdown.dart
@@ -630,9 +630,13 @@ String _extractStyledImageFrames(String html) {
   final imgRegex = ImgGenPatterns.htmlIigTagRegex;
   final imgRegexDouble = ImgGenPatterns.htmlIigTagDoubleRegex;
 
-  final matches = <RegExpMatch>[];
-  matches.addAll(imgRegex.allMatches(html));
-  matches.addAll(imgRegexDouble.allMatches(html));
+  // Only elements still waiting for a picture: the same element with an image
+  // in its `src` is the stored form of a finished block, and folding one back
+  // into `[IMG:GEN:…]` would drop the picture it already holds.
+  final matches = <RegExpMatch>[
+    ...imgRegex.allMatches(html),
+    ...imgRegexDouble.allMatches(html),
+  ].where((m) => ImgGenPatterns.isPendingIigElement(m.group(0)!)).toList();
   matches.sort((a, b) => a.start.compareTo(b.start));
 
   if (matches.isEmpty) return html;

--- a/lib/core/utils/platform_paths.dart
+++ b/lib/core/utils/platform_paths.dart
@@ -64,6 +64,45 @@ String? resolveGlazeFilePath(String? path) {
   return path;
 }
 
+/// [path] spelled relative to the Glaze data root when it lives inside it.
+///
+/// The inverse of [resolveGlazeFilePath], and the spelling every image path is
+/// stored in: a relative path survives the data root moving under it — a new
+/// iOS container UUID, a database copied between the desktop build channels —
+/// where an absolute one silently stops pointing at a file. Paths outside the
+/// data root (and anything that is already relative, or a URL) come back
+/// unchanged.
+String relativeGlazeFilePath(String path) {
+  if (path.isEmpty) return path;
+  if (_urlSchemeRegex.hasMatch(path)) return path;
+  final normalized = path.replaceAll('\\', '/');
+  if (!p.isAbsolute(path)) return normalized;
+
+  final base = _cachedAppDataDir;
+  if (base != null) {
+    final relative = p.relative(path, from: base);
+    if (!p.isAbsolute(relative) && !relative.startsWith('..')) {
+      return relative.replaceAll('\\', '/');
+    }
+  }
+  // No base cached yet (very early startup), or the file belongs to another
+  // installed build channel: the data-root name still tells us where it sat,
+  // and [resolveGlazeFilePath] rebases that suffix onto the current root.
+  final match = RegExp(
+    r'/(?:Glaze|Glaze-staging|Glaze-nightly)/',
+    caseSensitive: false,
+  ).allMatches(normalized).lastOrNull;
+  if (match != null) {
+    final suffix = normalized.substring(match.end);
+    if (suffix.isNotEmpty) return suffix;
+  }
+  return path;
+}
+
+/// A URL scheme, which a stored image path can also be (`data:`, `https:`).
+/// Two characters minimum, so a Windows drive letter is not read as one.
+final RegExp _urlSchemeRegex = RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]+:');
+
 /// Returns the on-disk path to the 512px thumbnail JPG for a stored avatar
 /// path when that thumbnail exists, otherwise the resolved full-resolution
 /// avatar path (or `null` when there is no avatar).

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -189,6 +189,19 @@ class ChatBridgeController {
     return ImageTagMarkup.rewriteResultPaths(text, resolveLocalFileUrl);
   }
 
+  /// Inverse of [resolveImgResults] for text on its way back from the page.
+  ///
+  /// The page holds the images as `/__glaze_file__` URLs on a loopback port
+  /// that only exists for this app launch. Saving one (an edited message used
+  /// to be stored exactly as the page had it) leaves a picture that is broken
+  /// from the next start onwards — and stays broken across a restart, because
+  /// the port is gone. Every text the WebView hands back is therefore put into
+  /// its stored spelling first: the served file, relative to the data root.
+  String restoreImgResults(String text) => ImageTagMarkup.rewriteResultPaths(
+    text,
+    restoreChatWebViewLocalFilePath,
+  );
+
   String? resolveLocalFileUrl(String? source) {
     return chatWebViewResolveLocalFileUrl(source);
   }
@@ -440,7 +453,7 @@ class ChatBridgeController {
             data['id'] as String? ?? '',
             data['isUser'] as bool? ?? false,
             data['isSystem'] as bool? ?? false,
-            data['content'] as String? ?? '',
+            restoreImgResults(data['content'] as String? ?? ''),
           );
         case 'onSwipe':
           onSwipe?.call(
@@ -455,7 +468,7 @@ class ChatBridgeController {
         case 'onSelectionAction':
           onSelectionAction?.call(
             data['action'] as String? ?? 'copy',
-            data['text'] as String? ?? '',
+            restoreImgResults(data['text'] as String? ?? ''),
           );
         case 'onPanelResize':
           final panelId = data['panelId'] as String? ?? '';
@@ -496,7 +509,7 @@ class ChatBridgeController {
     final s = args[1] as String? ?? '';
     switch (name) {
       case 'onEditSave':
-        onEditSave?.call(id, s);
+        onEditSave?.call(id, restoreImgResults(s));
       case 'onRegenerate':
         onRegenerate?.call(id, s);
     }

--- a/lib/features/chat/bridge/chat_webview_environment.dart
+++ b/lib/features/chat/bridge/chat_webview_environment.dart
@@ -7,6 +7,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:path/path.dart' as p;
 
 import '../../../core/constants/build_channel.dart';
+import '../../../core/utils/image_src.dart';
 import '../../../core/utils/platform_paths.dart';
 import 'chat_webview_settings.dart';
 
@@ -106,8 +107,26 @@ NavigationActionPolicy chatWebViewNavigationPolicy(WebUri? url) {
   return NavigationActionPolicy.CANCEL;
 }
 
+/// [source] with a chat-WebView local-file URL turned back into the path it
+/// serves, spelled relative to the Glaze data root; anything else comes back
+/// unchanged.
+///
+/// The loopback port is picked per app launch, so a `/__glaze_file__` URL is
+/// only valid for the session that produced it. One must never reach storage —
+/// a message that stored one showed a broken picture from the next start
+/// onwards — so every text the page hands back is put into its stored spelling
+/// first, and an already-stored URL is unwrapped here rather than migrated.
+String restoreChatWebViewLocalFilePath(String source) {
+  final served = glazeFilePathFromLoopbackUrl(source);
+  return relativeGlazeFilePath(served ?? source);
+}
+
 String? chatWebViewResolveLocalFileUrl(String? source) {
   if (source == null || source.isEmpty) return source;
+  // A URL from an earlier session carries the file it used to serve; resolve
+  // that file for this session instead of handing the page a dead port.
+  final stored = glazeFilePathFromLoopbackUrl(source);
+  if (stored != null) return chatWebViewResolveLocalFileUrl(stored);
   if (source.startsWith('data:') ||
       source.startsWith('http://') ||
       source.startsWith('https://')) {
@@ -388,6 +407,16 @@ String? _sourceToFilePath(String source) {
     }
   }
   if (source.startsWith('/') || RegExp(r'^[a-zA-Z]:[\\/]').hasMatch(source)) {
+    return source;
+  }
+  // Image paths are stored relative to the Glaze data root
+  // (`generated/imggen_….jpg`), which is what keeps them valid after the root
+  // moves. Only the media directories are candidates; every other relative
+  // string still fails closed here, and the joined path is checked against the
+  // data root afterwards like any absolute one.
+  final segments = p.split(source.replaceAll('\\', '/'));
+  if (segments.length > 1 &&
+      _allowedGlazeMediaDirectories.contains(segments.first)) {
     return source;
   }
   return null;

--- a/lib/features/chat/image_recovery_service.dart
+++ b/lib/features/chat/image_recovery_service.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import '../../core/constants/image_gen_patterns.dart';
 import '../../core/models/chat_message.dart';
 import '../../core/state/db_provider.dart';
+import '../../core/utils/platform_paths.dart';
 import '../../core/utils/time_helpers.dart';
 import '../image_gen/services/image_tag_markup.dart';
 import 'services/image_gen_processor.dart';
@@ -145,22 +146,26 @@ class ImageRecoveryService {
       ImgGenPatterns.imgSrcGenRegex,
       '[IMG:ERROR:${jsonEncode({'error': 'Generation interrupted'})}]',
     );
-    result = result.replaceAllMapped(ImgGenPatterns.htmlIigTagRegex, (m) {
-      final instruction = m.group(1) ?? '';
+    // Only elements still waiting for a picture; the same element with an
+    // image in its `src` is a finished block, which an interrupted generation
+    // must never turn into an error card.
+    String interrupted(Match m) {
+      if (!ImgGenPatterns.isPendingIigElement(m.group(0)!)) return m.group(0)!;
       final errorJson = jsonEncode({
         'error': 'Generation interrupted',
-        'instruction': instruction,
+        'instruction': m.group(1) ?? '',
       });
       return '[IMG:ERROR:$errorJson]';
-    });
-    result = result.replaceAllMapped(ImgGenPatterns.htmlIigTagDoubleRegex, (m) {
-      final instruction = m.group(1) ?? '';
-      final errorJson = jsonEncode({
-        'error': 'Generation interrupted',
-        'instruction': instruction,
-      });
-      return '[IMG:ERROR:$errorJson]';
-    });
+    }
+
+    result = result.replaceAllMapped(
+      ImgGenPatterns.htmlIigTagRegex,
+      interrupted,
+    );
+    result = result.replaceAllMapped(
+      ImgGenPatterns.htmlIigTagDoubleRegex,
+      interrupted,
+    );
     result = result.replaceAllMapped(ImgGenPatterns.imgGenRegex, (m) {
       final instruction = m.group(1) ?? '';
       final errorJson = instruction.isNotEmpty
@@ -175,26 +180,20 @@ class ImageRecoveryService {
   }
 
   static String replaceFirstImgErrorOrGen(String text, String resultPath) {
+    final replacement = ImageTagMarkup.encodeResultElement(
+      ImageBlockPayload(paths: [resultPath]),
+    );
     if (ImgGenPatterns.imgErrorRegex.hasMatch(text)) {
-      return text.replaceFirst(
-        ImgGenPatterns.imgErrorRegex,
-        '[IMG:RESULT:$resultPath]',
-      );
+      return text.replaceFirst(ImgGenPatterns.imgErrorRegex, replacement);
     }
     if (ImgGenPatterns.imgGenHtmlRegex.hasMatch(text)) {
-      return text.replaceFirst(
-        ImgGenPatterns.imgGenHtmlRegex,
-        '[IMG:RESULT:$resultPath]',
-      );
+      return text.replaceFirst(ImgGenPatterns.imgGenHtmlRegex, replacement);
     }
     if (text.contains('[IMG:GEN]')) {
-      return text.replaceFirst('[IMG:GEN]', '[IMG:RESULT:$resultPath]');
+      return text.replaceFirst('[IMG:GEN]', replacement);
     }
     if (ImgGenPatterns.imgGenRegex.hasMatch(text)) {
-      return text.replaceFirst(
-        ImgGenPatterns.imgGenRegex,
-        '[IMG:RESULT:$resultPath]',
-      );
+      return text.replaceFirst(ImgGenPatterns.imgGenRegex, replacement);
     }
     return text;
   }
@@ -281,7 +280,8 @@ class ImageRecoveryService {
     final hasRetryableContent =
         ImageTagMarkup.hasImageGenTags(lastMsg.content) ||
         lastMsg.content.contains('[IMG:ERROR:') ||
-        lastMsg.content.contains('[IMG:RESULT:');
+        lastMsg.content.contains('[IMG:RESULT:') ||
+        ImageTagMarkup.scanResultElements(lastMsg.content).isNotEmpty;
     if (!hasRetryableContent) return;
 
     final resetContent = resetImgTagsToGen(lastMsg.content);
@@ -543,8 +543,15 @@ class ImageRecoveryService {
       }
     }
 
+    // Stored paths are relative to the Glaze data root while the directory
+    // listing is absolute, so both sides are compared on the resolved path —
+    // without that every file reads as unclaimed and an image already shown in
+    // the message can be attached to a second block.
+    final claimedAbsolute = claimedPaths
+        .map((path) => resolveGlazeFilePath(path) ?? path)
+        .toSet();
     final unclaimed =
-        files.where((f) => !claimedPaths.contains(f.path)).toList()..sort(
+        files.where((f) => !claimedAbsolute.contains(f.path)).toList()..sort(
           (a, b) => b.lastAccessedSync().compareTo(a.lastAccessedSync()),
         );
 
@@ -569,7 +576,8 @@ class ImageRecoveryService {
 
     if (bestMatch == null) return;
 
-    final foundPath = bestMatch.path;
+    // Stored relative to the data root, like every other image path.
+    final foundPath = relativeGlazeFilePath(bestMatch.path);
 
     final updatedContent = attach(msg.content, foundPath);
     if (updatedContent == msg.content) return;

--- a/lib/features/cloud_sync/services/sync_image_stripper.dart
+++ b/lib/features/cloud_sync/services/sync_image_stripper.dart
@@ -1,4 +1,5 @@
 import 'package:glaze_flutter/core/constants/image_gen_patterns.dart';
+import 'package:glaze_flutter/features/image_gen/services/image_tag_markup.dart';
 
 final _imgResultRegex = ImgGenPatterns.imgResultStripRegex;
 final _imgErrorRegex = ImgGenPatterns.imgErrorStripRegex;
@@ -87,6 +88,11 @@ List<dynamic> _stripAgentSwipes(List<dynamic> swipes, void Function() changed) {
 
 String stripImageContent(String text) {
   var result = text;
+  // The stored `<img data-iig-…>` form of a finished block carries a path into
+  // this device's data root, so it goes the same way as [IMG:RESULT:…].
+  for (final element in ImageTagMarkup.scanResultElements(result).reversed) {
+    result = result.replaceRange(element.start, element.end, '');
+  }
   result = result.replaceAll(_imgResultRegex, '');
   result = result.replaceAll(_imgErrorRegex, '');
   result = result.replaceAll(_imgGenRegex, '');

--- a/lib/features/cloud_sync/services/sync_serialization.dart
+++ b/lib/features/cloud_sync/services/sync_serialization.dart
@@ -6,6 +6,7 @@ import '../../../core/models/chat_message.dart';
 import '../../../core/models/memory_book.dart';
 import '../../../core/constants/image_gen_patterns.dart';
 import '../../../features/extensions/models/info_block.dart';
+import '../../../features/image_gen/services/image_tag_markup.dart';
 import '../cloud_adapter.dart';
 import '../sync_models.dart';
 
@@ -126,8 +127,22 @@ class SyncSerialization {
 
   /// Replaces [IMG:RESULT:/abs/path|json] → [IMG:GEN:json]
   /// and [IMG:ERROR:...] → [IMG:GEN] so that pulled blocks can be regenerated.
+  ///
+  /// The stored `<img data-iig-…>` form of a finished block goes the same way:
+  /// the image file itself never leaves the device, so what is uploaded is the
+  /// instruction that can produce it again.
   static String normalizeImageGenContent(String content) {
-    var result = content.replaceAllMapped(ImgGenPatterns.imgResultRegex, (m) {
+    var result = content;
+    // Right to left, so replacing one element leaves the spans of the rest.
+    for (final element in ImageTagMarkup.scanResultElements(result).reversed) {
+      final instruction = element.payload.instruction;
+      result = result.replaceRange(
+        element.start,
+        element.end,
+        instruction.isEmpty ? '[IMG:GEN]' : '[IMG:GEN:$instruction]',
+      );
+    }
+    result = result.replaceAllMapped(ImgGenPatterns.imgResultRegex, (m) {
       final payload = m.group(1) ?? '';
       final pipeIdx = payload.indexOf('|');
       if (pipeIdx >= 0) {

--- a/lib/features/extensions/services/blocks/image_pixel_renderer.dart
+++ b/lib/features/extensions/services/blocks/image_pixel_renderer.dart
@@ -4,7 +4,6 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path/path.dart' as p;
 
-import '../../../../core/constants/image_gen_patterns.dart';
 import '../../../../core/db/repositories/info_blocks_repository.dart';
 import '../../../../core/models/character.dart';
 import '../../../../core/models/persona.dart';
@@ -202,13 +201,21 @@ class ImagePixelRenderer {
           'extblock_${DateTime.now().millisecondsSinceEpoch}.$extension';
       final filePath = p.join(dir.path, filename);
       await File(filePath).writeAsBytes(imageBytes);
+      // Stored relative to the Glaze data root, so the block keeps its picture
+      // when that root moves — same reason as _saveGeneratedImage.
+      final storedPath = p.url.join('generated', filename);
 
-      final hasResultToken = ImgGenPatterns.imgResultRegex.hasMatch(
-        sourceContent,
-      );
-      final content = hasResultToken
-          ? ImageTagMarkup.replaceExtBlockImageResult(sourceContent, filePath)
-          : ImageTagMarkup.replaceTagWithResult(sourceContent, 0, filePath);
+      // The block's first image block, whatever state it is in: a pending tag
+      // on the first run, and the finished block itself on a rerun — which is
+      // what makes the new picture land in the block that already has one
+      // instead of being dropped for want of a pending tag.
+      final content = ImageTagMarkup.scanImageBlocks(sourceContent).isEmpty
+          ? sourceContent
+          : ImageTagMarkup.replaceImageBlockWithResult(
+              sourceContent,
+              0,
+              storedPath,
+            );
       await repo.updateContent(placeholderId, content);
       await repo.updateStatus(placeholderId, BlockRunStatus.done);
 

--- a/lib/features/image_gen/services/image_gen_service.dart
+++ b/lib/features/image_gen/services/image_gen_service.dart
@@ -265,7 +265,12 @@ class ImageGenService {
     _saveSeq++;
     final path = p.join(dir.path, '$name.$extension');
     await File(path).writeAsBytes(bytes);
-    return path;
+    // Stored relative to the Glaze data root, never as the absolute path it
+    // was just written to: the root moves under an installed app (a new iOS
+    // container UUID, a database carried between desktop build channels) and
+    // an absolute path silently stops pointing at a file, while a relative one
+    // is re-joined onto the current root by resolveGlazeFilePath.
+    return p.url.join('generated', '$name.$extension');
   }
 
   static int _saveSeq = 0;

--- a/lib/features/image_gen/services/image_tag_markup.dart
+++ b/lib/features/image_gen/services/image_tag_markup.dart
@@ -5,8 +5,11 @@ import '../../../core/constants/image_gen_patterns.dart';
 /// The images one image block carries, which of them is on screen, and the
 /// instruction that produced them.
 ///
-/// A block keeps every image it has generated so the reader can page back
-/// through them, so the tag payload is a list rather than a single path:
+/// A finished block is stored as an `<img data-iig-…>` element
+/// ([ImageTagMarkup.encodeResultElement]); this codec is what a pending block
+/// and every message written before that form existed are spelled with. A
+/// block keeps every image it has generated so the reader can page back
+/// through them, so the payload is a list rather than a single path:
 ///
 ///     [IMG:RESULT:/a.png;;*/b.png|{"prompt":"…"}]
 ///     [IMG:GEN:@/a.png;;/b.png|{"prompt":"…"}]
@@ -39,6 +42,11 @@ class ImageBlockPayload {
   final String instruction;
 
   static const String _separator = ';;';
+
+  /// Separator between the images one block carries, in the tag payload and in
+  /// the `data-iig-variants` attribute alike. Mirrored by the WebView
+  /// formatter (`IMG_VARIANT_SEPARATOR`).
+  static const String variantSeparator = _separator;
   static const String _activeMarker = '*';
   static const String _pendingMarker = '@';
 
@@ -145,6 +153,16 @@ class ImageBlockPayload {
       _fromPathList(value, '').paths;
 }
 
+/// One finished image block written in the stored `<img data-iig-…>` form:
+/// the span it occupies and the payload its attributes carry.
+class ImageResultElement {
+  const ImageResultElement(this.start, this.end, this.payload);
+
+  final int start;
+  final int end;
+  final ImageBlockPayload payload;
+}
+
 /// One pending image tag located in a message: the span it occupies and the
 /// raw instruction payload it carries.
 class PendingImageTag {
@@ -217,9 +235,13 @@ class ImageBlock {
   }
 }
 
-/// Pure text transformations for `[IMG:GEN]` / `[IMG:RESULT:]` / `[IMG:ERROR]`
-/// image-gen tag markup. Has no dependency on image generation, file I/O, or
-/// network — only on [ImgGenPatterns] and JSON encoding.
+/// Pure text transformations for image-gen markup: the `<img data-iig-…>`
+/// element a finished block is stored as, the `[IMG:GEN]` / `[IMG:ERROR]` tags
+/// of a block that has no picture yet, and the `[IMG:RESULT:]` of messages
+/// written before the element form existed. Has no dependency on image
+/// generation, file I/O, or network — only on [ImgGenPatterns] and JSON
+/// encoding, so the paths it moves around are stored exactly as handed in
+/// (relative to the Glaze data root, as every caller writes them).
 ///
 /// Every operation is anchored on [scanPendingTags], a single document-ordered
 /// pass over the four tag spellings. Resolving one tag rewrites only that tag's
@@ -243,17 +265,33 @@ class ImageTagMarkup {
     bool overlapsExisting(int start, int end) =>
         tags.any((tag) => start < tag.end && tag.start < end);
 
-    void collect(RegExp pattern, String? Function(RegExpMatch) payloadOf) {
+    void collect(
+      RegExp pattern,
+      String? Function(RegExpMatch) payloadOf, {
+      bool Function(String element)? accept,
+    }) {
       for (final match in pattern.allMatches(text)) {
         if (overlapsExisting(match.start, match.end)) continue;
+        if (accept != null && !accept(match.group(0)!)) continue;
         tags.add(
           PendingImageTag(match.start, match.end, payloadOf(match) ?? ''),
         );
       }
     }
 
-    collect(ImgGenPatterns.htmlIigTagRegex, (m) => m.group(1));
-    collect(ImgGenPatterns.htmlIigTagDoubleRegex, (m) => m.group(1));
+    // The same `<img data-iig-instruction…>` element is the stored form of a
+    // *finished* block once its `src` names an image, so only the ones still
+    // waiting for a picture count as pending here.
+    collect(
+      ImgGenPatterns.htmlIigTagRegex,
+      (m) => m.group(1),
+      accept: ImgGenPatterns.isPendingIigElement,
+    );
+    collect(
+      ImgGenPatterns.htmlIigTagDoubleRegex,
+      (m) => m.group(1),
+      accept: ImgGenPatterns.isPendingIigElement,
+    );
     // `<img src="[IMG:GEN:…]">` without the instruction attribute: the payload
     // lives in the src, but the whole element is what gets replaced.
     collect(
@@ -267,6 +305,149 @@ class ImageTagMarkup {
   }
 
   static bool hasImageGenTags(String text) => scanPendingTags(text).isNotEmpty;
+
+  // ── Stored `<img data-iig-…>` form of a finished block ──────────────────
+
+  /// Instruction JSON of an image block, on both the pending element a model
+  /// writes and the finished one Glaze stores.
+  static const String instructionAttribute = 'data-iig-instruction';
+
+  /// The block's images, `;;`-separated. Absent while the block holds one.
+  static const String variantsAttribute = 'data-iig-variants';
+
+  /// Position inside [variantsAttribute] of the image the message shows.
+  static const String variantIndexAttribute = 'data-iig-index';
+
+  /// The stored spelling of a finished image block.
+  ///
+  /// Mirrors the tag the SillyTavern image extension writes, so message text
+  /// stays readable HTML: the visible image is the element's `src`, the other
+  /// images of the block ride along in [variantsAttribute] so that `src` is
+  /// always one plain path, and every path is relative to the Glaze data root
+  /// — which is what keeps a message working after that root moves (a new iOS
+  /// container, a database copied between build channels).
+  ///
+  /// `[IMG:RESULT:…]` is still read, so older messages render unchanged, but
+  /// it is never written any more.
+  static String encodeResultElement(ImageBlockPayload payload) {
+    final buffer = StringBuffer('<img $instructionAttribute=')
+      ..write("'${_escapeAttribute(payload.instruction, "'")}'");
+    if (payload.hasVariants) {
+      final joined = payload.paths.join(ImageBlockPayload.variantSeparator);
+      buffer
+        ..write(" $variantsAttribute='${_escapeAttribute(joined, "'")}'")
+        ..write(
+          " $variantIndexAttribute="
+          "'${payload.activeIndex.clamp(0, payload.paths.length - 1)}'",
+        );
+    }
+    buffer.write(' src="${_escapeAttribute(payload.activePath, '"')}">');
+    return buffer.toString();
+  }
+
+  /// Every finished block written in the stored `<img data-iig-…>` form, in
+  /// document order. Elements still waiting for their image are left to
+  /// [scanPendingTags]; the two never claim the same element.
+  static List<ImageResultElement> scanResultElements(String text) {
+    if (!text.contains(instructionAttribute)) return const [];
+
+    final elements = <ImageResultElement>[];
+    void collect(RegExp pattern) {
+      for (final match in pattern.allMatches(text)) {
+        final overlaps = elements.any(
+          (element) => match.start < element.end && element.start < match.end,
+        );
+        if (overlaps) continue;
+        final payload = _resultPayloadOfElement(match.group(0)!);
+        if (payload == null) continue;
+        elements.add(ImageResultElement(match.start, match.end, payload));
+      }
+    }
+
+    collect(ImgGenPatterns.htmlIigTagRegex);
+    collect(ImgGenPatterns.htmlIigTagDoubleRegex);
+    elements.sort((a, b) => a.start.compareTo(b.start));
+    return elements;
+  }
+
+  /// The payload an `<img …>` element carries, or null when it is not a
+  /// finished image block (no instruction attribute, or no image yet).
+  static ImageBlockPayload? _resultPayloadOfElement(String element) {
+    if (ImgGenPatterns.isPendingIigElement(element)) return null;
+    final attributes = ImgGenPatterns.imgAttributes(element);
+    if (!attributes.containsKey(instructionAttribute)) return null;
+    final src = _unescapeAttribute(attributes['src'] ?? '').trim();
+    if (src.isEmpty) return null;
+    final instruction = _unescapeAttribute(
+      attributes[instructionAttribute] ?? '',
+    );
+    final variants = _unescapeAttribute(attributes[variantsAttribute] ?? '');
+    final paths = variants.isEmpty
+        ? <String>[src]
+        : ImageBlockPayload.decodePathList(variants);
+    if (paths.isEmpty) {
+      return ImageBlockPayload(paths: [src], instruction: instruction);
+    }
+    // The declared index wins; without one the block shows whichever variant
+    // the `src` names, so a hand-edited element still renders the right image.
+    final declared = int.tryParse(attributes[variantIndexAttribute] ?? '');
+    final active = declared ?? paths.indexOf(src);
+    return ImageBlockPayload(
+      paths: paths,
+      activeIndex: active < 0 ? 0 : active.clamp(0, paths.length - 1),
+      instruction: instruction,
+    );
+  }
+
+  /// Sends every stored `<img data-iig-…>` block back to pending, keeping its
+  /// prompt and the images it already holds.
+  static String resetResultElements(String text) {
+    var result = text;
+    // Right to left: replacing one element must not move the spans of the
+    // elements still to be replaced.
+    for (final element in scanResultElements(text).reversed) {
+      result = result.replaceRange(
+        element.start,
+        element.end,
+        _pendingTag(element.payload),
+      );
+    }
+    return result;
+  }
+
+  static const Map<String, String> _attributeEntities = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    "'": '&#39;',
+    '"': '&quot;',
+  };
+
+  /// [value] as an attribute of an element delimited by [quote].
+  ///
+  /// Only the delimiter and the characters that would end the element are
+  /// encoded, so instruction JSON inside a single-quoted attribute keeps its
+  /// plain `"` — the spelling a model writes, and the one every reader of the
+  /// pending form already parses.
+  static String _escapeAttribute(String value, String quote) {
+    var escaped = value.replaceAll('&', _attributeEntities['&']!);
+    for (final char in ['<', '>', quote]) {
+      escaped = escaped.replaceAll(char, _attributeEntities[char]!);
+    }
+    return escaped;
+  }
+
+  static String _unescapeAttribute(String value) {
+    if (!value.contains('&')) return value;
+    return value
+        .replaceAll('&lt;', '<')
+        .replaceAll('&gt;', '>')
+        .replaceAll('&#39;', "'")
+        .replaceAll('&apos;', "'")
+        .replaceAll('&quot;', '"')
+        .replaceAll('&amp;', '&');
+  }
+
 
   /// How many image tags of [text] are still waiting for their image.
   static int pendingImageGenTagCount(String text) =>
@@ -293,9 +474,8 @@ class ImageTagMarkup {
     final instrJson = instruction.isNotEmpty ? jsonEncode(instruction) : '';
     final payload = ImageBlockPayload.parsePending(tag.payload)
         .withInstruction(instrJson)
-        .withNewImage(imagePath)
-        .encodeResult();
-    return text.replaceRange(tag.start, tag.end, '[IMG:RESULT:$payload]');
+        .withNewImage(imagePath);
+    return text.replaceRange(tag.start, tag.end, encodeResultElement(payload));
   }
 
   static String replaceTagWithError(String text, int index, String error) {
@@ -353,12 +533,13 @@ class ImageTagMarkup {
     });
   }
 
-  /// Sends every finished `[IMG:RESULT:…]` block back to pending, keeping its
-  /// prompt and the images it already holds.
+  /// Sends every finished block back to pending, in both stored forms, keeping
+  /// its prompt and the images it already holds.
   static String resetResultTags(String text) {
-    return text.replaceAllMapped(ImgGenPatterns.imgResultRegex, (m) {
+    final reset = text.replaceAllMapped(ImgGenPatterns.imgResultRegex, (m) {
       return _pendingTag(ImageBlockPayload.parseResult(m.group(1) ?? ''));
     });
+    return resetResultElements(reset);
   }
 
   static String _pendingTag(ImageBlockPayload payload) {
@@ -376,11 +557,27 @@ class ImageTagMarkup {
         _pendingBlock(tag),
     ];
 
-    // A resolved token can never sit inside a pending tag; the guard just keeps
-    // a tag whose payload happens to quote one from being counted twice.
+    // A resolved token can never sit inside a block already collected; the
+    // guard just keeps one quoted inside a tag payload or an element attribute
+    // from being counted twice.
     bool insidePendingTag(RegExpMatch match) => blocks.any(
       (block) => match.start < block.end && block.start < match.end,
     );
+
+    for (final element in scanResultElements(text)) {
+      final payload = element.payload;
+      blocks.add(
+        ImageBlock(
+          start: element.start,
+          end: element.end,
+          kind: ImageBlockKind.result,
+          instruction: payload.instruction,
+          imagePath: payload.activePath,
+          paths: payload.paths,
+          activeIndex: payload.activeIndex,
+        ),
+      );
+    }
 
     for (final match in ImgGenPatterns.imgResultRegex.allMatches(text)) {
       if (insidePendingTag(match)) continue;
@@ -463,8 +660,12 @@ class ImageTagMarkup {
       paths: block.paths,
       activeIndex: block.activeIndex,
       instruction: block.instruction,
-    ).withNewImage(imagePath).encodeResult();
-    return text.replaceRange(block.start, block.end, '[IMG:RESULT:$payload]');
+    ).withNewImage(imagePath);
+    return text.replaceRange(
+      block.start,
+      block.end,
+      encodeResultElement(payload),
+    );
   }
 
   /// Puts the [variantIndex]-th image of the [blockIndex]-th block on screen.
@@ -486,20 +687,26 @@ class ImageTagMarkup {
       paths: block.paths,
       activeIndex: variantIndex,
       instruction: block.instruction,
-    ).encodeResult();
-    return text.replaceRange(block.start, block.end, '[IMG:RESULT:$payload]');
+    );
+    return text.replaceRange(
+      block.start,
+      block.end,
+      encodeResultElement(payload),
+    );
   }
 
+  /// The visible image of every finished block, in document order — both the
+  /// stored `<img data-iig-…>` form and the `[IMG:RESULT:…]` of older messages.
   static List<String> extractImageResultPaths(String text) {
-    return ImgGenPatterns.imgResultRegex
-        .allMatches(text)
-        .map((m) => normalizeImageResultPayload(m.group(1) ?? ''))
-        .where((p) => p.isNotEmpty)
-        .toList();
+    return [
+      for (final block in scanImageBlocks(text))
+        if (block.kind == ImageBlockKind.result && block.imagePath.isNotEmpty)
+          block.imagePath,
+    ];
   }
 
-  /// Rewrites the file path inside every `[IMG:RESULT:…]` tag with [resolve],
-  /// dropping the whole tag when it returns null.
+  /// Rewrites the file path inside every finished image block with [resolve],
+  /// in both stored forms, dropping the whole block when it returns null.
   ///
   /// The payload is split exactly like the WebView formatter does — the tag
   /// ends at the first `]`, the path ends at the first `|` — so an instruction
@@ -512,26 +719,47 @@ class ImageTagMarkup {
     String text,
     String? Function(String path) resolve,
   ) {
-    return text.replaceAllMapped(ImgGenPatterns.imgResultRegex, (match) {
-      final payload = ImageBlockPayload.parseResult(match.group(1) ?? '');
-      // Every variant is resolved, not just the visible one: the switcher
-      // swaps the image in the page, and a variant it cannot address would
-      // read as a picture that vanished. A variant that cannot be served is
-      // dropped from the block instead.
-      final resolved = <String>[];
-      var active = 0;
-      for (var i = 0; i < payload.paths.length; i++) {
-        final url = resolve(payload.paths[i]);
-        if (url == null) continue;
-        if (i == payload.activeIndex) active = resolved.length;
-        resolved.add(url);
-      }
-      if (resolved.isEmpty) return '';
-      final rewritten = payload
-          .withPaths(resolved, activeIndex: active)
-          .encodeResult();
-      return '[IMG:RESULT:$rewritten]';
+    var result = text.replaceAllMapped(ImgGenPatterns.imgResultRegex, (match) {
+      final rewritten = _rewritePayload(
+        ImageBlockPayload.parseResult(match.group(1) ?? ''),
+        resolve,
+      );
+      return rewritten == null ? '' : '[IMG:RESULT:${rewritten.encodeResult()}]';
     });
+    // Scanned after the tag pass, so the spans are the ones of `result`, and
+    // walked right to left so replacing one element leaves the rest in place.
+    for (final element in scanResultElements(result).reversed) {
+      final rewritten = _rewritePayload(element.payload, resolve);
+      result = result.replaceRange(
+        element.start,
+        element.end,
+        rewritten == null ? '' : encodeResultElement(rewritten),
+      );
+    }
+    return result;
+  }
+
+  /// [payload] with [resolve] applied to every image it carries, or null when
+  /// none of them can be served.
+  ///
+  /// Every variant is resolved, not just the visible one: the switcher swaps
+  /// the image in the page, and a variant it cannot address would read as a
+  /// picture that vanished. A variant that cannot be served is dropped from
+  /// the block instead.
+  static ImageBlockPayload? _rewritePayload(
+    ImageBlockPayload payload,
+    String? Function(String path) resolve,
+  ) {
+    final resolved = <String>[];
+    var active = 0;
+    for (var i = 0; i < payload.paths.length; i++) {
+      final url = resolve(payload.paths[i]);
+      if (url == null) continue;
+      if (i == payload.activeIndex) active = resolved.length;
+      resolved.add(url);
+    }
+    if (resolved.isEmpty) return null;
+    return payload.withPaths(resolved, activeIndex: active);
   }
 
   /// The image an `[IMG:RESULT:…]` payload shows — instruction suffix and the
@@ -564,6 +792,13 @@ class ImageTagMarkup {
     if (fromGen.isNotEmpty) return fromGen;
 
     final fromResult = <Map<String, dynamic>>[];
+    for (final element in scanResultElements(text)) {
+      final instruction = element.payload.instruction;
+      if (instruction.isEmpty) continue;
+      try {
+        fromResult.add(jsonDecode(instruction) as Map<String, dynamic>);
+      } catch (_) {}
+    }
     for (final match in ImgGenPatterns.imgResultRegex.allMatches(text)) {
       final raw = match.group(1) ?? '';
       final pipeIdx = raw.indexOf('|');
@@ -575,21 +810,5 @@ class ImageTagMarkup {
       } catch (_) {}
     }
     return fromResult;
-  }
-
-  /// Replaces the [index]-th [IMG:RESULT:…] token, preserving instruction JSON.
-  static String replaceExtBlockImageResult(
-    String text,
-    String newPath, {
-    int index = 0,
-  }) {
-    var count = 0;
-    return text.replaceAllMapped(ImgGenPatterns.imgResultRegex, (match) {
-      if (count++ != index) return match.group(0)!;
-      final payload = ImageBlockPayload.parseResult(match.group(1)!)
-          .withNewImage(newPath)
-          .encodeResult();
-      return '[IMG:RESULT:$payload]';
-    });
   }
 }

--- a/test/chat_webview_security_test.dart
+++ b/test/chat_webview_security_test.dart
@@ -172,6 +172,33 @@ void main() {
       );
     });
 
+    // INV-IG9: the port in a `/__glaze_file__` URL only exists for the launch
+    // that produced it, so a message that stored one is unwrapped on the way
+    // in rather than migrated — and the relative path a block is stored with
+    // has to resolve at all.
+    test('a stale local-file URL resolves as the file it used to serve', () {
+      expect(
+        source,
+        contains('final stored = glazeFilePathFromLoopbackUrl(source);'),
+      );
+      expect(
+        RegExp(
+          r'final stored = glazeFilePathFromLoopbackUrl\(source\);\s*'
+          r'if \(stored != null\) return chatWebViewResolveLocalFileUrl\(stored\);'
+          r"[\s\S]*?source\.startsWith\('http://'\)",
+        ).hasMatch(source),
+        isTrue,
+        reason: 'the unwrap must run before the remote-URL passthrough',
+      );
+    });
+
+    test('a path relative to the data root is a local-file candidate', () {
+      expect(
+        source,
+        contains('_allowedGlazeMediaDirectories.contains(segments.first)'),
+      );
+    });
+
     test('file responses allow only GET and HEAD', () {
       expect(source, contains("request.method != 'GET'"));
       expect(source, contains("request.method != 'HEAD'"));

--- a/test/image_block_variants_test.dart
+++ b/test/image_block_variants_test.dart
@@ -59,7 +59,12 @@ void main() {
     test('a finished image is appended and put on screen', () {
       const text = 'x [IMG:GEN:@/a.png|{"prompt":"cat"}] y';
       final out = ImageTagMarkup.replaceTagWithResult(text, 0, '/b.png');
-      expect(out, 'x [IMG:RESULT:/a.png;;*/b.png|{"prompt":"cat"}] y');
+      expect(
+        out,
+        'x <img data-iig-instruction=\'{"prompt":"cat"}\' '
+            "data-iig-variants='/a.png;;/b.png' data-iig-index='1' "
+            'src="/b.png"> y',
+      );
 
       final block = ImageTagMarkup.scanImageBlocks(out).single;
       expect(block.paths, ['/a.png', '/b.png']);
@@ -75,7 +80,9 @@ void main() {
       final finished = ImageTagMarkup.replaceTagWithResult(pending, 0, '/c.png');
       expect(
         finished,
-        '[IMG:RESULT:/a.png;;/b.png;;*/c.png|{"prompt":"cat"}]',
+        '<img data-iig-instruction=\'{"prompt":"cat"}\' '
+            "data-iig-variants='/a.png;;/b.png;;/c.png' data-iig-index='2' "
+            'src="/c.png">',
       );
     });
 
@@ -107,7 +114,12 @@ void main() {
 
     test('puts another image of the block on screen', () {
       final out = ImageTagMarkup.setImageBlockVariant(text, 0, 2);
-      expect(out, 'a [IMG:RESULT:/a.png;;/b.png;;*/c.png|{"prompt":"cat"}] b');
+      expect(
+        out,
+        'a <img data-iig-instruction=\'{"prompt":"cat"}\' '
+            "data-iig-variants='/a.png;;/b.png;;/c.png' data-iig-index='2' "
+            'src="/c.png"> b',
+      );
       expect(ImageTagMarkup.scanImageBlocks(out).single.imagePath, '/c.png');
     });
 

--- a/test/image_gen_service_test.dart
+++ b/test/image_gen_service_test.dart
@@ -148,14 +148,19 @@ void main() {
   });
 
   group('replaceTagWithResult', () {
-    test('replaces [IMG:GEN:json] with [IMG:RESULT:path|instruction]', () {
+    test('replaces [IMG:GEN:json] with the stored <img> element', () {
       final result = ImageTagMarkup.replaceTagWithResult(
         'Hello [IMG:GEN:{"prompt":"test"}]',
         0,
         '/path/to/image.png',
       );
-      expect(result, contains('[IMG:RESULT:/path/to/image.png|'));
+      expect(
+        result,
+        'Hello <img data-iig-instruction=\'{"prompt":"test"}\' '
+            'src="/path/to/image.png">',
+      );
       expect(result, isNot(contains('[IMG:GEN')));
+      expect(result, isNot(contains('[IMG:RESULT')));
     });
 
     test('replaces HTML data-iig-instruction tag', () {
@@ -166,8 +171,9 @@ void main() {
         0,
         '/saved/img.png',
       );
-      expect(result, contains('[IMG:RESULT:/saved/img.png|'));
-      expect(result, isNot(contains('data-iig-instruction')));
+      expect(result, contains('src="/saved/img.png"'));
+      expect(result, contains(r'{"style":"manga","prompt":"test"}'));
+      expect(result, isNot(contains('[IMG:GEN')));
     });
 
     test('replaces whole HTML img tag with src IMG:GEN', () {
@@ -178,8 +184,8 @@ void main() {
         0,
         '/saved/img.png',
       );
-      expect(result, contains('[IMG:RESULT:/saved/img.png|'));
-      expect(result, isNot(contains('<img')));
+      expect(result, contains('src="/saved/img.png"'));
+      expect(result, isNot(contains('[IMG:GEN')));
       expect(result, contains('caption'));
     });
 
@@ -189,7 +195,7 @@ void main() {
         0,
         '/img1.png',
       );
-      expect(result, contains('[IMG:RESULT:/img1.png|'));
+      expect(result, contains('src="/img1.png"'));
       expect(result, contains('[IMG:GEN:{"prompt":"second"}]'));
     });
 
@@ -201,7 +207,7 @@ void main() {
 
       final result = ImageTagMarkup.replaceTagWithResult(html, 0, '/img1.png');
 
-      expect(result, contains('[IMG:RESULT:/img1.png|'));
+      expect(result, contains('src="/img1.png"'));
       expect(result, contains('caption'));
       expect(result, contains(r'{"prompt":"second"}'));
       expect(ImageTagMarkup.pendingImageGenTagCount(result), 1);
@@ -223,7 +229,7 @@ void main() {
         0,
         '/img2.png',
       );
-      expect(settled, contains('[IMG:RESULT:/img2.png|'));
+      expect(settled, contains('src="/img2.png"'));
       expect(settled, contains(r'{"prompt":"second"}'));
       expect(ImageTagMarkup.pendingImageGenTagCount(settled), 0);
     });
@@ -471,7 +477,12 @@ void main() {
         '/found.png',
       );
 
-      expect(result, contains('[IMG:RESULT:/found.png|{"prompt":"two"}]'));
+      expect(
+        result,
+        contains(
+          '<img data-iig-instruction=\'{"prompt":"two"}\' src="/found.png">',
+        ),
+      );
       expect(result, contains('[IMG:RESULT:/one.png|{"prompt":"one"}]'));
       expect(result, contains('[IMG:GEN:{"prompt":"three"}]'));
     });
@@ -599,14 +610,18 @@ void main() {
       expect(prompt, 'cinematic manga, A group enters');
     });
 
-    test('replaceTagWithResult on HTML removes entire img tag', () {
+    test('replaceTagWithResult on HTML replaces the whole img tag', () {
       const html = """<div>
   <img data-iig-instruction='{"style":"manga","prompt":"test"}' src="[IMG:GEN]">
   <i>caption</i>
 </div>""";
       final result = ImageTagMarkup.replaceTagWithResult(html, 0, '/img.png');
-      expect(result, contains('[IMG:RESULT:/img.png|'));
-      expect(result, isNot(contains('data-iig-instruction')));
+      expect(result, contains('src="/img.png"'));
+      expect(result, isNot(contains('[IMG:GEN')));
+      // The element that carried the instruction is gone, replaced whole by
+      // the one that carries the image — the surrounding card is untouched.
+      expect(result, isNot(contains('src="[IMG:GEN]"')));
+      expect(ImageTagMarkup.pendingImageGenTagCount(result), 0);
       expect(result, contains('caption'));
     });
 

--- a/test/image_stored_form_test.dart
+++ b/test/image_stored_form_test.dart
@@ -1,0 +1,306 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/constants/image_gen_patterns.dart';
+import 'package:glaze_flutter/core/utils/platform_paths.dart';
+import 'package:glaze_flutter/features/chat/bridge/chat_webview_environment.dart';
+import 'package:glaze_flutter/features/cloud_sync/services/sync_serialization.dart';
+import 'package:glaze_flutter/features/image_gen/services/image_tag_markup.dart';
+import 'package:path/path.dart' as p;
+
+/// The stored form of a finished image block (INV-IG9): an `<img>` element
+/// whose `src` is the visible image, relative to the Glaze data root.
+void main() {
+  group('the stored <img data-iig-…> element', () {
+    test('a single-image block is one element with a plain src', () {
+      const payload = ImageBlockPayload(
+        paths: ['generated/a.jpg'],
+        instruction: '{"prompt":"cat"}',
+      );
+      expect(
+        ImageTagMarkup.encodeResultElement(payload),
+        '<img data-iig-instruction=\'{"prompt":"cat"}\' '
+            'src="generated/a.jpg">',
+      );
+    });
+
+    test('the other images of the block ride along in the attributes', () {
+      const payload = ImageBlockPayload(
+        paths: ['generated/a.jpg', 'generated/b.jpg'],
+        activeIndex: 1,
+        instruction: '{"prompt":"cat"}',
+      );
+      expect(
+        ImageTagMarkup.encodeResultElement(payload),
+        '<img data-iig-instruction=\'{"prompt":"cat"}\' '
+            "data-iig-variants='generated/a.jpg;;generated/b.jpg' "
+            "data-iig-index='1' src=\"generated/b.jpg\">",
+      );
+    });
+
+    test('encode and scan round-trip a block with variants', () {
+      const payload = ImageBlockPayload(
+        paths: ['generated/a.jpg', 'generated/b.jpg', 'generated/c.jpg'],
+        activeIndex: 2,
+        instruction: '{"prompt":"cat"}',
+      );
+      final scanned = ImageTagMarkup.scanResultElements(
+        'x ${ImageTagMarkup.encodeResultElement(payload)} y',
+      ).single;
+      expect(scanned.payload.paths, payload.paths);
+      expect(scanned.payload.activeIndex, 2);
+      expect(scanned.payload.activePath, 'generated/c.jpg');
+      expect(scanned.payload.instruction, '{"prompt":"cat"}');
+    });
+
+    test('a quote or an ampersand in the prompt survives the round trip', () {
+      const instruction = '{"prompt":"a \'lone\' cat & a <dog>"}';
+      const payload = ImageBlockPayload(
+        paths: ['generated/a.jpg'],
+        instruction: instruction,
+      );
+      final encoded = ImageTagMarkup.encodeResultElement(payload);
+      expect(encoded, isNot(contains("'a 'lone' cat")));
+      expect(
+        ImageTagMarkup.scanResultElements(encoded).single.payload.instruction,
+        instruction,
+      );
+    });
+
+    test('an element without an image is pending, not a finished block', () {
+      const pending =
+          '<img data-iig-instruction=\'{"prompt":"cat"}\' src="[IMG:GEN]">';
+      expect(ImageTagMarkup.scanResultElements(pending), isEmpty);
+      expect(ImageTagMarkup.pendingImageGenTagCount(pending), 1);
+      expect(ImgGenPatterns.isPendingIigElement(pending), isTrue);
+
+      final finished = ImageTagMarkup.encodeResultElement(
+        const ImageBlockPayload(
+          paths: ['generated/a.jpg'],
+          instruction: '{"prompt":"cat"}',
+        ),
+      );
+      expect(ImageTagMarkup.pendingImageGenTagCount(finished), 0);
+      expect(ImgGenPatterns.isPendingIigElement(finished), isFalse);
+    });
+
+    test('an ordinary image in a message is not an image block', () {
+      const text = '<img src="generated/a.jpg"> ![alt](https://x/y.png)';
+      expect(ImageTagMarkup.scanResultElements(text), isEmpty);
+      expect(ImageTagMarkup.scanImageBlocks(text), isEmpty);
+    });
+  });
+
+  group('blocks of both stored forms in one message', () {
+    const text =
+        '[IMG:RESULT:/old.png|{"prompt":"one"}] a '
+        '<img data-iig-instruction=\'{"prompt":"two"}\' '
+        "data-iig-variants='generated/b.jpg;;generated/c.jpg' "
+        'data-iig-index=\'1\' src="generated/c.jpg"> b '
+        '[IMG:GEN:{"prompt":"three"}]';
+
+    test('are numbered together in document order', () {
+      final blocks = ImageTagMarkup.scanImageBlocks(text);
+      expect(blocks.map((b) => b.kind), [
+        ImageBlockKind.result,
+        ImageBlockKind.result,
+        ImageBlockKind.pending,
+      ]);
+      expect(blocks[0].imagePath, '/old.png');
+      expect(blocks[1].imagePath, 'generated/c.jpg');
+      expect(blocks[1].paths, ['generated/b.jpg', 'generated/c.jpg']);
+    });
+
+    test('only the visible image of each is offered as context', () {
+      expect(ImageTagMarkup.extractImageResultPaths(text), [
+        '/old.png',
+        'generated/c.jpg',
+      ]);
+    });
+
+    test('resetting one leaves the others alone', () {
+      final out = ImageTagMarkup.resetImageBlockAt(text, 1);
+      expect(
+        out,
+        contains('[IMG:GEN:@generated/b.jpg;;*generated/c.jpg|'
+            '{"prompt":"two"}]'),
+      );
+      expect(out, contains('[IMG:RESULT:/old.png|{"prompt":"one"}]'));
+      expect(out, isNot(contains('data-iig-instruction')));
+    });
+
+    test('a legacy block switched to another variant is stored as an element',
+        () {
+      final out = ImageTagMarkup.setImageBlockVariant(
+        '[IMG:RESULT:/a.png;;*/b.png|{"prompt":"cat"}]',
+        0,
+        0,
+      );
+      expect(out, startsWith('<img data-iig-instruction='));
+      expect(out, contains('src="/a.png"'));
+      expect(ImageTagMarkup.scanImageBlocks(out).single.imagePath, '/a.png');
+    });
+
+    test('resetErrorTags sends every finished block back to pending', () {
+      final out = ImageTagMarkup.resetErrorTags(text);
+      expect(out, isNot(contains('data-iig-instruction')));
+      expect(out, isNot(contains('[IMG:RESULT')));
+      expect(ImageTagMarkup.pendingImageGenTagCount(out), 3);
+    });
+  });
+
+  group('resolving the images of a stored element', () {
+    test('every variant is resolved and the element keeps its form', () {
+      final out = ImageTagMarkup.rewriteResultPaths(
+        ImageTagMarkup.encodeResultElement(
+          const ImageBlockPayload(
+            paths: ['generated/a.jpg', 'generated/b.jpg'],
+            activeIndex: 1,
+            instruction: '{}',
+          ),
+        ),
+        (path) => 'served:$path',
+      );
+      final payload = ImageTagMarkup.scanResultElements(out).single.payload;
+      expect(payload.paths, ['served:generated/a.jpg', 'served:generated/b.jpg']);
+      expect(payload.activeIndex, 1);
+      expect(out, contains('src="served:generated/b.jpg"'));
+    });
+
+    test('the block is dropped when nothing can be served', () {
+      final element = ImageTagMarkup.encodeResultElement(
+        const ImageBlockPayload(paths: ['generated/a.jpg']),
+      );
+      final out = ImageTagMarkup.rewriteResultPaths(
+        'x $element y',
+        (_) => null,
+      );
+      expect(out, 'x  y');
+    });
+
+    test('a resolved element restores to the path it was written with', () {
+      const stored = 'generated/imggen_1_0.jpg';
+      final original = ImageTagMarkup.encodeResultElement(
+        const ImageBlockPayload(paths: [stored], instruction: '{"prompt":"c"}'),
+      );
+      final resolved = ImageTagMarkup.rewriteResultPaths(
+        original,
+        (path) => 'http://127.0.0.1:35621/__glaze_file__?path=$path',
+      );
+      expect(resolved, contains('__glaze_file__'));
+
+      final restored = ImageTagMarkup.rewriteResultPaths(
+        resolved,
+        restoreChatWebViewLocalFilePath,
+      );
+      expect(restored, original);
+    });
+  });
+
+  group('restoreChatWebViewLocalFilePath', () {
+    test('unwraps a loopback URL from an app launch that is gone', () {
+      expect(
+        restoreChatWebViewLocalFilePath(
+          'http://127.0.0.1:35621/__glaze_file__'
+          '?path=%2Fdata%2FGlaze%2Fgenerated%2Fimggen_1_0.jpg',
+        ),
+        'generated/imggen_1_0.jpg',
+      );
+    });
+
+    test('leaves a remote image and a stored relative path alone', () {
+      expect(
+        restoreChatWebViewLocalFilePath('https://example.com/a.png'),
+        'https://example.com/a.png',
+      );
+      expect(
+        restoreChatWebViewLocalFilePath('generated/a.jpg'),
+        'generated/a.jpg',
+      );
+    });
+  });
+
+  group('relativeGlazeFilePath', () {
+    test('spells a path under a data root relative to it', () {
+      expect(
+        relativeGlazeFilePath('/data/user/0/app/files/Glaze/generated/a.jpg'),
+        'generated/a.jpg',
+      );
+      expect(
+        relativeGlazeFilePath('/home/u/.local/share/Glaze-nightly/avatars/a.png'),
+        'avatars/a.png',
+      );
+    });
+
+    test('leaves a relative path, a URL and an outside path alone', () {
+      expect(relativeGlazeFilePath('generated/a.jpg'), 'generated/a.jpg');
+      expect(relativeGlazeFilePath('data:image/png;base64,AA'),
+          'data:image/png;base64,AA');
+      expect(relativeGlazeFilePath('/etc/passwd'), '/etc/passwd');
+    });
+
+    test('round-trips against the current data root', () async {
+      final base = await getAppDataDir();
+      final absolute = p.join(base, 'generated', 'a.jpg');
+      final relative = relativeGlazeFilePath(absolute);
+      expect(relative, 'generated/a.jpg');
+      expect(resolveGlazeFilePath(relative), absolute);
+    });
+  });
+
+  group('an ext block that generates its image again', () {
+    // The rerun used to look for a pending tag, which a block that already has
+    // a picture no longer has: the new image was dropped on the floor.
+    test('keeps the earlier image and puts the new one on screen', () {
+      const source = '<div>Scene</div>[IMG:RESULT:generated/a.jpg|{"p":1}]';
+      final blocks = ImageTagMarkup.scanImageBlocks(source);
+      expect(blocks, hasLength(1));
+
+      final out = ImageTagMarkup.replaceImageBlockWithResult(
+        source,
+        0,
+        'generated/b.jpg',
+      );
+      final block = ImageTagMarkup.scanImageBlocks(out).single;
+      expect(block.paths, ['generated/a.jpg', 'generated/b.jpg']);
+      expect(block.imagePath, 'generated/b.jpg');
+      expect(out, startsWith('<div>Scene</div><img data-iig-instruction='));
+    });
+  });
+
+  group('cloud sync', () {
+    test('a finished block is uploaded as the instruction that made it', () {
+      final stored = ImageTagMarkup.encodeResultElement(
+        const ImageBlockPayload(
+          paths: ['generated/a.jpg', 'generated/b.jpg'],
+          activeIndex: 1,
+          instruction: '{"prompt":"a red dragon"}',
+        ),
+      );
+      final normalized = SyncSerialization.normalizeImageGenContent(
+        '<div>Scene</div>$stored',
+      );
+      expect(normalized, isNot(contains('generated/')));
+      expect(normalized, contains('<div>Scene</div>'));
+      expect(normalized, contains(r'[IMG:GEN:{"prompt":"a red dragon"}]'));
+    });
+  });
+
+  group('text coming back from the WebView', () {
+    final source = File(
+      'lib/features/chat/bridge/chat_bridge_controller.dart',
+    ).readAsStringSync();
+
+    // A message the page handed back used to be stored exactly as rendered,
+    // loopback URL included — a picture that stayed broken across restarts.
+    test('every inbound message text is put into its stored spelling', () {
+      for (final call in [
+        "onEditSave?.call(id, restoreImgResults(s))",
+        "restoreImgResults(data['content'] as String? ?? '')",
+        "restoreImgResults(data['text'] as String? ?? '')",
+      ]) {
+        expect(source, contains(call), reason: call);
+      }
+    });
+  });
+}

--- a/test/sync_image_stripper_test.dart
+++ b/test/sync_image_stripper_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glaze_flutter/features/cloud_sync/services/sync_image_stripper.dart';
+import 'package:glaze_flutter/features/image_gen/services/image_tag_markup.dart';
 
 void main() {
   test('strips local images from green and nested swipe content', () {
@@ -23,5 +24,27 @@ void main() {
     });
 
     expect(result.toString(), isNot(contains('C:/generated/')));
+  });
+
+  // INV-IG9: the stored form of a finished block carries a path into this
+  // device's data root, so it must not survive an upload either.
+  test('strips the stored <img data-iig-…> form of a finished block', () {
+    const stored =
+        '<img data-iig-instruction=\'{"prompt":"cat"}\' '
+        "data-iig-variants='generated/a.jpg;;generated/b.jpg' "
+        'data-iig-index=\'1\' src="generated/b.jpg">';
+    expect(stripImageContent('text $stored tail'), 'text  tail');
+  });
+
+  test('keeps a block that is still waiting for its image', () {
+    // Its instruction is what lets the pulling device generate the picture
+    // itself, so the element survives the strip (its `[IMG:GEN]` placeholder
+    // goes the way of every other pending tag).
+    const pending =
+        '<img data-iig-instruction=\'{"prompt":"cat"}\' src="[IMG:GEN]">';
+    final stripped = stripImageContent('text $pending');
+    expect(stripped, contains('data-iig-instruction'));
+    expect(stripped, contains(r'{"prompt":"cat"}'));
+    expect(ImageTagMarkup.pendingImageGenTagCount(stripped), 1);
   });
 }

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -641,6 +641,45 @@ void main() {
       expect(formatterFormatterJs, contains("IMG_VARIANT_ACTIVE_MARKER = '*'"));
     });
 
+    test('the stored <img data-iig-…> block renders as an image block', () {
+      // INV-IG9: the form every finished block is written in. It is pulled out
+      // with the other image tags in step 5c, so it gets the options button,
+      // the switcher and its data-img-index — not the bare <img> that step 6
+      // would leave.
+      expect(
+        formatterFormatterJs,
+        contains('export function parseImageResultElement('),
+      );
+      expect(formatterFormatterJs, contains('IIG_ELEMENT_REGEX'));
+      expect(formatterFormatterJs, contains("data-iig-variants"));
+      expect(formatterFormatterJs, contains("data-iig-index"));
+      expect(
+        RegExp(
+          r'html = html\.replace\(IIG_ELEMENT_REGEX[\s\S]*?'
+          r"imgBlocks\.push\(\{\s*type: 'result'",
+        ).hasMatch(formatterFormatterJs),
+        isTrue,
+      );
+      // An element with no image yet is a *pending* block and must fall
+      // through to the [IMG:GEN] handling instead.
+      expect(
+        formatterFormatterJs,
+        contains("if (!src || src.startsWith('[IMG:GEN')) return null;"),
+      );
+    });
+
+    test('an ext block renders the stored element with its own controls', () {
+      expect(
+        bridgeControllerJs,
+        contains('_extBlockLegacyImageTokens(block.content)'),
+      );
+      expect(
+        bridgeControllerJs,
+        contains("import { parseImageResultElement } from "
+            "'../formatter/formatter.js';"),
+      );
+    });
+
     test('paging a block swaps the picture in the page', () {
       expect(interactionDispatchJs, contains('_stepImageVariant('));
       expect(interactionDispatchJs, contains("'img-variant-prev'"));


### PR DESCRIPTION
A message stored the loopback URL its picture was served from, on a port that only exists for one app launch (`_startChatWebViewLocalFileServer` binds port 0). From the next start the image was broken for good — reopening the chat and restarting the app did not help, and the downloaded file was not an image either. Only a freshly generated picture worked, until something rewrote its tag with the resolved URL.

The URL reached the database through the page: `ChatBridgeController.resolveImgResults` leaves `section.dataset.rawText` holding the resolved text, `edit_controller.js` fills the textarea from it, and `editMessage()` stored it verbatim.

## Stop the loopback URL from reaching storage

- `restoreChatWebViewLocalFilePath` turns a `/__glaze_file__` URL back into the file it serves, reusing the existing `glazeFilePathFromLoopbackUrl` rather than a second parser
- `ChatBridgeController.restoreImgResults` runs on every text the page hands back — `onEditSave`, `onMessageContext` and `onSelectionAction`
- `chatWebViewResolveLocalFileUrl` unwraps such a URL before resolving, so messages that already stored one render again with no database migration

## Store a finished block as an `<img>` element (INV-IG9)

- `ImageTagMarkup.encodeResultElement` is now the only writer: ``'&lt;img data-iig-instruction='…' data-iig-variants='a;;b' data-iig-index='1' src="…"&gt;'``, mirroring the tag the SillyTavern image extension writes. `[IMG:RESULT:…]` is still read everywhere, so older messages render, reset and regenerate unchanged — it is just never written any more
- the same element with no image in its `src` is a *pending* block, which is what keeps `scanPendingTags()` and `scanResultElements()` from claiming the same element (`ImgGenPatterns.isPendingIigElement`). `cleanStuckImgGenTags` and `_extractStyledImageFrames` are guarded by the same rule, so an interrupted generation no longer turns a finished block into an error card
- `formatter.js` renders both forms through the same image block — options button, variant switcher, `data-img-index` — via `parseImageResultElement`, the mirror of the Dart writer; the ext-blocks panel renders it with its own download button

## Store every image path relative to the data root

- `_saveGeneratedImage`, the ext-block renderer and `findImageOnDisk` all store `generated/…` instead of an absolute path, and `resolveGlazeFilePath` joins it back onto the current root. This also fixes a picture lost to a new iOS container UUID or a database moved between desktop build channels
- `relativeGlazeFilePath` is the inverse of `resolveGlazeFilePath`; `_sourceToFilePath` accepts a relative media path as a local-file candidate, still gated by `_isAllowedGlazeMediaPath`
- `findImageOnDisk` compares claimed paths on the resolved path — without that every file read as unclaimed and an image already shown could be attached to a second block
- cloud sync strips the new form from an uploaded session and normalizes it to `[IMG:GEN:<instruction>]` for an InfoBlock, exactly as it did for `[IMG:RESULT:…]`

## Fixed along the way

- an ext block generating its image again looked for a pending tag, which a block that already has a picture no longer has: the new image was dropped. It now goes through `replaceImageBlockWithResult`, which keeps the earlier image as a variant. `replaceExtBlockImageResult` is gone with it — one writer for the whole app

## Verification

- `flutter analyze` — clean
- `flutter test` — 3057 passing, including a new `test/image_stored_form_test.dart` (encode/scan round trip with variants and escaped prompts, pending vs finished elements, mixed-form block numbering, reset, resolve/restore round trip, `relativeGlazeFilePath`, cloud sync) plus additions to the webview asset, security and sync stripper tests
- the WebView formatter was driven directly under node to confirm both stored forms render to the same block markup and that JS and Dart number the blocks identically (INV-IG6)
- not run: the app itself — no device in this environment, so the picture was not seen on screen

---
_Generated by [Claude Code](https://claude.ai/code/session_011LURJEDRKTtVMkN1WjaAHL)_