### PR TITLE
fix(chat): refresh search matches and highlights after a message changes

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -785,7 +785,7 @@ export class Bridge {
   }
   scrollToMessage(messageId, highlight = false) { this.virtualList.scrollToMessage(messageId, highlight); }
 
-  setSearch(query, activeIndex) { this.renderer.setSearch(query, activeIndex); }
+  setSearch(query, activeIndex, scroll = true) { this.renderer.setSearch(query, activeIndex, scroll); }
 
   setChatFont(fontFamily, fontDataUrl, fontSize, letterSpacing) {
     const root = document.documentElement;

--- a/assets/chat_webview/bridge/edit_controller.js
+++ b/assets/chat_webview/bridge/edit_controller.js
@@ -220,13 +220,22 @@ export class EditController {
     if (body) {
       delete body.dataset.originalHtml;   // discard stale snapshot
       if (window.bridge?.renderer) {
+        const renderer = window.bridge.renderer;
         const isUser = section.classList.contains('user');
-        window.bridge.renderer.updateMessageContent(
+        renderer.updateMessageContent(
           section,
           section.dataset.rawText || '',
           section.dataset.reasoning || null,
           isUser, false, false,
         );
+        // While the bubble was in edit mode it held a textarea instead of a
+        // content host, so a search pass that ran in the meantime skipped it
+        // and numbered the matches without it. Re-run the pass now that the
+        // saved text is back in the DOM, or the counter and the active-match
+        // highlight stay out of step with what is on screen.
+        if (renderer.searchQuery) {
+          renderer.setSearch(renderer.searchQuery, renderer.activeSearchIndex, false);
+        }
       }
     }
 

--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -1008,7 +1008,11 @@ if (messageData.isEditing) classes.push('editing');
     });
   }
 
