### PR TITLE
docs: reword the Marinara Engine and Lumiverse credits (staging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Primary technical references: `docs/ARCHITECTURE.md`, `docs/INVARIANTS.md`, `doc
 
 - [SillyImages](https://github.com/0xl0cal/sillyimages) — reference for the inline image generation implementation and its providers.
 - [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — reference for JanitorAI extraction through a browser.
-- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) — reference for Glaze Studio.
-- [Lumiverse](https://github.com/prolix-oc/Lumiverse) — reference for Glaze Studio.
+- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) — inspiration for the agentic workflow.
+- [Lumiverse](https://github.com/prolix-oc/Lumiverse) — inspiration for the agentic workflow.
 
 ## 📜 License
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -97,8 +97,8 @@ flutter test
 
 - [SillyImages](https://github.com/0xl0cal/sillyimages) — референс для реализации inline-генерации изображений и её провайдеров.
 - [SillyTavern-CharacterLibrary](https://github.com/Sillyanonymous/SillyTavern-CharacterLibrary) — референс для извлечения JanitorAI через браузер.
-- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) — референс для Glaze Studio.
-- [Lumiverse](https://github.com/prolix-oc/Lumiverse) — референс для Glaze Studio.
+- [Marinara Engine](https://github.com/Pasta-Devs/Marinara-Engine) — вдохновение для agentic workflow.
+- [Lumiverse](https://github.com/prolix-oc/Lumiverse) — вдохновение для agentic workflow.
 
 ## 📜 Лицензия
 


### PR DESCRIPTION
## Changes

- Note Marinara Engine and Lumiverse as inspiration for the agentic workflow instead of Glaze Studio references, in `README.md` and `README.ru.md`

Same change as the nightly PR, applied to `staging` so the channel stays in sync.

## Verification

Docs-only change; the `Credits` section was re-read after the edit on each channel branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ey6gaSFNaaKcpEJDtePFn)_