### PR TITLE
fix(sync): reconciliation order, card rewriter recovery, and in-game time tracking

### DIFF
--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -134,6 +134,11 @@ if (messageData.isEditing) classes.push('editing');
       stack.appendChild(this._createReasoningBlock(reasoning, this._isUser(role)));
     }
 
+    /* --- In-game clock (between reasoning and the main body) --- */
+    if (messageData.gameTime) {
+      stack.appendChild(this._createGameTimeBlock(messageData.gameTime));
+    }
+
     const wrapper = document.createElement('div');
     wrapper.className = 'msg-transition-wrapper';
 
@@ -311,6 +316,14 @@ if (messageData.isEditing) classes.push('editing');
     block.appendChild(header);
     block.appendChild(content);
     return block;
+  }
+
+  /* ----- In-game clock (ledger-stamped, display-only) ----- */
+  _createGameTimeBlock(gameTime) {
+    const el = document.createElement('div');
+    el.className = 'msg-game-time';
+    el.textContent = `⏱ ${gameTime}`;
+    return el;
   }
 
   /* ----- Error window ----- */
@@ -724,6 +737,23 @@ if (messageData.isEditing) classes.push('editing');
   }
 
   updateMessageMeta(sectionEl, msg) {
+    // In-game clock: the ledger stamps the message after the turn, so the
+    // element usually appears (or updates) via this live path rather than at
+    // initial render.
+    if (msg.gameTime) {
+      const stack = sectionEl.querySelector('.msg-content-stack');
+      if (stack) {
+        let clock = stack.querySelector('.msg-game-time');
+        if (!clock) {
+          clock = this._createGameTimeBlock(msg.gameTime);
+          const wrapper = stack.querySelector('.msg-transition-wrapper');
+          stack.insertBefore(clock, wrapper || null);
+        } else {
+          clock.textContent = `⏱ ${msg.gameTime}`;
+        }
+      }
+    }
+
     if (msg.messageIndex !== undefined && msg.messageIndex !== null) {
       sectionEl.dataset.messageIndex = String(msg.messageIndex);
       const idxStr = `#${msg.messageIndex + 1}`;

--- a/assets/chat_webview/styles.css
+++ b/assets/chat_webview/styles.css
@@ -558,6 +558,23 @@
 .reasoning-arrow { transition: transform 0.3s ease; }
 .msg-reasoning.collapsed .reasoning-arrow { transform: rotate(-90deg); }
 
+/* ============================================================
+ * In-game clock (ledger-stamped game time between reasoning and body)
+ * ============================================================ */
+.msg-game-time {
+  font-size: 0.78em;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-gray);
+  background-color: rgba(var(--ui-bg-rgb), var(--element-opacity, 0.8));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 3px 10px;
+  margin-bottom: 6px;
+  align-self: flex-start;
+  user-select: none;
+}
+
 .msg-studio-outputs {
   display: flex;
   flex-direction: column;

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2615,5 +2615,13 @@
   "card_rewriter_studio_stage_history_consolidation": "History consolidation",
   "card_rewriter_studio_stage_card_writer": "Card writer",
   "card_rewriter_studio_stage_card_repair": "Card repair",
-  "card_rewriter_studio_stage_lorebook_writer": "Lorebook writer"
+  "card_rewriter_studio_stage_lorebook_writer": "Lorebook writer",
+  "game_time_seed_title": "Game clock start",
+  "game_time_seed_description": "Anchor the ledger game clock. The day always starts at 0. The date is optional.",
+  "game_time_seed_time_label": "Time (HH:MM)",
+  "game_time_seed_date_label": "Date (DD.MM.YYYY, optional)",
+  "game_time_seed_skip": "Skip",
+  "game_time_seed_confirm": "Start",
+  "game_time_seed_invalid_time": "Enter the time as HH:MM (24-hour).",
+  "game_time_seed_invalid_date": "Enter the date as DD.MM.YYYY or leave it empty."
 }

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2373,7 +2373,7 @@
   "agent_ops_current_commits": "{count} current commits",
   "agent_ops_chain_integrity_failure": "Reconciliation chain integrity failure",
   "agent_ops_no_checkpoint": "No reconciliation checkpoint yet.",
-  "agent_ops_checkpoint": "Checkpoint: {count} messages, ending at {messageId}",
+  "agent_ops_checkpoint": "Checkpoint: {count} messages, ending at message {messageNumber}",
   "agent_ops_run_reconciliation": "Run reconciliation",
   "agent_ops_rerun_ledger": "Rerun latest Ledger",
   "agent_ops_commits": "Commits",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2611,6 +2611,7 @@
   "card_rewriter_studio_status_generating": "Generating",
   "card_rewriter_studio_status_completed": "Completed",
   "card_rewriter_studio_status_pending": "Pending",
+  "card_rewriter_studio_status_prepared": "Prepared (never sent)",
   "card_rewriter_studio_stage_history_consolidation": "History consolidation",
   "card_rewriter_studio_stage_card_writer": "Card writer",
   "card_rewriter_studio_stage_card_repair": "Card repair",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -2402,7 +2402,7 @@
   "agent_ops_current_commits": "Текущих коммитов: {count}",
   "agent_ops_chain_integrity_failure": "Нарушена целостность цепочки сверки",
   "agent_ops_no_checkpoint": "Контрольной точки сверки пока нет.",
-  "agent_ops_checkpoint": "Контрольная точка: сообщений — {count}, последнее — {messageId}",
+  "agent_ops_checkpoint": "Контрольная точка: сообщений — {count}, последнее — сообщение {messageNumber}",
   "agent_ops_run_reconciliation": "Запустить сверку",
   "agent_ops_rerun_ledger": "Повторить последний Ledger",
   "agent_ops_commits": "Коммиты",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -2640,6 +2640,7 @@
   "card_rewriter_studio_status_generating": "Генерация",
   "card_rewriter_studio_status_completed": "Завершён",
   "card_rewriter_studio_status_pending": "Ожидает",
+  "card_rewriter_studio_status_prepared": "Подготовлен (не отправлялся)",
   "card_rewriter_studio_stage_history_consolidation": "Консолидация истории",
   "card_rewriter_studio_stage_card_writer": "Писатель карточки",
   "card_rewriter_studio_stage_card_repair": "Исправление карточки",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -2644,5 +2644,13 @@
   "card_rewriter_studio_stage_history_consolidation": "Консолидация истории",
   "card_rewriter_studio_stage_card_writer": "Писатель карточки",
   "card_rewriter_studio_stage_card_repair": "Исправление карточки",
-  "card_rewriter_studio_stage_lorebook_writer": "Писатель лорбука"
+  "card_rewriter_studio_stage_lorebook_writer": "Писатель лорбука",
+  "game_time_seed_title": "Начало игрового времени",
+  "game_time_seed_description": "Задай точку отсчёта игровых часов леджера. День всегда начинается с 0. Дата необязательна.",
+  "game_time_seed_time_label": "Время (ЧЧ:ММ)",
+  "game_time_seed_date_label": "Дата (ДД.ММ.ГГГГ, необязательно)",
+  "game_time_seed_skip": "Пропустить",
+  "game_time_seed_confirm": "Начать",
+  "game_time_seed_invalid_time": "Введи время в формате ЧЧ:ММ (24 часа).",
+  "game_time_seed_invalid_date": "Введи дату в формате ДД.ММ.ГГГГ или оставь поле пустым."
 }

--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -3937,8 +3937,13 @@ ALLOWED CURRENT-STATE KEYS:
 - npc:Name.relationship_to_user, attitude_to_user, trust_to_user, boundaries, card_overrides, location, current_emotional_residue, current_goal, persistent_condition
 - relationship:A:B.trust, status, relationship, attitude, boundaries, card_override
 - arc:id.status, title, summary, do_not_reopen, card_override
-- world:location, time, date, active_threats, current_conditions
+- world:location, time, date, day, active_threats, current_conditions
 - scene.present_entities, absent_backstory_entities, immediate_thread, active_tensions
