### PR TITLE
fix(catalog): stop losing the JanitorAI session between launches

### DIFF
--- a/lib/features/catalog/services/janitor_session.dart
+++ b/lib/features/catalog/services/janitor_session.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+
+/// Pure helpers for keeping a JanitorAI account session alive across app
+/// launches and Cloudflare challenges. Kept out of the WebView proxy so both
+/// rules — what makes a stored session cookie survive, and when the access
+/// token it carries has to be refreshed — are testable without a WebView.
+
+/// Whether [name] is one of the Supabase session cookies JanitorAI signs in
+/// with (`sb-<ref>-auth-token`, plus its `.0`, `.1`, … chunks).
+///
+/// These are the only cookies that must survive a Cloudflare cookie wipe: lose
+/// one chunk and the session is gone, which is what "logged out again" looks
+/// like to the user.
+bool isJanitorAuthCookie(String name) =>
+    name.startsWith('sb-') && name.contains('-auth-token');
+
+/// How long a restored auth cookie should live, in milliseconds since epoch.
+///
+/// The expiry read back from the platform cannot be trusted. Android's WebView
+/// returns no attributes at all unless `GET_COOKIE_INFO` is supported, and when
+/// it is, a `Max-Age` is converted as `now + maxAge` **milliseconds** instead of
+/// seconds — so a 400-day cookie reads back as roughly nine hours. Re-setting
+/// either value downgrades a persistent login to something that dies with the
+/// process (a null expiry makes it session-only), which is exactly the "have to
+/// log in again after every launch" report.
+///
+/// So an expiry is only kept when it is plausibly a real one; anything missing
+/// or suspiciously near is replaced with Supabase's own horizon.
+int janitorAuthCookieExpiry(int? readBackMs, {required int nowMs}) {
+  const minimumPlausible = Duration(days: 2);
+  const supabaseDefault = Duration(days: 400);
+  if (readBackMs != null &&
+      readBackMs - nowMs >= minimumPlausible.inMilliseconds) {
+    return readBackMs;
+  }
+  return nowMs + supabaseDefault.inMilliseconds;
+}
+
+/// The expiry stamped in a JWT's `exp` claim, or null when [jwt] carries none
+/// that can be read.
+DateTime? janitorTokenExpiry(String jwt) {
+  final parts = jwt.split('.');
+  if (parts.length != 3) return null;
+  final Map<String, dynamic> payload;
+  try {
+    final decoded = utf8.decode(
+      base64Url.decode(base64Url.normalize(parts[1])),
+    );
+    final parsed = jsonDecode(decoded);
+    if (parsed is! Map) return null;
+    payload = Map<String, dynamic>.from(parsed);
+  } on Object {
+    return null;
+  }
+  final exp = payload['exp'];
+  if (exp is! num) return null;
+  return DateTime.fromMillisecondsSinceEpoch(exp.toInt() * 1000, isUtc: true);
+}
+
+/// Whether the access token [jwt] is spent — expired, or close enough that a
+/// request made with it would arrive after it lapsed.
+///
+/// JanitorAI's Supabase access token lives about an hour, while the refresh
+/// token stored beside it in the same cookie lives for weeks. Glaze never
+/// refreshes the pair itself — the page's own Supabase client does, on load —
+/// so a session that is perfectly valid still hands out a stale JWT the first
+/// time the app is opened the next day. Every authenticated call then answers
+/// 401 and reads as "session expired, log in again" when nothing of the sort
+/// happened: the page just has to reload first.
+///
+/// A token with no readable `exp` is treated as usable — a request that fails
+/// says more than a guess here.
+bool isJanitorTokenExpired(
+  String jwt, {
+  Duration skew = const Duration(seconds: 60),
+  DateTime? now,
+}) {
+  final expiry = janitorTokenExpiry(jwt);
+  if (expiry == null) return false;
+  final at = (now ?? DateTime.now().toUtc()).add(skew);
+  return !expiry.isAfter(at);
+}

--- a/lib/features/catalog/services/janitor_webview_proxy.dart
+++ b/lib/features/catalog/services/janitor_webview_proxy.dart
@@ -8,6 +8,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import '../../chat/bridge/chat_webview_environment.dart';
 import 'cf_challenge_service.dart';
 import 'janitor_separate.dart';
+import 'janitor_session.dart';
 
 void _log(String m) => debugPrint('[CF-proxy] $m');
 
