### PR TITLE
docs: add a Credits section to the READMEs (staging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Primary technical references: `docs/ARCHITECTURE.md`, `docs/INVARIANTS.md`, `doc
 ## 🙏 Credits
 
 - [SillyImages](https://github.com/0xl0cal/sillyimages) — reference for the inline image generation implementation and its providers.
-- [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — reference for JanitorAI through a browser.
+- [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — reference for JanitorAI extraction through a browser.
 - [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) — reference for Glaze Studio.
 - [Lumiverse](https://github.com/prolix-oc/Lumiverse) — reference for Glaze Studio.
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ Glaze Studio was informed by prior work from:
 - [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine)
 - [Lumiverse](https://github.com/prolix-oc/Lumiverse)
 
+## 🙏 Credits
+
+- [SillyImages](https://github.com/0xl0cal/sillyimages) — reference for the inline image generation implementation and its providers.
+- [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — reference for JanitorAI through a browser.
+
 ## 📜 License
 
 This project is licensed under the [GNU Affero General Public License v3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -141,17 +141,12 @@ test/                       # Unit, characterization, extension, and asset-guard
 
 Primary technical references: `docs/ARCHITECTURE.md`, `docs/INVARIANTS.md`, `docs/rules/`, `docs/WORKFLOW.md`, and `docs/BUILD_NOTES.md` for Windows build and dependency-override context.
 
-## 🙏 Studio References
-
-Glaze Studio was informed by prior work from:
-
-- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine)
-- [Lumiverse](https://github.com/prolix-oc/Lumiverse)
-
 ## 🙏 Credits
 
 - [SillyImages](https://github.com/0xl0cal/sillyimages) — reference for the inline image generation implementation and its providers.
 - [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — reference for JanitorAI through a browser.
+- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) — reference for Glaze Studio.
+- [Lumiverse](https://github.com/prolix-oc/Lumiverse) — reference for Glaze Studio.
 
 ## 📜 License
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -97,6 +97,8 @@ flutter test
 
 - [SillyImages](https://github.com/0xl0cal/sillyimages) — референс для реализации inline-генерации изображений и её провайдеров.
 - [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — референс для JanitorAI через браузер.
+- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) — референс для Glaze Studio.
+- [Lumiverse](https://github.com/prolix-oc/Lumiverse) — референс для Glaze Studio.
 
 ## 📜 Лицензия
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -93,6 +93,11 @@ flutter run
 flutter test
 ```
 
+## 🙏 Благодарности
+
+- [SillyImages](https://github.com/0xl0cal/sillyimages) — референс для реализации inline-генерации изображений и её провайдеров.
+- [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — референс для JanitorAI через браузер.
+
 ## 📜 Лицензия
 
 Этот проект распространяется по лицензии [GNU Affero General Public License v3.0](LICENSE).

--- a/README.ru.md
+++ b/README.ru.md
@@ -96,7 +96,7 @@ flutter test
 ## 🙏 Благодарности
 
 - [SillyImages](https://github.com/0xl0cal/sillyimages) — референс для реализации inline-генерации изображений и её провайдеров.
-- [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — референс для JanitorAI через браузер.
+- [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — референс для извлечения JanitorAI через браузер.
 - [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) — референс для Glaze Studio.
 - [Lumiverse](https://github.com/prolix-oc/Lumiverse) — референс для Glaze Studio.
 


### PR DESCRIPTION
## Changes

Same docs-only change already merged into `nightly` (#297) and `stable` (#298), applied to `staging` so the channel stays in sync:

- Add a `Credits` section to `README.md` (and its `Благодарности` mirror in `README.ru.md`)
- Credit [SillyImages](https://github.com/0xl0cal/sillyimages) as the reference for the inline image generation implementation and its providers
- Credit [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) as the reference for JanitorAI extraction through a browser
- Remove the separate `Studio References` section and list Marinara Engine and Lumiverse under `Credits`, noted as references for Glaze Studio

## Verification

Docs-only change; `git diff origin/stable HEAD -- README.md README.ru.md` is empty, so the READMEs match what is already on `stable`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ey6gaSFNaaKcpEJDtePFn)_