+
+GAME CLOCK:
+- Keep world:time as the current in-game time of day in 24h HH:MM and advance it when narrated events imply elapsed time.
+- The clock only moves FORWARD. Never rewind it; flashbacks and memories stay in prose. Past midnight, advance world:day (day 0 = the first story day) and world:date when a date is tracked.
+- Do not invent time skips the narrative does not support; an immediately continuing scene moves time by only a few minutes.
 
 Return the mandatory <glaze_memory_export> JSON block followed by a compact diagnostic <studio_ledger> block. Never expose either in story prose.''';
 

--- a/lib/core/db/repositories/card_evolution_repo.dart
+++ b/lib/core/db/repositories/card_evolution_repo.dart
@@ -304,14 +304,33 @@ class CardEvolutionRepo {
               ..limit(1))
             .getSingleOrNull();
     if (failed != null) {
-      final selected = failed.selectedInputJson;
-      return CardEvolutionClaimOutcome(
-        'failed',
-        selected == null || computeHash(selected) != failed.inputHash
-            ? null
-            : CardEvolutionClaim(row: failed, selectedInputJson: selected),
-        failed.failureCode,
-      );
+      // Validate the failed snapshot the way a real restart would: the stored
+      // input must still reproduce from the current chat and canon. Only a
+      // reproducible claim is recoverable through the manual recovery UI.
+      final selection = await _selectedInputForClaim(failed);
+      final selected = selection.json;
+      if (selected != null) {
+        return CardEvolutionClaimOutcome(
+          'failed',
+          CardEvolutionClaim(row: failed, selectedInputJson: selected),
+          failed.failureCode,
+        );
+      }
+      // The failed snapshot can no longer be reproduced (chat, canon, or the
+      // context format moved on), so no restart can ever succeed. Exit the
+      // restart loop instead of blocking the lane forever: drop the dead
+      // claim with its call chain and select a fresh snapshot below.
+      await (db.delete(
+        db.cardEvolutionWriterCalls,
+      )..where((row) => row.claimId.equals(failed.id))).go();
+      final deleted =
+          await (db.delete(db.cardEvolutionClaims)
+                ..where((row) => row.id.equals(failed.id))
+                ..where((row) => row.status.equals('failed')))
+              .go();
+      if (deleted != 1) {
+        return const CardEvolutionClaimOutcome('busy');
+      }
     }
     final selection = await _selectInput(
       sessionId,
@@ -437,7 +456,28 @@ class CardEvolutionRepo {
     )..where((item) => item.id.equals(claimId))).getSingle();
     final selected = row.selectedInputJson;
     if (selected == null || computeHash(selected) != row.inputHash) {
-      throw StateError('Stored Card Evolution input is invalid');
+      // The stored input is corrupt: put the claim back into its failed state
+      // so the recovery UI keeps showing it instead of stranding a claimed
+      // lease that can never produce a snapshot.
+      await (db.update(db.cardEvolutionClaims)..where(
+            (row) => row.id.equals(claimId) & row.ownerId.equals(ownerId),
+          ))
+          .write(
+            CardEvolutionClaimsCompanion(
+              status: const Value('failed'),
+              leaseExpiresAt: const Value(0),
+              failureCode: const Value('inputHashMismatch'),
+              failureDetail: const Value(
+                'Stored Card Evolution input is invalid',
+              ),
+              failedAt: Value(now),
+            ),
+          );
+      return const CardEvolutionClaimOutcome(
+        'stale',
+        null,
+        'inputHashMismatch',
+      );
     }
     return CardEvolutionClaimOutcome(
       'claimed',

--- a/lib/core/db/repositories/card_evolution_repo.dart
+++ b/lib/core/db/repositories/card_evolution_repo.dart
@@ -1496,7 +1496,14 @@ class CardEvolutionRepo {
       final overlay = overlays['${entry.lorebookId}\u0000${entry.entryId}'];
       final baseContent = overlay?.baseContent ?? entry.rawContent;
       final content = overlay?.content ?? entry.rawContent;
-      final size = baseContent.length + content.length;
+      // The base is materialized only when session evolution diverged from
+      // the source entry. Without an overlay base and content are identical,
+      // and echoing both would double the shared writer context for every
+      // injected entry.
+      final carriesBase = baseContent != content;
+      final size = carriesBase
+          ? baseContent.length + content.length
+          : content.length;
       // Exact content is required for safe anchored lorebook patching. Omit an
       // oversized target rather than truncating and weakening CAS validation.
       if (baseContent.length > _maxLorebookEntryCharacters ||
@@ -1507,7 +1514,7 @@ class CardEvolutionRepo {
       result.add(<String, Object?>{
         'lorebookId': entry.lorebookId,
         'entryId': entry.entryId,
-        'baseContent': baseContent,
+        if (carriesBase) 'baseContent': baseContent,
         'content': content,
         'expectedContentHash': CardCanonicalizer.scalarSha256(content),
       });
@@ -1711,15 +1718,18 @@ Map<String, (String, String)>? _loreTargetsFromInput(String selectedInputJson) {
     if (entries is! List) return null;
     final result = <String, (String, String)>{};
     for (final raw in entries) {
+      // Entries without session evolution carry no separate base; their
+      // current content is the CAS base the model must echo.
+      final base = raw is Map ? raw['baseContent'] ?? raw['content'] : null;
       if (raw is! Map ||
           raw['lorebookId'] is! String ||
           raw['entryId'] is! String ||
-          raw['baseContent'] is! String ||
+          base is! String ||
           raw['expectedContentHash'] is! String) {
         return null;
       }
       result['${raw['lorebookId']}\u0000${raw['entryId']}'] = (
-        raw['baseContent'] as String,
+        base,
         raw['expectedContentHash'] as String,
       );
     }

--- a/lib/core/db/repositories/card_evolution_repo.dart
+++ b/lib/core/db/repositories/card_evolution_repo.dart
@@ -1572,7 +1572,17 @@ class CardEvolutionRepo {
         sessionId: sessionId,
         characterId: characterId,
       );
-      return (input, const EffectiveCanonAssembler().assemble(input));
+      // The automated evolution lane stamps canon with the stable identity:
+      // the per-turn Ledger mutates committed trackers and facts every turn,
+      // which would invalidate every automated proposal within a minute.
+      // Per-operation anchor CAS and evidence validation carry the safety.
+      return (
+        input,
+        const EffectiveCanonAssembler().assemble(
+          input,
+          stampVolatileState: false,
+        ),
+      );
     } catch (_) {
       return null;
     }

--- a/lib/core/db/repositories/manual_rewrite_apply_repo.dart
+++ b/lib/core/db/repositories/manual_rewrite_apply_repo.dart
@@ -141,7 +141,15 @@ class ManualRewriteApplyRepo {
         }
         EffectiveCanonAssembly assembly;
         try {
-          assembly = _assembler.assemble(input);
+          // Automated evolution jobs (proposal != null) are stamped with the
+          // stable identity: the per-turn Ledger mutates committed trackers
+          // and facts after the proposal exists, and per-operation anchor CAS
+          // plus the proposal evidence validation above carry the safety.
+          // Manual jobs keep the full fence.
+          assembly = _assembler.assemble(
+            input,
+            stampVolatileState: proposal == null,
+          );
         } on EffectiveCanonAssemblyUnavailable {
           return const ManualRewriteApplyOutcome.blocked('invalidCanonContext');
         }

--- a/lib/core/llm/fallback_prompt_builder.dart
+++ b/lib/core/llm/fallback_prompt_builder.dart
@@ -17,6 +17,9 @@ PromptResult buildFallbackPrompt(PromptPayload payload) {
     sessionVars: payload.sessionVars,
     globalVars: payload.globalVars,
     macroName: payload.character.macroName,
+    gameTime: payload.gameTime,
+    gameDate: payload.gameDate,
+    gameDay: payload.gameDay,
   );
 
   const systemMessage = PromptMessage(
@@ -29,10 +32,16 @@ PromptResult buildFallbackPrompt(PromptPayload payload) {
     (message) => !message.isHidden && !message.isTyping,
   )) {
     final macroResult = replaceMacros(msg.content, macroCtx);
+    final gameTime = msg.time?.trim();
+    final content = gameTime == null || gameTime.isEmpty
+        ? macroResult.text
+        : macroResult.text.isEmpty
+        ? '[$gameTime]'
+        : '[$gameTime]\n${macroResult.text}';
     history.add(
       PromptMessage(
         role: msg.role,
-        content: macroResult.text,
+        content: content,
         reasoningContent: msg.reasoning,
         isHistory: true,
         sourceMessageId: msg.id,

--- a/lib/core/llm/game_time.dart
+++ b/lib/core/llm/game_time.dart
@@ -1,0 +1,106 @@
+import '../models/tracker.dart';
+
+/// Game clock state kept in the Studio Ledger under `world:` tracker keys.
+///
+/// The ledger maintains three keys:
+/// - `world:time` — current in-game time of day, `HH:MM` (24h);
+/// - `world:date` — optional in-game date, `DD.MM.YYYY`;
+/// - `world:day` — zero-based in-game day counter (day 0 = the day the
+///   story starts).
+///
+/// The clock only ever moves forward: when the narrative advances time, the
+/// ledger bumps `world:time`, rolls it past midnight into `world:date` /
+/// `world:day` as needed, and never rewinds it (flashbacks stay prose, not
+/// clock changes).
+class GameTimeState {
+  const GameTimeState({this.time, this.date, this.day});
+
+  static const String timeKey = 'world:time';
+  static const String dateKey = 'world:date';
+  static const String dayKey = 'world:day';
+
+  /// `HH:MM` in-game time of day, or null when the ledger has none yet.
+  final String? time;
+
+  /// `DD.MM.YYYY` in-game date, or null when the story has no calendar.
+  final String? date;
+
+  /// Zero-based in-game day number, or null when unset.
+  final int? day;
+
+  bool get isEmpty => time == null && date == null && day == null;
+
+  static GameTimeState fromTrackers(Iterable<Tracker> trackers) {
+    String? time;
+    String? date;
+    int? day;
+    for (final tracker in trackers) {
+      final value = tracker.value.trim();
+      if (value.isEmpty) continue;
+      switch (tracker.name) {
+        case timeKey:
+          time = _normalizeTime(value);
+        case dateKey:
+          date = _normalizeDate(value);
+        case dayKey:
+          day = int.tryParse(value);
+      }
+    }
+    return GameTimeState(time: time, date: date, day: day);
+  }
+
+  /// Compact display string: `DD.MM.YYYY · День N · HH:MM` with the parts
+  /// that exist. Returns null when no clock part is known at all.
+  String? format() {
+    if (time == null && date == null && day == null) return null;
+    final parts = <String>[?date, if (day != null) 'День $day', ?time];
+    return parts.join(' · ');
+  }
+
+  /// English display variant used where localization is not available.
+  String? formatEnglish() {
+    if (time == null && date == null && day == null) return null;
+    final parts = <String>[?date, if (day != null) 'Day $day', ?time];
+    return parts.join(' · ');
+  }
+
+  static String? _normalizeTime(String raw) {
+    final match = RegExp(r'(\d{1,2}):(\d{1,2})').firstMatch(raw);
+    if (match == null) return null;
+    final hour = int.parse(match.group(1)!);
+    final minute = int.parse(match.group(2)!);
+    if (hour > 23 || minute > 59) return null;
+    return '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}';
+  }
+
+  static String? _normalizeDate(String raw) {
+    final match = RegExp(r'(\d{2})\.(\d{2})\.(\d{4})').firstMatch(raw);
+    if (match == null) return null;
+    final day = int.parse(match.group(1)!);
+    final month = int.parse(match.group(2)!);
+    if (day < 1 || day > 31 || month < 1 || month > 12) return null;
+    return '${match.group(1)}.${match.group(2)}.${match.group(3)}';
+  }
+
+  /// Expands `{{gametime}}` / `{{gamedate}}` / `{{gameday}}` in user-authored
+  /// injection content (memory book entries, summary templates). Only the
+  /// game-clock macros are touched — the full macro engine is deliberately
+  /// not run over memory content.
+  String expandMacros(String text) {
+    var result = text;
+    if (result.isEmpty) return result;
+    result = result.replaceAllMapped(
+      RegExp(r'\{\{gametime\}\}', caseSensitive: false),
+      (_) => time ?? '',
+    );
+    result = result.replaceAllMapped(
+      RegExp(r'\{\{gamedate\}\}', caseSensitive: false),
+      (_) => date ?? '',
+    );
+    result = result.replaceAllMapped(
+      RegExp(r'\{\{gameday\}\}', caseSensitive: false),
+      (_) => day?.toString() ?? '',
+    );
+    return result;
+  }
+}

--- a/lib/core/llm/generation_context_inputs.dart
+++ b/lib/core/llm/generation_context_inputs.dart
@@ -60,6 +60,12 @@ class GenerationContextInputs {
   final String? arcContent;
   final String? entitiesContent;
   final String? studioSessionStateContent;
+
+  /// In-game clock from ledger `world:*` trackers for `{{gametime}}` /
+  /// `{{gamedate}}` / `{{gameday}}` macros. Null when no clock is tracked.
+  final String? gameTime;
+  final String? gameDate;
+  final String? gameDay;
   final String? characterKnowledgeContent;
   final String? recalledMessagesContent;
   final List<RecalledMessageChunk> recalledMessageChunks;
@@ -109,6 +115,9 @@ class GenerationContextInputs {
     this.arcContent,
     this.entitiesContent,
     this.studioSessionStateContent,
+    this.gameTime,
+    this.gameDate,
+    this.gameDay,
     this.characterKnowledgeContent,
     this.recalledMessagesContent,
     this.recalledMessageChunks = const [],

--- a/lib/core/llm/history_assembler.dart
+++ b/lib/core/llm/history_assembler.dart
@@ -19,7 +19,7 @@ class HistoryAssembler {
       messages.add(
         PromptMessage(
           role: msg.role,
-          content: normalized,
+          content: _withGameTime(normalized, msg),
           reasoningContent: msg.reasoning,
           isHistory: true,
           sourceMessageId: msg.id,
@@ -31,6 +31,16 @@ class HistoryAssembler {
     }
 
     return messages;
+  }
+
+  /// The in-game clock travels with the chat history itself: every message
+  /// stamped by the ledger carries its full game time, so the model sees the
+  /// whole progression of the clock instead of a single current timestamp.
+  String _withGameTime(String content, ChatMessage msg) {
+    final time = msg.time?.trim();
+    if (time == null || time.isEmpty) return content;
+    if (content.isEmpty) return '[$time]';
+    return '[$time]\n$content';
   }
 }
 

--- a/lib/core/llm/macro_engine.dart
+++ b/lib/core/llm/macro_engine.dart
@@ -27,6 +27,15 @@ class MacroContext {
   /// disabled or no state has been written yet.
   final String? studioSessionState;
 
+  /// In-game clock from the ledger (`world:time`, `HH:MM`). `{{gametime}}`.
+  final String? gameTime;
+
+  /// In-game date from the ledger (`world:date`, `DD.MM.YYYY`). `{{gamedate}}`.
+  final String? gameDate;
+
+  /// Zero-based in-game day number from the ledger (`world:day`). `{{gameday}}`.
+  final String? gameDay;
+
   const MacroContext({
     required this.charName,
     this.charDescription,
@@ -49,6 +58,9 @@ class MacroContext {
     this.arcContent,
     this.entitiesContent,
     this.studioSessionState,
+    this.gameTime,
+    this.gameDate,
+    this.gameDay,
   });
 
   /// Context for preset-only token accounting: external injections (character,
@@ -75,6 +87,9 @@ class MacroContext {
       guidanceText: null,
       macroName: null,
       studioSessionState: null,
+      gameTime: null,
+      gameDate: null,
+      gameDay: null,
     );
   }
 
@@ -91,6 +106,9 @@ class MacroContext {
     Object? arcContent = _sentinel,
     Object? entitiesContent = _sentinel,
     Object? studioSessionState = _sentinel,
+    Object? gameTime = _sentinel,
+    Object? gameDate = _sentinel,
+    Object? gameDay = _sentinel,
   }) {
     return MacroContext(
       charName: charName,
@@ -128,6 +146,15 @@ class MacroContext {
       studioSessionState: identical(studioSessionState, _sentinel)
           ? this.studioSessionState
           : studioSessionState as String?,
+      gameTime: identical(gameTime, _sentinel)
+          ? this.gameTime
+          : gameTime as String?,
+      gameDate: identical(gameDate, _sentinel)
+          ? this.gameDate
+          : gameDate as String?,
+      gameDay: identical(gameDay, _sentinel)
+          ? this.gameDay
+          : gameDay as String?,
     );
   }
 
@@ -155,6 +182,9 @@ class MacroContext {
     'arcContent': arcContent,
     'entitiesContent': entitiesContent,
     'studioSessionState': studioSessionState,
+    'gameTime': gameTime,
+    'gameDate': gameDate,
+    'gameDay': gameDay,
   };
 
   factory MacroContext.fromJson(Map<String, dynamic> json) => MacroContext(
@@ -179,6 +209,9 @@ class MacroContext {
     arcContent: json['arcContent'] as String?,
     entitiesContent: json['entitiesContent'] as String?,
     studioSessionState: json['studioSessionState'] as String?,
+    gameTime: json['gameTime'] as String?,
+    gameDate: json['gameDate'] as String?,
+    gameDay: json['gameDay'] as String?,
   );
 }
 
@@ -453,6 +486,24 @@ MacroResult replaceMacros(String text, MacroContext ctx) {
       final now = DateTime.now();
       return '${now.year.toString().padLeft(4, '0')}-${_pad2(now.month)}-${_pad2(now.day)}';
     },
+  );
+
+  // {{gametime}} / {{gamedate}} / {{gameday}} — in-game clock from the Studio
+  // Ledger (world:time / world:date / world:day). Expand to an empty string
+  // when the ledger has not established the clock yet.
+  result = result.replaceAllMapped(
+    RegExp(r'\{\{gametime\}\}', caseSensitive: false),
+    (_) => ctx.gameTime ?? '',
+  );
+
+  result = result.replaceAllMapped(
+    RegExp(r'\{\{gamedate\}\}', caseSensitive: false),
+    (_) => ctx.gameDate ?? '',
+  );
+
+  result = result.replaceAllMapped(
+    RegExp(r'\{\{gameday\}\}', caseSensitive: false),
+    (_) => ctx.gameDay ?? '',
   );
 
   // {{time::UTC±offset}} — current time shifted to the given UTC offset (in

--- a/lib/core/llm/memory_selector.dart
+++ b/lib/core/llm/memory_selector.dart
@@ -190,7 +190,7 @@ class MemorySelector {
       if (!legacyMode &&
           input.sourceWindowExclusion &&
           entry.messageIds.isNotEmpty &&
-          entry.messageIds.any(visibleSet.contains)) {
+          entry.messageIds.every(visibleSet.contains)) {
         scored.add(
           MemoryCandidateScore(
             entry: entry,

--- a/lib/core/llm/prompt/memory_block_injector.dart
+++ b/lib/core/llm/prompt/memory_block_injector.dart
@@ -236,6 +236,8 @@ Map<String, dynamic> finalizeMemoryCoverage(
     'excerptTokensPerChunk': tokensPerChunk,
     'excerptChunksPerEntry': chunksPerEntry,
     'entryIds': excerpted.entries.map((e) => e.id).toList(growable: false),
+    'candidatesTotal': selection.allScores.length,
+    'excludedBySourceWindow': selection.excludedBySourceWindow,
     'budgetTrimmed': excerpted.budgetTrimmed,
     'memoryMacroMissing': memoryMacroMissing,
     'diagnostics': diagnostics,

--- a/lib/core/llm/prompt/memory_block_injector.dart
+++ b/lib/core/llm/prompt/memory_block_injector.dart
@@ -1,5 +1,6 @@
 import '../../models/chat_message.dart';
 import '../context_calculator.dart';
+import '../game_time.dart';
 import '../history_assembler.dart';
 import '../memory_budget.dart';
 import '../memory_diagnostics.dart';
@@ -320,6 +321,7 @@ DeferredMemoryResult finalizeDeferredMemory({
   required ContextCalculator calculator,
   required int lorebookReserve,
   required int vectorLoreTokens,
+  required GameTimeState gameTime,
 }) {
   var breakdown = baseBreakdown;
   final selection = payload.memorySelection!;
@@ -353,8 +355,11 @@ DeferredMemoryResult finalizeDeferredMemory({
 
   if (excerpted.items.isNotEmpty) {
     final rebuilt = resolved.content!;
-    var memoryContent = rebuilt.hardBlockContent;
-    var memoryMacroContent = rebuilt.macroContent;
+    // Game-clock macros in memory entries ({{gametime}} and friends) expand
+    // here so Memory Book content can anchor itself to the current in-game
+    // time without the full macro engine running over entry text.
+    var memoryContent = gameTime.expandMacros(rebuilt.hardBlockContent);
+    var memoryMacroContent = gameTime.expandMacros(rebuilt.macroContent);
     final replacedMacro = replaceDeferredMemoryPlaceholders(
       messages,
       rebuilt.macroContent,

--- a/lib/core/llm/prompt/prompt_payload.dart
+++ b/lib/core/llm/prompt/prompt_payload.dart
@@ -67,6 +67,12 @@ class PromptPayload {
   /// state has been committed for this session yet.
   final String? studioSessionStateContent;
 
+  /// In-game clock from ledger `world:*` trackers for `{{gametime}}` /
+  /// `{{gamedate}}` / `{{gameday}}` macros. Null when no clock is tracked.
+  final String? gameTime;
+  final String? gameDate;
+  final String? gameDay;
+
   /// Scoped atomic character facts committed by Studio Ledger. This is a
   /// separate prompt layer and never mutates the base card payload.
   final String? characterKnowledgeContent;
@@ -159,6 +165,9 @@ class PromptPayload {
     this.arcContent,
     this.entitiesContent,
     this.studioSessionStateContent,
+    this.gameTime,
+    this.gameDate,
+    this.gameDay,
     this.characterKnowledgeContent,
     this.recalledMessagesContent,
     this.recalledMessageChunks = const [],
@@ -258,6 +267,9 @@ class PromptPayload {
       studioSessionStateContent: materialized != null
           ? materialized.studioSessionStateContent
           : (disabled ? null : inputs.studioSessionStateContent),
+      gameTime: inputs.gameTime,
+      gameDate: inputs.gameDate,
+      gameDay: inputs.gameDay,
       characterKnowledgeContent: materialized != null
           ? materialized.characterKnowledgeContent
           : (disabled ? null : inputs.characterKnowledgeContent),
@@ -319,6 +331,9 @@ class PromptPayload {
     arcContent: materialization.arcContent,
     entitiesContent: entitiesContent,
     studioSessionStateContent: materialization.studioSessionStateContent,
+    gameTime: gameTime,
+    gameDate: gameDate,
+    gameDay: gameDay,
     characterKnowledgeContent: materialization.characterKnowledgeContent,
     recalledMessagesContent: recalledMessagesContent,
     recalledMessageChunks: recalledMessageChunks,

--- a/lib/core/llm/prompt_builder.dart
+++ b/lib/core/llm/prompt_builder.dart
@@ -10,6 +10,7 @@ import '../models/preset.dart';
 import '../models/chat_message.dart';
 import '../models/lorebook.dart';
 import 'macro_engine.dart';
+import 'game_time.dart';
 import 'history_assembler.dart';
 import 'context_calculator.dart';
 import 'lorebook_scanner.dart';
@@ -195,6 +196,9 @@ PromptResult _buildPromptOnce(PromptPayload payload) {
     arcContent: payload.arcContent,
     entitiesContent: payload.entitiesContent,
     studioSessionState: payload.studioSessionStateContent,
+    gameTime: payload.gameTime,
+    gameDate: payload.gameDate,
+    gameDay: payload.gameDay,
   );
 
   var currentSessionVars = Map<String, String>.from(payload.sessionVars);
@@ -863,6 +867,11 @@ PromptResult _assembleMessages({
       calculator: calculator,
       lorebookReserve: lorebookReserve,
       vectorLoreTokens: vectorLoreTokens,
+      gameTime: GameTimeState(
+        time: payload.gameTime,
+        date: payload.gameDate,
+        day: int.tryParse(payload.gameDay ?? ''),
+      ),
     );
     breakdown = result.breakdown;
     finalMemorySelection = result.finalMemorySelection;

--- a/lib/core/llm/prompt_payload_builder.dart
+++ b/lib/core/llm/prompt_payload_builder.dart
@@ -21,6 +21,7 @@ import '../state/memory_settings_provider.dart';
 import '../state/summary_providers.dart';
 import 'memory_injection_service.dart';
 import 'memory_retrieval_mode.dart';
+import 'game_time.dart';
 import 'message_recall_service.dart';
 import 'memory_selector.dart';
 import 'generation_context_inputs.dart';
@@ -497,6 +498,9 @@ class PromptPayloadBuilder {
       session: session,
       context: effectiveContext,
     );
+    final gameTimeState = GameTimeState.fromTrackers(
+      ledgerTrackers ?? const <Tracker>[],
+    );
     return GenerationContextInputs(
       character: character,
       persona: persona,
@@ -532,6 +536,9 @@ class PromptPayloadBuilder {
       arcContent: arcContent,
       entitiesContent: entitiesContent,
       studioSessionStateContent: studioSessionStateContent,
+      gameTime: gameTimeState.time,
+      gameDate: gameTimeState.date,
+      gameDay: gameTimeState.day?.toString(),
       characterKnowledgeContent: characterKnowledgeContent,
       recalledMessagesContent: recalledMessagesContent,
       recalledMessageChunks: recalledMessageChunks,
@@ -686,6 +693,9 @@ class PromptPayloadBuilder {
       session: session,
       context: resolvedContext,
     );
+    final gameTimeState = GameTimeState.fromTrackers(
+      projection?.trackers ?? const <Tracker>[],
+    );
     return PromptPayload(
       character: effectiveCharacter,
       persona: persona,
@@ -721,6 +731,9 @@ class PromptPayloadBuilder {
       arcContent: arcContent,
       entitiesContent: entitiesContent,
       studioSessionStateContent: materialized?.studioSessionStateContent,
+      gameTime: gameTimeState.time,
+      gameDate: gameTimeState.date,
+      gameDay: gameTimeState.day?.toString(),
       characterKnowledgeContent: materialized?.characterKnowledgeContent,
       recalledMessagesContent: recalledMessagesContent,
       recalledMessageChunks: const [],

--- a/lib/core/llm/prompt_worker_codec.dart
+++ b/lib/core/llm/prompt_worker_codec.dart
@@ -58,6 +58,9 @@ Map<String, dynamic> serializePayload(PromptPayload p) => {
   'arcContent': p.arcContent,
   'entitiesContent': p.entitiesContent,
   'studioSessionStateContent': p.studioSessionStateContent,
+  'gameTime': p.gameTime,
+  'gameDate': p.gameDate,
+  'gameDay': p.gameDay,
   'characterKnowledgeContent': p.characterKnowledgeContent,
   'recalledMessagesContent': p.recalledMessagesContent,
   'recalledMessageChunks': p.recalledMessageChunks
@@ -189,6 +192,9 @@ PromptPayload deserializePayload(Map<String, dynamic> json) {
             LedgerPromptInjectionMode.disabled
         ? null
         : json['studioSessionStateContent'] as String?,
+    gameTime: json['gameTime'] as String?,
+    gameDate: json['gameDate'] as String?,
+    gameDay: json['gameDay'] as String?,
     characterKnowledgeContent:
         _decodedLedgerPolicy(json).effectiveMode ==
             LedgerPromptInjectionMode.disabled

--- a/lib/core/llm/studio/studio_context_preparer.dart
+++ b/lib/core/llm/studio/studio_context_preparer.dart
@@ -6,6 +6,7 @@ import '../../utils/cast_helpers.dart';
 import '../../models/ledger_prompt_injection_mode.dart';
 import '../../models/ledger_prompt_injection_policy.dart';
 import '../generation_context_inputs.dart';
+import '../game_time.dart';
 import '../history_assembler.dart';
 import '../macro_engine.dart';
 import '../prompt/lorebook_context_resolver.dart';
@@ -102,6 +103,9 @@ final class StudioContextPreparer {
       arcContent: arcContent,
       entitiesContent: inputs.entitiesContent,
       studioSessionState: studioSessionState,
+      gameTime: inputs.gameTime,
+      gameDate: inputs.gameDate,
+      gameDay: inputs.gameDay,
     );
     final lore = const LorebookContextResolver().resolve(
       history: inputs.history,
@@ -255,7 +259,19 @@ final class StudioContextPreparer {
           ? null
           : '${inputs.summaryPrefix ?? ''}${inputs.summaryContent}',
     );
-    add(StudioContextSlot.memory, memoryHardContent ?? inputs.memoryContent);
+    final gameTimeState = GameTimeState(
+      time: inputs.gameTime,
+      date: inputs.gameDate,
+      day: int.tryParse(inputs.gameDay ?? ''),
+    );
+    // Game-clock macros ({{gametime}} and friends) expand in the packed
+    // memory content so Memory Book entries can anchor to in-game time.
+    add(
+      StudioContextSlot.memory,
+      gameTimeState.expandMacros(
+        memoryHardContent ?? inputs.memoryContent ?? '',
+      ),
+    );
     slots[StudioContextSlot.loreBefore]!.addAll(lore.loreBefore);
     slots[StudioContextSlot.loreAfter]!.addAll(lore.loreAfter);
     add(StudioContextSlot.loreMacro, loreMacroContent);

--- a/lib/core/llm/studio_ledger_prompt.dart
+++ b/lib/core/llm/studio_ledger_prompt.dart
@@ -386,7 +386,12 @@ Rules:
 - Relationship keys: relationship:A:B.trust, relationship:A:B.status, relationship:A:B.relationship, relationship:A:B.attitude, relationship:A:B.boundaries, relationship:A:B.card_override
 - Never write npc:*.knowledge or relationship:*.knowledge. Use knowledgeFacts.
 - Arc keys: arc:id.status, arc:id.summary, arc:id.do_not_reopen, arc:id.card_override
-- World/scene keys: world:location, world:time, world:date, world:active_threats, scene.present_entities, scene.absent_backstory_entities''';
+- World/scene keys: world:location, world:time, world:date, world:day, world:active_threats, scene.present_entities, scene.absent_backstory_entities
+- Game clock: keep world:time in 24h HH:MM as the current in-game time of day and
+  advance it when narrated events imply elapsed time. The clock only moves
+  FORWARD — never rewind it; flashbacks stay in prose. Past midnight, advance
+  world:day (day 0 = first story day) and world:date when a date is tracked.
+  Do not invent time skips the narrative does not support.''';
 
   static const String _legacyTurnOnlySystemPrompt =
       '''You are Studio Ledger, an internal continuity and state extractor.