@@ -724,6 +725,9 @@ class JanitorWebViewProxy {
     if (!await isLoggedIn()) {
       throw Exception('Not logged into JanitorAI — log in first (Menu → JanitorAI).');
     }
+    // The capture spends the session across a dozen account calls and cannot
+    // retry from the middle, so it starts on a token that is known good.
+    await _refreshSession();
 
     // Force the account into proxy mode against an unreachable dummy preset (and
     // context_length 0) so the captured `/generateAlpha` prompt keeps its
@@ -1484,6 +1488,78 @@ class JanitorWebViewProxy {
     }
   }
 
+  /// The account access token as the page currently sees it, or null when the
+  /// page holds no session at all.
+  Future<String?> _readAccessToken() async {
+    final controller = _controller;
+    if (controller == null) return null;
+    try {
+      final res = await controller
+          .callAsyncJavaScript(
+            functionBody: '$_findTokenJs return __glazeFindToken();',
+          )
+          .timeout(const Duration(seconds: 10));
+      final value = res?.value;
+      return (value is String && value.isNotEmpty) ? value : null;
+    } catch (e) {
+      _log('readAccessToken error: $e');
+      return null;
+    }
+  }
+
+  /// Gives the page a chance to mint a fresh access token before one is spent.
+  ///
+  /// The stored session carries a short-lived JWT next to a long-lived refresh
+  /// token, and only JanitorAI's own Supabase client trades one for the other —
+  /// on page load. Opening the app the day after a login therefore starts with
+  /// an expired JWT that 401s every authenticated call, which the UI can only
+  /// report as "session expired, log in again" even though the session is fine.
+  /// Reloading the page and waiting for the refresh to land recovers it without
+  /// touching the user.
+  ///
+  /// [force] reloads even when the token still looks valid — the answer to a
+  /// 401 that came back anyway (a rotated or server-side revoked token).
+  /// Returns true when a usable token is in place afterwards.
+  Future<bool> _refreshSession({bool force = false}) async {
+    final token = await _readAccessToken();
+    if (token == null) return false;
+    if (!force && !isJanitorTokenExpired(token)) return true;
+    _log('access token stale (force=$force) — reloading to refresh it');
+    await _reload();
+    final deadline = DateTime.now().add(const Duration(seconds: 8));
+    while (DateTime.now().isBefore(deadline)) {
+      final fresh = await _readAccessToken();
+      if (fresh != null && !isJanitorTokenExpired(fresh)) {
+        _log('session refreshed in-page');
+        return true;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+    }
+    _log('session still stale after reload — the refresh token is gone too');
+    return false;
+  }
+
+  /// Commits the WebView cookie jar to disk.
+  ///
+  /// Android keeps cookies in memory and writes them out on its own schedule,
+  /// so a login followed by a quick app kill is simply lost. The plugin exposes
+  /// no flush of its own, but every cookie write it performs flushes the whole
+  /// store — hence the throwaway cookie on an origin that is never requested.
+  static Future<void> flushCookies() async {
+    try {
+      final url = WebUri('https://glaze-cookie-flush.invalid/');
+      await CookieManager.instance().setCookie(
+        url: url,
+        name: 'gz_flush',
+        value: '1',
+        path: '/',
+      );
+      await CookieManager.instance().deleteCookie(url: url, name: 'gz_flush');
+    } catch (e) {
+      _log('cookie flush error: $e');
+    }
+  }
+
   /// Returns true if a JanitorAI account token is detectable from [controller]'s
   /// page (shared cookie jar / `localStorage`). The login sheet uses this to
   /// confirm the session was actually persisted before it auto-closes — the
@@ -1592,7 +1668,15 @@ class JanitorWebViewProxy {
     }
     // 401 is the session, not the request: the capture creates a persona, a
     // chat and a proxy preset on the account, and all of them start failing at
-    // once when the JWT goes stale. Say which one it is.
+    // once when the JWT goes stale. A stale JWT is recoverable, though — the
+    // refresh token beside it outlives it by weeks — so reload the page for a
+    // fresh one and try again before telling the user to log in.
+    if (result.status == 401) {
+      _log('401 — refreshing the session and retrying once');
+      if (await _refreshSession(force: true)) {
+        result = await _rawFetch(url, method: method, body: body);
+      }
+    }
     if (result.status == 401) {
       throw const JanitorAuthException();
     }
@@ -1659,6 +1743,10 @@ class JanitorWebViewProxy {
     await created.future;
     await _awaitLoad();
     await _waitForClearance();
+    // A session stored before the app was last closed usually comes back with
+    // an expired access token; catch it here, once per proxy lifetime, rather
+    // than on the first authenticated call.
+    await _refreshSession();
   }
 
   Future<void> _reload() async {

--- a/lib/features/catalog/widgets/catalog_detail_launcher.dart
+++ b/lib/features/catalog/widgets/catalog_detail_launcher.dart
@@ -11,6 +11,7 @@ import '../../character_list/character_detail_screen.dart';
 import '../../settings/app_settings_provider.dart';
 import '../catalog_models.dart';
 import '../catalog_provider.dart';
+import '../janitor_account_provider.dart';
 import '../services/chub_provider.dart';
 // `ExtractionResult` here is DataCat's own; the one this file uses is
 // JanitorExtractor's, so the DataCat name is hidden to keep it unambiguous.
@@ -309,6 +310,10 @@ class _CatalogDetailLauncherState
       // The account session went stale mid-import. Ask for a fresh login and
       // pick the import back up once it is done.
       if (e is JanitorAuthException) {
+        // The session survived neither the refresh nor the retry, so stop
+        // claiming an account is signed in while every call to it 401s.
+        await ref.read(janitorAccountProvider.notifier).setUserName(null);
+        if (!mounted) return;
         final loggedIn = await showJanitorSessionExpiredSheet(context);
         if (mounted && loggedIn) {
           await _doImport(mode: mode, skipExtraction: skipExtraction);

--- a/lib/features/catalog/widgets/catalog_grid.dart
+++ b/lib/features/catalog/widgets/catalog_grid.dart
@@ -17,6 +17,7 @@ import '../../settings/app_settings_provider.dart';
 import '../catalog_models.dart';
 import '../catalog_provider.dart';
 import '../services/cf_challenge_service.dart';
+import '../services/janitor_session.dart';
 import '../services/janitor_webview_proxy.dart';
 import '../services/chub_provider.dart';
 import '../services/datacat_provider.dart';
@@ -369,26 +370,32 @@ class _CfChallengeWebViewState extends State<_CfChallengeWebView> {
     // time CF re-challenges (the "creds lost after a while" bug). Capture those
     // cookies first and restore them after the wipe so only CF's cookies are
     // actually reset.
+    //
+    // The restore deliberately does NOT re-use the attributes read back with the
+    // cookie: Android's WebView returns none at all on older versions, and a
+    // mangled `Max-Age` on newer ones, so re-setting what was read downgrades a
+    // 400-day login to a session cookie (or to a few hours) and the account is
+    // gone by the next launch. Supabase's own attributes are restated instead —
+    // host-only, site-wide, secure, lax — with the expiry [janitorAuthCookieExpiry]
+    // picks.
     try {
       final origin = WebUri('https://janitorai.com');
       final before = await CookieManager.instance().getCookies(url: origin);
       debugPrint('[CF] Cookies before wipe: ${before.map((c) => c.name).join(', ')}');
-      final authCookies = before
-          .where((c) => c.name.startsWith('sb-') && c.name.contains('-auth-token'))
-          .toList();
+      final authCookies =
+          before.where((c) => isJanitorAuthCookie(c.name)).toList();
       await CookieManager.instance().deleteAllCookies();
+      final nowMs = DateTime.now().millisecondsSinceEpoch;
       for (final c in authCookies) {
         try {
           await CookieManager.instance().setCookie(
             url: origin,
             name: c.name,
             value: c.value.toString(),
-            domain: c.domain,
-            path: c.path ?? '/',
-            expiresDate: c.expiresDate,
-            isSecure: c.isSecure,
-            isHttpOnly: c.isHttpOnly,
-            sameSite: c.sameSite,
+            path: '/',
+            expiresDate: janitorAuthCookieExpiry(c.expiresDate, nowMs: nowMs),
+            isSecure: true,
+            sameSite: HTTPCookieSameSitePolicy.LAX,
           );
         } catch (e) {
           debugPrint('[CF] auth cookie restore error (${c.name}): $e');

--- a/lib/features/catalog/widgets/janitor_login_sheet.dart
+++ b/lib/features/catalog/widgets/janitor_login_sheet.dart
@@ -117,6 +117,10 @@ class _JanitorLoginSheetState extends ConsumerState<JanitorLoginSheet> {
     if (userName != null) {
       await ref.read(janitorAccountProvider.notifier).setUserName(userName);
     }
+    // Commit the session cookies the login just wrote. Android holds them in
+    // memory and writes them out on its own schedule, so an app killed shortly
+    // after signing in comes back signed out.
+    await JanitorWebViewProxy.flushCookies();
     // Drop the anonymous catalog results so the now-authenticated character set
     // is fetched — mirrors the logout path. Fires regardless of which entry
     // point (menu or catalog) opened this sheet.

--- a/lib/features/catalog/widgets/janitor_lorebook_capture_sheet.dart
+++ b/lib/features/catalog/widgets/janitor_lorebook_capture_sheet.dart
@@ -561,6 +561,12 @@ class _JanitorLorebookCaptureState
       // the prompt (creator locked the card to their own model) is a permanent
       // answer, not a failure worth retrying — `describeCatalogError` quotes its
       // wording and says what it means for these books.
+      // A session that failed even the proxy's refresh-and-retry is dead: drop
+      // the stored account so the sheet asks for a login instead of offering a
+      // capture that cannot run.
+      if (e is JanitorAuthException) {
+        await ref.read(janitorAccountProvider.notifier).setUserName(null);
+      }
       if (mounted) {
         setState(() {
           _extractError = describeCatalogError(

--- a/test/janitor_session_test.dart
+++ b/test/janitor_session_test.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/catalog/services/janitor_session.dart';
+
+/// A JWT with the given `exp` (seconds since epoch). Only the payload matters —
+/// nothing here verifies a signature.
+String _jwt({int? exp, String header = 'eyJhbGciOiJIUzI1NiJ9'}) {
+  final payload = base64Url
+      .encode(utf8.encode(jsonEncode({'sub': 'u1', 'exp': ?exp})))
+      .replaceAll('=', '');
+  return '$header.$payload.c2ln';
+}
+
+void main() {
+  group('isJanitorAuthCookie', () {
+    test('matches the Supabase session cookie and every chunk of it', () {
+      expect(isJanitorAuthCookie('sb-abcdef-auth-token'), isTrue);
+      expect(isJanitorAuthCookie('sb-abcdef-auth-token.0'), isTrue);
+      expect(isJanitorAuthCookie('sb-abcdef-auth-token.1'), isTrue);
+    });
+
+    test('leaves the cookies the wipe is meant to reset alone', () {
+      expect(isJanitorAuthCookie('cf_clearance'), isFalse);
+      expect(isJanitorAuthCookie('__cf_bm'), isFalse);
+      expect(isJanitorAuthCookie('sb-abcdef-other'), isFalse);
+    });
+  });
+
+  group('janitorAuthCookieExpiry', () {
+    final now = DateTime.utc(2026, 8, 25).millisecondsSinceEpoch;
+
+    test('a missing expiry becomes a persistent one', () {
+      // Android returns no attributes at all on older WebViews; re-setting null
+      // would make the login a session cookie and lose it on the next launch.
+      final expiry = janitorAuthCookieExpiry(null, nowMs: now);
+      expect(expiry - now, const Duration(days: 400).inMilliseconds);
+    });
+
+    test('a mangled short expiry is replaced, not trusted', () {
+      // What Android reports for a 400-day Max-Age: `now + maxAge` treated as
+      // milliseconds, i.e. about nine hours.
+      final mangled =
+          now + const Duration(hours: 9, minutes: 36).inMilliseconds;
+      expect(
+        janitorAuthCookieExpiry(mangled, nowMs: now),
+        now + const Duration(days: 400).inMilliseconds,
+      );
+    });
+
+    test('an expiry already in the past is replaced', () {
+      final stale = now - const Duration(days: 1).inMilliseconds;
+      expect(
+        janitorAuthCookieExpiry(stale, nowMs: now),
+        now + const Duration(days: 400).inMilliseconds,
+      );
+    });
+
+    test('a real long-lived expiry is kept as read', () {
+      final real = now + const Duration(days: 30).inMilliseconds;
+      expect(janitorAuthCookieExpiry(real, nowMs: now), real);
+    });
+  });
+
+  group('janitorTokenExpiry', () {
+    test('reads the exp claim', () {
+      final expiry = janitorTokenExpiry(_jwt(exp: 1787000000));
+      expect(
+        expiry,
+        DateTime.fromMillisecondsSinceEpoch(1787000000 * 1000, isUtc: true),
+      );
+    });
+
+    test('returns null for a token that carries none', () {
+      expect(janitorTokenExpiry(_jwt()), isNull);
+    });
+
+    test('returns null for something that is not a JWT', () {
+      expect(janitorTokenExpiry('not-a-token'), isNull);
+      expect(janitorTokenExpiry('a.b'), isNull);
+      expect(janitorTokenExpiry('a.!!!.c'), isNull);
+    });
+  });
+
+  group('isJanitorTokenExpired', () {
+    final now = DateTime.utc(2026, 8, 25, 12);
+    int at(Duration offset) => now.add(offset).millisecondsSinceEpoch ~/ 1000;
+
+    test('a token from the previous session is spent', () {
+      // The case behind "log in again after every launch": the JWT lives an
+      // hour, the refresh token beside it lives for weeks.
+      expect(
+        isJanitorTokenExpired(
+          _jwt(exp: at(const Duration(hours: -3))),
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a token about to lapse is treated as spent', () {
+      expect(
+        isJanitorTokenExpired(
+          _jwt(exp: at(const Duration(seconds: 30))),
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a fresh token is usable', () {
+      expect(
+        isJanitorTokenExpired(
+          _jwt(exp: at(const Duration(minutes: 45))),
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('an unreadable expiry is not guessed at', () {
+      // Better to let the request answer than to force a reload on a hunch.
+      expect(isJanitorTokenExpired(_jwt(), now: now), isFalse);
+      expect(isJanitorTokenExpired('not-a-token', now: now), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
The JanitorAI account "falls off" and has to be signed in again, sometimes on every app start. Three separate reasons, all of them in how the session is stored and spent rather than in the session itself.

## A Cloudflare challenge downgraded the stored login

`_CfChallengeWebView` wipes the whole cookie store (CF's own cookie cannot be deleted on its own) and restores the Supabase `sb-*-auth-token` chunks afterwards — but it restored them with the attributes it had just read back, and those cannot be trusted on Android:

- without `WebViewFeature.GET_COOKIE_INFO` the platform returns no attributes at all, so the cookie was re-set with a null expiry — i.e. session-only — and died with the process;
- with it, the plugin converts a `Max-Age` as `now + maxAge` **milliseconds** instead of seconds, so a 400-day login came back as roughly nine hours.

Changes:

- Restate Supabase's own attributes on restore (host-only, `Path=/`, Secure, SameSite=Lax) instead of echoing what was read back.
- Pick the expiry with `janitorAuthCookieExpiry`: keep a plausible read-back, replace a missing, near or already-past one with Supabase's own 400-day horizon.

## An expired access token was reported as a dead session

The session cookie holds a ~1h Supabase access token next to a refresh token good for weeks, and only JanitorAI's own client trades one for the other, on page load. `JanitorWebViewProxy` read the JWT and sent it as-is, so the first authenticated call after a launch answered 401 and the UI asked for a fresh login although nothing was wrong with the session.

- `janitorTokenExpiry` / `isJanitorTokenExpired` decode the JWT's `exp`.
- `JanitorWebViewProxy._refreshSession` reloads the page and waits (bounded) for the in-page refresh to land. It runs once when the proxy starts, and again before a capture — which spends the session across a dozen account calls and cannot retry from the middle.
- A 401 in `_fetchLocked` now forces one refresh and retries the request once before raising `JanitorAuthException`.
- A 401 that survives that clears the stored account name, so the menu and the lorebook capture sheet stop offering a session that is really gone.

## Cookies were never committed to disk

Android holds WebView cookies in memory and writes them out on its own schedule, so an app killed shortly after signing in came back signed out. `JanitorWebViewProxy.flushCookies` commits the store right after a login lands — through a throwaway cookie write, which is the only flush the plugin exposes.

## Verification

- `flutter analyze` — no new issues (the two `unused_element` warnings in `janitor_lorebook_capture_sheet.dart` are pre-existing on `nightly`).
- `flutter test` — full suite green, 3238 tests.
- New `test/janitor_session_test.dart` (13 tests): which cookies the CF wipe must preserve, the expiry rule for a restored cookie (missing / mangled short / past / real), JWT `exp` decoding, and when a token counts as spent.
- Not verified at runtime: every path here runs inside the WebView and needs a device with a real Janitor.AI account. The `[CF-proxy]` / `[CF]` logs now say which branch was taken (`access token stale — reloading`, `session refreshed in-page`, `N auth restored`).

Left alone deliberately: `JanitorWebViewProxy.logout()` still calls `deleteAllCookies()`, which clears every origin's cookies in the app, not just janitorai.com. It is user-initiated and unrelated to this bug, but worth narrowing separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7b7Re3UvvDbPKvDbcC5qy)_