### PR TITLE
fix(chat): keep the header's hide-on-scroll alive during generation

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -23,9 +23,9 @@ export class Bridge {
     this.isGeneratingImage = false;
     this.isPostGenRunning = false;
     // Scroll-hide header state. Lifted out of the _setupScrollListener closure
-    // so setGenerating() can re-show the header when a generation ends (see
-    // setGenerating): the header is frozen for the whole streaming window and
-    // must never be left stuck hidden afterwards.
+    // so the rest of the controller can reach it: _ensureHeaderReachable()
+    // un-hides the header when the list shrinks out of scroll range, and
+    // showHeader() clears it when a chat opens.
     this._headerHidden = false;
     // Last scroll offset the header tracker decided on, and the deadline until
     // which it only re-baselines instead of deciding. Both are instance fields
@@ -133,18 +133,10 @@ export class Bridge {
     const wasGenerating = this.isGenerating;
     this.isGenerating = !!value;
     this._syncGenerationTimer();
-    // updateHeader() early-returns for the whole streaming window, so the
-    // scroll-hide header is frozen at whatever state it had when generation
-    // started. If it was hidden — and especially if the chat then shrank (a
-    // cancelled generation trims its empty placeholder) so it no longer
-    // scrolls and the bounds check also early-returns — the header could never
-    // re-appear. Re-show it once when generation ends so it is never stuck
-    // hidden after a (possibly cancelled) generation. Emitting keeps JS the
-    // single source of truth for the Flutter header state.
-    if (wasGenerating && !this.isGenerating && this._headerHidden) {
-      this._headerHidden = false;
-      this._sendToFlutter('onHeaderScroll', [false]);
-    }
+    // A cancelled generation trims its empty placeholder, so the list can
+    // shrink right here — possibly below the scroll range a hidden header
+    // needs to be scrolled back into view. See _ensureHeaderReachable().
+    if (wasGenerating && !this.isGenerating) this._ensureHeaderReachable();
   }
 
   setPostGenRunning(value) {
@@ -242,6 +234,38 @@ export class Bridge {
     this._trackpadScroll.scrollBy(dx, dy, x, y);
   }
 
+  // True while the list is being scrolled by us rather than by the user. The
+  // virtual list raises the flag around its own scrolls (streaming
+  // auto-follow, scroll-to-bottom / -message, anchor restore) and the bridge
+  // raises it around the bottom-inset re-pin glide (see
+  // _reconcileBottomInset), which also drives `_repinAnimating`.
+  _isProgrammaticScroll() {
+    return !!(this._repinAnimating || this.virtualList?.isProgrammaticScrolling);
+  }
+
+  // Re-shows the header when scrolling can no longer bring it back.
+  //
+  // The tracker only un-hides on an upward scroll, so a hidden header stays
+  // recoverable only while the list has scroll range left. Losing it strands
+  // the header off screen with no gesture that could restore it — which is
+  // what a cancelled generation does when it trims its empty placeholder and
+  // the remaining chat is shorter than the viewport.
+  //
+  // Deliberately conditional: while the list still scrolls, the header belongs
+  // to the user, so this must not undo a hide they asked for by scrolling down
+  // mid-stream. Emitting keeps JS the single source of truth for the Flutter
+  // header state.
+  _ensureHeaderReachable() {
+    if (!this._headerHidden) return;
+    const container = this.virtualList?.container;
+    if (!container) return;
+    // Mirrors the `st > 50` hide threshold: with less range than that left
+    // there is no upward scroll available to bring the header back.
+    if (container.scrollHeight - container.clientHeight > 50) return;
+    this._headerHidden = false;
+    this._sendToFlutter('onHeaderScroll', [false]);
+  }
+
   // Re-shows the header and re-baselines the hide-on-scroll tracker. Flutter
   // calls this whenever a chat is opened or a session is switched.
   //
@@ -272,8 +296,8 @@ export class Bridge {
     let lastShowScrollToBottom = null;
     // Header hide-on-scroll (ported from Glaze/src/core/services/ui.js initHeaderScroll).
     // `_headerHidden` / `_headerLastTop` are instance fields (see constructor)
-    // so setGenerating() can re-show the header when a generation ends and
-    // showHeader() can re-baseline the tracker when a chat opens.
+    // so _ensureHeaderReachable() can re-show the header when the list shrinks
+    // and showHeader() can re-baseline the tracker when a chat opens.
     let ticking = false;
     const container = this.virtualList.container;
 
@@ -302,9 +326,22 @@ export class Bridge {
         this._headerLastTop = st <= 0 ? 0 : st;
         return;
       }
-      // Streaming auto-follow must not hide the header, but an explicit upward
-      // scroll should still restore an already-hidden header.
-      if (this.isGenerating) {
+      // Scrolls we caused ourselves are not user intent: the streaming
+      // auto-follow, the keyboard / input-bar re-pin glide, scroll-to-message
+      // and the anchor restore all move scrollTop on their own. Follow the
+      // offset without deciding, so none of them hides the header.
+      //
+      // This replaced a blanket freeze on the generation flag, which suspended
+      // hide-on-scroll for the whole streaming window: during a long reply the
+      // header simply stopped responding to scrolling. Only the auto-follow
+      // needs suppressing, and it already announces itself through the virtual
+      // list's own programmatic-scroll flag.
+      //
+      // An upward move still restores an already-hidden header. The auto-follow
+      // only ever pins downward, so an upward one inside this window is the
+      // user's — and it is how they detach from the follow in the first place
+      // (the flag stays set for ~80ms after the last pin, see smartScroll()).
+      if (this._isProgrammaticScroll()) {
         if (st < this._headerLastTop - 3 && this._headerHidden) {
           this._headerHidden = false;
           this._sendToFlutter('onHeaderScroll', [false]);
@@ -312,6 +349,8 @@ export class Bridge {
         this._headerLastTop = st <= 0 ? 0 : st;
         return;
       }
+      // A shrink can clamp scrollTop without leaving room to scroll back up.
+      this._ensureHeaderReachable();
       if (st < 0 || st + container.clientHeight > container.scrollHeight) {
         this._headerLastTop = st <= 0 ? 0 : st;
         return;
@@ -724,10 +763,16 @@ export class Bridge {
           this.virtualList.remove(messageId);
         }
         this._pruneOrphanSeparators();
+        // The list just got shorter; a hidden header may have lost the scroll
+        // range that lets the user bring it back. This lands ~340ms after the
+        // exit animation started, which is why setGenerating()'s own check
+        // (the placeholder is still on screen there) is not enough.
+        this._ensureHeaderReachable();
       });
     } else {
       this.virtualList.remove(messageId);
       this._pruneOrphanSeparators();
+      this._ensureHeaderReachable();
     }
   }
 

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -1367,8 +1367,19 @@ void main() {
       expect(body, contains('this._syncGenerationTimer()'));
     });
 
-    test('upward scroll restores a hidden header during generation', () {
-      final marker = 'if (this.isGenerating) {';
+    test('hide-on-scroll is not frozen for the whole streaming window', () {
+      final idx = bridgeControllerJs.indexOf('const updateHeader = () => {');
+      expect(idx, isNot(-1));
+      final body = _extractBlockBody(bridgeControllerJs, idx);
+      // Gating the tracker on the generation flag suspended hide-on-scroll for
+      // as long as a reply streamed — the header stopped responding to
+      // scrolling entirely. Only our own scrolls may be suppressed.
+      expect(body, isNot(contains('this.isGenerating')));
+      expect(body, contains('this._isProgrammaticScroll()'));
+    });
+
+    test('upward scroll restores a hidden header during auto-follow', () {
+      final marker = 'if (this._isProgrammaticScroll()) {';
       final updateHeaderIdx = bridgeControllerJs.indexOf(
         'const updateHeader = () => {',
       );
@@ -1380,6 +1391,57 @@ void main() {
       expect(body, contains('this._headerHidden = false'));
       expect(body, contains("this._sendToFlutter('onHeaderScroll', [false])"));
       expect(body, isNot(contains('[true]')));
+    });
+
+    test('programmatic-scroll probe reads the virtual list flag', () {
+      final marker = '_isProgrammaticScroll() {';
+      final idx = bridgeControllerJs.indexOf(marker);
+      expect(idx, isNot(-1));
+      final body = _extractBlockBody(bridgeControllerJs, idx);
+      // Streaming auto-follow / scroll-to-bottom / anchor restore raise the
+      // virtual list's own flag; the bottom-inset re-pin glide raises
+      // `_repinAnimating`. Both are ours, neither is the user scrolling.
+      expect(body, contains('this.virtualList?.isProgrammaticScrolling'));
+      expect(body, contains('this._repinAnimating'));
+      expect(virtualScrollJs, contains('this.isProgrammaticScrolling = true'));
+    });
+
+    test('ending a generation re-shows the header only if it is stranded', () {
+      final marker = 'setGenerating(value) {';
+      final idx = bridgeControllerJs.indexOf(marker);
+      expect(idx, isNot(-1));
+      final body = _extractBlockBody(bridgeControllerJs, idx);
+      // A hide the user asked for by scrolling down mid-stream must survive the
+      // end of the generation, so the falling edge no longer force-shows.
+      expect(body, contains('this._ensureHeaderReachable()'));
+      expect(body, isNot(contains("this._sendToFlutter('onHeaderScroll'")));
+
+      final helperIdx = bridgeControllerJs.indexOf(
+        '_ensureHeaderReachable() {',
+      );
+      expect(helperIdx, isNot(-1));
+      final helper = _extractBlockBody(bridgeControllerJs, helperIdx);
+      // Only when the list no longer has the scroll range that an upward
+      // scroll would need to bring the header back.
+      expect(helper, contains('if (!this._headerHidden) return'));
+      expect(
+        helper,
+        contains('container.scrollHeight - container.clientHeight > 50'),
+      );
+      expect(helper, contains('this._headerHidden = false'));
+      expect(helper, contains("this._sendToFlutter('onHeaderScroll', [false])"));
+    });
+
+    test('a trimmed message re-checks that the header is reachable', () {
+      final idx = bridgeControllerJs.indexOf('removeMessage(messageId) {');
+      expect(idx, isNot(-1));
+      final body = _extractBlockBody(bridgeControllerJs, idx);
+      // The cancelled-generation placeholder is dropped ~340ms later, behind
+      // its exit animation — long after setGenerating() ran its own check.
+      expect(
+        '_ensureHeaderReachable()'.allMatches(body).length,
+        greaterThanOrEqualTo(2),
+      );
     });
 
     test('showHeader re-shows the header and re-baselines the tracker', () {


### PR DESCRIPTION
The chat header stopped responding to scrolling while a reply streamed in. The scroll-hide tracker in `chat_bridge_controller.js` (`updateHeader`, inside `_setupScrollListener`) was frozen on the generation flag: for the whole streaming window it early-returned, so the header could no longer be hidden or shown by scrolling until the generation ended. Only the streaming auto-follow needed suppressing there — and it already announces itself through the virtual list's own programmatic-scroll flag.

## Changes

- Gate `updateHeader` on the new `Bridge._isProgrammaticScroll()` instead of `isGenerating`. It reads `UseVirtualScroll.isProgrammaticScrolling` (streaming auto-follow via `smartScroll()`, `scrollToBottom()`, `scrollToMessage()`, `restoreAnchor()`) and `Bridge._repinAnimating` (the bottom-inset re-pin glide in `_reconcileBottomInset` / `_glideScrollTo`). Real user scrolls now hide and show the header while a reply streams; our own scrolls still only re-baseline the tracker.
- An upward move inside that window keeps restoring an already-hidden header, unchanged: the auto-follow only ever pins downward, and an upward scroll is how the user detaches from it (`isProgrammaticScrolling` stays set for ~80 ms after the last pin).
- Fixes the same freeze outside generation as a side effect: the keyboard / input-bar re-pin glide scrolls the list down on its own and used to drag the header away with it.
- Replace the unconditional re-show on the falling edge of `setGenerating()` with `Bridge._ensureHeaderReachable()`, which un-hides only when the list no longer has the scroll range an upward scroll would need (`scrollHeight - clientHeight <= 50`, mirroring the `st > 50` hide threshold). A hide the user asked for mid-stream now survives the end of the reply, while a cancelled generation that trims its placeholder down to a non-scrolling chat still cannot strand the header off screen.
- Call `_ensureHeaderReachable()` where the list actually shrinks: in `Bridge.removeMessage()` (the streaming placeholder is dropped ~340 ms later, behind its exit animation — long after `setGenerating()` ran its own check) and in the scroll path, where a shrink clamps `scrollTop`.
- Comments on `_headerHidden` in the constructor and in `_setupScrollListener` updated — they documented the removed freeze.

## Verification

- `test/webview_assets_test.dart`: the `upward scroll restores a hidden header during generation` case is rewritten for the new gate, plus four new static assertions — the tracker no longer references the generation flag, the programmatic-scroll probe reads both flags (and the virtual list really raises its own), the generation falling edge re-shows only through the conditional helper, and `removeMessage` re-checks reachability on both removal paths.
- Not run here: `flutter analyze` and `flutter test`. This agent session has no Flutter SDK, so the gate is CI. The new assertions were instead evaluated against the patched JS with an equivalent script (all pass), and `chat_bridge_controller.js` parses clean as an ES module (`node --check`).
- Runtime behavior in a live app was not verified — the change is in a WebView asset, which needs a hot restart rather than a hot reload.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6BNb5gmvPkDxtGyg6TacZ)_