--- a/lib/core/llm/studio_ledger_reconciliation.dart
+++ b/lib/core/llm/studio_ledger_reconciliation.dart
@@ -264,7 +264,14 @@ Knowledge cleanup may only repair facts listed in <knowledge_facts>:
   range explicitly resolves a placeholder or descriptive identity. Never
   rename an already named person into a different named person.
 Never create facts, rewrite fact content, or retract a fact merely because it is
-old or absent from the review range.''';
+old or absent from the review range.
+
+Game clock (world:time, world:date, world:day): advance world:time (24h HH:MM)
+through the review range according to how much in-game time the narrated events
+take, crossing midnight into the next world:day (day 0 = first story day) and
+world:date when tracked. The clock only moves FORWARD — never rewind it; treat
+flashbacks and memories as prose, not clock changes. When the range continues a
+scene immediately, advance time by only a few minutes.''';
   }
 
   List<CharacterKnowledgeFact> relevantKnowledgeFacts(

--- a/lib/core/llm/studio_ledger_service.dart
+++ b/lib/core/llm/studio_ledger_service.dart
@@ -1801,7 +1801,19 @@ Never append history to a state value. Keep each value under 1200 characters.
 Never write npc:*.knowledge or relationship:*.knowledge; durable propositions belong in knowledgeFacts.
 Relationship trust/status/attitude and card overrides are current state and must be updated with set whenever they change.
 Reuse an exact key from <current_state> or <existing_keys> for the same fact; update it with set instead of creating a synonym key.
-Allowed eventState: planned, suggested, threatened, attempted, completed, failed, cancelled, unknown (or omit).''';
+Allowed eventState: planned, suggested, threatened, attempted, completed, failed, cancelled, unknown (or omit).
+
+Game clock (world:time, world:date, world:day):
+- Maintain world:time as the current in-game time of day in 24h HH:MM format.
+- When the final response or chat implies elapsed time, advance world:time to the
+  new in-game time based on how much time the narrated events would take.
+- The game clock only moves FORWARD. Never rewind time; flashbacks and memories
+  stay in prose without touching world:time. When time passes midnight, advance
+  world:day (day 0 is the first day of the story) and world:date when a calendar
+  date is tracked.
+- Do not invent time skips that the narrative does not support. When the scene
+  clearly continues immediately, keep world:time unchanged or move it by only a
+  few minutes.''';
 
     return const StudioAuxPromptAssembler().assemble(
       blocks: ledgerBlocks,

--- a/lib/core/llm/summary_service.dart
+++ b/lib/core/llm/summary_service.dart
@@ -204,7 +204,13 @@ class SummaryService {
     for (final msg in messages) {
       if (msg.role == 'user' || msg.role == 'assistant') {
         final speaker = msg.role == 'user' ? 'User' : 'Character';
-        buf.writeln('$speaker: ${msg.content}');
+        // The ledger-stamped game clock travels with the transcript so the
+        // summary stays time-anchored instead of teleporting across hours.
+        final gameTime = msg.time?.trim();
+        final timePrefix = gameTime == null || gameTime.isEmpty
+            ? ''
+            : '[$gameTime] ';
+        buf.writeln('$speaker: $timePrefix${msg.content}');
       }
     }
     return buf.toString();

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -29,7 +29,7 @@ const _writerMaxTokens = 40000;
 const _writerLeaseSeconds = 600;
 const _writerCollectorBatchSize = 2;
 const _writerSnapshotCharacterLimit = 600000;
-const _writerContextCharacterLimit = 180000;
+const _writerContextCharacterLimit = 400000;
 const _historyConsolidationInstruction =
     'Consolidate this next immutable Card Rewriter evidence segment into a '
     'compact cumulative factual handoff. Preserve all durable character '
@@ -1361,7 +1361,10 @@ class AutomatedCardEvolutionService {
         'Stored writer input cannot be decoded for consolidation',
       );
       return _PreparedWriterContext.failure(
-        _snapshotTooLarge(selectedInputJson.length),
+        _snapshotTooLarge(
+          selectedInputJson.length,
+          limit: _writerContextCharacterLimit,
+        ),
       );
     }
     final history = decoded['chatHistory'];
@@ -1374,7 +1377,10 @@ class AutomatedCardEvolutionService {
         'Stored writer input has no valid chat history',
       );
       return _PreparedWriterContext.failure(
-        _snapshotTooLarge(selectedInputJson.length),
+        _snapshotTooLarge(
+          selectedInputJson.length,
+          limit: _writerContextCharacterLimit,
+        ),
       );
     }
     final common = Map<String, dynamic>.from(decoded)
@@ -1389,7 +1395,11 @@ class AutomatedCardEvolutionService {
         'Shared writer context exceeds the safe request limit',
       );
       return _PreparedWriterContext.failure(
-        _snapshotTooLarge(jsonEncode(common).length, stage: 'shared context'),
+        _snapshotTooLarge(
+          jsonEncode(common).length,
+          stage: 'shared context',
+          limit: _writerContextCharacterLimit,
+        ),
       );
     }
     String? handoff;
