### PR TITLE
feat(bug-triage): read screenshots and sweep the board

### DIFF
--- a/.github/workflows/bug-triage-check.yml
+++ b/.github/workflows/bug-triage-check.yml
@@ -29,11 +29,18 @@ jobs:
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
+          DEEPSEEK_VISION_MODEL: ${{ vars.DEEPSEEK_VISION_MODEL }}
+          VISION_ENABLED: ${{ vars.VISION_ENABLED }}
           TRELLO_KEY: ${{ secrets.TRELLO_KEY }}
           TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
           TRELLO_BOARD_ID: ${{ vars.TRELLO_BOARD_ID }}
           TRELLO_NEW_BUG_LIST_ID: ${{ vars.TRELLO_NEW_BUG_LIST_ID }}
           TRELLO_AUDITED_LABEL_ID: ${{ vars.TRELLO_AUDITED_LABEL_ID }}
+          TRELLO_SKIP_LIST_IDS: ${{ vars.TRELLO_SKIP_LIST_IDS }}
+          REAUDIT_IMAGE_BLOCKED: ${{ vars.REAUDIT_IMAGE_BLOCKED }}
+          MAX_REAUDITS_PER_RUN: ${{ vars.MAX_REAUDITS_PER_RUN }}
+          AUDIT_BOARD_CARDS: ${{ vars.AUDIT_BOARD_CARDS }}
+          MAX_BOARD_AUDITS_PER_RUN: ${{ vars.MAX_BOARD_AUDITS_PER_RUN }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
           DISCORD_FORUM_CHANNEL_ID: ${{ vars.DISCORD_FORUM_CHANNEL_ID }}

--- a/.github/workflows/bug-triage.yml
+++ b/.github/workflows/bug-triage.yml
@@ -55,11 +55,13 @@ jobs:
           AUDIT_REPO_ROOT: ${{ github.workspace }}/audit-src
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
+          DEEPSEEK_VISION_MODEL: ${{ vars.DEEPSEEK_VISION_MODEL }}
           TRELLO_KEY: ${{ secrets.TRELLO_KEY }}
           TRELLO_TOKEN: ${{ secrets.TRELLO_TOKEN }}
           TRELLO_BOARD_ID: ${{ vars.TRELLO_BOARD_ID }}
           TRELLO_NEW_BUG_LIST_ID: ${{ vars.TRELLO_NEW_BUG_LIST_ID }}
           TRELLO_AUDITED_LABEL_ID: ${{ vars.TRELLO_AUDITED_LABEL_ID }}
+          TRELLO_SKIP_LIST_IDS: ${{ vars.TRELLO_SKIP_LIST_IDS }}
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_GUILD_ID: ${{ vars.DISCORD_GUILD_ID }}
           DISCORD_FORUM_CHANNEL_ID: ${{ vars.DISCORD_FORUM_CHANNEL_ID }}
@@ -69,6 +71,13 @@ jobs:
           MAX_MATCH_CANDIDATES: ${{ vars.MAX_MATCH_CANDIDATES }}
           MAX_NEW_CARDS_PER_RUN: ${{ vars.MAX_NEW_CARDS_PER_RUN }}
           MAX_AUDITS_PER_RUN: ${{ vars.MAX_AUDITS_PER_RUN }}
+          VISION_ENABLED: ${{ vars.VISION_ENABLED }}
+          MAX_IMAGES_PER_AUDIT: ${{ vars.MAX_IMAGES_PER_AUDIT }}
+          MAX_IMAGE_BYTES: ${{ vars.MAX_IMAGE_BYTES }}
+          REAUDIT_IMAGE_BLOCKED: ${{ vars.REAUDIT_IMAGE_BLOCKED }}
+          MAX_REAUDITS_PER_RUN: ${{ vars.MAX_REAUDITS_PER_RUN }}
+          AUDIT_BOARD_CARDS: ${{ vars.AUDIT_BOARD_CARDS }}
+          MAX_BOARD_AUDITS_PER_RUN: ${{ vars.MAX_BOARD_AUDITS_PER_RUN }}
           DRY_RUN: ${{ inputs.dry_run }}
         # -u: unbuffered, so progress shows up in the Actions log live
         # instead of arriving in one block when the process exits.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,23 @@ jobs:
 
       - name: Test
         run: flutter test --reporter expanded
+
+  bug-triage:
+    name: Bug-triage agent (unit tests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: pip install -r tools/bug_triage/requirements.txt
+
+      # Pure logic: which card gets audited, what the model is shown, what the
+      # comment records. Nothing here touches Discord, Trello or DeepSeek.
+      - name: Test
+        working-directory: tools/bug_triage
+        run: python -m unittest discover -p 'test_*.py' -v

--- a/tools/bug_triage/README.md
+++ b/tools/bug_triage/README.md
@@ -1,11 +1,19 @@
 # Bug-triage agent
 
 A daily, **read-only** agent that keeps the Trello board in sync with the Discord
-bug-report forum and drops an AI audit on each open bug. The **Discord forum is
-the only work queue**; Trello is consulted purely to cross-check those threads
-(has this one a card? was that card already audited?). It **never** changes code
-or opens PRs — it only creates Trello cards and posts comments for a human to
-act on.
+bug-report forum and drops an AI audit on each open bug. It **never** changes
+code or opens PRs — it only creates Trello cards and posts comments for a human
+to act on.
+
+Screenshots are part of the report now: reports that carry pictures are audited
+by DeepSeek's multimodal model (`deepseek-v4-flash-vision-exp`), which reads
+error dialogs, stack traces and UI state straight off the image. Text-only
+reports stay on the cheaper text model.
+
+The Discord forum is still the primary queue, but it is no longer the only one.
+After the forum is mirrored and audited, the board itself is swept twice: for
+cards whose earlier audit gave up on a screenshot, and for cards nobody mirrored
+from Discord at all.
 
 ## What it does (once per day)
 
@@ -14,11 +22,10 @@ act on.
    threads, archived (closed) threads, and posts carrying an ignored forum tag.
    Note Discord also auto-archives inactive posts, so a quiet-but-open report is
    dropped too; set `DISCORD_SKIP_ARCHIVED=false` to triage those as well.
+   Image attachments and image embeds are collected as links; the bytes are
+   downloaded later and only for the reports that actually reach an audit.
 2. Fetches the Trello cards once and indexes them by their
-   `discord-thread:<id>` marker. The board is **only a cross-check** for the
-   threads found in step 1 — it is never scanned for work of its own, so a card
-   written by hand (in any list, anywhere on the board) is never commented on
-   or labelled.
+   `discord-thread:<id>` marker.
 3. For any Discord post **not yet linked to a card**, checks whether the board
    already tracks that same bug: one DeepSeek call compares the thread against
    the existing cards — both the ones a human typed in and the ones earlier
@@ -30,27 +37,50 @@ act on.
    so a second report always joins **the card that reported the bug first**.
    The matcher is deliberately conservative: below 0.7 confidence it answers
    "no match", because a missed link only costs a duplicate a human can merge,
-   while a wrong link hangs a thread on an unrelated card. Set
+   while a wrong link hangs a thread on an unrelated card. This step is
+   text-only — it compares wording, not pictures. Set
    `MATCH_EXISTING_CARDS=false` to skip the check entirely.
-4. If every open thread already carries the `audited` label, **exits before
+4. If none of the three audit passes below has anything to do, **exits before
    calling the LLM** (no token spend).
-5. For each remaining thread, runs a DeepSeek agent over that ONE report —
-   title, original post and replies, read live from Discord, so replies added
-   after the card was mirrored are included — that greps / reads the source,
-   then posts a structured audit as a comment on the thread's card and applies
-   the `audited` label. A card that collected several duplicate threads is
+5. **Pass 1 — the forum.** For each open thread whose card lacks the `audited`
+   label, runs a DeepSeek agent over that ONE report — title, original post,
+   replies and attached images, read live from Discord — that greps / reads the
+   source, then posts a structured audit as a comment on the thread's card and
+   applies the label. A card that collected several duplicate threads is
    audited once, on the first of them.
+6. **Pass 2 — the image backlog.** Walks the board for cards whose recorded
+   verdict was "could not judge this, it's a screenshot" and audits them again
+   with the pictures attached. This is what drains the reports the text-only era
+   could only answer with NEED MORE INFO. The pass retires itself per card: once
+   a vision verdict exists, that card is never re-opened by it again, so a
+   report that is genuinely missing information is asked once, not daily.
+7. **Pass 3 — the rest of the board.** Cards with no `discord-thread:` marker
+   and no `audited` label — the ones a human typed straight onto the board — are
+   audited from their title, description, comments and attached images, then
+   labelled. Columns listed in `TRELLO_SKIP_LIST_IDS` (Done, Released, Ideas…)
+   are left alone, as are cards already carrying an audit comment.
 
-Reports that cannot be judged from text (screenshot-only posts, missing repro
-steps) get a **NEED MORE INFO** comment naming what to ask instead of a guess.
-A post with no readable text at all skips the LLM entirely.
+A report with no readable text **and** no readable picture still skips the LLM
+entirely and gets a NEED MORE INFO comment naming what to ask.
 
 De-dup has no external database: each card that tracks a thread carries a hidden
 `discord-thread:<id>` marker in its description, and that's the source of truth.
 A card can carry **several** markers — that is what a duplicate looks like on the
 board. Cards written by hand get their first marker when the matcher recognises
-their bug in the forum, and behave like mirrored ones from then on, including
-getting audited if they don't already carry the `audited` label.
+their bug in the forum, and behave like mirrored ones from then on.
+
+Every comment the agent posts ends with a second hidden marker recording how
+that audit went:
+
+```
+glaze-triage:v2 mode=vision images=3 blocked=no
+```
+
+`mode` is the model that judged it (`text` / `vision` / `none`), `images` is how
+many pictures reached it, and `blocked=yes` means "this is a request for
+information, not a verdict". That line is what pass 2 reads to find its work.
+Comments written before the marker existed are recognised by their headline, so
+the existing backlog is picked up too.
 
 **The audited source is always `nightly`.** The workflow checks the triage code
 out from the branch the run was started on, and `nightly` separately into
@@ -64,18 +94,39 @@ code the fix has long since left.
 Two steps are agentic (both DeepSeek, via Pydantic AI): the **audit**
 (`search_code`/`read_file` tools over the checked-out repo) and the
 **duplicate check** (no tools — it only compares text, and only for threads
-that have no card yet). Polling, card creation and marker-based de-dup are
-plain deterministic code — cheaper and more reliable than handing those to the
-model.
+that have no card yet). Polling, card creation, image fetching and marker-based
+de-dup are plain deterministic code — cheaper and more reliable than handing
+those to the model.
 
 ```
-triage.py         orchestrator (Discord-driven) + early-exit
+triage.py         orchestrator: fetch, mirror, early-exit, run the three passes
 config.py         env-var loading (fails fast on missing secrets)
-discord_client.py read-only forum access (REST)
-trello_client.py  cards / comments / labels (source of truth)
+discord_client.py read-only forum access (REST) + image links
+trello_client.py  cards / comments / attachments / labels (source of truth)
+images.py         image refs + download, format sniffing, size and count caps
+subjects.py       one shape for "the report under audit", card or thread
+mirror.py         Discord -> Trello: link to an existing card, or create one
 matcher.py        "is this bug already a card?" — DeepSeek, no tools
-auditor.py        Pydantic AI agent (DeepSeek) + structured BugAudit output
+auditor.py        Pydantic AI agents (text + vision) + structured BugAudit
+runner.py         audits one subject: load images, pick the model, fall back
+audit_pass.py     the three passes and their shared commit path
+audit_comment.py  what gets written on a card, and how a later run reads it back
+test_triage.py    unit tests (stdlib unittest, no network) — run in CI
 ```
+
+### Which model judges what
+
+| Report | Model | Why |
+|--------|-------|-----|
+| Text, no pictures | `DEEPSEEK_MODEL` | Cheaper; there is nothing to look at. |
+| Any readable picture | `DEEPSEEK_VISION_MODEL` | Images are attached to the message as base64 parts. |
+| Vision call fails | `DEEPSEEK_MODEL` | One retry without the images — a bad day on an experimental endpoint costs a weaker audit, not a lost report. |
+| No text and no readable picture | none | NEED MORE INFO, no tokens spent. |
+
+Each image costs up to 384 tokens, so `MAX_IMAGES_PER_AUDIT` (default 4) caps
+how many of a report's pictures are shown. Only JPEG, PNG, GIF and WebP are
+sent, and the format is sniffed from the bytes rather than trusted from the file
+name.
 
 ## Secrets & variables (GitHub → Settings)
 
@@ -91,10 +142,12 @@ auditor.py        Pydantic AI agent (DeepSeek) + structured BugAudit output
 
 | Name | What | Default |
 |------|------|---------|
-| `DEEPSEEK_MODEL` | model id | `deepseek-chat` |
+| `DEEPSEEK_MODEL` | model id for text-only reports | `deepseek-chat` |
+| `DEEPSEEK_VISION_MODEL` | model id for reports with pictures | `deepseek-v4-flash-vision-exp` |
 | `TRELLO_BOARD_ID` | main board id | — |
 | `TRELLO_NEW_BUG_LIST_ID` | list where new bugs land | — |
 | `TRELLO_AUDITED_LABEL_ID` | label id meaning "AI audited" | — |
+| `TRELLO_SKIP_LIST_IDS` | lists the board passes never touch (comma-separated) | empty |
 | `DISCORD_GUILD_ID` | your server id | — |
 | `DISCORD_FORUM_CHANNEL_ID` | the bug-report forum channel id | — |
 | `DISCORD_IGNORED_TAG_IDS` | forum tag ids meaning closed (comma-separated) | empty |
@@ -102,14 +155,26 @@ auditor.py        Pydantic AI agent (DeepSeek) + structured BugAudit output
 | `MATCH_EXISTING_CARDS` | ask the model whether a hand-written card already tracks the bug | `true` |
 | `MAX_MATCH_CANDIDATES` | cards shown to the model per duplicate check | `20` |
 | `MAX_NEW_CARDS_PER_RUN` | cap on cards created per run (0 = unlimited) | `25` |
-| `MAX_AUDITS_PER_RUN` | cap on DeepSeek audits per run (0 = unlimited) | `15` |
+| `MAX_AUDITS_PER_RUN` | cap on Discord audits per run (0 = unlimited) | `15` |
+| `VISION_ENABLED` | read images at all; off = the pre-vision behaviour | `true` |
+| `MAX_IMAGES_PER_AUDIT` | pictures shown to the model per report | `4` |
+| `MAX_IMAGE_BYTES` | images larger than this are skipped | `8000000` |
+| `REAUDIT_IMAGE_BLOCKED` | pass 2 — re-audit cards blocked on a screenshot | `true` |
+| `MAX_REAUDITS_PER_RUN` | cap on pass 2 (0 = unlimited) | `10` |
+| `AUDIT_BOARD_CARDS` | pass 3 — audit cards that never came from Discord | `true` |
+| `MAX_BOARD_AUDITS_PER_RUN` | cap on pass 3 (0 = unlimited) | `10` |
 
 The connection check prints the forum's tag names with their ids, so run it
-once and copy the closed/solved tag id into `DISCORD_IGNORED_TAG_IDS`.
+once and copy the closed/solved tag id into `DISCORD_IGNORED_TAG_IDS`. It also
+prints how many cards each board pass would pick up, which is worth reading once
+before the first run with passes 2 and 3 enabled — on a board that has never
+been swept, that backlog can be large. Cap it with `MAX_BOARD_AUDITS_PER_RUN`
+and let it drain over a few days.
 
 Finding IDs:
 - Trello: append `.json` to a board URL, or hit
-  `https://api.trello.com/1/members/me/boards?key=…&token=…`.
+  `https://api.trello.com/1/members/me/boards?key=…&token=…`. List ids come from
+  the same JSON (`lists[].id`), which is where `TRELLO_SKIP_LIST_IDS` comes from.
 - Discord: enable Developer Mode → right-click → "Copy ID".
 
 ## Running locally
@@ -118,7 +183,12 @@ Finding IDs:
 pip install -r requirements.txt
 # export all the env vars above, then:
 DRY_RUN=true python triage.py   # dry-run: fetches + logs, no writes
+python check_connections.py     # read-only: credentials, ids, pass previews
+python -m unittest discover -p 'test_*.py'
 ```
+
+`DRY_RUN=true` still downloads images and still calls the models — it is a
+"what would it say" run. Only the writes to Trello are suppressed.
 
 ## Schedule
 

--- a/tools/bug_triage/audit_comment.py
+++ b/tools/bug_triage/audit_comment.py
@@ -1,0 +1,166 @@
+"""What the agent writes on a card, and how a later run reads it back.
+
+The board is the only database this pipeline has. Since the vision pass, one
+more fact has to survive between runs: *why* an audit ended the way it did —
+because a screenshot could not be read, or because the report itself was too
+thin. That is what lets the next run come back for exactly the cards whose
+verdict a picture might change, instead of re-auditing the whole board.
+
+So every comment this agent posts ends with a marker line:
+
+    glaze-triage:v2 mode=vision images=3 blocked=no
+
+`mode` is the model that judged it (`text` / `vision` / `none` when no model ran
+at all), `images` is how many pictures actually reached it, and `blocked=yes`
+means "this verdict is a request for information, not an audit".
+
+Comments written before the marker existed are still recognised, by the two
+headlines the old code emitted — a card audited last month is picked up by the
+image sweep just like a fresh one.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterable, Sequence
+
+if TYPE_CHECKING:  # pragma: no cover — import cycle at runtime, types only
+    from auditor import BugAudit
+    from trello_client import Comment
+
+_MARKER_RE = re.compile(
+    r"glaze-triage:v\d+\s+mode=(\w+)\s+images=(\d+)\s+blocked=(yes|no)"
+)
+# Headlines of the pre-marker comments. Only these two shapes were ever posted.
+_LEGACY_AUDIT = "**Automated audit**"
+_LEGACY_BLOCKED = "**NEED MORE INFO**"
+
+
+def marker(mode: str, images: int, blocked: bool) -> str:
+    return (
+        f"glaze-triage:v2 mode={mode} images={images} "
+        f"blocked={'yes' if blocked else 'no'}"
+    )
+
+
+def is_triage_comment(text: str) -> bool:
+    """Did this agent write that comment? (marker, or a pre-marker headline)"""
+    return bool(_MARKER_RE.search(text)) or (
+        _LEGACY_AUDIT in text or _LEGACY_BLOCKED in text
+    )
+
+
+@dataclass(frozen=True)
+class AuditState:
+    """How this card's most recent audit ended."""
+
+    audited: bool = False
+    mode: str = ""  # "text" / "vision" / "none" / "" when never audited
+    images_seen: int = 0
+    blocked_on_images: bool = False
+
+    @property
+    def wants_vision(self) -> bool:
+        """Would showing the pictures to a vision model change anything?
+
+        Yes when an audit exists, it ended as a request for information, and no
+        vision model has looked at this card yet. A card the vision model
+        already saw is never re-opened — if it still says NEED MORE INFO, the
+        answer really is missing, and repeating the call would only spend
+        tokens to post the same comment again.
+        """
+        return self.audited and self.blocked_on_images and self.mode != "vision"
+
+
+def read_state(comments: Iterable["Comment"]) -> AuditState:
+    """Replay a card's comments (oldest first) into the state they leave behind."""
+    state = AuditState()
+    for c in comments:
+        text = c.text or ""
+        m = _MARKER_RE.search(text)
+        if m:
+            state = AuditState(
+                audited=True,
+                mode=m.group(1),
+                images_seen=int(m.group(2)),
+                blocked_on_images=m.group(3) == "yes",
+            )
+        elif _LEGACY_BLOCKED in text:
+            state = AuditState(audited=True, mode="text", blocked_on_images=True)
+        elif _LEGACY_AUDIT in text:
+            state = AuditState(audited=True, mode="text", blocked_on_images=False)
+    return state
+
+
+def _footer(source_url: str | None, mode: str, images: int, blocked: bool) -> str:
+    src = f"\nSource: {source_url}" if source_url else ""
+    return f"{src}\n\n{marker(mode, images, blocked)}"
+
+
+def unreadable(source_url: str | None, images_attempted: int) -> str:
+    """No text, and no picture we could read either — ask a human.
+
+    `images_attempted` separates the two cases in the wording: a report with no
+    attachments at all is missing its description, while one whose attachments
+    all failed to load needs them re-uploaded.
+    """
+    if images_attempted:
+        why = (
+            f"Its {images_attempted} attachment(s) could not be read — they may "
+            f"be an unsupported format, too large, or no longer available."
+        )
+    else:
+        why = "It carries no attachments to read either."
+    return (
+        f"⚠️ **NEED MORE INFO** — this report carries no readable "
+        f"text. {why}\n\nPlease add: what you did, what you expected, and what "
+        f"happened instead. A screenshot of the problem helps — it is read "
+        f"automatically.\n\n*(No audit was performed. Nothing was changed.)*"
+        f"{_footer(source_url, 'none', 0, True)}"
+    )
+
+
+def render(
+    audit: "BugAudit",
+    source_url: str | None,
+    mode: str,
+    images: Sequence[object] = (),
+) -> str:
+    """The audit as a Trello comment (markdown-ish), marker included."""
+    seen = len(images)
+    src = f"\nSource: {source_url}" if source_url else ""
+    shown = (
+        f"\n\n**Images read** ({seen})\n{audit.image_findings.strip()}"
+        if seen and audit.image_findings.strip()
+        else ""
+    )
+
+    if audit.needs_more_info:
+        asks = audit.missing_info.strip() or (
+            "The report does not say enough to tell what went wrong. Ask the "
+            "reporter for steps to reproduce."
+        )
+        return (
+            f"⚠️ **NEED MORE INFO** — automated triage could not "
+            f"judge this report.{src}\n\n"
+            f"**What was understood**\n{audit.summary}{shown}\n\n"
+            f"**What is missing**\n{asks}\n\n"
+            f"*(No audit was performed. Nothing was changed.)*\n\n"
+            f"{marker(mode, seen, True)}"
+        )
+
+    files = "\n".join(f"- {f}" for f in audit.relevant_files) or "- (none identified)"
+    verdict = "actionable" if audit.is_actionable else "NOT clearly actionable"
+    notes = f"\n**Notes:** {audit.notes}" if audit.notes else ""
+    eyes = " \U0001f441 read the attached image(s)" if seen else ""
+    return (
+        f"\U0001f916 **Automated audit** (DeepSeek{eyes}) — {verdict}, severity "
+        f"**{audit.severity}**, confidence **{audit.confidence}**{src}\n\n"
+        f"**Summary**\n{audit.summary}{shown}\n\n"
+        f"**Suspected root cause**\n{audit.root_cause}\n\n"
+        f"**Proposed fix (needs human approval — nothing was changed)**\n"
+        f"{audit.proposed_fix}\n\n"
+        f"**Relevant files**\n{files}{notes}\n\n"
+        f"{marker(mode, seen, False)}"
+    )

--- a/tools/bug_triage/audit_pass.py
+++ b/tools/bug_triage/audit_pass.py
@@ -1,0 +1,189 @@
+"""The three passes that actually audit something, in the order they run.
+
+1. `discord`  — the forum queue: every open thread whose card is not yet
+   labelled `audited`. Unchanged in spirit; it just goes through the runner now,
+   so a screenshot-only report reaches the vision model instead of a
+   "NEED MORE INFO" boilerplate.
+2. `image_blocked` — the catch-up: cards whose recorded verdict was "could not
+   read this, it's a screenshot". They were audited under a blind model, so the
+   board is walked once to find them and they are judged again with their
+   pictures attached. This is the pass that drains the backlog the text-only era
+   left behind, and it retires itself — once a card has a vision verdict it is
+   never re-opened by it again.
+3. `board` — the sweep the pipeline never had: cards nobody mirrored from
+   Discord and nobody audited, i.e. the ones a human typed straight onto the
+   board. Title, description, comments and attached images all go in.
+
+All three share one commit path (comment + `audited` label) and one per-card
+cache, so a card whose comments were read in pass 2 costs no second request in
+pass 3. A card touched by an earlier pass is never touched again in the same
+run.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+import audit_comment
+import subjects
+from config import Config
+from discord_client import ForumPost
+from images import ImageRef
+from runner import AuditRunner
+from subjects import AuditSubject
+from trello_client import Card, Comment, TrelloClient
+
+
+@dataclass
+class _CardContext:
+    comments: list[Comment]
+    attachments: list[ImageRef]
+
+
+class AuditPass:
+    """Runs an audit pass over cards and commits the verdict to the board."""
+
+    def __init__(self, cfg: Config, trello: TrelloClient, runner: AuditRunner):
+        self._cfg = cfg
+        self._trello = trello
+        self._runner = runner
+        self._ctx: dict[str, _CardContext] = {}
+        self._touched: set[str] = set()
+        self.failures = 0
+
+    # --- board reads -------------------------------------------------------
+
+    def _context(self, card: Card) -> _CardContext:
+        if card.id not in self._ctx:
+            self._ctx[card.id] = _CardContext(
+                comments=self._trello.fetch_comments(card),
+                attachments=self._trello.fetch_attachments(card),
+            )
+        return self._ctx[card.id]
+
+    def has_work(self, cards: list[Card]) -> bool:
+        """Would pass 2 or pass 3 do anything on this board?
+
+        Answered without an LLM — pass 3's candidates are visible in the cards
+        already in hand, and pass 2's only needs the comments of cards that have
+        any. Those reads land in the same cache the passes use, so asking costs
+        nothing beyond what running would have cost anyway. This is what keeps
+        the orchestrator's early exit meaningful now that the board is a queue.
+        """
+        for card in cards:
+            if self._skipped(card):
+                continue
+            if (
+                self._cfg.audit_board_cards
+                and not card.is_discord_linked
+                and self._cfg.trello_audited_label_id not in card.label_ids
+                and not audit_comment.read_state(self._context(card).comments).audited
+            ):
+                return True
+            if (
+                self._cfg.reaudit_image_blocked
+                and self._cfg.vision_enabled
+                and card.comment_count
+                and audit_comment.read_state(self._context(card).comments).wants_vision
+            ):
+                return True
+        return False
+
+    def _skipped(self, card: Card) -> bool:
+        return (
+            card.id in self._touched
+            or card.list_id in self._cfg.trello_skip_list_ids
+        )
+
+    # --- one audit ---------------------------------------------------------
+
+    def _commit(self, card: Card, subject: AuditSubject, tag: str) -> None:
+        """Audit one subject and write the verdict onto its card."""
+        try:
+            result = self._runner.audit(subject)
+        except Exception as e:  # noqa: BLE001 — one bad report must not sink the run
+            print(f"[{tag}] audit FAILED for {subject.key}: {e}", file=sys.stderr)
+            self.failures += 1
+            return
+
+        self._trello.add_comment(card.id, result.comment)
+        if self._cfg.trello_audited_label_id not in card.label_ids:
+            self._trello.add_label(card.id, self._cfg.trello_audited_label_id)
+        self._touched.add(card.id)
+
+        flag = " [NEED MORE INFO]" if result.needs_more_info else ""
+        seen = f", {result.images} image(s)" if result.images else ""
+        print(f"[{tag}] {subject.key}: {subject.title!r} — {result.mode}{seen}{flag}")
+
+    # --- pass 1: the Discord queue ----------------------------------------
+
+    def discord(self, queue: list[tuple[ForumPost, Card]]) -> None:
+        for post, card in queue:
+            self._commit(card, subjects.from_post(post), "discord")
+
+    # --- pass 2: cards whose audit died on a screenshot -------------------
+
+    def image_blocked(self, cards: list[Card], posts: dict[str, ForumPost]) -> None:
+        """Re-audit the cards a blind model could not judge.
+
+        A linked card is re-read from its Discord thread rather than from its
+        own description: the thread is where the screenshots live, and by now it
+        may also carry replies the card never got.
+        """
+        if not self._cfg.vision_enabled:
+            print("[reaudit] VISION_ENABLED=false — nothing this pass can add")
+            return
+
+        cap = self._cfg.max_reaudits_per_run
+        done = 0
+        for card in cards:
+            if self._skipped(card):
+                continue
+            if cap and done >= cap:
+                print(f"[reaudit] cap reached ({cap}), the rest waits for the "
+                      f"next run")
+                return
+            if not audit_comment.read_state(self._context(card).comments).wants_vision:
+                continue
+
+            subject = self._subject(card, posts)
+            if not subject.has_images:
+                print(f"[reaudit] card {card.id} {card.name!r}: blocked on images "
+                      f"but none can be reached — left as is")
+                continue
+            self._commit(card, subject, "reaudit")
+            done += 1
+
+    # --- pass 3: cards nobody mirrored and nobody audited -----------------
+
+    def board(self, cards: list[Card]) -> None:
+        cap = self._cfg.max_board_audits_per_run
+        done = 0
+        for card in cards:
+            if self._skipped(card):
+                continue
+            if card.is_discord_linked:
+                continue  # the forum owns those; pass 1 already had its say
+            if self._cfg.trello_audited_label_id in card.label_ids:
+                continue
+            if cap and done >= cap:
+                print(f"[board] cap reached ({cap}), the rest waits for the "
+                      f"next run")
+                return
+            ctx = self._context(card)
+            if audit_comment.read_state(ctx.comments).audited:
+                continue  # audited before the label existed / was removed by hand
+            subject = subjects.from_card(card, ctx.comments, ctx.attachments)
+            self._commit(card, subject, "board")
+            done += 1
+
+    # --- helpers -----------------------------------------------------------
+
+    def _subject(self, card: Card, posts: dict[str, ForumPost]) -> AuditSubject:
+        for tid in card.discord_thread_ids:
+            post = posts.get(tid)
+            if post is not None:
+                return subjects.from_post(post)
+        ctx = self._context(card)
+        return subjects.from_card(card, ctx.comments, ctx.attachments)

--- a/tools/bug_triage/auditor.py
+++ b/tools/bug_triage/auditor.py
@@ -5,8 +5,21 @@ checked-out repo (ripgrep search + file read) and must return a *structured*
 audit. It never edits code, never opens PRs — the orchestrator only posts its
 output as a Trello comment for a human to act on.
 
-One report is audited per agent run: title, original post and replies travel
-together, but threads are never mixed.
+One report is audited per agent run: title, description and follow-up messages
+travel together, but reports are never mixed.
+
+Two agents can be built from here, differing only in the model and in what the
+system prompt promises about eyesight:
+
+  * the text agent (`DEEPSEEK_MODEL`, e.g. `deepseek-chat`) — cheaper, used for
+    reports that carry no pictures;
+  * the vision agent (`DEEPSEEK_VISION_MODEL`, default
+    `deepseek-v4-flash-vision-exp`) — gets the screenshots as image parts
+    alongside the text, and is used whenever a report has any.
+
+Both keep the same tools and the same structured output, so a caller can swap
+one for the other — which is exactly what happens when a vision call fails and
+the run falls back to text rather than losing the report.
 """
 
 from __future__ import annotations
@@ -14,12 +27,14 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Sequence
 
 from pydantic import BaseModel, Field
-from pydantic_ai import Agent, PromptedOutput
+from pydantic_ai import Agent, BinaryContent, PromptedOutput
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
+
+from images import LoadedImage
 
 # The tree the agent is allowed to grep and read. Defaults to this checkout
 # (two levels up from tools/bug_triage/auditor.py); CI points AUDIT_REPO_ROOT at
@@ -32,11 +47,12 @@ REPO_ROOT = Path(
 _MAX_FILE_BYTES = 40_000
 _MAX_RG_MATCHES = 60
 
-_SYSTEM_PROMPT = """\
+_BASE_PROMPT = """\
 You are a bug-triage engineer for Glaze, a Flutter (Dart) LLM roleplay frontend.
-You receive ONE bug report at a time: its title, the original post, and any
-replies from the thread. Judge them together — a reply often carries the repro
-steps or the correction that the title alone is missing.
+You receive ONE bug report at a time: its title, the original description, and
+any follow-up messages (Discord replies or Trello comments). Judge them together
+— a follow-up often carries the repro steps or the correction that the title
+alone is missing.
 
 Your job: investigate the CURRENT source code using the `search_code` and
 `read_file` tools, then produce a structured audit. Rules:
@@ -45,11 +61,33 @@ Your job: investigate the CURRENT source code using the `search_code` and
 - Prefer concrete file:line references over vague statements.
 - Propose a fix as a description, NOT as a patch. Do not invent files.
 - Be concise. A human will read this in a Trello comment.
+"""
 
+# Appended when the report has no pictures, or the model cannot see them.
+_TEXT_TAIL = """\
 You CANNOT see images. When a report leans on screenshots, or the text is too
 vague to tell what actually went wrong, set `needs_more_info` to true and put
 the specific questions a human should ask in `missing_info`. Never guess the
 contents of an attachment, and never invent repro steps that were not reported.
+"""
+
+# Appended when the screenshots themselves are attached to the message.
+_VISION_TAIL = """\
+The report's images are attached to this message — LOOK AT THEM. They are
+usually screenshots of the app, an error dialog, a stack trace or a log. Read
+the text in them, note which screen is shown and what state the UI is in, and
+treat that as part of the report: a screenshot of an exception is a repro
+detail, not a decoration.
+
+Write what you actually saw into `image_findings` — one short line per image,
+quoting any error text verbatim. If an image is unreadable, irrelevant or shows
+nothing about the bug, say that instead; never describe an image you were not
+given, and never soften a blank screenshot into a guess.
+
+Only set `needs_more_info` when the text AND the images together still leave you
+unable to tell what went wrong — with the pictures in hand that should be rare.
+Put the specific questions a human should ask in `missing_info`, and never
+invent repro steps that were not reported or shown.
 """
 
 
@@ -77,6 +115,13 @@ class BugAudit(BaseModel):
         description="What exactly to ask the reporter, when needs_more_info is true.",
     )
     notes: str = Field(default="", description="Anything a human should double-check.")
+    image_findings: str = Field(
+        default="",
+        description=(
+            "What the attached images actually show — one short line per image, "
+            "error text quoted verbatim. Empty when no images were attached."
+        ),
+    )
 
 
 def _safe_path(rel: str) -> Path | None:
@@ -89,7 +134,15 @@ def _safe_path(rel: str) -> Path | None:
     return p
 
 
-def build_agent(api_key: str, base_url: str, model_name: str) -> Agent[None, BugAudit]:
+def build_agent(
+    api_key: str, base_url: str, model_name: str, can_see_images: bool = False
+) -> Agent[None, BugAudit]:
+    """An audit agent over `model_name`.
+
+    `can_see_images` only changes the system prompt — telling a blind model to
+    look at attachments produces confident fiction, and telling a vision model
+    it cannot see makes it ignore the screenshot it was just handed.
+    """
     model = OpenAIChatModel(
         model_name,
         provider=OpenAIProvider(base_url=base_url, api_key=api_key),
@@ -102,7 +155,7 @@ def build_agent(api_key: str, base_url: str, model_name: str) -> Agent[None, Bug
         # for the JSON in the prompt keeps `search_code` / `read_file` as
         # ordinary optional tools, which those models do accept.
         output_type=PromptedOutput(BugAudit),
-        system_prompt=_SYSTEM_PROMPT,
+        system_prompt=_BASE_PROMPT + (_VISION_TAIL if can_see_images else _TEXT_TAIL),
         retries=2,
     )
 
@@ -137,32 +190,19 @@ def build_agent(api_key: str, base_url: str, model_name: str) -> Agent[None, Bug
     return agent
 
 
-def format_comment(audit: BugAudit, source_url: str | None) -> str:
-    """Render the audit as a Trello comment (markdown-ish)."""
-    src = f"\nSource: {source_url}" if source_url else ""
+def run(
+    agent: Agent[None, BugAudit],
+    report: str,
+    images: Sequence[LoadedImage] = (),
+) -> BugAudit:
+    """Audit one report, with its pictures attached as image parts.
 
-    if audit.needs_more_info:
-        asks = audit.missing_info.strip() or (
-            "The report relies on context that is not readable from text "
-            "(screenshots?). Ask the reporter for steps to reproduce."
-        )
-        return (
-            f"\u26a0\ufe0f **NEED MORE INFO** \u2014 automated triage could not "
-            f"judge this report.{src}\n\n"
-            f"**What was understood**\n{audit.summary}\n\n"
-            f"**What is missing**\n{asks}\n\n"
-            f"*(No audit was performed. Nothing was changed.)*"
-        )
-
-    files = "\n".join(f"- {f}" for f in audit.relevant_files) or "- (none identified)"
-    verdict = "actionable" if audit.is_actionable else "NOT clearly actionable"
-    notes = f"\n**Notes:** {audit.notes}" if audit.notes else ""
-    return (
-        f"\U0001f916 **Automated audit** (DeepSeek) \u2014 {verdict}, severity "
-        f"**{audit.severity}**, confidence **{audit.confidence}**{src}\n\n"
-        f"**Summary**\n{audit.summary}\n\n"
-        f"**Suspected root cause**\n{audit.root_cause}\n\n"
-        f"**Proposed fix (needs human approval \u2014 nothing was changed)**\n"
-        f"{audit.proposed_fix}\n\n"
-        f"**Relevant files**\n{files}{notes}"
-    )
+    Pydantic AI takes a list as the user prompt: the text first, then one
+    `BinaryContent` per image, which the OpenAI-compatible client turns into the
+    base64 data URLs DeepSeek's vision endpoint expects.
+    """
+    prompt: list[str | BinaryContent] = [report]
+    prompt += [
+        BinaryContent(data=img.data, media_type=img.media_type) for img in images
+    ]
+    return agent.run_sync(prompt).output

--- a/tools/bug_triage/check_connections.py
+++ b/tools/bug_triage/check_connections.py
@@ -1,7 +1,13 @@
 """Read-only smoke test. Verifies every credential/ID works BEFORE the real run.
 
 Creates nothing, comments nothing. For DeepSeek it sends one tiny 1-token
-request just to confirm the key + model are valid.
+request per model — the text one and the vision one — just to confirm the key
+and both ids are valid; an experimental model id that has been retired shows up
+here rather than halfway through a run.
+
+It also prints what the two board passes would pick up (cards nobody audited,
+cards whose verdict was blocked on a screenshot), so a dry run can be judged
+before it is started.
 
 Run:  python check_connections.py
 """
@@ -12,12 +18,16 @@ import sys
 
 import requests
 
+import audit_comment
 from config import Config
 from discord_client import DiscordClient
 from trello_client import TrelloClient
 
 OK = "OK  "
 BAD = "FAIL"
+
+# Cards whose comments the check reads before reporting the image backlog.
+_MAX_SCANNED = 60
 
 
 def _line(status: str, label: str, detail: str = "") -> None:
@@ -68,8 +78,15 @@ def check_discord(cfg: Config) -> bool:
 
         posts = dc.fetch_posts()
         empty = sum(1 for p in posts if not p.has_text)
+        pics = sum(len(p.images) for p in posts)
+        blind = sum(1 for p in posts if not p.has_text and p.has_images)
         _line(OK, "Discord forum read",
-              f"{len(posts)} open post(s), {empty} without readable text")
+              f"{len(posts)} open post(s), {empty} without readable text, "
+              f"{pics} image(s) across them")
+        if blind:
+            _line(OK, "Discord screenshot-only posts",
+                  f"{blind} post(s) are pictures with no text — the vision model "
+                  f"is what makes those auditable")
         if posts and empty == len(posts):
             _line(BAD, "Discord message content",
                   "all bodies empty → enable MESSAGE CONTENT INTENT")
@@ -93,13 +110,11 @@ def check_trello(cfg: Config) -> bool:
         b.raise_for_status()
         _line(OK, "Trello board", b.json().get("name"))
 
-        cards = TrelloClient(
-            cfg.trello_key, cfg.trello_token, cfg.trello_board_id
-        ).fetch_cards()
-        linked = sum(1 for c in cards if c.discord_thread_ids)
-        _line(OK, "Trello cards read",
-              f"{len(cards)} card(s), {linked} discord-linked "
-              f"(only discord-linked cards are ever touched)")
+        tc = TrelloClient(cfg.trello_key, cfg.trello_token, cfg.trello_board_id)
+        cards = tc.fetch_cards()
+        linked = sum(1 for c in cards if c.is_discord_linked)
+        _line(OK, "Trello cards read", f"{len(cards)} card(s), {linked} discord-linked")
+        _report_board_passes(cfg, tc, cards)
 
         lst = requests.get(
             f"https://api.trello.com/1/lists/{cfg.trello_new_bug_list_id}",
@@ -134,27 +149,66 @@ def check_trello(cfg: Config) -> bool:
         return False
 
 
-def check_deepseek(cfg: Config) -> bool:
+def _report_board_passes(cfg: Config, tc: TrelloClient, cards: list) -> None:
+    """What the two board passes would find. Read-only, and capped.
+
+    Only cards that carry comments are inspected, and only the first
+    `_MAX_SCANNED` of them — this is a smoke test, not the run itself.
+    """
+    hand_written = [
+        c for c in cards
+        if not c.is_discord_linked
+        and cfg.trello_audited_label_id not in c.label_ids
+        and c.list_id not in cfg.trello_skip_list_ids
+    ]
+    _line(OK, "Board pass (unmarked cards)",
+          f"{len(hand_written)} card(s) would be audited "
+          f"(AUDIT_BOARD_CARDS={cfg.audit_board_cards}, cap "
+          f"{cfg.max_board_audits_per_run})")
+
+    with_comments = [
+        c for c in cards
+        if c.comment_count and c.list_id not in cfg.trello_skip_list_ids
+    ][:_MAX_SCANNED]
+    blocked = 0
+    for c in with_comments:
+        if audit_comment.read_state(tc.fetch_comments(c)).wants_vision:
+            blocked += 1
+    _line(OK, "Board pass (blocked on images)",
+          f"{blocked} card(s) of {len(with_comments)} scanned were left "
+          f"unjudged because of a picture (REAUDIT_IMAGE_BLOCKED="
+          f"{cfg.reaudit_image_blocked}, cap {cfg.max_reaudits_per_run})")
+
+
+def _ping_model(cfg: Config, model: str, label: str) -> bool:
     try:
         r = requests.post(
             f"{cfg.deepseek_base_url}/chat/completions",
             headers={"Authorization": f"Bearer {cfg.deepseek_api_key}"},
             json={
-                "model": cfg.deepseek_model,
+                "model": model,
                 "messages": [{"role": "user", "content": "ping"}],
                 "max_tokens": 1,
             },
             timeout=30,
         )
         r.raise_for_status()
-        _line(OK, "DeepSeek", f"model {cfg.deepseek_model} responded")
+        _line(OK, label, f"model {model} responded")
         return True
     except requests.HTTPError as e:
-        _line(BAD, "DeepSeek", f"{e.response.status_code} {e.response.text[:160]}")
+        _line(BAD, label, f"{e.response.status_code} {e.response.text[:160]}")
         return False
     except Exception as e:  # noqa: BLE001
-        _line(BAD, "DeepSeek", str(e))
+        _line(BAD, label, str(e))
         return False
+
+
+def check_deepseek(cfg: Config) -> bool:
+    ok = _ping_model(cfg, cfg.deepseek_model, "DeepSeek (text)")
+    if not cfg.vision_enabled:
+        _line(OK, "DeepSeek (vision)", "VISION_ENABLED=false — images are ignored")
+        return ok
+    return _ping_model(cfg, cfg.deepseek_vision_model, "DeepSeek (vision)") and ok
 
 
 def main() -> int:

--- a/tools/bug_triage/config.py
+++ b/tools/bug_triage/config.py
@@ -27,6 +27,10 @@ def _optional(name: str, default: str = "") -> str:
     return os.environ.get(name, "").strip() or default
 
 
+def _flag(name: str, default: str) -> bool:
+    return _optional(name, default).lower() in ("1", "true", "yes")
+
+
 def _csv(name: str) -> tuple[str, ...]:
     raw = _optional(name)
     return tuple(x.strip() for x in raw.split(",") if x.strip())
@@ -38,6 +42,9 @@ class Config:
     deepseek_api_key: str
     deepseek_base_url: str
     deepseek_model: str
+    # Multimodal sibling, used for any report that carries a picture. Same API,
+    # same tools — it just has eyes. Text-only reports stay on the cheap model.
+    deepseek_vision_model: str
 
     # --- Trello ---
     trello_key: str
@@ -45,6 +52,9 @@ class Config:
     trello_board_id: str
     trello_new_bug_list_id: str  # where freshly-discovered bugs land
     trello_audited_label_id: str  # label meaning "AI already audited this"
+    # Lists the board sweep never touches — Done / Released / Ideas columns a
+    # human keeps for themselves.
+    trello_skip_list_ids: tuple[str, ...]
 
     # --- Discord ---
     discord_bot_token: str
@@ -69,27 +79,58 @@ class Config:
     max_new_cards_per_run: int
     max_audits_per_run: int
 
+    # --- Vision ---
+    # Master switch. Off = images are never downloaded and the vision model is
+    # never built; the pipeline behaves exactly as it did before.
+    vision_enabled: bool
+    # Pictures shown to the model per report. Each one costs up to 384 tokens,
+    # and the fifth screenshot of the same dialog rarely adds anything.
+    max_images_per_audit: int
+    # Images larger than this are skipped rather than uploaded.
+    max_image_bytes: int
+
+    # --- Board passes (they read the board as a queue, not just as an index) --
+    # Re-open cards whose audit ended "NEED MORE INFO" because it could not see
+    # the screenshot, and run them again with the vision model.
+    reaudit_image_blocked: bool
+    max_reaudits_per_run: int
+    # Audit cards that were never mirrored from Discord: no `discord-thread:`
+    # marker, no audited label — someone typed them straight onto the board.
+    audit_board_cards: bool
+    max_board_audits_per_run: int
+
     @staticmethod
     def load() -> "Config":
         return Config(
             deepseek_api_key=_require("DEEPSEEK_API_KEY"),
             deepseek_base_url=_optional("DEEPSEEK_BASE_URL", "https://api.deepseek.com"),
             deepseek_model=_optional("DEEPSEEK_MODEL", "deepseek-chat"),
+            deepseek_vision_model=_optional(
+                "DEEPSEEK_VISION_MODEL", "deepseek-v4-flash-vision-exp"
+            ),
             trello_key=_require("TRELLO_KEY"),
             trello_token=_require("TRELLO_TOKEN"),
             trello_board_id=_require("TRELLO_BOARD_ID"),
             trello_new_bug_list_id=_require("TRELLO_NEW_BUG_LIST_ID"),
             trello_audited_label_id=_require("TRELLO_AUDITED_LABEL_ID"),
+            trello_skip_list_ids=_csv("TRELLO_SKIP_LIST_IDS"),
             discord_bot_token=_require("DISCORD_BOT_TOKEN"),
             discord_guild_id=_require("DISCORD_GUILD_ID"),
             discord_forum_channel_id=_require("DISCORD_FORUM_CHANNEL_ID"),
             discord_ignored_tag_ids=_csv("DISCORD_IGNORED_TAG_IDS"),
-            discord_skip_archived=_optional("DISCORD_SKIP_ARCHIVED", "true").lower()
-            in ("1", "true", "yes"),
-            dry_run=_optional("DRY_RUN", "false").lower() in ("1", "true", "yes"),
-            match_existing_cards=_optional("MATCH_EXISTING_CARDS", "true").lower()
-            in ("1", "true", "yes"),
+            discord_skip_archived=_flag("DISCORD_SKIP_ARCHIVED", "true"),
+            dry_run=_flag("DRY_RUN", "false"),
+            match_existing_cards=_flag("MATCH_EXISTING_CARDS", "true"),
             max_match_candidates=int(_optional("MAX_MATCH_CANDIDATES", "20")),
             max_new_cards_per_run=int(_optional("MAX_NEW_CARDS_PER_RUN", "25")),
             max_audits_per_run=int(_optional("MAX_AUDITS_PER_RUN", "15")),
+            vision_enabled=_flag("VISION_ENABLED", "true"),
+            max_images_per_audit=int(_optional("MAX_IMAGES_PER_AUDIT", "4")),
+            max_image_bytes=int(_optional("MAX_IMAGE_BYTES", "8000000")),
+            reaudit_image_blocked=_flag("REAUDIT_IMAGE_BLOCKED", "true"),
+            max_reaudits_per_run=int(_optional("MAX_REAUDITS_PER_RUN", "10")),
+            audit_board_cards=_flag("AUDIT_BOARD_CARDS", "true"),
+            max_board_audits_per_run=int(
+                _optional("MAX_BOARD_AUDITS_PER_RUN", "10")
+            ),
         )

--- a/tools/bug_triage/discord_client.py
+++ b/tools/bug_triage/discord_client.py
@@ -14,16 +14,22 @@ are handled separately:
                   quiet-but-open reports too; DISCORD_SKIP_ARCHIVED=false keeps
                   them.
 
-Attachments are counted but never downloaded: the auditor cannot see images, so
-a report that leans on screenshots is flagged for a human instead of guessed at.
+Attachments are collected as `ImageRef`s, not just counted: DeepSeek's vision
+model reads screenshots, and a bug report on a Discord forum is very often a
+screenshot with three words under it. The bytes are fetched later (images.py)
+and only for the reports that actually reach an audit, so a run that has nothing
+to audit still downloads nothing.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any
 
 import requests
+
+from images import ImageRef, dedup
 
 _API = "https://discord.com/api/v10"
 
@@ -32,6 +38,8 @@ _MSG_LIMIT = 100
 # Replies longer than this are trimmed so one rambling thread can't blow up the
 # prompt; the auditor gets the gist, a human still has the Discord link.
 _MAX_REPLY_CHARS = 1500
+# Used only when Discord gives no content_type for an upload.
+_IMAGE_EXT_RE = re.compile(r"\.(?:png|jpe?g|gif|webp)$", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -42,10 +50,18 @@ class ForumPost:
     replies: tuple[str, ...]
     attachment_count: int
     url: str
+    # Every picture in the thread, in posting order. `attachment_count` counts
+    # all attachments (a log file, a video); this holds the ones worth showing
+    # to a vision model.
+    images: tuple[ImageRef, ...] = ()
 
     @property
     def has_text(self) -> bool:
         return bool(self.body.strip() or any(r.strip() for r in self.replies))
+
+    @property
+    def has_images(self) -> bool:
+        return bool(self.images)
 
 
 class DiscordClient:
@@ -117,20 +133,53 @@ class DiscordClient:
         embeds = [e for e in msg.get("embeds", []) if e.get("type") == "image"]
         return len(msg.get("attachments", [])) + len(embeds)
 
-    def _thread_content(self, thread_id: str) -> tuple[str, tuple[str, ...], int]:
-        """Return (starter_body, replies, attachment_count) for one thread."""
+    @staticmethod
+    def _image_refs(msg: dict, origin: str) -> list[ImageRef]:
+        """Pictures in one message: real attachments first, then image embeds.
+
+        Discord CDN links are pre-signed and expire in about a day, which is
+        fine — they are fetched during this same run, never stored.
+        """
+        refs: list[ImageRef] = []
+        for a in msg.get("attachments", []) or []:
+            url = a.get("url") or a.get("proxy_url") or ""
+            ctype = (a.get("content_type") or "").lower()
+            name = a.get("filename", "")
+            if not url:
+                continue
+            # Discord fills content_type for uploads; when it does not, fall
+            # back to the file name and let images.py sniff the real bytes.
+            if ctype and not ctype.startswith("image/"):
+                continue
+            if not ctype and not _IMAGE_EXT_RE.search(name):
+                continue
+            refs.append(ImageRef(url=url, name=name, origin=origin))
+        for e in msg.get("embeds", []) or []:
+            if e.get("type") != "image":
+                continue
+            src = (e.get("image") or e.get("thumbnail") or {})
+            url = src.get("url") or src.get("proxy_url") or ""
+            if url:
+                refs.append(ImageRef(url=url, name="", origin=f"{origin} (embed)"))
+        return refs
+
+    def _thread_content(
+        self, thread_id: str
+    ) -> tuple[str, tuple[str, ...], int, tuple[ImageRef, ...]]:
+        """Return (starter_body, replies, attachment_count, images)."""
         msgs: list[dict] = self._get(
             f"/channels/{thread_id}/messages", limit=_MSG_LIMIT
         )
         msgs = list(reversed(msgs))  # API returns newest-first; read chronologically
         if not msgs:
-            return "", (), 0
+            return "", (), 0, ()
 
         attachments = sum(self._attachment_count(m) for m in msgs)
 
         # In a forum thread the starter message shares the thread's id.
         starter = next((m for m in msgs if str(m.get("id")) == thread_id), msgs[0])
         body = (starter.get("content") or "").strip()
+        images = self._image_refs(starter, "original post")
 
         replies: list[str] = []
         for m in msgs:
@@ -140,13 +189,14 @@ class DiscordClient:
             if not text and not self._attachment_count(m):
                 continue  # join/system noise
             author = (m.get("author") or {}).get("username", "unknown")
+            images.extend(self._image_refs(m, f"reply by {author}"))
             if len(text) > _MAX_REPLY_CHARS:
                 text = text[:_MAX_REPLY_CHARS] + " …[trimmed]"
             if not text:
                 text = "(image/attachment only)"
             replies.append(f"{author}: {text}")
 
-        return body, tuple(replies), attachments
+        return body, tuple(replies), attachments, tuple(dedup(images))
 
     def fetch_posts(self) -> list[ForumPost]:
         posts: list[ForumPost] = []
@@ -158,7 +208,7 @@ class DiscordClient:
                 print(f"[discord] skip closed thread {thread.get('id')} ({reason})")
                 continue
             tid = str(thread["id"])
-            body, replies, attachments = self._thread_content(tid)
+            body, replies, attachments, images = self._thread_content(tid)
             posts.append(
                 ForumPost(
                     thread_id=tid,
@@ -167,6 +217,7 @@ class DiscordClient:
                     replies=replies,
                     attachment_count=attachments,
                     url=f"https://discord.com/channels/{self._guild_id}/{tid}",
+                    images=images,
                 )
             )
         if skipped:

--- a/tools/bug_triage/images.py
+++ b/tools/bug_triage/images.py
@@ -1,0 +1,164 @@
+"""Image plumbing for the vision-capable audit.
+
+The pipeline used to *count* attachments and give up on them ("images are NOT
+readable by the triage agent"). DeepSeek's vision model can read them, so the
+images themselves now have to travel from Discord / Trello into the prompt.
+
+Two jobs live here and nothing else:
+  * `ImageRef` — "there is a picture at this URL", produced by the Discord and
+    Trello clients, cheap to build (no download, no auth).
+  * `ImageLoader` — turns refs into bytes, once, with the credentials the host
+    demands and hard ceilings on size and count.
+
+Downloads are cached per URL for the whole run: the same screenshot can be
+reached through a Discord thread, the mirrored card and a re-audit pass, and
+paying for it three times would be silly.
+
+The media type is sniffed from the first bytes, never taken from the file name
+or the server's `Content-Type` — DeepSeek does the same, and Discord happily
+serves a `.png` that is really a JPEG. Anything that is not one of the four
+formats the API accepts (JPEG / PNG / GIF / WebP) is dropped here rather than
+rejected with a 400 in the middle of an audit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+import requests
+
+# The four formats DeepSeek's vision endpoint accepts. `_sniff` matches on the
+# magic bytes; WebP needs two windows, so it is handled separately below.
+_MAGIC: tuple[tuple[bytes, str], ...] = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+_TIMEOUT = 30
+
+
+def _sniff(data: bytes) -> str | None:
+    """The media type of these bytes, or None if it is not a supported image."""
+    for magic, mime in _MAGIC:
+        if data.startswith(magic):
+            return mime
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+@dataclass(frozen=True)
+class ImageRef:
+    """A picture we know how to reach. Nothing is downloaded to build one."""
+
+    url: str
+    name: str = ""
+    # Human-readable provenance, shown to the model so it can say "the
+    # screenshot in the second reply" instead of "image 2".
+    origin: str = "attachment"
+
+    @property
+    def label(self) -> str:
+        return f"{self.name} ({self.origin})" if self.name else self.origin
+
+
+@dataclass(frozen=True)
+class LoadedImage:
+    ref: ImageRef
+    data: bytes
+    media_type: str
+
+
+def dedup(refs: list[ImageRef]) -> list[ImageRef]:
+    """Same picture referenced twice (post + embed, card + comment) -> once."""
+    seen: set[str] = set()
+    out: list[ImageRef] = []
+    for r in refs:
+        if r.url in seen:
+            continue
+        seen.add(r.url)
+        out.append(r)
+    return out
+
+
+class ImageLoader:
+    """Downloads `ImageRef`s, with the auth each host needs and a byte ceiling.
+
+    Discord's CDN links are pre-signed, so they must NOT carry the bot token.
+    Trello's own attachment URLs are the opposite: they 401 without the OAuth
+    header built from the API key + token. Everything else (a link a human
+    pasted onto a card) is fetched anonymously.
+    """
+
+    def __init__(
+        self,
+        trello_key: str,
+        trello_token: str,
+        max_bytes: int,
+        timeout: int = _TIMEOUT,
+    ):
+        self._trello_auth = (
+            f'OAuth oauth_consumer_key="{trello_key}", oauth_token="{trello_token}"'
+        )
+        self._max_bytes = max_bytes
+        self._timeout = timeout
+        self._s = requests.Session()
+        self._s.headers.update(
+            {"User-Agent": "GlazeBugTriage (https://github.com/hydall/Glaze, 1.0)"}
+        )
+        self._cache: dict[str, LoadedImage | None] = {}
+
+    def _headers(self, url: str) -> dict[str, str]:
+        host = (urlsplit(url).hostname or "").lower()
+        if host == "trello.com" or host.endswith(".trello.com"):
+            return {"Authorization": self._trello_auth}
+        return {}
+
+    def _download(self, ref: ImageRef) -> LoadedImage | None:
+        try:
+            r = self._s.get(
+                ref.url,
+                headers=self._headers(ref.url),
+                timeout=self._timeout,
+                stream=True,
+            )
+            r.raise_for_status()
+            # Read one byte past the ceiling: if it arrives, the image is over
+            # budget and gets dropped without buffering the whole thing.
+            data = r.raw.read(self._max_bytes + 1, decode_content=True)
+        except Exception as e:  # noqa: BLE001 — a dead link must not sink a run
+            print(f"[images] skip {ref.url[:80]}: {e}")
+            return None
+
+        if len(data) > self._max_bytes:
+            print(f"[images] skip {ref.label}: larger than {self._max_bytes} bytes")
+            return None
+        mime = _sniff(data)
+        if mime is None:
+            print(f"[images] skip {ref.label}: not a JPEG/PNG/GIF/WebP")
+            return None
+        return LoadedImage(ref=ref, data=data, media_type=mime)
+
+    def load(self, refs: list[ImageRef], limit: int) -> list[LoadedImage]:
+        """The first `limit` refs that turn out to be real, supported images.
+
+        Refs that fail to download are skipped, not counted — a broken link at
+        the front of the list must not eat the whole budget.
+        """
+        out: list[LoadedImage] = []
+        for ref in dedup(refs):
+            if limit and len(out) >= limit:
+                print(f"[images] {ref.label}: over the per-audit cap ({limit}), "
+                      f"not sent to the model")
+                break
+            if ref.url not in self._cache:
+                self._cache[ref.url] = self._download(ref)
+            got = self._cache[ref.url]
+            if got is not None:
+                # Cached under a different ref (same URL, other provenance):
+                # keep this call's label so the prompt stays accurate.
+                out.append(LoadedImage(ref, got.data, got.media_type))
+        return out

--- a/tools/bug_triage/matcher.py
+++ b/tools/bug_triage/matcher.py
@@ -30,7 +30,7 @@ from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 
 from discord_client import ForumPost
-from trello_client import Card
+from trello_client import Card, strip_markers
 
 # Below this the model is guessing; we open a fresh card instead.
 _MIN_CONFIDENCE = 0.7
@@ -59,11 +59,6 @@ unsure, answer 0. Set `confidence` to how sure you are that the card you picked
 is the same bug (0.0-1.0); when you answer 0, confidence is ignored.
 """
 
-_MARKER_LINE_RE = re.compile(
-    r"^(?:---|discord-thread:\d+|(?:Also )?[Rr]eported on Discord:.*|"
-    r"Attachments:.*)$\n?",
-    re.MULTILINE,
-)
 _WORD_RE = re.compile(r"[^\W\d_]+", re.UNICODE)
 _STOP = {
     "when", "with", "that", "this", "from", "have", "does", "doesn", "there",
@@ -125,16 +120,6 @@ def shortlist(post: ForumPost, cards: list[Card], limit: int) -> list[Card]:
     return sorted(picked, key=lambda c: c.created_at)
 
 
-def _strip_markers(desc: str) -> str:
-    """Card text without the bookkeeping footer.
-
-    The `discord-thread:` markers and back-links say nothing about what the bug
-    is, and on a card that already collected several reports they would crowd
-    out the part the model has to judge.
-    """
-    return _MARKER_LINE_RE.sub("", desc).strip()
-
-
 def _trim(text: str, limit: int) -> str:
     text = text.strip()
     return text if len(text) <= limit else text[:limit] + " …[trimmed]"
@@ -151,7 +136,7 @@ def _prompt(post: ForumPost, candidates: list[Card]) -> str:
     ]
     for i, c in enumerate(candidates, start=1):
         lines.append(f"{i}. {c.name}")
-        desc = _trim(_strip_markers(c.desc), _MAX_CARD_DESC_CHARS)
+        desc = _trim(strip_markers(c.desc), _MAX_CARD_DESC_CHARS)
         if desc:
             lines.append(f"   {desc}")
     lines.append("")

--- a/tools/bug_triage/mirror.py
+++ b/tools/bug_triage/mirror.py
@@ -1,0 +1,109 @@
+"""Discord -> Trello mirroring: give every open forum post a card.
+
+Deterministic, apart from the duplicate check it delegates to `matcher.py`. A
+thread already carrying a `discord-thread:` marker somewhere on the board is
+left alone; the rest either join the card that reported the same bug first, or
+open a new one in the "new bugs" list.
+
+Nothing here audits anything — mirroring finishes before the first LLM audit
+call, which is what lets a run with nothing new exit without spending tokens.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from config import Config
+from discord_client import ForumPost
+from matcher import build_matcher, find_existing_card
+from trello_client import Card, TrelloClient, marker_for
+
+
+def card_body(post: ForumPost) -> str:
+    """Title/body/replies of one thread, plus the de-dup marker footer."""
+    parts = [post.body.strip() or "(no text in the original post)"]
+
+    if post.replies:
+        parts.append("**Replies from the thread:**")
+        parts.extend(f"- {r}" for r in post.replies)
+
+    footer = ["---"]
+    if post.attachment_count:
+        readable = (
+            f", {len(post.images)} of them image(s) the triage agent reads"
+            if post.images
+            else " (no readable image among them)"
+        )
+        footer.append(f"Attachments: {post.attachment_count}{readable}.")
+    footer.append(f"Reported on Discord: {post.url}")
+    footer.append(marker_for(post.thread_id))
+
+    return "\n\n".join(parts) + "\n\n" + "\n".join(footer)
+
+
+def linked_desc(card: Card, post: ForumPost) -> str:
+    """A human-written card's description with the Discord link glued on.
+
+    Only the footer is appended — whatever a human typed stays untouched, so
+    linking a card can never destroy the report they wrote.
+    """
+    return (
+        f"{card.desc.rstrip()}\n\n---\n"
+        f"Also reported on Discord: {post.url}\n"
+        f"{marker_for(post.thread_id)}"
+    )
+
+
+def mirror(
+    cfg: Config,
+    trello: TrelloClient,
+    posts: list[ForumPost],
+    cards: list[Card],
+    by_thread: dict[str, Card],
+) -> None:
+    """Give every unlinked post a card, in place: `by_thread` and `cards` grow.
+
+    `cards` keeps mirroring the board so the later passes see the cards this run
+    just created, and the duplicate check gets them as candidates too — two
+    threads about one bug in the same batch land on one card.
+    """
+    new_posts = [p for p in posts if p.thread_id not in by_thread]
+    if cfg.max_new_cards_per_run and len(new_posts) > cfg.max_new_cards_per_run:
+        print(f"[triage] {len(new_posts)} new thread(s); capped to "
+              f"{cfg.max_new_cards_per_run} this run (MAX_NEW_CARDS_PER_RUN)")
+        new_posts = new_posts[: cfg.max_new_cards_per_run]
+
+    matcher = None  # built lazily: no new threads -> no lookup, no tokens
+
+    for post in new_posts:
+        hit = None
+        if cfg.match_existing_cards and cards:
+            if matcher is None:
+                matcher = build_matcher(
+                    cfg.deepseek_api_key, cfg.deepseek_base_url, cfg.deepseek_model
+                )
+            hit = find_existing_card(matcher, post, cards, cfg.max_match_candidates)
+
+        if hit is not None:
+            desc = linked_desc(hit, post)
+            trello.set_desc(hit.id, desc)
+            also = f" (now tracks {len(hit.discord_thread_ids) + 1} threads)"
+            print(f"[triage] linked thread {post.thread_id} to existing card "
+                  f"{hit.id}: {hit.name!r}{also}")
+            linked = replace(hit, desc=desc)
+            by_thread[post.thread_id] = linked
+            cards[cards.index(hit)] = linked
+            continue
+
+        body = card_body(post)
+        new_id = trello.create_card(cfg.trello_new_bug_list_id, post.title, body)
+        print(f"[triage] created card for thread {post.thread_id}: {post.title!r}")
+        fresh = Card(
+            id=new_id,
+            name=post.title,
+            desc=body,
+            list_id=cfg.trello_new_bug_list_id,
+            label_ids=(),
+        )
+        by_thread[post.thread_id] = fresh
+        cards.append(fresh)

--- a/tools/bug_triage/runner.py
+++ b/tools/bug_triage/runner.py
@@ -1,0 +1,130 @@
+"""Audit one subject: fetch its pictures, pick a model, render the comment.
+
+This is where "the triage agent can now read screenshots" actually happens. The
+orchestrator hands over an `AuditSubject` and gets back the text to post; which
+model ran, whether the images made it, and what to do when the vision call falls
+over are all decided here.
+
+Model choice is mechanical:
+  * pictures loaded  -> the vision model, with them attached;
+  * no pictures      -> the cheaper text model, exactly as before;
+  * vision call fails -> retry once on the text model, so an experimental
+    endpoint having a bad day costs a weaker audit, not a lost report.
+
+Both agents are built lazily and reused for the whole run: a batch of text-only
+reports never constructs the vision agent, and a batch of screenshots never
+constructs the text one.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+
+import audit_comment
+from auditor import BugAudit, build_agent, run
+from config import Config
+from images import ImageLoader, LoadedImage
+from subjects import AuditSubject
+
+# Below this much readable text, and with no picture to look at, a report cannot
+# be audited at all — so we skip the LLM entirely and ask a human instead.
+_MIN_REPORT_CHARS = 15
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    comment: str  # ready to post on the card
+    mode: str  # "vision" / "text" / "none"
+    images: int  # how many pictures the model actually received
+    needs_more_info: bool
+
+
+class AuditRunner:
+    def __init__(self, cfg: Config, loader: ImageLoader):
+        self._cfg = cfg
+        self._loader = loader
+        self._text = None
+        self._vision = None
+
+    def _text_agent(self):
+        if self._text is None:
+            print(f"[audit] using text model {self._cfg.deepseek_model}")
+            self._text = build_agent(
+                self._cfg.deepseek_api_key,
+                self._cfg.deepseek_base_url,
+                self._cfg.deepseek_model,
+                can_see_images=False,
+            )
+        return self._text
+
+    def _vision_agent(self):
+        if self._vision is None:
+            print(f"[audit] using vision model {self._cfg.deepseek_vision_model}")
+            self._vision = build_agent(
+                self._cfg.deepseek_api_key,
+                self._cfg.deepseek_base_url,
+                self._cfg.deepseek_vision_model,
+                can_see_images=True,
+            )
+        return self._vision
+
+    def _load_images(self, subject: AuditSubject) -> list[LoadedImage]:
+        if not subject.images:
+            return []
+        if not self._cfg.vision_enabled:
+            print(f"[audit] {subject.key}: {len(subject.images)} image(s) ignored "
+                  f"(VISION_ENABLED=false)")
+            return []
+        got = self._loader.load(
+            list(subject.images), self._cfg.max_images_per_audit
+        )
+        print(f"[audit] {subject.key}: {len(got)}/{len(subject.images)} image(s) "
+              f"loaded for the model")
+        return got
+
+    def audit(self, subject: AuditSubject) -> AuditResult:
+        """Audit one report. Raises only if every model attempt failed."""
+        images = self._load_images(subject)
+
+        # Nothing to read and nothing to look at -> ask a human, spend nothing.
+        if not images and len(subject.text) < _MIN_REPORT_CHARS:
+            return AuditResult(
+                comment=audit_comment.unreadable(
+                    subject.source_url, len(subject.images)
+                ),
+                mode="none",
+                images=0,
+                needs_more_info=True,
+            )
+
+        report = subject.report([img.ref for img in images])
+
+        if images:
+            try:
+                out = run(self._vision_agent(), report, images)
+                return self._result(out, subject, "vision", images)
+            except Exception as e:  # noqa: BLE001 — fall back, don't lose the card
+                print(f"[audit] vision call FAILED for {subject.key}: {e} — "
+                      f"retrying on {self._cfg.deepseek_model} without images",
+                      file=sys.stderr)
+                report = subject.report()
+
+        out = run(self._text_agent(), report, ())
+        return self._result(out, subject, "text", [])
+
+    def _result(
+        self,
+        audit: BugAudit,
+        subject: AuditSubject,
+        mode: str,
+        images: list[LoadedImage],
+    ) -> AuditResult:
+        return AuditResult(
+            comment=audit_comment.render(
+                audit, subject.source_url, mode, [i.ref for i in images]
+            ),
+            mode=mode,
+            images=len(images),
+            needs_more_info=audit.needs_more_info,
+        )

--- a/tools/bug_triage/subjects.py
+++ b/tools/bug_triage/subjects.py
@@ -1,0 +1,123 @@
+"""One shape for "the thing being audited", whatever it came from.
+
+The auditor used to take a Discord thread and nothing else. It now also has to
+judge a card a human typed straight onto the board, and to re-open a card whose
+first audit died on a screenshot. Those three inputs differ only in where their
+text and pictures live, so they are normalised here once and the agent never
+learns the difference.
+
+Nothing in here talks to the network: an `AuditSubject` is assembled from data
+the clients already fetched, and its images are still just references.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from audit_comment import is_triage_comment
+from discord_client import ForumPost
+from images import ImageRef, dedup
+from trello_client import Card, Comment, image_refs_in_text, strip_markers
+
+# A card comment quoted into the prompt is trimmed like a Discord reply is.
+_MAX_COMMENT_CHARS = 1500
+
+
+@dataclass(frozen=True)
+class AuditSubject:
+    key: str  # thread id or card id — for logs only
+    kind: str  # "Discord thread" / "Trello card"
+    title: str
+    body: str
+    replies: tuple[str, ...]
+    images: tuple[ImageRef, ...]
+    source_url: str
+
+    @property
+    def text(self) -> str:
+        """The human-written part — what decides whether text alone can be read.
+
+        The title counts. On a Trello card typed by a human it is often the
+        whole report ("audio stops after switching character"), and a thread
+        whose title says what broke is auditable even with an empty body.
+        """
+        return "\n".join([self.title, self.body, *self.replies]).strip()
+
+    @property
+    def has_images(self) -> bool:
+        return bool(self.images)
+
+    def report(self, shown: Sequence[ImageRef] = ()) -> str:
+        """The report as the model sees it.
+
+        `shown` is what actually got attached to the message — never the full
+        `images` list. A picture that failed to download, or fell outside the
+        per-audit cap, must not be announced to a model that cannot see it.
+        """
+        parts = [
+            f"{self.kind} — {self.title}",
+            self.body.strip() or "(no text in the original report)",
+        ]
+        if self.replies:
+            parts.append("Follow-up messages:\n" + "\n".join(f"- {r}" for r in self.replies))
+        if shown:
+            parts.append(
+                "Attached images (shown to you below, in this order):\n"
+                + "\n".join(
+                    f"- Image {i}: {ref.label}"
+                    for i, ref in enumerate(shown, start=1)
+                )
+            )
+        elif self.images:
+            parts.append(
+                f"This report has {len(self.images)} attachment(s), but none of "
+                f"them is available to you in this message."
+            )
+        if self.source_url:
+            parts.append(f"Source: {self.source_url}")
+        return "\n\n".join(parts)
+
+
+def _trim(text: str, limit: int) -> str:
+    text = text.strip()
+    return text if len(text) <= limit else text[:limit] + " …[trimmed]"
+
+
+def from_post(post: ForumPost) -> AuditSubject:
+    return AuditSubject(
+        key=post.thread_id,
+        kind="Discord thread",
+        title=post.title,
+        body=post.body,
+        replies=post.replies,
+        images=post.images,
+        source_url=post.url,
+    )
+
+
+def from_card(card: Card, comments: list[Comment], attachments: list[ImageRef]) -> AuditSubject:
+    """A card as a bug report: its description, the human comments, its pictures.
+
+    Our own audit comments are dropped — they are this agent's earlier output,
+    not something the reporter said, and feeding them back would let one shaky
+    guess harden into a fact over successive runs.
+    """
+    replies: list[str] = []
+    images: list[ImageRef] = list(attachments)
+    images += image_refs_in_text(card.desc, "linked in the description")
+    for c in comments:
+        if is_triage_comment(c.text):
+            continue
+        images += image_refs_in_text(c.text, f"linked in a comment by {c.author}")
+        if c.text:
+            replies.append(f"{c.author}: {_trim(c.text, _MAX_COMMENT_CHARS)}")
+    return AuditSubject(
+        key=card.id,
+        kind="Trello card",
+        title=card.name,
+        body=strip_markers(card.desc),
+        replies=tuple(replies),
+        images=tuple(dedup(images)),
+        source_url=card.url,
+    )

--- a/tools/bug_triage/test_triage.py
+++ b/tools/bug_triage/test_triage.py
@@ -1,0 +1,578 @@
+"""Unit tests for the bug-triage agent (stdlib `unittest`, no network).
+
+Run:  python -m unittest discover -s tools/bug_triage -p 'test_*.py'
+
+Everything that talks to Discord, Trello or DeepSeek is faked. What is actually
+under test is the logic that decides *which* card gets looked at and *what* the
+model is shown — the part that silently rots when a rule changes.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import audit_comment
+import images
+import mirror
+import subjects
+import trello_client
+from audit_pass import AuditPass
+from config import Config
+from discord_client import DiscordClient, ForumPost
+from images import ImageRef, LoadedImage
+from runner import AuditRunner
+from trello_client import Card, Comment
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"0" * 32
+JPEG = b"\xff\xd8\xff" + b"0" * 32
+
+
+def make_config(**over) -> Config:
+    base = dict(
+        deepseek_api_key="k",
+        deepseek_base_url="https://api.deepseek.com",
+        deepseek_model="deepseek-chat",
+        deepseek_vision_model="deepseek-v4-flash-vision-exp",
+        trello_key="tk",
+        trello_token="tt",
+        trello_board_id="b",
+        trello_new_bug_list_id="new",
+        trello_audited_label_id="lbl",
+        trello_skip_list_ids=(),
+        discord_bot_token="d",
+        discord_guild_id="g",
+        discord_forum_channel_id="f",
+        discord_ignored_tag_ids=(),
+        discord_skip_archived=True,
+        dry_run=False,
+        match_existing_cards=False,
+        max_match_candidates=20,
+        max_new_cards_per_run=25,
+        max_audits_per_run=15,
+        vision_enabled=True,
+        max_images_per_audit=4,
+        max_image_bytes=8_000_000,
+        reaudit_image_blocked=True,
+        max_reaudits_per_run=10,
+        audit_board_cards=True,
+        max_board_audits_per_run=10,
+    )
+    base.update(over)
+    return Config(**base)
+
+
+def make_card(cid="c1", name="Card", desc="", labels=(), **kw) -> Card:
+    return Card(
+        id=cid, name=name, desc=desc, list_id=kw.pop("list_id", "todo"),
+        label_ids=tuple(labels), url=kw.pop("url", "https://trello.com/c/x"),
+        attachment_count=kw.pop("attachment_count", 0),
+        comment_count=kw.pop("comment_count", 0),
+    )
+
+
+def make_comment(text: str, author: str = "human") -> Comment:
+    return Comment(id="a1", text=text, author=author, author_id="m1", date="")
+
+
+class FakeTrello:
+    """Records writes; serves canned comments/attachments per card id."""
+
+    def __init__(self, comments=None, attachments=None):
+        self._comments = comments or {}
+        self._attachments = attachments or {}
+        self.comments_posted: list[tuple[str, str]] = []
+        self.labels: list[tuple[str, str]] = []
+        self.comment_reads = 0
+
+    def fetch_comments(self, card):
+        self.comment_reads += 1
+        return list(self._comments.get(card.id, []))
+
+    def fetch_attachments(self, card):
+        return list(self._attachments.get(card.id, []))
+
+    def add_comment(self, card_id, text):
+        self.comments_posted.append((card_id, text))
+
+    def add_label(self, card_id, label_id):
+        self.labels.append((card_id, label_id))
+
+
+class FakeRunner:
+    """Stands in for AuditRunner: records subjects, returns a canned verdict."""
+
+    def __init__(self, result=None, boom=False):
+        from runner import AuditResult
+
+        self.seen: list = []
+        self.boom = boom
+        self.result = result or AuditResult(
+            comment="verdict " + audit_comment.marker("vision", 1, False),
+            mode="vision", images=1, needs_more_info=False,
+        )
+
+    def audit(self, subject):
+        self.seen.append(subject)
+        if self.boom:
+            raise RuntimeError("model exploded")
+        return self.result
+
+
+# --------------------------------------------------------------------------
+class SniffTest(unittest.TestCase):
+    def test_supported_formats(self):
+        self.assertEqual(images._sniff(PNG), "image/png")
+        self.assertEqual(images._sniff(JPEG), "image/jpeg")
+        self.assertEqual(images._sniff(b"GIF89a...."), "image/gif")
+        self.assertEqual(images._sniff(b"RIFF1234WEBPxx"), "image/webp")
+
+    def test_rejects_everything_else(self):
+        self.assertIsNone(images._sniff(b"%PDF-1.7"))
+        self.assertIsNone(images._sniff(b""))
+
+    def test_dedup_keeps_first_occurrence(self):
+        a = ImageRef("http://x/1.png", "a", "post")
+        b = ImageRef("http://x/1.png", "b", "reply")
+        c = ImageRef("http://x/2.png", "c", "reply")
+        self.assertEqual(images.dedup([a, b, c]), [a, c])
+
+
+class ImageLoaderTest(unittest.TestCase):
+    def setUp(self):
+        self.loader = images.ImageLoader("tk", "tt", max_bytes=100)
+
+    def test_trello_urls_get_oauth_the_others_get_nothing(self):
+        head = self.loader._headers("https://trello.com/1/cards/x/attachments/y")
+        self.assertIn("oauth_consumer_key=\"tk\"", head["Authorization"])
+        self.assertEqual(self.loader._headers("https://cdn.discordapp.com/a.png"), {})
+
+    def test_oversized_and_unsupported_images_are_dropped(self):
+        with mock.patch.object(images.ImageLoader, "_download") as dl:
+            dl.return_value = None
+            got = self.loader.load([ImageRef("http://x/1.png")], limit=4)
+        self.assertEqual(got, [])
+
+    def test_cap_stops_at_the_limit_and_download_happens_once(self):
+        loaded = LoadedImage(ImageRef("u"), PNG, "image/png")
+        with mock.patch.object(
+            images.ImageLoader, "_download", return_value=loaded
+        ) as dl:
+            refs = [ImageRef(f"http://x/{i}.png") for i in range(5)]
+            got = self.loader.load(refs, limit=2)
+            # The same URL twice must not hit the network twice.
+            self.loader.load([refs[0]], limit=2)
+        self.assertEqual(len(got), 2)
+        self.assertEqual(dl.call_count, 2)
+
+
+class MarkerTest(unittest.TestCase):
+    def test_marker_round_trip(self):
+        state = audit_comment.read_state(
+            [make_comment(audit_comment.marker("vision", 3, False))]
+        )
+        self.assertEqual(
+            (state.audited, state.mode, state.images_seen, state.blocked_on_images),
+            (True, "vision", 3, False),
+        )
+
+    def test_legacy_comments_are_recognised(self):
+        blocked = audit_comment.read_state(
+            [make_comment("⚠️ **NEED MORE INFO** — screenshots only")]
+        )
+        self.assertTrue(blocked.wants_vision)
+        done = audit_comment.read_state([make_comment("🤖 **Automated audit** ...")])
+        self.assertFalse(done.wants_vision)
+
+    def test_last_comment_wins_and_vision_retires_the_card(self):
+        state = audit_comment.read_state([
+            make_comment("⚠️ **NEED MORE INFO** — screenshots only"),
+            make_comment("a human replying"),
+            make_comment("verdict " + audit_comment.marker("vision", 2, True)),
+        ])
+        self.assertTrue(state.blocked_on_images)
+        self.assertFalse(state.wants_vision)  # vision already had its chance
+
+    def test_human_comments_are_not_ours(self):
+        self.assertFalse(audit_comment.is_triage_comment("looks like a dupe of #4"))
+        self.assertTrue(
+            audit_comment.is_triage_comment("x " + audit_comment.marker("text", 0, True))
+        )
+
+    def test_every_posted_comment_carries_a_marker(self):
+        self.assertIn("glaze-triage:v2", audit_comment.unreadable("http://x", 2))
+        audit = mock.Mock(
+            needs_more_info=False, is_actionable=True, severity="high",
+            summary="s", root_cause="r", proposed_fix="f", relevant_files=["a.dart"],
+            confidence="high", notes="", image_findings="a red error dialog",
+        )
+        text = audit_comment.render(audit, "http://x", "vision", [ImageRef("u")])
+        self.assertIn("glaze-triage:v2 mode=vision images=1 blocked=no", text)
+        self.assertIn("a red error dialog", text)
+
+
+class TrelloParsingTest(unittest.TestCase):
+    def test_badges_become_counts(self):
+        card = trello_client._card_from_json({
+            "id": "1", "name": "n", "desc": "d", "idList": "l", "idLabels": ["x"],
+            "shortUrl": "http://t/c", "badges": {"attachments": 2, "comments": 3},
+        })
+        self.assertEqual((card.attachment_count, card.comment_count), (2, 3))
+        self.assertFalse(card.is_discord_linked)
+
+    def test_markers_are_stripped_from_the_report_text(self):
+        desc = "It crashes\n\n---\nReported on Discord: http://d/1\ndiscord-thread:42"
+        self.assertEqual(trello_client.strip_markers(desc), "It crashes")
+        self.assertEqual(make_card(desc=desc).discord_thread_ids, ("42",))
+
+    def test_image_links_in_text(self):
+        refs = trello_client.image_refs_in_text(
+            "see https://trello.com/1/cards/a/attachments/b/download/x.png and "
+            "http://e.com/doc.pdf",
+            "comment",
+        )
+        self.assertEqual([r.url for r in refs],
+                         ["https://trello.com/1/cards/a/attachments/b/download/x.png"])
+
+
+class DiscordImageTest(unittest.TestCase):
+    def test_only_images_are_collected(self):
+        msg = {
+            "attachments": [
+                {"url": "http://c/a.png", "content_type": "image/png",
+                 "filename": "a.png"},
+                {"url": "http://c/log.txt", "content_type": "text/plain",
+                 "filename": "log.txt"},
+                {"url": "http://c/b.JPG", "filename": "b.JPG"},  # no content_type
+            ],
+            "embeds": [{"type": "image", "image": {"url": "http://e/i.webp"}}],
+        }
+        refs = DiscordClient._image_refs(msg, "original post")
+        self.assertEqual([r.url for r in refs],
+                         ["http://c/a.png", "http://c/b.JPG", "http://e/i.webp"])
+
+
+class SubjectTest(unittest.TestCase):
+    def test_card_subject_drops_our_own_comments_but_keeps_humans(self):
+        card = make_card(desc="Broken since 0.7", comment_count=2)
+        subject = subjects.from_card(
+            card,
+            [
+                make_comment("also on Android", "bob"),
+                make_comment("verdict " + audit_comment.marker("text", 0, True), "bot"),
+            ],
+            [ImageRef("http://t/x.png", "x.png", "card attachment")],
+        )
+        self.assertEqual(subject.replies, ("bob: also on Android",))
+        self.assertEqual(len(subject.images), 1)
+        self.assertIn("Card", subject.text)  # the title counts as report text
+
+    def test_comment_image_links_join_the_attachments(self):
+        card = make_card(comment_count=1)
+        subject = subjects.from_card(
+            card, [make_comment("here: http://e/shot.png", "bob")], []
+        )
+        self.assertEqual([r.url for r in subject.images], ["http://e/shot.png"])
+
+    def test_report_announces_only_the_images_actually_attached(self):
+        post = ForumPost("1", "Crash", "boom", (), 2, "http://d/1",
+                         (ImageRef("u1", "a.png", "original post"),
+                          ImageRef("u2", "b.png", "reply by bob")))
+        subject = subjects.from_post(post)
+        with_one = subject.report([post.images[0]])
+        self.assertIn("Image 1: a.png (original post)", with_one)
+        self.assertNotIn("b.png", with_one)
+        self.assertIn("none of them is available to you", subject.report())
+
+
+class RunnerTest(unittest.TestCase):
+    def setUp(self):
+        self.cfg = make_config()
+        self.loader = mock.Mock()
+        self.runner = AuditRunner(self.cfg, self.loader)
+        self.audit = mock.Mock(needs_more_info=False, is_actionable=True,
+                               severity="low", summary="s", root_cause="r",
+                               proposed_fix="f", relevant_files=[], confidence="low",
+                               notes="", image_findings="")
+
+    def _subject(self, text="a real report, long enough", imgs=()):
+        return subjects.AuditSubject(
+            key="k", kind="Trello card", title="T", body=text, replies=(),
+            images=tuple(imgs), source_url="http://x",
+        )
+
+    def test_no_text_and_no_image_never_calls_the_model(self):
+        self.loader.load.return_value = []
+        with mock.patch("runner.run") as run:
+            result = self.runner.audit(self._subject(text="", imgs=[]))
+        run.assert_not_called()
+        self.assertEqual(result.mode, "none")
+        self.assertTrue(result.needs_more_info)
+
+    def test_images_route_to_the_vision_model(self):
+        loaded = [LoadedImage(ImageRef("u", "a.png"), PNG, "image/png")]
+        self.loader.load.return_value = loaded
+        with mock.patch("runner.build_agent") as build, \
+             mock.patch("runner.run", return_value=self.audit) as run:
+            result = self.runner.audit(self._subject(imgs=[ImageRef("u")]))
+        self.assertEqual(build.call_args.args[2], self.cfg.deepseek_vision_model)
+        self.assertTrue(build.call_args.kwargs["can_see_images"])
+        self.assertEqual(run.call_args.args[2], loaded)
+        self.assertEqual((result.mode, result.images), ("vision", 1))
+
+    def test_a_failing_vision_call_falls_back_to_text(self):
+        self.loader.load.return_value = [
+            LoadedImage(ImageRef("u", "a.png"), PNG, "image/png")
+        ]
+        with mock.patch("runner.build_agent"), \
+             mock.patch("runner.run", side_effect=[RuntimeError("400"), self.audit]):
+            result = self.runner.audit(self._subject(imgs=[ImageRef("u")]))
+        self.assertEqual((result.mode, result.images), ("text", 0))
+
+    def test_vision_disabled_keeps_the_old_behaviour(self):
+        runner = AuditRunner(make_config(vision_enabled=False), self.loader)
+        with mock.patch("runner.build_agent") as build, \
+             mock.patch("runner.run", return_value=self.audit):
+            runner.audit(self._subject(imgs=[ImageRef("u")]))
+        self.loader.load.assert_not_called()
+        self.assertEqual(build.call_args.args[2], self.cfg.deepseek_model)
+
+
+class ImageBlockedPassTest(unittest.TestCase):
+    """Pass 2 — the backlog of cards a blind model could not judge."""
+
+    def _pass(self, cards, comments, attachments=None, cfg=None):
+        trello = FakeTrello(comments, attachments)
+        runner = FakeRunner()
+        passes = AuditPass(cfg or make_config(), trello, runner)
+        return passes, trello, runner, cards
+
+    def test_a_blocked_card_with_a_picture_is_audited_again(self):
+        card = make_card("c1", "Crash", labels=("lbl",), comment_count=1,
+                         attachment_count=1)
+        passes, trello, runner, cards = self._pass(
+            [card],
+            {"c1": [make_comment("⚠️ **NEED MORE INFO** — screenshots only")]},
+            {"c1": [ImageRef("http://t/x.png", "x.png", "card attachment")]},
+        )
+        passes.image_blocked(cards, {})
+        self.assertEqual(len(runner.seen), 1)
+        self.assertEqual(trello.comments_posted[0][0], "c1")
+        # Already labelled — the pass must not label it twice.
+        self.assertEqual(trello.labels, [])
+
+    def test_a_blocked_card_without_any_picture_is_left_alone(self):
+        card = make_card("c1", "Vague", labels=("lbl",), comment_count=1)
+        passes, trello, runner, cards = self._pass(
+            [card], {"c1": [make_comment("⚠️ **NEED MORE INFO** — no repro steps")]}
+        )
+        passes.image_blocked(cards, {})
+        self.assertEqual(runner.seen, [])
+        self.assertEqual(trello.comments_posted, [])
+
+    def test_a_card_the_vision_model_already_saw_is_not_reopened(self):
+        card = make_card("c1", "Crash", labels=("lbl",), comment_count=1,
+                         attachment_count=1)
+        passes, trello, runner, cards = self._pass(
+            [card],
+            {"c1": [make_comment("v " + audit_comment.marker("vision", 2, True))]},
+            {"c1": [ImageRef("http://t/x.png")]},
+        )
+        passes.image_blocked(cards, {})
+        self.assertEqual(runner.seen, [])
+
+    def test_a_linked_card_is_re_read_from_its_discord_thread(self):
+        card = make_card("c1", "Crash", desc="discord-thread:42",
+                         labels=("lbl",), comment_count=1)
+        post = ForumPost("42", "Crash", "see pic", (), 1, "http://d/42",
+                         (ImageRef("http://cdn/s.png", "s.png", "original post"),))
+        passes, trello, runner, cards = self._pass(
+            [card], {"c1": [make_comment("⚠️ **NEED MORE INFO**")]}
+        )
+        passes.image_blocked(cards, {"42": post})
+        self.assertEqual(len(runner.seen), 1)
+        self.assertEqual(runner.seen[0].key, "42")  # the thread, not the card
+
+    def test_the_whole_pass_is_off_when_vision_is(self):
+        card = make_card("c1", "Crash", labels=("lbl",), comment_count=1,
+                         attachment_count=1)
+        passes, trello, runner, cards = self._pass(
+            [card],
+            {"c1": [make_comment("⚠️ **NEED MORE INFO** — screenshots only")]},
+            {"c1": [ImageRef("http://t/x.png")]},
+            cfg=make_config(vision_enabled=False),
+        )
+        passes.image_blocked(cards, {})
+        self.assertEqual(runner.seen, [])
+        self.assertEqual(trello.comment_reads, 0)  # not even a board read
+
+    def test_the_cap_stops_the_pass(self):
+        cards = [
+            make_card(f"c{i}", "Crash", labels=("lbl",), comment_count=1,
+                      attachment_count=1)
+            for i in range(4)
+        ]
+        comments = {c.id: [make_comment("⚠️ **NEED MORE INFO**")] for c in cards}
+        attach = {c.id: [ImageRef(f"http://t/{c.id}.png")] for c in cards}
+        passes, trello, runner, cards = self._pass(
+            cards, comments, attach, cfg=make_config(max_reaudits_per_run=2)
+        )
+        passes.image_blocked(cards, {})
+        self.assertEqual(len(runner.seen), 2)
+
+
+class BoardPassTest(unittest.TestCase):
+    """Pass 3 — cards nobody mirrored from Discord and nobody audited."""
+
+    def test_hand_written_unlabelled_cards_are_audited_and_labelled(self):
+        card = make_card("c1", "Audio cuts out", desc="since 0.7")
+        trello, runner = FakeTrello(), FakeRunner()
+        AuditPass(make_config(), trello, runner).board([card])
+        self.assertEqual([s.key for s in runner.seen], ["c1"])
+        self.assertEqual(trello.labels, [("c1", "lbl")])
+
+    def test_linked_or_audited_or_skip_listed_cards_are_left_alone(self):
+        cards = [
+            make_card("c1", desc="discord-thread:7"),          # the forum owns it
+            make_card("c2", labels=("lbl",)),                   # already audited
+            make_card("c3", list_id="done"),                    # excluded column
+        ]
+        trello, runner = FakeTrello(), FakeRunner()
+        cfg = make_config(trello_skip_list_ids=("done",))
+        AuditPass(cfg, trello, runner).board(cards)
+        self.assertEqual(runner.seen, [])
+
+    def test_a_card_audited_before_the_label_existed_is_not_redone(self):
+        card = make_card("c1", comment_count=1)
+        trello = FakeTrello({"c1": [make_comment("🤖 **Automated audit** — ...")]})
+        runner = FakeRunner()
+        AuditPass(make_config(), trello, runner).board([card])
+        self.assertEqual(runner.seen, [])
+
+    def test_one_card_is_never_audited_by_two_passes(self):
+        card = make_card("c1", "Crash", comment_count=1, attachment_count=1)
+        trello = FakeTrello(
+            {"c1": [make_comment("⚠️ **NEED MORE INFO** — screenshots only")]},
+            {"c1": [ImageRef("http://t/x.png")]},
+        )
+        runner = FakeRunner()
+        passes = AuditPass(make_config(), trello, runner)
+        passes.image_blocked([card], {})
+        passes.board([card])
+        self.assertEqual(len(runner.seen), 1)
+
+    def test_the_cap_stops_the_pass(self):
+        cards = [make_card(f"c{i}", "Bug") for i in range(5)]
+        trello, runner = FakeTrello(), FakeRunner()
+        cfg = make_config(max_board_audits_per_run=2)
+        AuditPass(cfg, trello, runner).board(cards)
+        self.assertEqual(len(runner.seen), 2)
+
+    def test_a_failing_audit_is_counted_not_raised(self):
+        trello, runner = FakeTrello(), FakeRunner(boom=True)
+        passes = AuditPass(make_config(), trello, runner)
+        passes.board([make_card("c1")])
+        self.assertEqual(passes.failures, 1)
+        self.assertEqual(trello.comments_posted, [])
+
+    def test_has_work_is_false_on_a_fully_audited_board(self):
+        cards = [make_card("c1", labels=("lbl",)), make_card("c2", desc="discord-thread:7")]
+        passes = AuditPass(make_config(), FakeTrello(), FakeRunner())
+        self.assertFalse(passes.has_work(cards))
+
+    def test_has_work_spots_a_hand_written_card(self):
+        passes = AuditPass(make_config(), FakeTrello(), FakeRunner())
+        self.assertTrue(passes.has_work([make_card("c1")]))
+
+    def test_card_reads_are_cached_across_passes(self):
+        card = make_card("c1", comment_count=1)
+        trello = FakeTrello({"c1": [make_comment("human note")]})
+        passes = AuditPass(make_config(), trello, FakeRunner())
+        passes.has_work([card])
+        passes.board([card])
+        self.assertEqual(trello.comment_reads, 1)
+
+
+class MirrorBodyTest(unittest.TestCase):
+    def test_the_footer_says_images_are_readable_now(self):
+        post = ForumPost("1", "Crash", "boom", (), 2, "http://d/1",
+                         (ImageRef("u", "a.png", "original post"),))
+        body = mirror.card_body(post)
+        self.assertIn("Attachments: 2, 1 of them image(s) the triage agent reads",
+                      body)
+        self.assertIn("discord-thread:1", body)
+
+    def test_a_thread_with_no_readable_image_says_so(self):
+        post = ForumPost("1", "Crash", "boom", (), 1, "http://d/1", ())
+        self.assertIn("(no readable image among them)", mirror.card_body(post))
+
+
+class EndToEndTest(unittest.TestCase):
+    """One full `main()` with every boundary faked: does the wiring hold?"""
+
+    def test_a_run_covers_all_three_passes(self):
+        import triage
+
+        post = ForumPost(
+            thread_id="42", title="Crash on export", body="", replies=(),
+            attachment_count=1, url="http://d/42",
+            images=(ImageRef("http://cdn/s.png", "s.png", "original post"),),
+        )
+        blocked = make_card("c-blocked", "Old report", labels=("lbl",),
+                            comment_count=1, attachment_count=1)
+        hand = make_card("c-hand", "Audio cuts out", desc="since 0.7")
+
+        trello = FakeTrello(
+            {"c-blocked": [make_comment("⚠️ **NEED MORE INFO** — screenshots only")]},
+            {"c-blocked": [ImageRef("http://t/x.png", "x.png", "card attachment")]},
+        )
+        trello.fetch_cards = lambda: [blocked, hand]
+        trello.set_desc = lambda *a: None
+        trello.create_card = lambda *a: "c-new"
+
+        discord = mock.Mock()
+        discord.fetch_posts.return_value = [post]
+
+        audit = mock.Mock(needs_more_info=False, is_actionable=True, severity="low",
+                          summary="s", root_cause="r", proposed_fix="f",
+                          relevant_files=[], confidence="low", notes="",
+                          image_findings="a red dialog")
+        loaded = LoadedImage(ImageRef("u", "a.png"), PNG, "image/png")
+
+        with mock.patch.object(triage.Config, "load", staticmethod(make_config)), \
+             mock.patch.object(triage, "DiscordClient", return_value=discord), \
+             mock.patch.object(triage, "TrelloClient", return_value=trello), \
+             mock.patch.object(images.ImageLoader, "_download", return_value=loaded), \
+             mock.patch("runner.build_agent"), \
+             mock.patch("runner.run", return_value=audit) as run:
+            self.assertEqual(triage.main(), 0)
+
+        # One audit per pass: the new card, the blocked card, the hand-written one.
+        commented = [cid for cid, _ in trello.comments_posted]
+        self.assertEqual(commented, ["c-new", "c-blocked", "c-hand"])
+        self.assertEqual(run.call_count, 3)
+        # The screenshot-only thread reached a model instead of being written off.
+        self.assertTrue(all(c.args[2] for c in run.call_args_list[:2]))
+        for _, text in trello.comments_posted:
+            self.assertIn("glaze-triage:v2", text)
+
+    def test_a_quiet_board_never_builds_an_agent(self):
+        import triage
+
+        cards = [make_card("c1", labels=("lbl",), desc="discord-thread:7")]
+        trello = FakeTrello()
+        trello.fetch_cards = lambda: cards
+        discord = mock.Mock()
+        discord.fetch_posts.return_value = []
+
+        with mock.patch.object(triage.Config, "load", staticmethod(make_config)), \
+             mock.patch.object(triage, "DiscordClient", return_value=discord), \
+             mock.patch.object(triage, "TrelloClient", return_value=trello), \
+             mock.patch("runner.build_agent") as build:
+            self.assertEqual(triage.main(), 0)
+        build.assert_not_called()
+        self.assertEqual(trello.comments_posted, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bug_triage/trello_client.py
+++ b/tools/bug_triage/trello_client.py
@@ -1,7 +1,13 @@
 """Trello REST access. The board holds the triage state (which Discord thread
-already has a card, and whether it was audited); we never store state elsewhere.
-It is not a work queue — the agent only ever acts on cards that carry a Discord
-marker, and finds them by walking the forum, not the board.
+already has a card, whether it was audited, and — since the vision pass — how
+that audit ended); we never store state elsewhere.
+
+The board is now read as a work queue too, not only as a cross-check for the
+forum: after the Discord phase the run sweeps cards that carry no Discord marker
+and no audited label, and re-visits cards whose audit was blocked on a
+screenshot. That means reading each card's attachments and comments, so those
+two calls live here as well — made only for cards whose badges say there is
+something to fetch.
 
 De-dup contract: every card that tracks a Discord post carries a hidden marker
 line in its description:
@@ -21,12 +27,60 @@ from dataclasses import dataclass
 
 import requests
 
+from images import ImageRef
+
 _API = "https://api.trello.com/1"
 _MARKER_RE = re.compile(r"discord-thread:(\d+)")
+# How many comments of one card are replayed. A bug card does not have a
+# thousand; the cap only stops a runaway request.
+_MAX_COMMENTS = 50
+_IMAGE_URL_RE = re.compile(r"\.(?:png|jpe?g|gif|webp)(?:\?|$)", re.IGNORECASE)
+# Bare or markdown-embedded links inside a comment body.
+_URL_IN_TEXT_RE = re.compile(r"https?://[^\s<>()\[\]\"']+", re.IGNORECASE)
+# The bookkeeping footer a card grows: markers and back-links, no bug content.
+_FOOTER_LINE_RE = re.compile(
+    r"^(?:---|discord-thread:\d+|(?:Also )?[Rr]eported on Discord:.*|"
+    r"Attachments:.*)$\n?",
+    re.MULTILINE,
+)
 
 
 def marker_for(thread_id: str) -> str:
     return f"discord-thread:{thread_id}"
+
+
+def strip_markers(desc: str) -> str:
+    """Card text without the bookkeeping footer.
+
+    The `discord-thread:` markers and back-links say nothing about what the bug
+    is, and on a card that already collected several reports they would crowd
+    out the part a model has to judge.
+    """
+    return _FOOTER_LINE_RE.sub("", desc).strip()
+
+
+def image_refs_in_text(text: str, origin: str) -> list[ImageRef]:
+    """Image links pasted into a card description or comment.
+
+    Trello has no attachment concept for comments, so a screenshot discussed in
+    a comment is a URL in its body — usually the card's own attachment link.
+    """
+    return [
+        ImageRef(url=u.rstrip(".,);"), name="", origin=origin)
+        for u in _URL_IN_TEXT_RE.findall(text)
+        if _IMAGE_URL_RE.search(u) or "/attachments/" in u
+    ]
+
+
+@dataclass(frozen=True)
+class Comment:
+    """One `commentCard` action: what a human (or this agent) said on a card."""
+
+    id: str
+    text: str
+    author: str
+    author_id: str
+    date: str
 
 
 @dataclass(frozen=True)
@@ -36,6 +90,11 @@ class Card:
     desc: str
     list_id: str
     label_ids: tuple[str, ...]
+    url: str = ""
+    # From the card's badges — how many attachments / comments it carries.
+    # Zero means the per-card fetches below can be skipped entirely.
+    attachment_count: int = 0
+    comment_count: int = 0
 
     @property
     def discord_thread_ids(self) -> tuple[str, ...]:
@@ -54,6 +113,24 @@ class Card:
             return int(self.id[:8], 16)
         except ValueError:
             return 0
+
+    @property
+    def is_discord_linked(self) -> bool:
+        return bool(self.discord_thread_ids)
+
+
+def _card_from_json(c: dict) -> Card:
+    badges = c.get("badges") or {}
+    return Card(
+        id=c["id"],
+        name=c.get("name", ""),
+        desc=c.get("desc", ""),
+        list_id=c.get("idList", ""),
+        label_ids=tuple(c.get("idLabels", [])),
+        url=c.get("shortUrl", ""),
+        attachment_count=int(badges.get("attachments") or 0),
+        comment_count=int(badges.get("comments") or 0),
+    )
 
 
 class TrelloClient:
@@ -74,18 +151,76 @@ class TrelloClient:
         raw = self._req(
             "GET",
             f"/boards/{self._board_id}/cards",
-            fields="name,desc,idList,idLabels",
+            fields="name,desc,idList,idLabels,shortUrl,badges",
         )
-        return [
-            Card(
-                id=c["id"],
-                name=c.get("name", ""),
-                desc=c.get("desc", ""),
-                list_id=c.get("idList", ""),
-                label_ids=tuple(c.get("idLabels", [])),
+        return [_card_from_json(c) for c in raw]  # type: ignore[union-attr]
+
+    def fetch_attachments(self, card: Card) -> list[ImageRef]:
+        """The card's image attachments, as refs (nothing is downloaded here).
+
+        Trello reports the attachment count in the card's badges, so a card
+        with none costs no request at all.
+        """
+        if not card.attachment_count:
+            return []
+        try:
+            raw = self._req(
+                "GET",
+                f"/cards/{card.id}/attachments",
+                fields="name,url,mimeType,bytes",
             )
-            for c in raw  # type: ignore[union-attr]
+        except requests.RequestException as e:
+            print(f"[trello] attachments unavailable for {card.id}: {e}")
+            return []
+        refs: list[ImageRef] = []
+        for a in raw:  # type: ignore[union-attr]
+            url = a.get("url") or ""
+            if not url:
+                continue
+            mime = (a.get("mimeType") or "").lower()
+            if not (mime.startswith("image/") or _IMAGE_URL_RE.search(url)):
+                continue
+            refs.append(
+                ImageRef(url=url, name=a.get("name", ""), origin="card attachment")
+            )
+        return refs
+
+    def fetch_comments(self, card: Card) -> list[Comment]:
+        """The card's comments, oldest first. Skipped when the badge says none."""
+        if not card.comment_count:
+            return []
+        try:
+            raw = self._req(
+                "GET",
+                f"/cards/{card.id}/actions",
+                filter="commentCard",
+                limit=_MAX_COMMENTS,
+            )
+        except requests.RequestException as e:
+            print(f"[trello] comments unavailable for {card.id}: {e}")
+            return []
+        out = [
+            Comment(
+                id=a.get("id", ""),
+                text=((a.get("data") or {}).get("text") or "").strip(),
+                author=((a.get("memberCreator") or {}).get("username") or "unknown"),
+                author_id=a.get("idMemberCreator", ""),
+                date=a.get("date", ""),
+            )
+            for a in raw  # type: ignore[union-attr]
         ]
+        out.reverse()  # the API returns newest-first; audit history reads forward
+        return out
+
+    def me(self) -> str:
+        """The member id this token acts as — that is what marks our own
+        comments as ours when a card's audit history is replayed."""
+        try:
+            m = self._req("GET", "/members/me", fields="id")
+            return str(m.get("id", ""))  # type: ignore[union-attr]
+        except requests.RequestException as e:
+            print(f"[trello] could not identify the token's member: {e}")
+            return ""
 
     def create_card(self, list_id: str, name: str, desc: str) -> str:
         if self._dry_run:

--- a/tools/bug_triage/triage.py
+++ b/tools/bug_triage/triage.py
@@ -1,28 +1,26 @@
 """Orchestrator. Runs once per invocation (the workflow schedules it daily).
 
-Discord is the only work queue: the run walks the open forum threads and uses
-Trello purely to cross-check them. The board is never scanned for work of its
-own, so a card written by hand — anywhere on the board, in any list — is never
-picked up, commented on or labelled by this agent.
+Discord is still the primary work queue, but it is no longer the only one: after
+the forum is mirrored and audited, the board itself is swept twice — once for
+cards whose earlier audit gave up on a screenshot, once for cards nobody
+mirrored from Discord at all.
 
-Flow (only the audit step touches the LLM):
+Flow (only the audit passes touch the LLM):
   1. Pull the open Discord forum posts.
-  2. Pull Trello cards ONCE, to index them by their `discord-thread:<id>`
-     markers. That index answers two questions per thread and nothing else:
-     does it already have a card, and was that card already audited?
-  3. Any thread with no card of its own -> check whether one of the board's
-     cards already reports that same bug (matcher.py, one DeepSeek call).
-     Candidates include cards a human typed in AND cards earlier threads
-     produced, so a second thread about a known bug lands on the card that
-     reported it first instead of opening a duplicate. On a hit, append the
-     marker + back-link to that card; otherwise create a new card.
-  4. EARLY EXIT: if every thread already carries the audited label, stop
-     before the (far more expensive) audit agent is ever built. A run with no
-     new threads and nothing to audit spends zero tokens.
-  5. For each remaining thread: run the agent on that ONE report (title +
-     post + replies, read live from Discord), post the result as a comment on
-     its card, then apply the "audited" label. A card that collected several
-     threads is audited once, on the first of them.
+  2. Pull Trello cards ONCE, and index them by their `discord-thread:<id>`
+     markers: does this thread already have a card, and was that card audited?
+  3. mirror.py — any thread with no card of its own either joins the card that
+     already reports that bug (one DeepSeek text call) or gets a new one.
+  4. EARLY EXIT: nothing to audit in any of the three passes -> stop before the
+     agents are ever built. A quiet day still spends zero tokens.
+  5. Pass 1 (discord): every open thread whose card lacks the audited label.
+     A report carrying screenshots goes to the vision model with the pictures
+     attached; a text-only report stays on the cheap text model.
+  6. Pass 2 (reaudit): cards whose recorded verdict was "blocked on images" —
+     the backlog the text-only era left behind — judged again with their
+     pictures. Retires itself per card once a vision verdict exists.
+  7. Pass 3 (board): cards with no Discord marker and no audited label, i.e.
+     hand-written ones. Title, description, comments and attached images.
 
 Nothing here ever modifies source code or opens a PR.
 """
@@ -30,65 +28,42 @@ Nothing here ever modifies source code or opens a PR.
 from __future__ import annotations
 
 import sys
-from dataclasses import replace
 
-from auditor import build_agent, format_comment
+import mirror
+from audit_pass import AuditPass
 from config import Config
 from discord_client import DiscordClient, ForumPost
-from matcher import build_matcher, find_existing_card
-from trello_client import Card, TrelloClient, marker_for
-
-# Below this much readable text a report cannot be audited at all, so we skip
-# the LLM entirely and ask a human for details instead of burning tokens.
-_MIN_REPORT_CHARS = 15
+from images import ImageLoader
+from runner import AuditRunner
+from trello_client import Card, TrelloClient
 
 
-def _card_body(post: ForumPost) -> str:
-    """Title/body/replies of one thread, plus the de-dup marker footer."""
-    parts = [post.body.strip() or "(no text in the original post)"]
+def _audit_queue(
+    posts: list[ForumPost],
+    by_thread: dict[str, Card],
+    audited_label_id: str,
+) -> list[tuple[ForumPost, Card]]:
+    """Threads still needing a first audit, one entry per card.
 
-    if post.replies:
-        parts.append("**Replies from the thread:**")
-        parts.extend(f"- {r}" for r in post.replies)
-
-    footer = ["---"]
-    if post.attachment_count:
-        footer.append(
-            f"Attachments: {post.attachment_count} — images are NOT readable by "
-            f"the triage agent."
-        )
-    footer.append(f"Reported on Discord: {post.url}")
-    footer.append(marker_for(post.thread_id))
-
-    return "\n\n".join(parts) + "\n\n" + "\n".join(footer)
-
-
-def _linked_desc(card: Card, post: ForumPost) -> str:
-    """A human-written card's description with the Discord link glued on.
-
-    Only the footer is appended — whatever a human typed stays untouched, so
-    linking a card can never destroy the report they wrote.
+    Driven by the forum, never by the board: a thread is a candidate only if its
+    card is missing the audited label. Threads whose card creation was capped
+    during mirroring simply wait for the next run. Duplicates share a card, and
+    a card is audited once — the later threads add their link, not a second
+    audit of the same bug.
     """
-    return (
-        f"{card.desc.rstrip()}\n\n---\n"
-        f"Also reported on Discord: {post.url}\n"
-        f"{marker_for(post.thread_id)}"
-    )
-
-
-def _report_text(post: ForumPost) -> str:
-    """The human-written part of a thread — what the auditor has to read."""
-    return "\n".join([post.body, *post.replies]).strip()
-
-
-def _unreadable_comment(source_url: str) -> str:
-    return (
-        f"⚠️ **NEED MORE INFO** — this report carries no readable "
-        f"text.\nSource: {source_url}\n\n"
-        f"It looks like screenshots or attachments only. Please add: what you "
-        f"did, what you expected, and what happened instead.\n\n"
-        f"*(No audit was performed. Nothing was changed.)*"
-    )
+    queue: list[tuple[ForumPost, Card]] = []
+    claimed: set[str] = set()
+    for p in posts:
+        card = by_thread.get(p.thread_id)
+        if card is None or audited_label_id in card.label_ids:
+            continue
+        if card.id in claimed:
+            print(f"[triage] thread {p.thread_id} shares card {card.id} with an "
+                  f"earlier thread — no second audit")
+            continue
+        claimed.add(card.id)
+        queue.append((p, card))
+    return queue
 
 
 def main() -> int:
@@ -105,128 +80,51 @@ def main() -> int:
         cfg.trello_key, cfg.trello_token, cfg.trello_board_id, dry_run=cfg.dry_run
     )
 
-    # --- Step 1+2: the forum is the queue, the board is only the cross-check --
+    # --- Step 1+2: the forum queue and the board index ----------------------
     posts = discord.fetch_posts()
     cards = trello.fetch_cards()
-    by_thread: dict[str, Card] = {
-        tid: c for c in cards for tid in c.discord_thread_ids
-    }
-    print(f"[triage] discord posts={len(posts)} trello cards={len(cards)} "
-          f"already-linked-threads={len(by_thread)}")
+    by_thread: dict[str, Card] = {tid: c for c in cards for tid in c.discord_thread_ids}
+    images_seen = sum(len(p.images) for p in posts)
+    print(f"[triage] discord posts={len(posts)} (images={images_seen}) "
+          f"trello cards={len(cards)} already-linked-threads={len(by_thread)}")
 
     # --- Step 3: mirror new Discord posts into Trello -----------------------
-    new_posts = [p for p in posts if p.thread_id not in by_thread]
-    if cfg.max_new_cards_per_run and len(new_posts) > cfg.max_new_cards_per_run:
-        print(f"[triage] {len(new_posts)} new thread(s); capped to "
-              f"{cfg.max_new_cards_per_run} this run (MAX_NEW_CARDS_PER_RUN)")
-        new_posts = new_posts[: cfg.max_new_cards_per_run]
+    mirror.mirror(cfg, trello, posts, cards, by_thread)
 
-    # Every card on the board is a candidate for "this bug is already tracked" —
-    # one a human typed in, or one an earlier thread produced. Cards created
-    # during this run join the pool too, so two duplicate threads in the same
-    # batch also end up on one card.
-    candidates = list(cards)
-    matcher = None  # built lazily: no new threads -> no lookup, no tokens
+    # --- Step 4: is there anything to audit at all? -------------------------
+    queue = _audit_queue(posts, by_thread, cfg.trello_audited_label_id)
+    if cfg.max_audits_per_run and len(queue) > cfg.max_audits_per_run:
+        print(f"[triage] {len(queue)} thread(s) pending; auditing "
+              f"{cfg.max_audits_per_run} this run (MAX_AUDITS_PER_RUN)")
+        queue = queue[: cfg.max_audits_per_run]
 
-    for post in new_posts:
-        hit = None
-        if cfg.match_existing_cards and candidates:
-            if matcher is None:
-                matcher = build_matcher(
-                    cfg.deepseek_api_key, cfg.deepseek_base_url, cfg.deepseek_model
-                )
-            hit = find_existing_card(
-                matcher, post, candidates, cfg.max_match_candidates
-            )
+    # Building the passes costs nothing — both agents are lazy — so the board
+    # scan below can reuse the very cache the passes will run on.
+    passes = AuditPass(
+        cfg,
+        trello,
+        AuditRunner(
+            cfg,
+            ImageLoader(cfg.trello_key, cfg.trello_token, cfg.max_image_bytes),
+        ),
+    )
 
-        if hit is not None:
-            desc = _linked_desc(hit, post)
-            trello.set_desc(hit.id, desc)
-            also = f" (now tracks {len(hit.discord_thread_ids) + 1} threads)"
-            print(f"[triage] linked thread {post.thread_id} to existing card "
-                  f"{hit.id}: {hit.name!r}{also}")
-            linked = replace(hit, desc=desc)
-            by_thread[post.thread_id] = linked
-            candidates[candidates.index(hit)] = linked
-            continue
-
-        body = _card_body(post)
-        new_id = trello.create_card(cfg.trello_new_bug_list_id, post.title, body)
-        print(f"[triage] created card for thread {post.thread_id}: {post.title!r}")
-        fresh = Card(
-            id=new_id,
-            name=post.title,
-            desc=body,
-            list_id=cfg.trello_new_bug_list_id,
-            label_ids=(),
-        )
-        by_thread[post.thread_id] = fresh
-        candidates.append(fresh)
-
-    # --- Step 4: which threads still need an audit? -------------------------
-    # Driven by the forum, never by the board: a thread is a candidate only if
-    # its card is missing the audited label. Threads whose card creation was
-    # capped above simply wait for the next run. Duplicates share a card, and a
-    # card is audited once — the later threads add their link, not a second
-    # audit of the same bug.
-    to_audit: list[tuple[ForumPost, Card]] = []
-    claimed: set[str] = set()
-    for p in posts:
-        card = by_thread.get(p.thread_id)
-        if card is None or cfg.trello_audited_label_id in card.label_ids:
-            continue
-        if card.id in claimed:
-            print(f"[triage] thread {p.thread_id} shares card {card.id} with an "
-                  f"earlier thread — no second audit")
-            continue
-        claimed.add(card.id)
-        to_audit.append((p, card))
-
-    # --- Step 5: early exit before spending any tokens ---------------------
-    if not to_audit:
+    if not queue and not passes.has_work(cards):
         print("[triage] nothing new to audit — exiting before LLM.")
         return 0
 
-    if cfg.max_audits_per_run and len(to_audit) > cfg.max_audits_per_run:
-        print(f"[triage] {len(to_audit)} thread(s) pending; auditing "
-              f"{cfg.max_audits_per_run} this run (MAX_AUDITS_PER_RUN)")
-        to_audit = to_audit[: cfg.max_audits_per_run]
+    # --- Steps 5-7: the three audit passes ---------------------------------
+    passes.discord(queue)
 
-    agent = None  # built lazily: unreadable-only batches never need the LLM
-    failures = 0
+    posts_by_thread = {p.thread_id: p for p in posts}
+    if cfg.reaudit_image_blocked:
+        passes.image_blocked(cards, posts_by_thread)
+    if cfg.audit_board_cards:
+        passes.board(cards)
 
-    for post, card in to_audit:
-        # Cheap path: nothing to read -> ask a human, don't call DeepSeek.
-        if len(_report_text(post)) < _MIN_REPORT_CHARS:
-            trello.add_comment(card.id, _unreadable_comment(post.url))
-            trello.add_label(card.id, cfg.trello_audited_label_id)
-            print(f"[triage] NEED MORE INFO (no text) for thread {post.thread_id}")
-            continue
-
-        if agent is None:
-            print(f"[triage] using model {cfg.deepseek_model}")
-            agent = build_agent(
-                cfg.deepseek_api_key, cfg.deepseek_base_url, cfg.deepseek_model
-            )
-
-        # Read from the thread, not from the card: replies posted after the
-        # card was mirrored are part of the report the agent sees.
-        prompt = f"Bug title: {post.title}\n\nBug report:\n{_card_body(post)}"
-        try:
-            result = agent.run_sync(prompt)
-        except Exception as e:  # noqa: BLE001 — one bad thread must not sink the run
-            print(f"[triage] audit FAILED for thread {post.thread_id}: {e}",
-                  file=sys.stderr)
-            failures += 1
-            continue
-
-        trello.add_comment(card.id, format_comment(result.output, post.url))
-        trello.add_label(card.id, cfg.trello_audited_label_id)
-        flag = " [NEED MORE INFO]" if result.output.needs_more_info else ""
-        print(f"[triage] audited thread {post.thread_id}: {post.title!r}{flag}")
-
-    if failures:
-        print(f"[triage] completed with {failures} audit failure(s).", file=sys.stderr)
+    if passes.failures:
+        print(f"[triage] completed with {passes.failures} audit failure(s).",
+              file=sys.stderr)
         return 1
     return 0
 


### PR DESCRIPTION
The triage agent could not see images, so a report that was a screenshot with three words under it could only ever get a "NEED MORE INFO" comment. DeepSeek's multimodal model reads those, so the pictures now travel into the prompt — and the cards the blind era wrote off are revisited.

## Vision

- Add a vision agent over `DEEPSEEK_VISION_MODEL` (default `deepseek-v4-flash-vision-exp`) in `auditor.build_agent`, used for any report carrying a readable picture; text-only reports stay on the cheaper `DEEPSEEK_MODEL`.
- Collect image attachments and image embeds from Discord threads (`DiscordClient._image_refs`), and attachments plus comment image links from Trello cards (`TrelloClient.fetch_attachments`, `image_refs_in_text`).
- Add `images.py`: download with the auth each host needs (pre-signed Discord CDN links unauthenticated, Trello's own URLs with the OAuth header), sniff the format from the bytes rather than the file name, and cap size and count per audit.
- Fall back to the text model without images when a vision call fails (`AuditRunner.audit`), so an experimental endpoint having a bad day costs a weaker audit rather than a lost report.
- Announce images to the model only when they actually got attached (`AuditSubject.report`), and record what it saw in a new `BugAudit.image_findings` field that is rendered into the comment.

## Board passes

- Every posted comment now ends with a `glaze-triage:v2 mode=… images=… blocked=…` marker recording how that audit ended; pre-marker comments are still recognised by their headline, so the existing backlog is picked up.
- Pass 2 (`AuditPass.image_blocked`) re-audits cards whose verdict was blocked on a screenshot, with the pictures attached. It retires itself per card once a vision verdict exists, so a report that is genuinely missing information is asked once, not daily.
- Pass 3 (`AuditPass.board`) sweeps cards that never came from Discord and carry no audited label, judging title, description, comments and attached images, then labelling them.
- Both passes skip `TRELLO_SKIP_LIST_IDS` columns, share one per-card read cache, and never touch a card an earlier pass already handled.
- The early exit still holds: `AuditPass.has_work` answers "is there anything to do" without an LLM, so a quiet board builds no agent and spends no tokens.

## Structure

- Split the grown orchestrator into `mirror.py`, `subjects.py`, `runner.py`, `audit_pass.py` and `audit_comment.py`; `triage.py` is now a thin orchestrator, per `docs/CODE_STYLE.md`.
- Move `strip_markers` out of `matcher.py` into `trello_client.py`, its only owner.

## Config

New variables, all with defaults, wired through both triage workflows and documented in `tools/bug_triage/README.md`: `DEEPSEEK_VISION_MODEL`, `VISION_ENABLED`, `MAX_IMAGES_PER_AUDIT`, `MAX_IMAGE_BYTES`, `REAUDIT_IMAGE_BLOCKED`, `MAX_REAUDITS_PER_RUN`, `AUDIT_BOARD_CARDS`, `MAX_BOARD_AUDITS_PER_RUN`, `TRELLO_SKIP_LIST_IDS`.

## Verification

- `python -m unittest discover -s tools/bug_triage` — 41 tests, all green: model routing and the vision→text fallback, marker round-trips and legacy-comment detection, pass selection and caps, and a full `main()` with Discord, Trello and the models faked.
- Confirmed Pydantic AI maps `BinaryContent` to the base64 `image_url` block DeepSeek's vision endpoint expects.
- A new `bug-triage` job in `ci.yml` runs those tests on every PR.
- No Dart changed, so `flutter analyze` / `flutter test` were not run locally (no SDK in the agent environment) — CI covers them.
- The agent cannot reach Discord, Trello or DeepSeek, so no live run was performed. Worth one `check_connections.py` and one `DRY_RUN=true` run before the first real one: on a board that has never been swept, passes 2 and 3 can find a large backlog, and the check now prints how many cards each would take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSDVc4eiL14YZSeyDsDbVr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSDVc4eiL14YZSeyDsDbVr)_