-  setSearch(query, activeIndex = -1, _retried = false) {
+  // `scroll` brings the active match into view. A refresh pass (the messages
+  // changed under an open search) passes false: it only has to re-number the
+  // highlights, and scrolling would yank the reader away from the message they
+  // just edited.
+  setSearch(query, activeIndex = -1, scroll = true, _retried = false) {
     // Nothing highlighted and nothing to highlight: skip the full re-render.
     // This is the common path when a chat opens without an active search.
     if (!query && !this.searchQuery) {
@@ -1073,9 +1077,11 @@ if (messageData.isEditing) classes.push('editing');
     // syntax, display regexes). Rather than leaving the arrows dead when the
     // requested index overshoots, clamp into range and re-run once.
     if (!_retried && activeIndex >= total && total > 0) {
-      this.setSearch(query, total - 1, true);
+      this.setSearch(query, total - 1, scroll, true);
       return;
     }
+
+    if (!scroll) return;
 
     if (activeMessageId && window.bridge) {
       // The match may live in a message the virtual list has not mounted:

--- a/lib/features/chat/bridge/bridge_layout_commands.dart
+++ b/lib/features/chat/bridge/bridge_layout_commands.dart
@@ -11,9 +11,18 @@ class LayoutBridgeCommands {
 
   LayoutBridgeCommands(this._host);
 
-  Future<void> setSearch({required String query, int activeIndex = -1}) {
+  /// [scroll] brings the active match into view. Pass `false` for a refresh
+  /// pass that only has to re-number the highlights after the messages
+  /// changed — scrolling there would yank the reader away from the message
+  /// they just edited.
+  Future<void> setSearch({
+    required String query,
+    int activeIndex = -1,
+    bool scroll = true,
+  }) {
     return _host.evalJs(
-      'window.bridge?.setSearch("${_host.escape(query)}", $activeIndex)',
+      'window.bridge?.setSearch("${_host.escape(query)}", $activeIndex, '
+      '$scroll)',
     );
   }
 

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -684,8 +684,15 @@ class ChatBridgeController {
   Future<void> applyLayout(String l) => identity.applyLayout(l);
 
   // Layout
-  Future<void> setSearch({required String query, int activeIndex = -1}) =>
-      layout.setSearch(query: query, activeIndex: activeIndex);
+  Future<void> setSearch({
+    required String query,
+    int activeIndex = -1,
+    bool scroll = true,
+  }) => layout.setSearch(
+    query: query,
+    activeIndex: activeIndex,
+    scroll: scroll,
+  );
   Future<void> setBottomPadding(double px, {double viewportHeight = 0}) =>
       layout.setBottomPadding(px, viewportHeight: viewportHeight);
   Future<void> setTopPadding(double px) => layout.setTopPadding(px);

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -140,6 +140,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
   late final ChatDrawerController _drawerCtrl;
   late final ChatSearchDelegate _search;
 
+  /// Guards against queueing one post-frame recount per rebuild while a
+  /// search is open.
+  bool _searchRecountScheduled = false;
+
   @override
   void initState() {
     super.initState();
@@ -171,6 +175,27 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
   void _onSearchChanged() {
     if (!mounted) return;
     setState(() {});
+  }
+
+  /// Keeps the open search in sync with the chat.
+  ///
+  /// Editing a message (or deleting one, or swiping a variation) does not go
+  /// through the search field's `onChanged`, so the delegate kept serving the
+  /// match list it built when the query was typed: the "n / m" counter and the
+  /// WebView highlights both went stale. Re-counting cannot happen inside
+  /// `build` — the delegate notifies its listeners, and this state's listener
+  /// calls `setState` — so it is deferred to the end of the frame.
+  void _scheduleSearchRecount() {
+    if (!_search.showSearch || _search.searchQuery.isEmpty) return;
+    if (_searchRecountScheduled) return;
+    _searchRecountScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _searchRecountScheduled = false;
+      if (!mounted) return;
+      final state = ref.read(chatProvider(widget.charId)).value;
+      if (state == null || state.isGenerating) return;
+      _search.syncWithMessages(state.messages);
+    });
   }
 
   @override
@@ -257,6 +282,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
     final charId = widget.charId;
     final chatStateAsync = ref.watch(chatProvider(charId));
     final chatState = chatStateAsync.value;
+    if (chatState != null && !chatState.isGenerating) {
+      _scheduleSearchRecount();
+    }
 
     final character = ref.watch(characterByIdProvider(charId));
     final title = character?.name ?? 'Chat';
@@ -1752,6 +1780,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                         isSelectionMode: _selectionCtrl.isSelectionMode,
                         searchQuery: widget.search.searchQuery,
                         searchCurrentIndex: widget.search.searchCurrentIndex,
+                        searchRevision: widget.search.searchRevision,
                       ),
                     ),
                   ),

--- a/lib/features/chat/chat_search_delegate.dart
+++ b/lib/features/chat/chat_search_delegate.dart
@@ -13,6 +13,8 @@ class ChatSearchDelegate extends ChangeNotifier {
   String _searchQuery = '';
   List<SearchMatch> _searchMatches = [];
   int _searchCurrentIndex = 0;
+  int _searchRevision = 0;
+  int? _countedMessagesSignature;
   final TextEditingController searchController = TextEditingController();
 
   bool get showSearch => _showSearch;
@@ -20,6 +22,12 @@ class ChatSearchDelegate extends ChangeNotifier {
   List<SearchMatch> get searchMatches => _searchMatches;
   int get searchCurrentIndex => _searchCurrentIndex;
   int get matchCount => _searchMatches.length;
+
+  /// Bumped every time the match list is recounted over a *changed* message
+  /// list (see [syncWithMessages]). The query and the active index can both
+  /// come out of such a recount unchanged, so they are not enough to tell the
+  /// WebView that its highlights are stale — this counter is.
+  int get searchRevision => _searchRevision;
 
   VoidCallback? get onSearchPrev =>
       _searchCurrentIndex > 0 ? searchPrev : null;
@@ -30,6 +38,7 @@ class ChatSearchDelegate extends ChangeNotifier {
     _searchQuery = '';
     _searchMatches = [];
     _searchCurrentIndex = 0;
+    _countedMessagesSignature = null;
     searchController.clear();
     _showSearch = true;
     notifyListeners();
@@ -41,80 +50,126 @@ class ChatSearchDelegate extends ChangeNotifier {
     _searchQuery = '';
     _searchMatches = [];
     _searchCurrentIndex = 0;
+    _countedMessagesSignature = null;
     notifyListeners();
   }
 
   void search(String query, List<ChatMessage> messages) {
+    _searchQuery = query;
+    _searchMatches = _collectMatches(query, messages);
+    _searchCurrentIndex = 0;
+    _countedMessagesSignature = _signatureOf(messages);
+    notifyListeners();
+  }
+
+  /// Recounts the active query against [messages] when the chat changed
+  /// underneath an open search.
+  ///
+  /// The match list used to be built only from the text field's `onChanged`,
+  /// so editing (or deleting, or swiping) a message while the search bar was
+  /// open froze it: the "n / m" counter kept reporting occurrences that no
+  /// longer existed, and prev/next walked positions that had moved. The
+  /// delegate now fingerprints the messages it counted over and recounts as
+  /// soon as that fingerprint moves.
+  ///
+  /// Returns `true` when a recount happened, i.e. when listeners were
+  /// notified.
+  bool syncWithMessages(List<ChatMessage> messages) {
+    if (!_showSearch || _searchQuery.isEmpty) return false;
+    final signature = _signatureOf(messages);
+    if (signature == _countedMessagesSignature) return false;
+    _countedMessagesSignature = signature;
+
+    final matches = _collectMatches(_searchQuery, messages);
+    _searchMatches = matches;
+    // Stay on the occurrence the reader was looking at instead of snapping
+    // back to the first one; only clamp when the edit dropped the matches
+    // after it.
+    final lastIndex = matches.length - 1;
+    _searchCurrentIndex = _searchCurrentIndex > lastIndex
+        ? (lastIndex < 0 ? 0 : lastIndex)
+        : _searchCurrentIndex;
+    // The bubbles that changed were re-rendered by the message sync, which
+    // highlights them without global match numbering — always ask for a fresh
+    // highlight pass, even when the count and the index both came out the same.
+    _searchRevision++;
+    notifyListeners();
+    return true;
+  }
+
+  /// Cheap fingerprint of everything [_collectMatches] reads. Ids are included
+  /// so an insert/delete that happens to preserve the total text still counts
+  /// as a change.
+  int _signatureOf(List<ChatMessage> messages) => Object.hashAll([
+    for (final m in messages) ...[m.id, m.content, m.reasoning],
+  ]);
+
+  List<SearchMatch> _collectMatches(String query, List<ChatMessage> messages) {
     final matches = <SearchMatch>[];
-    if (query.isNotEmpty) {
-      final lower = query.toLowerCase();
-      for (int i = 0; i < messages.length; i++) {
-        var raw = messages[i].content;
-        if (raw.contains('<think')) {
-          raw = raw.replaceAll(
-            RegExp(
-              r'<think\b[^>]*>[\s\S]*?<\/think\b[^>]*>',
-              caseSensitive: false,
-            ),
-            '',
-          );
-          raw = raw.replaceAll(
-            RegExp(
-              r'<think\b([^>]*?)(?:>|\n)([\s\S]*?)<\/think\b',
-              caseSensitive: false,
-            ),
-            '',
-          );
-        }
-        if (raw.contains('<thinking')) {
-          raw = raw.replaceAll(
-            RegExp(
-              r'<thinking\b[^>]*>[\s\S]*?<\/thinking\b[^>]*>',
-              caseSensitive: false,
-            ),
-            '',
-          );
-          raw = raw.replaceAll(
-            RegExp(
-              r'<thinking\b([^>]*?)(?:>|\n)([\s\S]*?)<\/thinking\b',
-              caseSensitive: false,
-            ),
-            '',
-          );
-        }
-        raw = raw.trim();
-        final content = raw.toLowerCase();
+    if (query.isEmpty) return matches;
+    final lower = query.toLowerCase();
+    for (int i = 0; i < messages.length; i++) {
+      var raw = messages[i].content;
+      if (raw.contains('<think')) {
+        raw = raw.replaceAll(
+          RegExp(
+            r'<think\b[^>]*>[\s\S]*?<\/think\b[^>]*>',
+            caseSensitive: false,
+          ),
+          '',
+        );
+        raw = raw.replaceAll(
+          RegExp(
+            r'<think\b([^>]*?)(?:>|\n)([\s\S]*?)<\/think\b',
+            caseSensitive: false,
+          ),
+          '',
+        );
+      }
+      if (raw.contains('<thinking')) {
+        raw = raw.replaceAll(
+          RegExp(
+            r'<thinking\b[^>]*>[\s\S]*?<\/thinking\b[^>]*>',
+            caseSensitive: false,
+          ),
+          '',
+        );
+        raw = raw.replaceAll(
+          RegExp(
+            r'<thinking\b([^>]*?)(?:>|\n)([\s\S]*?)<\/thinking\b',
+            caseSensitive: false,
+          ),
+          '',
+        );
+      }
+      raw = raw.trim();
+      final content = raw.toLowerCase();
 
-        final reasoning = messages[i].reasoning?.toLowerCase() ?? '';
+      final reasoning = messages[i].reasoning?.toLowerCase() ?? '';
 
-        int matchIndex = 0;
+      int matchIndex = 0;
 
-        if (reasoning.isNotEmpty) {
-          int startIndex = 0;
-          while (true) {
-            final idx = reasoning.indexOf(lower, startIndex);
-            if (idx == -1) break;
-            matches.add(SearchMatch(i, matchIndex));
-            matchIndex++;
-            startIndex = idx + lower.length;
-          }
-        }
-
+      if (reasoning.isNotEmpty) {
         int startIndex = 0;
         while (true) {
-          final idx = content.indexOf(lower, startIndex);
+          final idx = reasoning.indexOf(lower, startIndex);
           if (idx == -1) break;
           matches.add(SearchMatch(i, matchIndex));
           matchIndex++;
           startIndex = idx + lower.length;
         }
       }
-    }
 
-    _searchQuery = query;
-    _searchMatches = matches;
-    _searchCurrentIndex = 0;
-    notifyListeners();
+      int startIndex = 0;
+      while (true) {
+        final idx = content.indexOf(lower, startIndex);
+        if (idx == -1) break;
+        matches.add(SearchMatch(i, matchIndex));
+        matchIndex++;
+        startIndex = idx + lower.length;
+      }
+    }
+    return matches;
   }
 
   void searchNext() {

--- a/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
+++ b/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
@@ -132,7 +132,11 @@ class ChatWebViewSyncDispatcher {
     _maybeApplyChatFont(bridge: bridge, old: old, current: current);
     _maybeApplySelectionMode(bridge: bridge, old: old, current: current);
     _maybeApplyMessageSettings(bridge: bridge, old: old, current: current);
-    _maybeApplySearch(bridge: bridge, old: old, current: current);
+    final rehighlightSearch = _maybeApplySearch(
+      bridge: bridge,
+      old: old,
+      current: current,
+    );
     _maybeApplyInsets(bridge: bridge, old: old, current: current);
 
     _maybeApplyGeneratingState(bridge: bridge, old: old, current: current);
@@ -199,6 +203,7 @@ class ChatWebViewSyncDispatcher {
       appendPlaceholder: shouldInjectPlaceholder,
       sessionSwitched: false,
       placeholder: shouldInjectPlaceholder ? buildStreamingPlaceholder() : null,
+      rehighlightSearch: rehighlightSearch,
     );
   }
 
@@ -320,21 +325,49 @@ class ChatWebViewSyncDispatcher {
     }
   }
 
-  void _maybeApplySearch({
+  /// Returns `true` when the highlight pass must run *after* the message sync
+  /// instead of now.
+  ///
+  /// A revision bump means the messages themselves changed under an open
+  /// search (an edit, a delete, a swipe). Highlighting reads the bubbles that
+  /// are currently in the DOM, and the message sync that carries the new text
+  /// is queued after this dispatch — re-highlighting here would number the
+  /// matches over the *old* text and then have the edited bubble rewritten on
+  /// top, which is exactly the stale highlight this defers around.
+  bool _maybeApplySearch({
     required ChatBridgeController bridge,
     required ChatWebViewWidgetFields old,
     required ChatWebViewWidgetFields current,
   }) {
-    if (current.searchQuery != old.searchQuery ||
-        current.searchCurrentIndex != old.searchCurrentIndex) {
-      if (current.searchQuery != null && current.searchQuery!.isNotEmpty) {
-        bridge.setSearch(
-          query: current.searchQuery!,
-          activeIndex: current.searchCurrentIndex,
-        );
-      } else {
-        bridge.setSearch(query: '', activeIndex: -1);
-      }
+    if (current.searchRevision != old.searchRevision) return true;
+    if (current.searchQuery == old.searchQuery &&
+        current.searchCurrentIndex == old.searchCurrentIndex) {
+      return false;
+    }
+    applySearch(bridge: bridge, fields: current);
+    return false;
+  }
+
+  /// Pushes the current query + active index into the page. Public so the
+  /// widget can re-run it once the deferred message sync has landed.
+  ///
+  /// [scroll] is `false` for that deferred re-run: it only re-numbers the
+  /// highlights over the new text, and scrolling to the active match would
+  /// yank the reader away from the message they just edited.
+  void applySearch({
+    required ChatBridgeController bridge,
+    required ChatWebViewWidgetFields fields,
+    bool scroll = true,
+  }) {
+    final query = fields.searchQuery;
+    if (query != null && query.isNotEmpty) {
+      bridge.setSearch(
+        query: query,
+        activeIndex: fields.searchCurrentIndex,
+        scroll: scroll,
+      );
+    } else {
+      bridge.setSearch(query: '', activeIndex: -1);
     }
   }
 
@@ -461,6 +494,7 @@ class ChatWebViewSyncResult {
     required this.appendPlaceholder,
     required this.sessionSwitched,
     this.placeholder,
+    this.rehighlightSearch = false,
   });
 
   /// `true` when the caller should call
@@ -479,6 +513,11 @@ class ChatWebViewSyncResult {
 
   /// Placeholder to append when [appendPlaceholder] is `true`.
   final ChatMessage? placeholder;
+
+  /// `true` when the search highlights must be re-applied once the queued
+  /// message mutations have landed — the message list changed under an open
+  /// search, so the page is showing highlights numbered over the old text.
+  final bool rehighlightSearch;
 }
 
 /// Pure data snapshot of all the [ChatWebViewWidget] fields that the
@@ -504,6 +543,7 @@ class ChatWebViewWidgetFields {
     this.blurRegions = const [],
     required this.searchQuery,
     required this.searchCurrentIndex,
+    this.searchRevision = 0,
     required this.chatLayout,
     required this.themeSyncKey,
     required this.elementOpacity,
@@ -565,6 +605,10 @@ class ChatWebViewWidgetFields {
   final List<ChatOverlayBlurRegion> blurRegions;
   final String? searchQuery;
   final int searchCurrentIndex;
+
+  /// Bumped when the search matches were recounted over a changed message
+  /// list. See [ChatWebViewSyncResult.rehighlightSearch].
+  final int searchRevision;
   final String? chatLayout;
   final String? themeSyncKey;
   final double elementOpacity;

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -72,6 +72,12 @@ class ChatWebViewWidget extends ConsumerStatefulWidget {
   final List<ChatOverlayBlurRegion> blurRegions;
   final String? searchQuery;
   final int searchCurrentIndex;
+
+  /// Bumped by `ChatSearchDelegate` whenever the match list is recounted over
+  /// a changed message list. The query and the active index can both survive
+  /// such a recount unchanged while the highlights in the page are stale, so
+  /// this is what tells the sync dispatcher to re-run the highlight pass.
+  final int searchRevision;
   final String? chatLayout;
 
   /// Changes when preset colors/layout tokens affecting the WebView change.
@@ -149,6 +155,7 @@ class ChatWebViewWidget extends ConsumerStatefulWidget {
     this.blurRegions = const [],
     this.searchQuery,
     this.searchCurrentIndex = 0,
+    this.searchRevision = 0,
     this.chatLayout,
     this.themeSyncKey,
     this.elementOpacity = 0.8,
@@ -876,6 +883,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       blurRegions: w.blurRegions,
       searchQuery: w.searchQuery,
       searchCurrentIndex: w.searchCurrentIndex,
+      searchRevision: w.searchRevision,
       chatLayout: w.chatLayout,
       themeSyncKey: w.themeSyncKey,
       elementOpacity: w.elementOpacity,
@@ -977,6 +985,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     if (result.runMessageSync) unawaited(_syncExtBlockPanels());
     if (bridge != null &&
         (result.runMessageSync ||
+            result.rehighlightSearch ||
             (result.appendPlaceholder && result.placeholder != null))) {
       final charId = widget.charId;
       final sessionId = widget.sessionId;
@@ -1003,6 +1012,22 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
                 isGenerating: isGenerating,
                 sessionSwitching: sessionSwitching,
                 bridge: bridge,
+              );
+            }
+            if (result.rehighlightSearch &&
+                mounted &&
+                identical(_bridge, bridge) &&
+                _ready &&
+                !_sessionSwitching &&
+                widget.charId == charId &&
+                widget.sessionId == sessionId) {
+              // Runs after the message sync above so the highlight pass reads
+              // the edited bubbles: re-numbering the matches over the old text
+              // is what left the counter and the highlights out of step.
+              _syncDispatcher.applySearch(
+                bridge: bridge,
+                fields: _fieldsFor(widget),
+                scroll: false,
               );
             }
             if (placeholder == null || !isCurrent()) return;

--- a/test/chat_search_delegate_test.dart
+++ b/test/chat_search_delegate_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/features/chat/chat_search_delegate.dart';
+
+ChatMessage _msg(String id, String content, {String? reasoning}) => ChatMessage(
+  id: id,
+  role: 'assistant',
+  content: content,
+  timestamp: 1,
+  reasoning: reasoning,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ChatSearchDelegate.syncWithMessages', () {
+    test('recounts the matches after a message was edited', () {
+      final delegate = ChatSearchDelegate()..openSearch();
+      final messages = [_msg('m1', 'foo and foo'), _msg('m2', 'nothing')];
+      delegate.search('foo', messages);
+      expect(delegate.matchCount, 2);
+
+      final edited = [_msg('m1', 'foo and foo'), _msg('m2', 'foo again')];
+      expect(delegate.syncWithMessages(edited), isTrue);
+      expect(delegate.matchCount, 3);
+
+      delegate.dispose();
+    });
+
+    test('drops matches removed by an edit and clamps the active index', () {
+      final delegate = ChatSearchDelegate()..openSearch();
+      delegate.search('foo', [_msg('m1', 'foo'), _msg('m2', 'foo foo')]);
+      delegate.searchNext();
+      delegate.searchNext();
+      expect(delegate.searchCurrentIndex, 2);
+
+      delegate.syncWithMessages([_msg('m1', 'foo'), _msg('m2', 'gone')]);
+
+      expect(delegate.matchCount, 1);
+      expect(delegate.searchCurrentIndex, 0);
+      expect(delegate.onSearchNext, isNull);
+
+      delegate.dispose();
+    });
+
+    test('keeps the reader on the active match when it survives', () {
+      final delegate = ChatSearchDelegate()..openSearch();
+      delegate.search('foo', [_msg('m1', 'foo'), _msg('m2', 'foo foo')]);
+      delegate.searchNext();
+      expect(delegate.searchCurrentIndex, 1);
+
+      delegate.syncWithMessages([
+        _msg('m1', 'foo'),
+        _msg('m2', 'foo foo'),
+        _msg('m3', 'foo'),
+      ]);
+
+      expect(delegate.matchCount, 4);
+      expect(delegate.searchCurrentIndex, 1);
+
+      delegate.dispose();
+    });
+
+    test('bumps the revision so the WebView re-numbers its highlights', () {
+      final delegate = ChatSearchDelegate()..openSearch();
+      delegate.search('foo', [_msg('m1', 'foo')]);
+      final before = delegate.searchRevision;
+
+      // Same match count, same active index — only the surrounding text moved.
+      expect(delegate.syncWithMessages([_msg('m1', 'a foo b')]), isTrue);
+
+      expect(delegate.matchCount, 1);
+      expect(delegate.searchCurrentIndex, 0);
+      expect(delegate.searchRevision, before + 1);
+
+      delegate.dispose();
+    });
+
+    test('is a no-op when the messages did not change', () {
+      final delegate = ChatSearchDelegate()..openSearch();
+      final messages = [_msg('m1', 'foo')];
+      delegate.search('foo', messages);
+      var notifications = 0;
+      void listener() => notifications++;
+      delegate.addListener(listener);
+
+      expect(delegate.syncWithMessages([_msg('m1', 'foo')]), isFalse);
+      expect(notifications, 0);
+
+      delegate.removeListener(listener);
+      delegate.dispose();
+    });
+
+    test('a delete that preserves the total text still recounts', () {
+      final delegate = ChatSearchDelegate()..openSearch();
+      delegate.search('foo', [_msg('m1', 'foo'), _msg('m2', 'foo')]);
+
+      // Deleting the first message keeps the total text identical, so only the
+      // ids in the fingerprint can tell the two lists apart.
+      expect(
+        delegate.syncWithMessages([_msg('m2', 'foo'), _msg('m3', 'foo')]),
+        isTrue,
+      );
+
+      delegate.dispose();
+    });
+
+    test('does nothing while the search bar is closed', () {
+      final delegate = ChatSearchDelegate();
+      expect(delegate.syncWithMessages([_msg('m1', 'foo')]), isFalse);
+      expect(delegate.matchCount, 0);
+      delegate.dispose();
+    });
+
+    test('counts reasoning occurrences too', () {
+      final delegate = ChatSearchDelegate()..openSearch();
+      delegate.search('foo', [_msg('m1', 'foo', reasoning: 'foo')]);
+      expect(delegate.matchCount, 2);
+
+      delegate.syncWithMessages([_msg('m1', 'foo', reasoning: 'no hit')]);
+      expect(delegate.matchCount, 1);
+
+      delegate.dispose();
+    });
+  });
+}

--- a/test/chat_webview_sync_dispatcher_test.dart
+++ b/test/chat_webview_sync_dispatcher_test.dart
@@ -193,6 +193,85 @@ void main() {
       },
     );
 
+    test('pushes the search as soon as the query changes', () {
+      final bridge = _FakeBridge();
+      final dispatcher = ChatWebViewSyncDispatcher(state: ChatWebViewSyncState());
+
+      final result = dispatcher.dispatch(
+        bridge: bridge,
+        old: _fields(isGenerating: false, messages: const []),
+        current: _fields(
+          isGenerating: false,
+          messages: const [],
+          searchQuery: 'foo',
+          searchCurrentIndex: 0,
+        ),
+        oldMessages: const [],
+        newMessages: const [],
+        streamingId: '__streaming__',
+        onSyncExtBlockPanels: () async {},
+        appendMessage: (_) async {},
+        buildStreamingPlaceholder: () => _assistant('__streaming__'),
+      );
+
+      expect(bridge.searchCalls, [('foo', 0, true)]);
+      expect(result.rehighlightSearch, isFalse);
+    });
+
+    test('defers the highlight pass when the messages changed under a '
+        'search', () {
+      final bridge = _FakeBridge();
+      final dispatcher = ChatWebViewSyncDispatcher(state: ChatWebViewSyncState());
+      final edited = _assistant('a1').copyWith(content: 'edited');
+
+      final result = dispatcher.dispatch(
+        bridge: bridge,
+        old: _fields(
+          isGenerating: false,
+          messages: [_assistant('a1')],
+          searchQuery: 'foo',
+          searchCurrentIndex: 0,
+        ),
+        current: _fields(
+          isGenerating: false,
+          messages: [edited],
+          searchQuery: 'foo',
+          searchCurrentIndex: 0,
+          searchRevision: 1,
+        ),
+        oldMessages: [_assistant('a1')],
+        newMessages: [edited],
+        streamingId: '__streaming__',
+        onSyncExtBlockPanels: () async {},
+        appendMessage: (_) async {},
+        buildStreamingPlaceholder: () => _assistant('__streaming__'),
+      );
+
+      // Highlighting now would number the matches over the pre-edit text: the
+      // message sync that carries the new text is queued after this dispatch.
+      expect(bridge.searchCalls, isEmpty);
+      expect(result.rehighlightSearch, isTrue);
+      expect(result.runMessageSync, isTrue);
+    });
+
+    test('re-numbers without scrolling on the deferred pass', () {
+      final bridge = _FakeBridge();
+      final dispatcher = ChatWebViewSyncDispatcher(state: ChatWebViewSyncState());
+
+      dispatcher.applySearch(
+        bridge: bridge,
+        fields: _fields(
+          isGenerating: false,
+          messages: const [],
+          searchQuery: 'foo',
+          searchCurrentIndex: 2,
+        ),
+        scroll: false,
+      );
+
+      expect(bridge.searchCalls, [('foo', 2, false)]);
+    });
+
     test('session switch invalidates a delayed streaming delta', () async {
       final bridge = _FakeBridge();
       final delayedAppend = Completer<void>();
@@ -468,6 +547,9 @@ ChatWebViewWidgetFields _fields({
   String? continuationTargetId,
   List<ChatOverlayBlurRegion> blurRegions = const [],
   List<dynamic> memoryDrafts = const [],
+  String? searchQuery,
+  int searchCurrentIndex = -1,
+  int searchRevision = 0,
 }) => ChatWebViewWidgetFields(
   continuationTargetId: continuationTargetId,
   blurRegions: blurRegions,
@@ -484,8 +566,9 @@ ChatWebViewWidgetFields _fields({
   bgNoiseIntensity: 0,
   bottomInset: 0,
   topInset: 0,
-  searchQuery: null,
-  searchCurrentIndex: -1,
+  searchQuery: searchQuery,
+  searchCurrentIndex: searchCurrentIndex,
+  searchRevision: searchRevision,
   chatLayout: 'default',
   themeSyncKey: 'theme',
   elementOpacity: 1,
@@ -534,6 +617,7 @@ class _FakeBridge implements ChatBridgeController {
 
   final List<List<ChatOverlayBlurRegion>> overlayBlurCalls = [];
   final List<String> evalCalls = [];
+  final List<(String, int, bool)> searchCalls = [];
   final List<ChatMessage> updatedMessages = [];
   final List<ChatMessage> appendedMessages = [];
   final List<bool> updatedIsLast = [];
@@ -557,6 +641,15 @@ class _FakeBridge implements ChatBridgeController {
 
   @override
   Future<void> removeMessage(String _) async {}
+
+  @override
+  Future<void> setSearch({
+    required String query,
+    int activeIndex = -1,
+    bool scroll = true,
+  }) async {
+    searchCalls.add((query, activeIndex, scroll));
+  }
 
   @override
   Future<void> appendMessages(

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -234,6 +234,35 @@ void main() {
       expect(searchBlock, contains('this.allowMessageScripts'));
     });
 
+    test('search refresh pass can re-number without scrolling', () {
+      expect(
+        rendererMessageJs,
+        contains('setSearch(query, activeIndex = -1, scroll = true'),
+      );
+      final searchBlock = _extractBlockBody(
+        rendererMessageJs,
+        rendererMessageJs.indexOf('setSearch(query, activeIndex = -1'),
+      );
+      expect(searchBlock, contains('if (!scroll) return;'));
+      // The clamp retry must keep the caller's scroll choice.
+      expect(searchBlock, contains('this.setSearch(query, total - 1, scroll,'));
+      expect(
+        bridgeControllerJs,
+        contains('setSearch(query, activeIndex, scroll = true)'),
+      );
+    });
+
+    test('leaving edit mode re-numbers the open search', () {
+      expect(editControllerJs, contains('if (renderer.searchQuery) {'));
+      expect(
+        editControllerJs,
+        contains(
+          'renderer.setSearch(renderer.searchQuery, '
+          'renderer.activeSearchIndex, false);',
+        ),
+      );
+    });
+
     test('app bridge changes only the message renderer policy', () {
       expect(bridgeControllerJs, contains('setAllowMessageScripts(enabled)'));
       expect(


### PR DESCRIPTION
Editing a message while the chat search bar is open left the search stale: the "n / m" counter kept reporting occurrences that no longer existed, and the WebView kept highlights numbered over the pre-edit text.

`ChatSearchDelegate.search()` only ran from the search field's `onChanged` (`chat_screen.dart`), and an edit (or a delete, or a swipe) never goes through that path. On the JS side, saving an edit re-renders only that one bubble through `Renderer.updateMessageContent` → `_writeShadowContent`, which applies the highlight *without* the global match numbering `setSearch` does — so the active match drifted onto the wrong occurrence.

## Changes

- `ChatSearchDelegate` now fingerprints the messages it counted over and recounts them in the new `syncWithMessages()` as soon as that fingerprint moves; the match collection itself moved into `_collectMatches` so both entry points share it.
- The recount keeps the reader on the occurrence they were on, clamping the active index only when the edit dropped the matches after it.
- `_ChatScreenState` schedules that recount at the end of the frame whenever the chat state changes under an open search (skipped while generating, so streaming does not re-scan the chat per chunk).
- A new `searchRevision` counter travels from the delegate through `ChatWebViewWidget` into `ChatWebViewSyncDispatcher`. On a revision bump the dispatcher returns `rehighlightSearch` instead of pushing immediately, and `ChatWebViewWidgetState.didUpdateWidget` re-runs `applySearch` inside the message-mutation queue — so the re-numbering reads the edited bubbles instead of the text they replaced.
- `setSearch` gained a `scroll` flag through `LayoutBridgeCommands` / `ChatBridgeController` / `Bridge` / `Renderer.setSearch`. The refresh pass passes `false`, so a refresh no longer yanks the reader to the active match after an edit; typing and the prev/next arrows still scroll.
- `EditController.stopEdit` re-runs the highlight pass after restoring the bubble from `dataset.rawText`. This closes the race where a pass that ran while the bubble still held a textarea skipped it and numbered the matches without it.

## Verification

- New `test/chat_search_delegate_test.dart`: recount after an edit, matches dropped by an edit clamping the active index, the active match surviving an insert, the revision bump when the count is unchanged, the no-op when nothing changed, and reasoning occurrences.
- New cases in `test/chat_webview_sync_dispatcher_test.dart`: a query change pushes `setSearch` immediately, a revision bump defers it (nothing pushed during dispatch), and the deferred pass pushes `scroll: false`.
- New cases in `test/webview_assets_test.dart` covering the `scroll` parameter through `Renderer.setSearch` / `Bridge.setSearch` and the re-numbering in `stopEdit`.
- `flutter analyze` and `flutter test` were **not** run: this agent's container has no Flutter SDK. The JS modules were parse-checked with Node. Relying on CI for analyze + test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W84AEac1qFAbWJxhnJsZ9Z)_