@@ -1468,7 +1478,11 @@ class AutomatedCardEvolutionService {
         'Final consolidated writer context exceeds the safe request limit',
       );
       return _PreparedWriterContext.failure(
-        _snapshotTooLarge(context.length, stage: 'final writer context'),
+        _snapshotTooLarge(
+          context.length,
+          stage: 'final writer context',
+          limit: _writerContextCharacterLimit,
+        ),
       );
     }
     return _PreparedWriterContext.context(
@@ -1900,11 +1914,12 @@ class AutomatedCardEvolutionService {
   static CardEvolutionFinalizeOutcome _snapshotTooLarge(
     int actual, {
     String stage = 'snapshot',
+    int limit = _writerSnapshotCharacterLimit,
   }) => CardEvolutionFinalizeOutcome(
     'snapshotTooLarge',
     null,
     'Card Rewriter $stage is $actual characters; the safe request limit is '
-        '$_writerSnapshotCharacterLimit.',
+        '$limit.',
   );
 
   static String _cardWriterContext(String selectedInputJson) {

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -1926,7 +1926,7 @@ class AutomatedCardEvolutionService {
     try {
       final input = Map<String, Object?>.from(
         jsonDecode(selectedInputJson) as Map,
-      );
+      )..remove('card');
       final observations = input['accumulatedObservations'];
       input['accumulatedObservations'] = observations is List
           ? [

--- a/lib/core/services/card_rewriter/automated_card_evolution_service.dart
+++ b/lib/core/services/card_rewriter/automated_card_evolution_service.dart
@@ -446,20 +446,39 @@ class AutomatedCardEvolutionService {
     LedgerReconciliationSuccessfulRunRow reconciliationRun, {
     void Function(AutomatedCardEvolutionStage stage)? onStage,
   }) async {
-    final pending = await collectorRunRepo.pendingValidPairs(
-      reconciliationRun.sessionId,
-      currentRun: reconciliationRun,
-    );
-    for (final pair in pending) {
-      final collected = await _runCollector(pair, onStage: onStage);
-      if (!collected) {
-        return const CardEvolutionFinalizeOutcome('collectorUnavailable');
+    try {
+      final pending = await collectorRunRepo.pendingValidPairs(
+        reconciliationRun.sessionId,
+        currentRun: reconciliationRun,
+      );
+      for (final pair in pending) {
+        final collected = await _runCollector(pair, onStage: onStage);
+        if (!collected) {
+          return const CardEvolutionFinalizeOutcome('collectorUnavailable');
+        }
       }
+      return await _continueWriterAfterCollectors(
+        reconciliationRun.sessionId,
+        onStage: onStage,
+      );
+    } catch (error, stackTrace) {
+      debugPrint(
+        '[CardRewriter] automatic lane failed before a durable writer result: '
+        '$error\n$stackTrace',
+      );
+      await _saveSelectionBail(
+        sessionId: reconciliationRun.sessionId,
+        outcome: 'unexpectedFailure',
+        reason: error.toString(),
+        throughCollectorOrdinal: 0,
+        reconciliationRunIds: [reconciliationRun.id],
+      );
+      return CardEvolutionFinalizeOutcome(
+        'unexpectedFailure',
+        null,
+        error.toString(),
+      );
     }
-    return _continueWriterAfterCollectors(
-      reconciliationRun.sessionId,
-      onStage: onStage,
-    );
   }
 
   Future<CardEvolutionFinalizeOutcome> _continueWriterAfterCollectors(

--- a/lib/core/services/card_rewriter/card_rewrite_operation_parser.dart
+++ b/lib/core/services/card_rewriter/card_rewrite_operation_parser.dart
@@ -198,7 +198,6 @@ abstract final class CardRewriteOperationParser {
         jsonEncode(rawOperation),
         expectedField: field,
         allowEmptyAnchor: false,
-        recomputeAnchorHash: true,
       );
       if (parsed.snapshot == null) {
         final reason = parsed.rejection?.name ?? 'unknown rejection';
@@ -212,6 +211,12 @@ abstract final class CardRewriteOperationParser {
   }
 
   /// Parses the separate writer lane for session-local lorebook patches.
+  ///
+  /// An LLM cannot compute SHA-256 digests, so the model contract no longer
+  /// asks for `anchorSha256`; any model-supplied value is overwritten with
+  /// the recomputed hash before structural validation. The apply layer
+  /// remains the final authority and re-validates anchors against live
+  /// content.
   static List<LorebookRewriteOperationSnapshot>? parseLorebookEvolutionBatch(
     String output,
   ) {
@@ -228,10 +233,23 @@ abstract final class CardRewriteOperationParser {
       final targets = <String>{};
       for (final rawOperation in decoded['operations'] as List) {
         if (rawOperation is! Map) return null;
-        final snapshot = RewriteOperationSnapshotCodec.tryDecode({
+        final normalized = <String, Object?>{
           'target': 'lorebook',
           ...Map<String, Object?>.from(rawOperation),
-        });
+        };
+        final patchesValue = normalized['patches'];
+        if (patchesValue is! List) return null;
+        final patches = <Map<String, Object?>>[];
+        for (final rawPatch in patchesValue) {
+          if (rawPatch is! Map) return null;
+          final patch = Map<String, Object?>.from(rawPatch);
+          final anchor = patch['anchor'];
+          if (anchor is! String) return null;
+          patch['anchorSha256'] = CardCanonicalizer.scalarSha256(anchor);
+          patches.add(patch);
+        }
+        normalized['patches'] = patches;
+        final snapshot = RewriteOperationSnapshotCodec.tryDecode(normalized);
         if (snapshot is! LorebookRewriteOperationSnapshot ||
             !targets.add('${snapshot.lorebookId}\u0000${snapshot.entryId}')) {
           return null;
@@ -248,7 +266,6 @@ abstract final class CardRewriteOperationParser {
     String output, {
     required CardRewriteField expectedField,
     bool allowEmptyAnchor = false,
-    bool recomputeAnchorHash = false,
   }) {
     final raw = extractJsonObject(output);
     if (raw == null) {
@@ -334,11 +351,11 @@ abstract final class CardRewriteOperationParser {
       final value = rawPatch['value'];
       if (scopeKey is! String ||
           anchor is! String ||
-          anchorSha256 is! String ||
+          anchorSha256 != null && anchorSha256 is! String ||
           value is! String) {
         return const CardRewriteOperationParseResult.failure(
           CardRewriteOperationParseRejection.malformedPatch,
-          'patch members scopeKey, anchor, anchorSha256, value must be strings',
+          'patch members scopeKey, anchor, value must be strings',
         );
       }
       final canonicalScopeKey = _canonicalScopeKey(scopeKey);
@@ -353,12 +370,11 @@ abstract final class CardRewriteOperationParser {
           CardRewriteOperationParseRejection.emptyAnchor,
         );
       }
+      // The model cannot compute SHA-256 digests, so the instruction no
+      // longer asks for anchorSha256: any supplied value is advisory and
+      // the hash is always recomputed here. Exact live-anchor checks on
+      // the apply side remain the real safety boundary.
       final computedAnchorHash = CardCanonicalizer.scalarSha256(anchor);
-      if (!recomputeAnchorHash && computedAnchorHash != anchorSha256) {
-        return const CardRewriteOperationParseResult.failure(
-          CardRewriteOperationParseRejection.staleAnchorHash,
-        );
-      }
       if (!AnchoredScalarPatchValidator.preservesMacroTokens(anchor, value)) {
         return const CardRewriteOperationParseResult.failure(
           CardRewriteOperationParseRejection.macroTokensChanged,
@@ -370,9 +386,7 @@ abstract final class CardRewriteOperationParser {
           scopeKey: canonicalScopeKey,
           field: field,
           anchor: anchor,
-          // The automated batch is still bounded by exact live-anchor checks,
-          // but an LLM cannot reliably produce a cryptographic digest.
-          anchorSha256: recomputeAnchorHash ? computedAnchorHash : anchorSha256,
+          anchorSha256: computedAnchorHash,
           value: value,
         ),
       );

--- a/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
+++ b/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
@@ -47,8 +47,8 @@ abstract final class CardRewriterPromptBuilder {
       ..writeln(
         'Respond with exactly one JSON object and nothing else: '
         '{"operations":[{"field":"description|personality|scenario",'
-        '"patches":[{"scopeKey":"...","anchor":"...",'
-        '"anchorSha256":"...","value":"..."}],"transition":'
+        '"patches":[{"scopeKey":"...","anchor":"...","value":"..."}],'
+        '"transition":'
         '{"id":"...","scopeKey":"...","canonicalClaim":"...",'
         '"promotionDestination":"...","affectedTrackerKeys":[],'
         '"factIds":[],"chatSessionId":null}}]}.',
@@ -115,9 +115,7 @@ abstract final class CardRewriterPromptBuilder {
         'transliterate, case-fold, or invent an identity.',
       )
       ..writeln(
-        '- Each anchor must occur exactly once in its current field and its '
-        'anchorSha256 must be present as a string; the application recomputes '
-        'it from the anchor bytes. '
+        '- Each anchor must occur exactly once in its current field. '
         'Empty anchors are forbidden. Use a meaningful literal phrase of at '
         'least 12 code units, never an isolated word, number, punctuation mark, '
         'or identifier. Never '
@@ -289,8 +287,8 @@ NPC-owned facts may patch only an existing supplied injected lorebook entry. Mai
 
 # Response format
 Respond with exactly one JSON object and nothing else:
-{"operations":[{"lorebookId":"...","entryId":"...","baseContent":"...","expectedContentHash":"...","patches":[{"anchor":"...","anchorSha256":"...","value":"..."}]}]}
-Each target may occur at most once. Return an empty "operations" list ONLY when no supported durable update belongs in any supplied target. A Ledger fact is accepted evidence, not a reason to omit an eligible lorebook patch. baseContent and expectedContentHash must exactly echo the supplied target; when a target has no baseContent field, echo its content as baseContent. Each anchor must occur exactly once in its supplied current content; anchorSha256 is its lowercase SHA-256 UTF-8 hash. Use smallest exact fragment replacements, never rewrite an entire entry. Preserve every {{...}} macro token byte-for-byte.
+{"operations":[{"lorebookId":"...","entryId":"...","baseContent":"...","expectedContentHash":"...","patches":[{"anchor":"...","value":"..."}]}]}
+Each target may occur at most once. Return an empty "operations" list ONLY when no supported durable update belongs in any supplied target. A Ledger fact is accepted evidence, not a reason to omit an eligible lorebook patch. baseContent and expectedContentHash must exactly echo the supplied target; when a target has no baseContent field, echo its content as baseContent. Each anchor must occur exactly once in its supplied current content. Use smallest exact fragment replacements, never rewrite an entire entry. Preserve every {{...}} macro token byte-for-byte.
 
 # Instruction
 $instruction''';
@@ -334,7 +332,7 @@ $instruction''';
       )
       ..writeln(
         '{"field":"${field.wireName}","patches":[{"scopeKey":"...","anchor":"...",'
-        '"anchorSha256":"...","value":"..."}],"transition":{"id":"...","scopeKey":"...",'
+        '"value":"..."}],"transition":{"id":"...","scopeKey":"...",'
         '"canonicalClaim":"...","promotionDestination":"...","affectedTrackerKeys":[],'
         '"factIds":[],"chatSessionId":null}}',
       )
@@ -342,7 +340,7 @@ $instruction''';
       ..writeln('- "field" MUST be exactly "${field.wireName}".')
       ..writeln(
         '- "patches" MUST be a non-empty list of objects with exactly the '
-        'keys scopeKey, anchor, anchorSha256, value.',
+        'keys scopeKey, anchor, value.',
       )
       ..writeln(
         '- "scopeKey" MUST parse as one of npc:<subject>, '
@@ -355,11 +353,7 @@ $instruction''';
         '- "anchor" MUST be a literal fragment of the current '
         '"${field.wireName}" text that occurs there EXACTLY ONCE; each anchor '
         'is replaced by its "value". If and only if the current field is empty, '
-        'use an empty anchor with its SHA-256 to initialize it.',
-      )
-      ..writeln(
-        '- "anchorSha256" MUST be the lowercase hex SHA-256 of the anchor\'s '
-        'UTF-8 bytes. The receiver recomputes it and rejects any mismatch.',
+        'use an empty anchor to initialize it.',
       )
       ..writeln(
         '- "transition.id", "transition.canonicalClaim", and '

--- a/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
+++ b/lib/core/services/card_rewriter/card_rewrite_prompt_builder.dart
@@ -290,7 +290,7 @@ NPC-owned facts may patch only an existing supplied injected lorebook entry. Mai
 # Response format
 Respond with exactly one JSON object and nothing else:
 {"operations":[{"lorebookId":"...","entryId":"...","baseContent":"...","expectedContentHash":"...","patches":[{"anchor":"...","anchorSha256":"...","value":"..."}]}]}
-Each target may occur at most once. Return an empty "operations" list ONLY when no supported durable update belongs in any supplied target. A Ledger fact is accepted evidence, not a reason to omit an eligible lorebook patch. baseContent and expectedContentHash must exactly echo the supplied target. Each anchor must occur exactly once in its supplied current content; anchorSha256 is its lowercase SHA-256 UTF-8 hash. Use smallest exact fragment replacements, never rewrite an entire entry. Preserve every {{...}} macro token byte-for-byte.
+Each target may occur at most once. Return an empty "operations" list ONLY when no supported durable update belongs in any supplied target. A Ledger fact is accepted evidence, not a reason to omit an eligible lorebook patch. baseContent and expectedContentHash must exactly echo the supplied target; when a target has no baseContent field, echo its content as baseContent. Each anchor must occur exactly once in its supplied current content; anchorSha256 is its lowercase SHA-256 UTF-8 hash. Use smallest exact fragment replacements, never rewrite an entire entry. Preserve every {{...}} macro token byte-for-byte.
 
 # Instruction
 $instruction''';

--- a/lib/core/services/card_rewriter/effective_canon_assembler.dart
+++ b/lib/core/services/card_rewriter/effective_canon_assembler.dart
@@ -58,7 +58,16 @@ final class EffectiveCanonAssembly {
 class EffectiveCanonAssembler {
   const EffectiveCanonAssembler();
 
-  EffectiveCanonAssembly assemble(EffectiveCanonAssemblyInput input) {
+  /// [stampVolatileState] controls whether per-turn Ledger state (knowledge
+  /// facts and committed trackers) participates in the identity hash. Manual
+  /// rewrite jobs keep the full fence. Automated evolution proposals use the
+  /// stable stamp: the per-turn Ledger mutates committed trackers and facts on
+  /// every turn, and per-operation anchor CAS plus dedicated evidence
+  /// validation already protect the automated lane's targets.
+  EffectiveCanonAssembly assemble(
+    EffectiveCanonAssemblyInput input, {
+    bool stampVolatileState = true,
+  }) {
     if (input.lineage.isEmpty) {
       throw const EffectiveCanonAssemblyUnavailable('Source lineage is empty.');
     }
@@ -79,7 +88,11 @@ class EffectiveCanonAssembler {
       lineage: lineage,
       resolution: resolution,
       requiresBaselineDecision: selection.requiresDecision,
-      identity: _stampIdentity(input, selection.revision),
+      identity: _stampIdentity(
+        input,
+        selection.revision,
+        stampVolatileState: stampVolatileState,
+      ),
     );
   }
 
@@ -130,8 +143,9 @@ class EffectiveCanonAssembler {
 
   String _stampIdentity(
     EffectiveCanonAssemblyInput input,
-    CanonRevisionIdentity revision,
-  ) => _hash(
+    CanonRevisionIdentity revision, {
+    bool stampVolatileState = true,
+  }) => _hash(
     _json({
       'baseline': input.baseline == null
           ? null
@@ -161,36 +175,38 @@ class EffectiveCanonAssembler {
           },
         ),
       ),
-      'facts': _sorted(
-        input.facts.map(
-          (item) => {
-            'id': item.id,
-            'chatSessionId': item.chatSessionId,
-            'knowerKey': item.knowerKey,
-            'knowerName': item.knowerName,
-            'subjectKey': item.subjectKey,
-            'subjectName': item.subjectName,
-            'factClass': item.factClass.wireName,
-            'scopeKey': item.scopeKey,
-            'predicate': item.predicate,
-            'object': item.object,
-            'epistemicState': item.epistemicState.wireName,
-            'confidence': item.confidence,
-            'importance': item.importance,
-            'entities': [...item.entities]..sort(),
-            'topics': [...item.topics]..sort(),
-            'sourceMessageId': item.sourceMessageId,
-            'sourceSwipeId': item.sourceSwipeId,
-            'sourceAgentSwipeId': item.sourceAgentSwipeId,
-            'sourceKind': item.sourceKind,
-            'supersedesId': item.supersedesId,
-            'lifecycle': item.lifecycle.wireName,
-            'basisRevisionNumber': item.basisRevisionNumber,
-            'basisRevisionHash': item.basisRevisionHash,
-          },
+      if (stampVolatileState)
+        'facts': _sorted(
+          input.facts.map(
+            (item) => {
+              'id': item.id,
+              'chatSessionId': item.chatSessionId,
+              'knowerKey': item.knowerKey,
+              'knowerName': item.knowerName,
+              'subjectKey': item.subjectKey,
+              'subjectName': item.subjectName,
+              'factClass': item.factClass.wireName,
+              'scopeKey': item.scopeKey,
+              'predicate': item.predicate,
+              'object': item.object,
+              'epistemicState': item.epistemicState.wireName,
+              'confidence': item.confidence,
+              'importance': item.importance,
+              'entities': [...item.entities]..sort(),
+              'topics': [...item.topics]..sort(),
+              'sourceMessageId': item.sourceMessageId,
+              'sourceSwipeId': item.sourceSwipeId,
+              'sourceAgentSwipeId': item.sourceAgentSwipeId,
+              'sourceKind': item.sourceKind,
+              'supersedesId': item.supersedesId,
+              'lifecycle': item.lifecycle.wireName,
+              'basisRevisionNumber': item.basisRevisionNumber,
+              'basisRevisionHash': item.basisRevisionHash,
+            },
+          ),
         ),
-      ),
-      'committedTrackers': _sorted(input.committedTrackers.map(_tracker)),
+      if (stampVolatileState)
+        'committedTrackers': _sorted(input.committedTrackers.map(_tracker)),
       'manualControls': _sorted(input.manualControls.map(_tracker)),
       'transitionFactRefs': _sorted(
         input.transitionFactRefs.map(

--- a/lib/features/card_rewrite/card_rewriter_studio_sheet.dart
+++ b/lib/features/card_rewrite/card_rewriter_studio_sheet.dart
@@ -734,6 +734,7 @@ class _WriterCallTile extends StatelessWidget {
       leading: Icon(switch (call.status) {
         'completed' => Icons.check_circle_outline,
         'failed' => Icons.error_outline,
+        'prepared' => Icons.pause_circle_outline,
         _ => Icons.hourglass_top,
       }, color: color),
       title: Text(
@@ -843,6 +844,9 @@ String _writerStageLabel(String stage) => switch (stage) {
 String _writerCallStatusLabel(String status) => switch (status) {
   'completed' => 'card_rewriter_studio_status_completed'.tr(),
   'failed' => 'card_rewriter_studio_status_failed'.tr(),
+  // Recovery chains only render failed claims, so a prepared call is always
+  // a checkpoint of an interrupted attempt — never an in-flight request.
+  'prepared' => 'card_rewriter_studio_status_prepared'.tr(),
   _ => 'card_rewriter_studio_status_pending'.tr(),
 };
 

--- a/lib/features/card_rewrite/rewrite_review_provider.dart
+++ b/lib/features/card_rewrite/rewrite_review_provider.dart
@@ -122,6 +122,7 @@ class RewriteReviewController extends Notifier<RewriteReviewUiState> {
     final fresh = await computeFreshCanonIdentity(
       sessionId: job.chatSessionId,
       character: character,
+      stableStamp: isAutomatedEvolutionJob(job),
     );
     final next = fresh == null
         ? RewriteCanonFreshness.unavailable
@@ -133,15 +134,21 @@ class RewriteReviewController extends Notifier<RewriteReviewUiState> {
   }
 
   /// Fresh read-side canon stamp. Null when the assembly is unreadable.
+  /// [stableStamp] mirrors the guarded apply: automated evolution jobs are
+  /// compared against the stable identity that ignores per-turn Ledger
+  /// tracker/fact drift; manual jobs use the full fence.
   Future<String?> computeFreshCanonIdentity({
     required String sessionId,
     required Character character,
+    bool stableStamp = false,
   }) async {
     try {
       final input = await ref
           .read(_canonReaderProvider)
           .readFromSource(sessionId: sessionId, sourceCharacter: character);
-      return const EffectiveCanonAssembler().assemble(input).identity;
+      return const EffectiveCanonAssembler()
+          .assemble(input, stampVolatileState: !stableStamp)
+          .identity;
     } catch (_) {
       return null;
     }
@@ -290,6 +297,7 @@ class RewriteReviewController extends Notifier<RewriteReviewUiState> {
       final stamp = await computeFreshCanonIdentity(
         sessionId: snap.job.chatSessionId,
         character: character,
+        stableStamp: isAutomatedEvolutionJob(snap.job),
       );
       if (stamp == null) {
         return const ManualRewriteApplyOutcome.blocked('invalidCanonContext');

--- a/lib/features/chat/bridge/chat_message_mapper.dart
+++ b/lib/features/chat/bridge/chat_message_mapper.dart
@@ -145,6 +145,7 @@ class ChatMessageMapper {
       if (m.agentSwipes.length > 1)
         'agentSwipeFinalCount': m.agentSwipes.length,
       if (m.genTime != null) 'genTime': m.genTime,
+      if (m.time != null && m.time!.isNotEmpty) 'gameTime': m.time,
       if (m.tokens != null) 'tokens': m.tokens,
       'isError': m.isError,
       if (m.isTyping) 'isTyping': true,

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -16,6 +16,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 import '../../core/debug/perf_debug.dart';
+import '../../core/llm/game_time.dart';
 import '../../core/utils/image_src.dart';
 import '../../core/utils/platform_paths.dart';
 import '../../shared/widgets/glaze_spinner.dart';
@@ -25,10 +26,12 @@ import '../../core/state/character_provider.dart';
 import '../../core/state/active_selection_provider.dart';
 import '../../core/state/memory_settings_provider.dart';
 import '../../core/state/shared_prefs_provider.dart';
+import '../../core/state/studio_turn_config_resolver.dart';
 import '../../shared/theme/app_colors.dart';
 import '../../shared/shell/desktop/desktop_layout_provider.dart'
     show isDesktopLayout;
 import 'widgets/message_actions.dart';
+import 'widgets/game_time_seed_dialog.dart';
 import '../../shared/theme/theme_font_provider.dart';
 import '../../shared/theme/theme_preset.dart';
 import '../../shared/theme/theme_provider.dart';
@@ -893,6 +896,55 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
           ),
       ],
     );
+  }
+
+  /// Before the first message of a Studio chat with the ledger enabled, offer
+  /// to anchor the ledger game clock (world:time / world:date / world:day).
+  /// Best-effort: any failure or a skipped dialog never blocks the send.
+  Future<void> _maybeSeedGameTime() async {
+    try {
+      final session = widget.state.session;
+      if (session == null) return;
+      if (widget.state.messages.any((m) => m.role == 'user')) return;
+      final turnConfig = await ref
+          .read(studioTurnConfigResolverProvider)
+          .resolve(session.id);
+      if (!turnConfig.enabled || !turnConfig.ledgerEnabled) return;
+      final trackerRepo = ref.read(trackerRepoProvider);
+      final existing = await trackerRepo.get(session.id, GameTimeState.timeKey);
+      if (existing != null && existing.value.trim().isNotEmpty) return;
+      if (!mounted) return;
+      final result = await showDialog<GameTimeSeedResult>(
+        context: context,
+        builder: (_) => const GameTimeSeedDialog(),
+      );
+      if (result == null) return;
+      await trackerRepo.upsertValue(
+        session.id,
+        GameTimeState.timeKey,
+        result.time,
+        scope: 'ledger',
+        provenance: 'game_time_seed',
+      );
+      if (result.date != null) {
+        await trackerRepo.upsertValue(
+          session.id,
+          GameTimeState.dateKey,
+          result.date!,
+          scope: 'ledger',
+          provenance: 'game_time_seed',
+        );
+      }
+      await trackerRepo.upsertValue(
+        session.id,
+        GameTimeState.dayKey,
+        '0',
+        scope: 'ledger',
+        provenance: 'game_time_seed',
+      );
+    } catch (_) {
+      // Seeding is best-effort — never block the first send on it.
+    }
   }
 
   /// Guards message sending behind an explicitly selected persona. When no
@@ -1984,6 +2036,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                         if (text.trim().isEmpty) {
                                           return false;
                                         }
+                                        await _maybeSeedGameTime();
                                         final accepted = await ref
                                             .read(
                                               chatProvider(
@@ -2001,6 +2054,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                         if (text.trim().isEmpty) {
                                           return false;
                                         }
+                                        await _maybeSeedGameTime();
                                         final accepted = await ref
                                             .read(
                                               chatProvider(
@@ -2023,6 +2077,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                             guidanceText,
                                             imageDataUrl,
                                           ) async {
+                                            await _maybeSeedGameTime();
                                             final accepted = await ref
                                                 .read(
                                                   chatProvider(

--- a/lib/features/chat/services/current_ledger_injection_preview_service.dart
+++ b/lib/features/chat/services/current_ledger_injection_preview_service.dart
@@ -78,6 +78,24 @@ final class CurrentLedgerInjectionPreviewService {
     required String sessionId,
     String? expectedCharacterId,
   }) async {
+    for (var attempt = 0; ; attempt++) {
+      try {
+        return await _loadOnce(
+          sessionId: sessionId,
+          expectedCharacterId: expectedCharacterId,
+        );
+      } on _PreviewChanged {
+        if (attempt > 0) {
+          throw StateError('Chat or canon changed while building the preview.');
+        }
+      }
+    }
+  }
+
+  Future<CurrentLedgerInjectionPreview> _loadOnce({
+    required String sessionId,
+    String? expectedCharacterId,
+  }) async {
     final session = await _chatRepo.getById(sessionId);
     if (session == null) throw StateError('Chat session not found.');
     if (expectedCharacterId != null &&
@@ -136,7 +154,7 @@ final class CurrentLedgerInjectionPreviewService {
           stamp: canon.stamp,
         );
     if (freshSession != session || !canonIsCurrent) {
-      throw StateError('Chat or canon changed while building the preview.');
+      throw const _PreviewChanged();
     }
 
     final projection = EffectiveCanonPromptProjection.fromContext(canon);
@@ -181,6 +199,10 @@ final class CurrentLedgerInjectionPreviewService {
       gapFiller: materialize(LedgerPromptInjectionMode.gapFiller),
     );
   }
+}
+
+final class _PreviewChanged implements Exception {
+  const _PreviewChanged();
 }
 
 typedef CurrentLedgerInjectionPreviewKey = ({

--- a/lib/features/chat/services/reconciler_view_service.dart
+++ b/lib/features/chat/services/reconciler_view_service.dart
@@ -51,12 +51,14 @@ final class ReconcilerViewSnapshot {
     required this.runs,
     required this.debugRuns,
     required this.checkpoint,
+    required this.checkpointEndMessageOrdinal,
   });
 
   final ReconciliationRunIntegrity integrity;
   final List<ReconciliationRunView> runs;
   final List<LedgerDebugRunRow> debugRuns;
   final LedgerReconciliationCheckpoint? checkpoint;
+  final int? checkpointEndMessageOrdinal;
 
   bool get chainIsValid => integrity is ReconciliationRunValid;
 }
@@ -116,6 +118,9 @@ class ReconcilerViewService {
     return ReconcilerViewSnapshot(
       integrity: integrity,
       checkpoint: checkpoint,
+      checkpointEndMessageOrdinal: checkpoint == null
+          ? null
+          : messageOrdinals[checkpoint.endMessageId],
       debugRuns: debugRows,
       runs: [
         for (final row in physical)

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -346,6 +346,7 @@ class LedgerStage {
                   'canonUnavailable',
                   'fieldMismatch',
                   'unexpectedFailure',
+                  'failed',
                 }.contains(rewriteOutcome.kind);
                 final detail = rewriteOutcome.kind == 'persisted'
                     ? 'Card Rewriter created a review proposal'

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -21,9 +21,14 @@ import '../../../../core/state/card_rewriter_providers.dart';
 import '../../../../core/state/persona_resolution.dart';
 import '../../../../core/state/studio_turn_config_resolver.dart';
 import '../../../../shared/widgets/glaze_toast.dart';
+import '../../../card_rewrite/card_rewriter_recovery_view_service.dart';
 import '../../state/agent_operations_log_provider.dart';
 import '../../state/post_gen_status_provider.dart';
+import '../collector_view_service.dart';
+import '../current_ledger_injection_preview_service.dart';
 import '../pipeline_utils.dart';
+import '../prompt_capture_view_service.dart';
+import '../reconciler_view_service.dart';
 import 'stage_context.dart';
 
 /// Stage 7: Studio Ledger trigger.
@@ -478,6 +483,7 @@ class LedgerStage {
         isError: true,
       );
     } finally {
+      _invalidateAgentOpsViews(sessionId);
       // Covers cancellation and exceptions in catch-side diagnostics. Identity
       // plus session/task checks ensure an older run cannot clear a newer one.
       if (ownedRunningStatus != null && ownsRunningStatus()) {
@@ -490,6 +496,21 @@ class LedgerStage {
         );
       }
     }
+  }
+
+  void _invalidateAgentOpsViews(String sessionId) {
+    if (!ctx.ref.mounted) return;
+    ctx.ref.invalidate(reconcilerViewProvider(sessionId));
+    ctx.ref.invalidate(
+      currentLedgerInjectionPreviewProvider((
+        sessionId: sessionId,
+        characterId: ctx.charId,
+      )),
+    );
+    ctx.ref.invalidate(collectorViewProvider(sessionId));
+    ctx.ref.invalidate(promptCaptureViewsProvider(sessionId));
+    ctx.ref.invalidate(cardRewriteDebugRunsProvider(sessionId));
+    ctx.ref.invalidate(cardRewriterRecoveryViewsProvider(sessionId));
   }
 
   String _personaName(Iterable<ChatMessage> messages) {

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../core/llm/aux_llm_client.dart' show AuxApiConfig;
+import '../../../../core/llm/game_time.dart';
 import '../../../../core/llm/macro_engine.dart';
 import '../../../../core/llm/studio_ledger_service.dart';
 import '../../../../core/llm/studio_ledger_reconciliation.dart';
@@ -20,7 +22,9 @@ import '../../../../core/state/character_provider.dart';
 import '../../../../core/state/card_rewriter_providers.dart';
 import '../../../../core/state/persona_resolution.dart';
 import '../../../../core/state/studio_turn_config_resolver.dart';
+import '../../../../core/utils/time_helpers.dart';
 import '../../../../shared/widgets/glaze_toast.dart';
+import '../../chat_session_service.dart';
 import '../../../card_rewrite/card_rewriter_recovery_view_service.dart';
 import '../../state/agent_operations_log_provider.dart';
 import '../../state/post_gen_status_provider.dart';
@@ -454,6 +458,12 @@ class LedgerStage {
         'elapsedMs=${result.elapsedMs} '
         'error=${result.error ?? "none"}',
       );
+
+      await _syncGameTimeToMessage(
+        sessionId: sessionId,
+        targetMessage: targetMessage,
+        isCurrent: isCurrent,
+      );
     } catch (e) {
       debugPrint(
         '[StudioLedger] pipeline trigger failed session=$sessionId: $e',
@@ -512,6 +522,42 @@ class LedgerStage {
     ctx.ref.invalidate(promptCaptureViewsProvider(sessionId));
     ctx.ref.invalidate(cardRewriteDebugRunsProvider(sessionId));
     ctx.ref.invalidate(cardRewriterRecoveryViewsProvider(sessionId));
+  }
+
+  /// Best-effort: stamps the current ledger game clock (world:time/date/day)
+  /// onto the assistant message as a display-only field. The value is never
+  /// injected into the main prompt — the clock reaches the model through the
+  /// ledger state block — but auxiliary systems (memory/summary history) read
+  /// it so their outputs stay time-anchored.
+  Future<void> _syncGameTimeToMessage({
+    required String sessionId,
+    required ChatMessage targetMessage,
+    required bool Function() isCurrent,
+  }) async {
+    try {
+      final trackers = await ctx.ref
+          .read(trackerRepoProvider)
+          .getBySessionAndScope(sessionId, 'ledger');
+      final display = GameTimeState.fromTrackers(trackers).format();
+      if (display == null || display == targetMessage.time) return;
+      if (!isCurrent()) return;
+
+      final updated = await ctx.ref
+          .read(chatRepoProvider)
+          .mutateMessage(
+            sessionId: sessionId,
+            messageId: targetMessage.id,
+            updatedAt: currentTimestampSeconds(),
+            mutate: (message) => message.copyWith(time: display),
+          );
+      if (updated == null) return;
+      ChatSessionService.updateCache(updated);
+      final liveState = ctx.getState().value;
+      if (liveState == null || liveState.session?.id != updated.id) return;
+      ctx.setState(AsyncData(liveState.copyWith(session: updated)));
+    } catch (e) {
+      debugPrint('[StudioLedger] game time sync failed session=$sessionId: $e');
+    }
   }
 
   String _personaName(Iterable<ChatMessage> messages) {

--- a/lib/features/chat/services/summary_generation_service.dart
+++ b/lib/features/chat/services/summary_generation_service.dart
@@ -1,10 +1,12 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/llm/game_time.dart';
 import '../../../core/llm/macro_engine.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/state/active_selection_provider.dart';
 import '../../../core/state/character_provider.dart';
+import '../../../core/state/db_provider.dart';
 import '../../../core/state/summary_providers.dart';
 import '../../settings/api_list_provider.dart';
 
@@ -35,25 +37,44 @@ class SummaryGenerationService {
     await _ref.read(apiListProvider.future);
     final apiConfig = _ref.read(activeApiConfigProvider);
     if (apiConfig == null || apiConfig.mode == 'embedding') {
-      throw Exception('No chat API config found. Add one in API Settings first.');
+      throw Exception(
+        'No chat API config found. Add one in API Settings first.',
+      );
     }
 
     final service = _ref.read(summaryServiceProvider);
     final template = await service.getSummaryPrompt(session.id);
 
+    final gameTime = await _readGameTime(session.id);
     return service.generateSummary(
       sessionId: session.id,
       history: session.messages,
       apiConfig: apiConfig,
       customPrompt: template,
-      macroContext: _macroContext(charId: charId, session: session),
+      macroContext: _macroContext(
+        charId: charId,
+        session: session,
+        gameTime: gameTime,
+      ),
       cancelToken: cancelToken,
     );
+  }
+
+  Future<GameTimeState> _readGameTime(String sessionId) async {
+    try {
+      final trackers = await _ref
+          .read(trackerRepoProvider)
+          .getBySessionAndScope(sessionId, 'ledger');
+      return GameTimeState.fromTrackers(trackers);
+    } catch (_) {
+      return const GameTimeState();
+    }
   }
 
   MacroContext _macroContext({
     required String charId,
     required ChatSession session,
+    GameTimeState gameTime = const GameTimeState(),
   }) {
     final character = _ref.read(characterByIdProvider(charId));
     final persona = _ref.read(
@@ -72,6 +93,9 @@ class SummaryGenerationService {
       globalVars: _ref.read(globalVarsProvider),
       charId: charId,
       sessionId: session.id,
+      gameTime: gameTime.time,
+      gameDate: gameTime.date,
+      gameDay: gameTime.day?.toString(),
     );
   }
 }

--- a/lib/features/chat/widgets/agentic_reconciler_tab.dart
+++ b/lib/features/chat/widgets/agentic_reconciler_tab.dart
@@ -268,7 +268,8 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
                               namedArgs: {
                                 'count':
                                     '${data.checkpoint!.messageIds.length}',
-                                'messageId': data.checkpoint!.endMessageId,
+                                'messageNumber':
+                                    '${data.checkpointEndMessageOrdinal ?? '?'}',
                               },
                             ),
                       style: TextStyle(

--- a/lib/features/chat/widgets/chat_message_sync.dart
+++ b/lib/features/chat/widgets/chat_message_sync.dart
@@ -159,6 +159,9 @@ class ChatMessageSync {
       // reload from DB.
       final genTimeChanged = o.genTime != n.genTime;
       final tokensChanged = o.tokens != n.tokens;
+      // The ledger stamps the game clock onto the message after the turn,
+      // post-bubble-render — the same badge-style update path as genTime.
+      final timeChanged = o.time != n.time;
 
       final needsUpdate =
           contentChanged ||
@@ -174,7 +177,8 @@ class ChatMessageSync {
           greetingChanged ||
           studioOutputsChanged ||
           genTimeChanged ||
-          tokensChanged;
+          tokensChanged ||
+          timeChanged;
 
       if (needsUpdate) {
         await bridge.updateMessage(n);

--- a/lib/features/chat/widgets/game_time_seed_dialog.dart
+++ b/lib/features/chat/widgets/game_time_seed_dialog.dart
@@ -1,0 +1,128 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Result of the first-message game time seeding dialog.
+class GameTimeSeedResult {
+  const GameTimeSeedResult({required this.time, this.date});
+
+  /// `HH:MM` in-game time of day for message zero.
+  final String time;
+
+  /// `DD.MM.YYYY` in-game date, or null when the story has no calendar.
+  final String? date;
+}
+
+/// Shown before the first message of a Studio chat so the player can anchor
+/// the ledger game clock (world:time / world:date / world:day). The in-game
+/// day always starts at 0; only the time of day and the optional date are
+/// entered here.
+class GameTimeSeedDialog extends StatefulWidget {
+  const GameTimeSeedDialog({super.key});
+
+  @override
+  State<GameTimeSeedDialog> createState() => _GameTimeSeedDialogState();
+}
+
+class _GameTimeSeedDialogState extends State<GameTimeSeedDialog> {
+  final _dateController = TextEditingController();
+  final _timeController = TextEditingController(text: '09:00');
+
+  static final _timeRe = RegExp(r'^(\d{1,2}):(\d{2})$');
+  static final _dateRe = RegExp(r'^\d{2}\.\d{2}\.\d{4}$');
+
+  String? _error;
+
+  @override
+  void dispose() {
+    _dateController.dispose();
+    _timeController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final timeMatch = _timeRe.firstMatch(_timeController.text.trim());
+    if (timeMatch == null ||
+        int.parse(timeMatch.group(1)!) > 23 ||
+        int.parse(timeMatch.group(2)!) > 59) {
+      setState(() => _error = 'game_time_seed_invalid_time'.tr());
+      return;
+    }
+    final dateRaw = _dateController.text.trim();
+    if (dateRaw.isNotEmpty && !_dateRe.hasMatch(dateRaw)) {
+      setState(() => _error = 'game_time_seed_invalid_date'.tr());
+      return;
+    }
+    final hour = int.parse(timeMatch.group(1)!).toString().padLeft(2, '0');
+    final minute = timeMatch.group(2)!;
+    Navigator.of(context).pop(
+      GameTimeSeedResult(
+        time: '$hour:$minute',
+        date: dateRaw.isEmpty ? null : dateRaw,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return AlertDialog(
+      title: Text('game_time_seed_title'.tr()),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('game_time_seed_description'.tr()),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _timeController,
+            decoration: InputDecoration(
+              labelText: 'game_time_seed_time_label'.tr(),
+              hintText: '09:00',
+              errorText: null,
+            ),
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9:]')),
+              LengthLimitingTextInputFormatter(5),
+            ],
+            keyboardType: TextInputType.datetime,
+            autofocus: true,
+            onSubmitted: (_) => _submit(),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _dateController,
+            decoration: InputDecoration(
+              labelText: 'game_time_seed_date_label'.tr(),
+              hintText: 'DD.MM.YYYY',
+            ),
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+              LengthLimitingTextInputFormatter(10),
+            ],
+            keyboardType: TextInputType.datetime,
+            onSubmitted: (_) => _submit(),
+          ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: Text(
+                _error!,
+                style: TextStyle(color: cs.error, fontSize: 13),
+              ),
+            ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text('game_time_seed_skip'.tr()),
+        ),
+        FilledButton(
+          onPressed: _submit,
+          child: Text('game_time_seed_confirm'.tr()),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/cloud_sync/services/sync_engine.dart
+++ b/lib/features/cloud_sync/services/sync_engine.dart
@@ -351,6 +351,13 @@ class SyncEngine {
         continue;
       }
 
+      // This aggregate is merge-only, but validating it reads the owning chat.
+      // Defer the merge until the ordered pull phase has applied that chat.
+      if (cloudEntry.type == 'reconciliation_state') {
+        pullEntries.add(cloudEntry);
+        continue;
+      }
+
       if (await _entriesSemanticallyEqual(
         cloudEntry,
         localEntry,
@@ -444,6 +451,10 @@ class SyncEngine {
           cloudEntry.deleted == localEntry?.deleted) {
         continue;
       }
+      if (cloudEntry.type == 'reconciliation_state') {
+        pullEntries.add(cloudEntry);
+        continue;
+      }
       if (await _entriesSemanticallyEqual(
         cloudEntry,
         localEntry,
@@ -501,42 +512,55 @@ class SyncEngine {
     void Function(SyncProgress) onProgress, {
     List<SyncManifestEntry> acceptedCloudEntries = const [],
   }) async {
-    final tasks = <Future<void> Function()>[];
     final appliedEntries = <SyncManifestEntry>[];
     var processed = 0;
+    final primaryEntries = pullEntries
+        .where((entry) => entry.type != 'reconciliation_state')
+        .toList(growable: false);
+    final reconciliationEntries = pullEntries
+        .where((entry) => entry.type == 'reconciliation_state')
+        .toList(growable: false);
 
-    for (final entry in pullEntries) {
-      tasks.add(() async {
-        processed++;
-        onProgress(
-          SyncProgress(
-            current: processed,
-            total: tasks.length,
-            message: 'Pulling ${entry.type}:${entry.id}',
-          ),
-        );
-        await _pullEntry(entry);
-        appliedEntries.add(entry);
-      });
-    }
-
-    onProgress(
-      SyncProgress(
-        current: 0,
-        total: tasks.length,
-        message: 'Pulling ${tasks.length} items...',
-      ),
-    );
-
-    List<Object>? taskErrors;
-    if (tasks.isNotEmpty) {
+    Future<List<Object>> applyEntries(List<SyncManifestEntry> entries) async {
+      final tasks = <Future<void> Function()>[];
+      for (final entry in entries) {
+        tasks.add(() async {
+          processed++;
+          onProgress(
+            SyncProgress(
+              current: processed,
+              total: pullEntries.length,
+              message: 'Pulling ${entry.type}:${entry.id}',
+            ),
+          );
+          await _pullEntry(entry);
+          appliedEntries.add(entry);
+        });
+      }
+      if (tasks.isEmpty) return const [];
       final result = await _queue.enqueueAll(
         tasks,
         concurrency: 3,
         delayMs: 300,
       );
-      taskErrors = result.errors;
+      return result.errors;
     }
+
+    onProgress(
+      SyncProgress(
+        current: 0,
+        total: pullEntries.length,
+        message: 'Pulling ${pullEntries.length} items...',
+      ),
+    );
+
+    // Reconciliation anchors are validated against the local chat transcript.
+    // Apply chat and other primary entities first so concurrent pull workers
+    // cannot validate a newer reconciliation chain against an older chat.
+    final taskErrors = <Object>[
+      ...await applyEntries(primaryEntries),
+      ...await applyEntries(reconciliationEntries),
+    ];
 
     await _finalizePull(
       localManifest,
@@ -544,7 +568,7 @@ class SyncEngine {
       acceptedCloudEntries: [...acceptedCloudEntries, ...appliedEntries],
     );
 
-    if (taskErrors != null && taskErrors.isNotEmpty) {
+    if (taskErrors.isNotEmpty) {
       throw SyncQueueAggregateError(taskErrors);
     }
   }

--- a/lib/features/memory/controllers/memory_draft_generation_controller.dart
+++ b/lib/features/memory/controllers/memory_draft_generation_controller.dart
@@ -124,7 +124,15 @@ class MemoryDraftGenerationController {
     }
 
     final historyText = draftMessages
-        .map((m) => '${m.role}: ${m.content}')
+        .map((m) {
+          // Ledger-stamped game clock travels with the transcript so memory
+          // entries stay time-anchored.
+          final gameTime = m.time?.trim();
+          final timePrefix = gameTime == null || gameTime.isEmpty
+              ? ''
+              : '[$gameTime] ';
+          return '${m.role}: $timePrefix${m.content}';
+        })
         .join('\n\n');
     final cancelToken = CancelToken();
     _cancelTokens[draftId] = cancelToken;

--- a/test/automated_card_evolution_service_test.dart
+++ b/test/automated_card_evolution_service_test.dart
@@ -481,6 +481,9 @@ void main() {
     expect(lorebookPrompt, contains('"description":"Alice is cautious."'));
     expect(lorebookPrompt, contains('# Proposed card operations (read-only)'));
     expect(lorebookPrompt, contains('increasingly trusting'));
+    // Without a session overlay the entry must not carry a duplicated base.
+    expect(lorebookPrompt, contains('"content":"entry one"'));
+    expect(lorebookPrompt, isNot(contains('"baseContent":"entry one"')));
     final operations = await fixture.db
         .select(fixture.db.rewriteOperations)
         .get();
@@ -495,6 +498,75 @@ void main() {
         .select(fixture.db.cardEvolutionDebugRuns)
         .get();
     expect(debug.map((row) => row.stage), containsAll(['card', 'lorebook']));
+  });
+
+  test('evolved lorebook entries keep their diverged base', () async {
+    await _seedManifest(fixture.db, 'a1', 'entry one');
+    await fixture.db
+        .into(fixture.db.sessionLorebookEvolutionRows)
+        .insert(
+          SessionLorebookEvolutionRowsCompanion.insert(
+            chatSessionId: 'session',
+            lorebookId: 'book-a1',
+            entryId: 'entry-a1-0',
+            baseContent: 'entry one',
+            baseContentHash: CardCanonicalizer.scalarSha256('entry one'),
+            content: 'entry one evolved',
+            contentHash: CardCanonicalizer.scalarSha256('entry one evolved'),
+            createdAt: 1,
+            updatedAt: 1,
+          ),
+        );
+    String? lorebookPrompt;
+    final result = await fixture
+        .service((_, prompt) async {
+          if (prompt.contains('Glaze lorebook rewriter')) {
+            lorebookPrompt = prompt;
+            return _ok(
+              jsonEncode({
+                'operations': [
+                  {
+                    'lorebookId': 'book-a1',
+                    'entryId': 'entry-a1-0',
+                    'baseContent': 'entry one',
+                    'expectedContentHash': CardCanonicalizer.scalarSha256(
+                      'entry one evolved',
+                    ),
+                    'patches': [
+                      {
+                        'anchor': 'evolved',
+                        'anchorSha256': CardCanonicalizer.scalarSha256(
+                          'evolved',
+                        ),
+                        'value': 'evolved further',
+                      },
+                    ],
+                  },
+                ],
+              }),
+            );
+          }
+          return _ok(fixture.cardBatchOutput);
+        })
+        .runOneBatch('session');
+
+    expect(result.kind, 'persisted', reason: result.detail);
+    expect(lorebookPrompt, contains('"baseContent":"entry one"'));
+    expect(lorebookPrompt, contains('"content":"entry one evolved"'));
+  });
+
+  test('oversized shared context reports the context gate limit', () async {
+    await _seedManifestEntries(
+      fixture.db,
+      'a1',
+      List.generate(7, (index) => 'x' * 60000),
+    );
+    final result = await fixture
+        .service((_, prompt) async => _ok('{"operations":[]}'))
+        .runOneBatch('session');
+
+    expect(result.kind, 'snapshotTooLarge');
+    expect(result.detail, contains('safe request limit is 400000'));
   });
 
   test(
@@ -702,7 +774,7 @@ final class _Fixture {
     'operations': [
       {
         'lorebookId': 'book-a1',
-        'entryId': 'entry-a1',
+        'entryId': 'entry-a1-0',
         'baseContent': 'entry one',
         'expectedContentHash': CardCanonicalizer.scalarSha256('entry one'),
         'patches': [
@@ -772,25 +844,31 @@ const _messages = [
   {'id': 'u2', 'role': 'user', 'content': 'user 2'},
 ];
 
-Future<void> _seedManifest(
+Future<void> _seedManifest(AppDatabase db, String messageId, String content) =>
+    _seedManifestEntries(db, messageId, [content]);
+
+Future<void> _seedManifestEntries(
   AppDatabase db,
   String messageId,
-  String content,
+  List<String> contents,
 ) async {
-  final entry = ExactLorebookManifestEntry.fromMergedEntry(
-    entry: LorebookEntry(
-      id: 'entry-$messageId',
-      lorebookId: 'book-$messageId',
-      content: content,
-      position: 'worldInfoBefore',
-    ),
-    source: 'keyword',
-    classification: 'worldInfoBefore',
-    injectionIndex: 0,
-    renderedContent: content,
-  );
+  final entries = [
+    for (var index = 0; index < contents.length; index++)
+      ExactLorebookManifestEntry.fromMergedEntry(
+        entry: LorebookEntry(
+          id: 'entry-$messageId-$index',
+          lorebookId: 'book-$messageId',
+          content: contents[index],
+          position: 'worldInfoBefore',
+        ),
+        source: 'keyword',
+        classification: 'worldInfoBefore',
+        injectionIndex: index,
+        renderedContent: contents[index],
+      ),
+  ];
   final manifest = ExactLorebookManifest(
-    entries: [entry],
+    entries: entries,
     promptProvenance: const ExactLorebookPromptProvenance(
       characterId: 'character',
       sessionId: 'session',
@@ -816,12 +894,13 @@ Future<void> _seedManifest(
     ),
     createdAt: 1,
     entries: [
-      LorebookUseManifestEntryInput(
-        lorebookId: entry.lorebookId,
-        entryId: entry.entryId,
-        entryOrder: 0,
-        evidenceJson: jsonEncode(entry.toJson()),
-      ),
+      for (var index = 0; index < entries.length; index++)
+        LorebookUseManifestEntryInput(
+          lorebookId: entries[index].lorebookId,
+          entryId: entries[index].entryId,
+          entryOrder: index,
+          evidenceJson: jsonEncode(entries[index].toJson()),
+        ),
     ],
   );
 }

--- a/test/automated_card_evolution_service_test.dart
+++ b/test/automated_card_evolution_service_test.dart
@@ -102,7 +102,13 @@ void main() {
     final claim = await fixture.db
         .select(fixture.db.cardEvolutionClaims)
         .getSingle();
-    expect(claim.leaseExpiresAt - claim.createdAt, 600);
+    // The writer renews the lease right before the model call, so a second
+    // boundary tick between claim creation and renewal legitimately extends
+    // the observed span beyond the base 600s lease.
+    expect(
+      claim.leaseExpiresAt - claim.createdAt,
+      inInclusiveRange(600, 660),
+    );
     final operations = await fixture.db
         .select(fixture.db.rewriteOperations)
         .get();

--- a/test/card_evolution_repo_test.dart
+++ b/test/card_evolution_repo_test.dart
@@ -134,6 +134,55 @@ void main() {
     expect(recovered.claim?.selectedInputJson, claimed.selectedInputJson);
   });
 
+  test(
+    'an unreproducible failed claim is dropped and replaced fresh',
+    () async {
+      final dead = (await evolution.claim(
+        sessionId: 'session',
+        ownerId: 'owner',
+        now: 10,
+        leaseSeconds: 30,
+      )).claim!;
+      await db.customStatement(
+        'UPDATE chat_sessions SET messages_json = ? WHERE session_id = ?',
+        [
+          jsonEncode([..._messages, _nextAssistant, _nextUser]),
+          'session',
+        ],
+      );
+      // A restart attempt fails to rebuild the snapshot from the changed
+      // chat and marks the claim failed with durable checkpoints.
+      expect(
+        await evolution.markWriterFailed(
+          claimId: dead.row.id,
+          ownerId: 'owner',
+          now: 11,
+          code: 'snapshotUnavailable',
+          detail: 'inputHashMismatch',
+        ),
+        isTrue,
+      );
+
+      // The dead claim no longer blocks the lane: the next claim attempt exits
+      // the restart loop by dropping it and selecting a fresh snapshot.
+      final fresh = await evolution.claim(
+        sessionId: 'session',
+        ownerId: 'automatic',
+        now: 13,
+        leaseSeconds: 30,
+      );
+      expect(fresh.kind, 'claimed');
+      expect(fresh.claim!.row.id, isNot(dead.row.id));
+      expect(fresh.claim!.selectedInputJson, isNot(dead.selectedInputJson));
+      expect(
+        await (db.select(
+          db.cardEvolutionClaims,
+        )..where((row) => row.id.equals(dead.row.id))).get(),
+        isEmpty,
+      );
+    },
+  );
+
   test('a changed chat snapshot makes a claimed lease stale', () async {
     final claim = (await evolution.claim(
       sessionId: 'session',

--- a/test/card_rewrite_observation_pass_test.dart
+++ b/test/card_rewrite_observation_pass_test.dart
@@ -163,6 +163,34 @@ void main() {
     },
   );
 
+  test('card writer prompt does not duplicate the card snapshot', () async {
+    await fixture.seedReconciliationRun(ordinal: 1);
+    String? cardPrompt;
+    await fixture
+        .service((_, prompt) async {
+          if (!prompt.contains('observation journal keeper')) {
+            cardPrompt = prompt;
+          }
+          return _ok(fixture.cardBatchOutput);
+        })
+        .runOneBatch('session');
+    expect(cardPrompt, isNotNull);
+    final snapshotIndex = cardPrompt!.indexOf(
+      '# Canonical character card snapshot (read-only)',
+    );
+    expect(snapshotIndex, greaterThanOrEqualTo(0));
+    final snapshotOccurrences = '# Canonical character card snapshot'
+        .allMatches(cardPrompt!)
+        .length;
+    expect(snapshotOccurrences, 1);
+    final historyStart = cardPrompt!.indexOf(
+      '# Immutable chat history and effective canon',
+    );
+    expect(historyStart, greaterThan(snapshotIndex));
+    final historyPayload = cardPrompt!.substring(historyStart);
+    expect(historyPayload, isNot(contains('"card":{')));
+  });
+
   test(
     'writer excludes an active observation unrelated to current ranges',
     () async {

--- a/test/card_rewrite_observation_pass_test.dart
+++ b/test/card_rewrite_observation_pass_test.dart
@@ -550,6 +550,36 @@ void main() {
   );
 
   test(
+    'unexpected automatic lane failure leaves durable diagnostics',
+    () async {
+      final service = fixture.service((_, prompt) async {
+        return _ok('{"observations":[]}');
+      });
+      for (var ordinal = 1; ordinal <= 3; ordinal++) {
+        await service.runAfterReconciliation(
+          await fixture.seedReconciliationRun(ordinal: ordinal),
+        );
+      }
+      await fixture.db.customStatement(
+        'DROP TABLE card_evolution_collector_runs',
+      );
+
+      final result = await service.runAfterReconciliation(
+        await fixture.seedReconciliationRun(ordinal: 4),
+      );
+
+      expect(result.kind, 'unexpectedFailure');
+      expect(result.detail, contains('card_evolution_collector_runs'));
+      final debug = await fixture.db
+          .select(fixture.db.cardEvolutionDebugRuns)
+          .getSingle();
+      expect(debug.stage, 'selection');
+      expect(debug.status, 'unexpectedFailure');
+      expect(debug.attemptsJson, contains('card_evolution_collector_runs'));
+    },
+  );
+
+  test(
     'oversized writer streams all immutable history into one handoff',
     () async {
       final messages = List<Map<String, String>>.generate(41, (index) {

--- a/test/card_rewrite_observation_pass_test.dart
+++ b/test/card_rewrite_observation_pass_test.dart
@@ -587,7 +587,7 @@ void main() {
           'id': 'long-$index',
           'role': index.isEven ? 'assistant' : 'user',
           'content':
-              '${index.isEven ? 'assistant' : 'user'}-$index ${'x' * 4920}',
+              '${index.isEven ? 'assistant' : 'user'}-$index ${'x' * 10300}',
         };
       });
       final starts = [0, 1, 21, 21];

--- a/test/card_rewrite_operation_parser_test.dart
+++ b/test/card_rewrite_operation_parser_test.dart
@@ -290,22 +290,38 @@ void main() {
     );
   });
 
-  test('rejects a mismatched anchorSha256 by recomputing the hash', () {
-    final payload = validPayload()
-      ..['patches'] = [validPatch()..['anchorSha256'] = 'not-the-real-hash'];
+  test('recomputes the anchor hash and tolerates missing or bogus values', () {
+    // The model contract no longer asks for anchorSha256; when absent the
+    // parser computes it, and a fabricated value is overwritten.
+    final missing = validPayload()
+      ..['patches'] = [validPatch()..remove('anchorSha256')];
+    final missingResult = parsePayload(missing);
+    expect(missingResult.isSuccess, isTrue, reason: missingResult.detail);
     expect(
-      rejectionOf(payload),
-      CardRewriteOperationParseRejection.staleAnchorHash,
+      missingResult.snapshot!.patches.single.anchorSha256,
+      CardCanonicalizer.scalarSha256(anchor),
     );
-    // The recomputed hash of some other text is equally rejected.
-    final foreign = validPayload()
-      ..['patches'] = [
-        validPatch()
-          ..['anchorSha256'] = CardCanonicalizer.scalarSha256('other text'),
-      ];
+
+    for (final bogus in [
+      'not-the-real-hash',
+      CardCanonicalizer.scalarSha256('other text'),
+    ]) {
+      final payload = validPayload()
+        ..['patches'] = [validPatch()..['anchorSha256'] = bogus];
+      final result = parsePayload(payload);
+      expect(result.isSuccess, isTrue, reason: bogus);
+      expect(
+        result.snapshot!.patches.single.anchorSha256,
+        CardCanonicalizer.scalarSha256(anchor),
+      );
+    }
+
+    // A non-string value is still structurally rejected.
+    final nonString = validPayload()
+      ..['patches'] = [validPatch()..['anchorSha256'] = 42];
     expect(
-      rejectionOf(foreign),
-      CardRewriteOperationParseRejection.staleAnchorHash,
+      rejectionOf(nonString),
+      CardRewriteOperationParseRejection.malformedPatch,
     );
   });
 
@@ -661,6 +677,54 @@ void main() {
       expect(result, hasLength(1));
       expect(result!.single.entryId, 'district');
     });
+
+    test(
+      'accepts a lorebook batch with fabricated or missing anchor hashes',
+      () {
+        // Regression for the live lorebook_writer failure: the model cannot
+        // compute SHA-256 and fabricated digests, so the whole batch was
+        // rejected as "not a valid operation batch".
+        const content = 'The district is dangerous.';
+        final operations = [
+          {
+            'lorebookId': 'book',
+            'entryId': 'district',
+            'baseContent': content,
+            'expectedContentHash': CardCanonicalizer.scalarSha256(content),
+            'patches': [
+              {
+                'anchor': 'dangerous',
+                'anchorSha256': '3f7c1e2a5b8d9046e1a7c3b5d8f2e0a4',
+                'value': 'dangerous but lively',
+              },
+            ],
+          },
+          {
+            'lorebookId': 'book',
+            'entryId': 'harbor',
+            'baseContent': content,
+            'expectedContentHash': CardCanonicalizer.scalarSha256(content),
+            'patches': [
+              {'anchor': 'dangerous', 'value': 'dangerous but lively'},
+            ],
+          },
+        ];
+
+        final result = CardRewriteOperationParser.parseLorebookEvolutionBatch(
+          jsonEncode({'operations': operations}),
+        );
+
+        expect(result, hasLength(2));
+        expect(
+          result!.first.patches.single.anchorSha256,
+          CardCanonicalizer.scalarSha256('dangerous'),
+        );
+        expect(
+          result.last.patches.single.anchorSha256,
+          CardCanonicalizer.scalarSha256('dangerous'),
+        );
+      },
+    );
   });
 
   group('macro preservation round-trip', () {

--- a/test/card_rewrite_prompt_builder_test.dart
+++ b/test/card_rewrite_prompt_builder_test.dart
@@ -162,31 +162,25 @@ void main() {
     },
   );
 
-  test(
-    'prompt describes the operation snapshot shape, hash rule, and scope grammar',
-    () {
-      final prompt = buildPrompt();
-      expect(
-        prompt,
-        contains(
-          '"patches":[{"scopeKey":"...","anchor":"...",'
-          '"anchorSha256":"...","value":"..."}]',
-        ),
-      );
-      expect(prompt, contains('"affectedTrackerKeys":[]'));
-      expect(prompt, contains('"chatSessionId":null'));
-      expect(prompt, contains('- "field" MUST be exactly "description".'));
-      expect(prompt, contains('- "patches" MUST be a non-empty list'));
-      expect(prompt, contains('npc:<subject>'));
-      expect(prompt, contains('relationship:<subject-a>:<subject-b>'));
-      expect(prompt, contains('always contains both subjects'));
-      expect(prompt, contains('arc:<subject>'));
-      expect(prompt, contains('world:<subject>'));
-      expect(prompt, contains('scene.<subject>'));
-      expect(prompt, contains('lowercase hex SHA-256 of the anchor'));
-      expect(prompt, contains('EXACTLY ONCE'));
-    },
-  );
+  test('prompt describes the operation snapshot shape and scope grammar', () {
+    final prompt = buildPrompt();
+    expect(
+      prompt,
+      contains('"patches":[{"scopeKey":"...","anchor":"...","value":"..."}]'),
+    );
+    expect(prompt, contains('"affectedTrackerKeys":[]'));
+    expect(prompt, contains('"chatSessionId":null'));
+    expect(prompt, contains('- "field" MUST be exactly "description".'));
+    expect(prompt, contains('- "patches" MUST be a non-empty list'));
+    expect(prompt, contains('npc:<subject>'));
+    expect(prompt, contains('relationship:<subject-a>:<subject-b>'));
+    expect(prompt, contains('always contains both subjects'));
+    expect(prompt, contains('arc:<subject>'));
+    expect(prompt, contains('world:<subject>'));
+    expect(prompt, contains('scene.<subject>'));
+    expect(prompt, contains('EXACTLY ONCE'));
+    expect(prompt, isNot(contains('anchorSha256')));
+  });
 
   test(
     'prompt forbids macro expansion and demands literal {{...}} preservation',

--- a/test/characterization/memory_selector_test.dart
+++ b/test/characterization/memory_selector_test.dart
@@ -65,6 +65,45 @@ void main() {
     });
 
     test(
+      'keeps partially visible entries and excludes only fully visible ones',
+      () {
+        final entries = [
+          _entry(
+            id: 'partial',
+            title: 'Bridge collapse',
+            content: 'episode about the bridge',
+            keys: const ['bridge'],
+            messageIds: const ['m1', 'm2', 'm3'],
+            createdAt: 1000,
+          ),
+          _entry(
+            id: 'full',
+            title: 'Harbor fire',
+            content: 'episode about the harbor',
+            keys: const ['harbor'],
+            messageIds: const ['m2', 'm3'],
+            createdAt: 1100,
+          ),
+        ];
+        final result = MemorySelector.select(
+          MemorySelectionInput(
+            entries: entries,
+            visibleMessageIds: const {'m2', 'm3'},
+            maxInjectedEntries: 5,
+            sourceWindowExclusion: true,
+          ),
+        );
+        // 'partial' lost m1 to history rotation, so its recall is still
+        // needed; 'full' is entirely visible in the prompt already.
+        expect(result.entries.map((e) => e.id), ['partial']);
+        expect(result.excludedBySourceWindow, 1);
+        final full = result.allScores.firstWhere((s) => s.entry.id == 'full');
+        expect(full.excludedBySourceWindow, isTrue);
+        expect(full.exclusionReason, 'source_visible_in_prompt');
+      },
+    );
+
+    test(
       'sourceWindowExclusion: false keeps all candidates even when overlap',
       () {
         final entries = [

--- a/test/current_ledger_injection_preview_service_test.dart
+++ b/test/current_ledger_injection_preview_service_test.dart
@@ -129,4 +129,43 @@ void main() {
       expect(await revisions.getForCharacter('c'), isEmpty);
     },
   );
+
+  test('retries once when chat changes during preview assembly', () async {
+    var injections = 0;
+    final retrying = CurrentLedgerInjectionPreviewService(
+      chats,
+      characters,
+      EffectiveCanonContextLoader(
+        db: db,
+        characterRepo: characters,
+        characterRevisionRepo: revisions,
+        baselineRepo: CharacterSessionBaselineRepo(db),
+        factRepo: facts,
+        transitionRepo: AppliedCanonTransitionRepo(db),
+        transitionFactRefRepo: CanonTransitionFactRefRepo(db),
+        loadRawTrackerState: (_) async =>
+            LedgerRawTrackerState(committedTrackers: [], manualControls: []),
+      ),
+      (_) async => StudioTurnConfigSnapshot(
+        config: const StudioConfig(sessionId: 's', enabled: true),
+        preset: const StudioPreset(id: 'preset'),
+        pipelineSettings: const PipelineSettings(),
+        apiConfigs: const [],
+        activeApiConfig: null,
+      ),
+      (_, messages) async {
+        if (injections++ == 0) {
+          final current = (await chats.getById('s'))!;
+          await chats.put(current.copyWith(updatedAt: 2));
+        }
+        return messages;
+      },
+      (_, _) => 'User',
+    );
+
+    final preview = await retrying.load(sessionId: 's');
+
+    expect(preview.visibleMessageIds, contains('m1'));
+    expect(injections, 2);
+  });
 }

--- a/test/game_time_test.dart
+++ b/test/game_time_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/game_time.dart';
+import 'package:glaze_flutter/core/llm/macro_engine.dart';
+import 'package:glaze_flutter/core/models/tracker.dart';
+
+Tracker tracker(String name, String value) =>
+    Tracker(sessionId: 'session', name: name, value: value, scope: 'ledger');
+
+void main() {
+  group('GameTimeState.fromTrackers', () {
+    test('parses and normalizes clock trackers', () {
+      final state = GameTimeState.fromTrackers([
+        tracker(GameTimeState.timeKey, '9:5'),
+        tracker(GameTimeState.dateKey, '03.04.2027'),
+        tracker(GameTimeState.dayKey, '2'),
+      ]);
+
+      expect(state.time, '09:05');
+      expect(state.date, '03.04.2027');
+      expect(state.day, 2);
+      expect(state.format(), '03.04.2027 · День 2 · 09:05');
+    });
+
+    test('rejects out-of-range values and ignores empty rows', () {
+      final state = GameTimeState.fromTrackers([
+        tracker(GameTimeState.timeKey, '25:99'),
+        tracker(GameTimeState.dateKey, ''),
+        tracker(GameTimeState.dayKey, 'not-a-number'),
+      ]);
+
+      expect(state.time, isNull);
+      expect(state.date, isNull);
+      expect(state.day, isNull);
+      expect(state.format(), isNull);
+    });
+
+    test('formats with only the parts that exist', () {
+      expect(GameTimeState(time: '12:30').format(), '12:30');
+      expect(GameTimeState(time: '12:30', day: 0).format(), 'День 0 · 12:30');
+      expect(GameTimeState(day: 4).formatEnglish(), 'Day 4');
+    });
+  });
+
+  group('GameTimeState.expandMacros', () {
+    test('expands game-clock macros only', () {
+      const state = GameTimeState(time: '18:40', date: '12.05.2027', day: 3);
+
+      expect(
+        state.expandMacros(
+          'Time {{gametime}}, date {{gamedate}}, day {{gameday}}.',
+        ),
+        'Time 18:40, date 12.05.2027, day 3.',
+      );
+    });
+
+    test('missing clock parts expand to an empty string', () {
+      const state = GameTimeState(time: '08:00');
+
+      expect(state.expandMacros('{{gamedate}}|{{gameday}}'), '|');
+    });
+
+    test('leaves unrelated macros untouched', () {
+      const state = GameTimeState(time: '08:00');
+
+      expect(
+        state.expandMacros('{{char}} {{roll::1d6}}'),
+        '{{char}} {{roll::1d6}}',
+      );
+    });
+  });
+
+  group('replaceMacros game-clock macros', () {
+    const ctx = MacroContext(
+      charName: 'Alison',
+      charId: 'character',
+      sessionId: 'session',
+      gameTime: '21:15',
+      gameDate: '04.06.2027',
+      gameDay: '5',
+    );
+
+    test('expands {{gametime}} / {{gamedate}} / {{gameday}}', () {
+      final result = replaceMacros(
+        'At {{gametime}} on {{gamedate}} (day {{gameday}}).',
+        ctx,
+      );
+
+      expect(result.text, 'At 21:15 on 04.06.2027 (day 5).');
+    });
+
+    test('real-time macros are unaffected by the game clock', () {
+      final result = replaceMacros('{{gametime}}', ctx);
+
+      expect(result.text, '21:15');
+    });
+
+    test('missing game clock expands to an empty string', () {
+      const emptyCtx = MacroContext(
+        charName: 'Alison',
+        charId: 'character',
+        sessionId: 'session',
+      );
+
+      expect(replaceMacros('<{{gametime}}>', emptyCtx).text, '<>');
+    });
+
+    test('MacroContext json round-trip preserves the game clock', () {
+      final restored = MacroContext.fromJson(ctx.toJson());
+
+      expect(restored.gameTime, '21:15');
+      expect(restored.gameDate, '04.06.2027');
+      expect(restored.gameDay, '5');
+    });
+  });
+}

--- a/test/history_game_time_test.dart
+++ b/test/history_game_time_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/fallback_prompt_builder.dart';
+import 'package:glaze_flutter/core/llm/history_assembler.dart';
+import 'package:glaze_flutter/core/llm/macro_engine.dart';
+import 'package:glaze_flutter/core/models/api_config.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/llm/prompt/prompt_payload.dart';
+
+void main() {
+  const macroCtx = MacroContext(
+    charName: 'Alison',
+    charId: 'character',
+    sessionId: 'session',
+  );
+
+  test('history assembler prefixes ledger-stamped game time', () {
+    final history = HistoryAssembler(macroCtx).assemble([
+      const ChatMessage(id: 'u1', role: 'user', content: 'Hello'),
+      const ChatMessage(
+        id: 'a1',
+        role: 'assistant',
+        content: 'She looks up.',
+        time: '12.05.2027 · День 0 · 09:15',
+      ),
+    ]);
+
+    expect(history[0].content, 'Hello');
+    expect(history[1].content, '[12.05.2027 · День 0 · 09:15]\nShe looks up.');
+  });
+
+  test('history assembler leaves unstamped messages untouched', () {
+    final history = HistoryAssembler(
+      macroCtx,
+    ).assemble([const ChatMessage(id: 'u1', role: 'user', content: 'Hello')]);
+
+    expect(history[0].content, 'Hello');
+  });
+
+  test('fallback prompt builder carries the game time into history', () {
+    final payload = PromptPayload(
+      character: const Character(id: 'character', name: 'Alison'),
+      history: const [
+        ChatMessage(
+          id: 'a1',
+          role: 'assistant',
+          content: 'Hi.',
+          time: 'День 2 · 18:30',
+        ),
+      ],
+      apiConfig: const ApiConfig(id: 'api'),
+      gameTime: '18:30',
+    );
+
+    final result = buildFallbackPrompt(payload);
+    final historyMessage = result.messages.firstWhere(
+      (m) => m.sourceMessageId == 'a1',
+    );
+
+    expect(historyMessage.content, '[День 2 · 18:30]\nHi.');
+  });
+}

--- a/test/manual_rewrite_apply_repo_test.dart
+++ b/test/manual_rewrite_apply_repo_test.dart
@@ -377,9 +377,24 @@ void main() {
     },
   );
 
+  /// Automated evolution jobs are stamped with the stable canon identity
+  /// (volatile Ledger state excluded). Restamps the seeded job accordingly.
+  Future<String> restampJobAsAutomated() async {
+    final stableStamp = const EffectiveCanonAssembler()
+        .assemble(
+          await reader.readInTransaction(sessionId: 's', characterId: 'c'),
+          stampVolatileState: false,
+        )
+        .identity;
+    await (db.update(db.rewriteJobs)..where((t) => t.id.equals('job')))
+        .write(RewriteJobsCompanion(canonStamp: Value(stableStamp)));
+    return stableStamp;
+  }
+
   test('valid automatic proposal evidence remains applyable', () async {
-    final stamp = await seed();
+    await seed();
     await addAutomaticProposal();
+    final stamp = await restampJobAsAutomated();
 
     final outcome = await ManualRewriteApplyRepo(db: db, canonReader: reader)
         .applyApproved(
@@ -394,7 +409,8 @@ void main() {
   test(
     'apply consumes only promoted observations targeted by applied ops',
     () async {
-      final stamp = await seed();
+      await seed();
+      final stamp = await restampJobAsAutomated();
       for (final entry in const [
         ('used', 'npc:alice', 'description', 'promoted'),
         ('wrong-field', 'stored:wrong-field', 'personality', 'promoted'),
@@ -687,6 +703,53 @@ void main() {
       expect((await characters.getById('c'))!.description, 'old text');
       expect(await revisions.getForCharacter('c'), hasLength(1));
       expect(await db.select(db.appliedCanonTransitionRows).get(), isEmpty);
+    },
+  );
+
+  test(
+    'automated evolution job applies despite volatile ledger drift',
+    () async {
+      final fullStamp = await seed();
+      await addAutomaticProposal();
+      final stableStamp = const EffectiveCanonAssembler()
+          .assemble(
+            await reader.readInTransaction(sessionId: 's', characterId: 'c'),
+            stampVolatileState: false,
+          )
+          .identity;
+      expect(stableStamp, isNot(fullStamp));
+      await (db.update(db.rewriteJobs)..where((t) => t.id.equals('job'))).write(
+        RewriteJobsCompanion(canonStamp: Value(stableStamp)),
+      );
+      // The per-turn Ledger committed new trackers after the automated
+      // proposal existed (normal LedgerStage ordering).
+      raw = LedgerRawTrackerState(
+        committedTrackers: const [
+          Tracker(sessionId: 's', name: 'arc.status', value: 'advanced'),
+        ],
+        manualControls: const [],
+      );
+      final freshStable = const EffectiveCanonAssembler()
+          .assemble(
+            await reader.readInTransaction(sessionId: 's', characterId: 'c'),
+            stampVolatileState: false,
+          )
+          .identity;
+      expect(freshStable, stableStamp);
+
+      final outcome = await ManualRewriteApplyRepo(db: db, canonReader: reader)
+          .applyApproved(
+            jobId: 'job',
+            expectedCanonStamp: freshStable,
+            expectedJobVersion: 1,
+          );
+
+      expect(outcome.kind, 'applied');
+      final session = await db.select(db.chatSessions).getSingle();
+      expect(
+        (await characters.getById(session.characterId))!.description,
+        'new text',
+      );
     },
   );
 

--- a/test/prompt_worker_codec_test.dart
+++ b/test/prompt_worker_codec_test.dart
@@ -35,6 +35,23 @@ void main() {
     expect(restored.effectiveCanonCacheIdentity, 'canon-cache-identity');
   });
 
+  test('prompt isolate codec preserves the ledger game clock', () {
+    final source = PromptPayload(
+      character: const Character(id: 'character', name: 'Alison'),
+      history: const [],
+      apiConfig: const ApiConfig(id: 'api'),
+      gameTime: '19:45',
+      gameDate: '08.11.2027',
+      gameDay: '3',
+    );
+
+    final restored = deserializePayload(serializePayload(source));
+
+    expect(restored.gameTime, '19:45');
+    expect(restored.gameDate, '08.11.2027');
+    expect(restored.gameDay, '3');
+  });
+
   test(
     'prompt isolate codec preserves Ledger policy and injection identity',
     () {

--- a/test/reconciler_view_service_test.dart
+++ b/test/reconciler_view_service_test.dart
@@ -34,6 +34,17 @@ void main() {
       await _seedSession(db);
       final run = _run();
       expect(await runRepo.append(run), isA<ReconciliationRunAppended>());
+      await LedgerReconciliationCheckpointRepo(db).upsert(
+        const LedgerReconciliationCheckpoint(
+          sessionId: 'session',
+          startMessageId: 'a1',
+          endMessageId: 'a2',
+          endSwipeId: 0,
+          endAgentSwipeId: 0,
+          messageIds: ['a1', 'u1', 'a2'],
+          rangeHash: 'range',
+        ),
+      );
       await db.customStatement(
         'INSERT INTO reconciliation_run_invalidations '
         '(session_id, run_id, cause_message_id, reason, created_at) '
@@ -46,6 +57,7 @@ void main() {
       expect(snapshot.runs, hasLength(1));
       expect(snapshot.runs.single.firstMessageOrdinal, 1);
       expect(snapshot.runs.single.lastMessageOrdinal, 3);
+      expect(snapshot.checkpointEndMessageOrdinal, 3);
       expect(
         snapshot.runs.single.status,
         ReconciliationRunViewStatus.invalidated,

--- a/test/summary_service_test.dart
+++ b/test/summary_service_test.dart
@@ -200,6 +200,34 @@ void main() {
     expect(llm.prompt, contains('User: Hi'));
   });
 
+  test('ledger-stamped game time travels with the transcript', () async {
+    final llm = _RecordingAuxLlmClient();
+    final service = SummaryService(repo, llm: llm);
+
+    await service.generateSummary(
+      sessionId: 'session',
+      history: const [
+        ChatMessage(id: '1', role: 'user', content: 'Morning.'),
+        ChatMessage(
+          id: '2',
+          role: 'assistant',
+          content: 'She nods.',
+          time: '12.05.2027 · День 0 · 09:15',
+        ),
+      ],
+      apiConfig: const ApiConfig(
+        id: 'api',
+        endpoint: 'https://example.com/v1',
+        apiKey: 'secret',
+        model: 'model',
+      ),
+      customPrompt: 'Context:\n{{history}}',
+    );
+
+    expect(llm.prompt, contains('User: Morning.'));
+    expect(llm.prompt, contains('[12.05.2027 · День 0 · 09:15] She nods.'));
+  });
+
   test('accepts an OpenRouter config with no endpoint', () async {
     final llm = _RecordingAuxLlmClient();
     final service = SummaryService(repo, llm: llm);

--- a/test/sync_lifecycle_test.dart
+++ b/test/sync_lifecycle_test.dart
@@ -58,6 +58,7 @@ class FakeCharacterStore implements SyncCharacterStore {
 
 class FakeChatStore implements SyncChatStore {
   final Map<String, ChatSession> data = {};
+  Duration putDelay = Duration.zero;
 
   @override
   Future<List<SessionMetadata>> getAllSessionMetadata() async {
@@ -81,6 +82,7 @@ class FakeChatStore implements SyncChatStore {
 
   @override
   Future<void> put(ChatSession s) async {
+    if (putDelay > Duration.zero) await Future<void>.delayed(putDelay);
     data[s.id] = s;
   }
 
@@ -393,6 +395,7 @@ class FakeReconciliationStateStore implements SyncReconciliationStateStore {
   final Map<String, Map<String, dynamic>> data = {};
   bool discardCollectors = false;
   bool discardAll = false;
+  Future<void> Function(String sessionId)? beforeMerge;
 
   @override
   Future<List<String>> getAllSessionIds() async => data.keys.toList();
@@ -406,6 +409,7 @@ class FakeReconciliationStateStore implements SyncReconciliationStateStore {
     String sessionId,
     Map<String, dynamic> incoming,
   ) async {
+    await beforeMerge?.call(sessionId);
     if (discardAll) {
       data.remove(sessionId);
       return {};
@@ -792,6 +796,90 @@ void main() {
       progressList.firstWhere(
         (p) => p.total > 0 || p.message?.contains('Nothing to push') == true,
       );
+
+  test('pull applies chat before its reconciliation state', () async {
+    final reconciliationStates = FakeReconciliationStateStore();
+    final world = SyncWorld(reconciliationStateStore: reconciliationStates);
+    const sessionId = 'ordered-pull-session';
+    const oldChat = ChatSession(
+      id: sessionId,
+      characterId: 'character',
+      sessionIndex: 0,
+      updatedAt: 1000,
+      messages: [ChatMessage(id: 'a1', role: 'assistant', content: 'Opening')],
+    );
+    const cloudChat = ChatSession(
+      id: sessionId,
+      characterId: 'character',
+      sessionIndex: 0,
+      updatedAt: 2000,
+      messages: [
+        ChatMessage(id: 'a1', role: 'assistant', content: 'Opening'),
+        ChatMessage(id: 'u1', role: 'user', content: 'Question'),
+        ChatMessage(id: 'a2', role: 'assistant', content: 'Answer'),
+      ],
+    );
+    await world.chats.put(oldChat);
+    reconciliationStates.data[sessionId] = {
+      'runs': [
+        {'id': 'local-run', 'ordinal': 1},
+      ],
+      'collectors': <dynamic>[],
+    };
+    await world.engine.pushEntities(onProgress: (_) {});
+    world.chats.putDelay = const Duration(milliseconds: 50);
+    reconciliationStates.beforeMerge = (_) async {
+      if (world.chats.data[sessionId]?.messages.length != 3) {
+        throw StateError('Reconciliation saw a stale chat transcript');
+      }
+    };
+    final statePayload = <String, dynamic>{
+      'runs': [
+        {'id': 'cloud-run', 'ordinal': 1},
+      ],
+      'collectors': <dynamic>[],
+    };
+    final chatEntry = SyncManifestEntry(
+      type: 'chat',
+      id: sessionId,
+      path: cloudPath('chat', sessionId),
+      updatedAt: 2000,
+      hash: SyncSerialization.computeChatMetadataHash(
+        const SessionMetadata(
+          sessionId: sessionId,
+          characterId: 'character',
+          sessionIndex: 0,
+          updatedAt: 2000,
+          messageCount: 3,
+          lastMessageContent: 'Answer',
+          lastMessageTimestamp: 0,
+        ),
+      ),
+    );
+    final stateEntry = SyncManifestEntry(
+      type: 'reconciliation_state',
+      id: sessionId,
+      path: cloudPath('reconciliation_state', sessionId),
+      updatedAt: 2000,
+      hash: SyncSerialization.computeSyncHash(statePayload),
+    );
+    final cloudManifest = SyncManifest(
+      deviceId: 'cloud-device',
+      createdAt: 1,
+      lastSync: 2000,
+      entries: {stateEntry.key: stateEntry, chatEntry.key: chatEntry},
+    );
+    world.cloud.files[stateEntry.path] = jsonEncode(statePayload);
+    world.cloud.files[chatEntry.path] = jsonEncode(cloudChat.toJson());
+    world.cloud.files[cloudPath('manifest', 'manifest')] = jsonEncode(
+      cloudManifest.toJson(),
+    );
+
+    await world.engine.pullEntities(onProgress: (_) {}, onConflict: (_) {});
+
+    expect(world.chats.data[sessionId], cloudChat);
+    expect(reconciliationStates.data[sessionId], statePayload);
+  });
 
   test(
     'Push pre-merges cloud-only reconciliation state before rebuilding manifest',


### PR DESCRIPTION
## Summary

- **Reconciliation sync order** (056384f): pull entries now apply chats before their reconciliation state, preventing a race where the reconciliation merge validated anchors against a stale local chat and silently dropped the tail of the chain.
- **Pipeline diagnostics refresh** (d84c45a): LedgerStage invalidates Agent Ops view providers after each run; the ledger injection preview absorbs one expected canon transition instead of caching a red error.
- **Card Rewriter context gates** (