### PR TITLE
fix(chat): in-message edit controls and streaming scroll

### DIFF
--- a/assets/chat_webview/styles.css
+++ b/assets/chat_webview/styles.css
@@ -963,6 +963,26 @@
   justify-self: end;
   gap: 8px;
   grid-column: 3;
+  min-height: 28px;
+}
+
+/* The Save/Cancel row is part of the edited message's own layout box: it keeps
+   a full-height row plus a gap beneath it, so the message measures taller while
+   it is being edited. The chat container's bottom inset (input bar + keyboard)
+   then clears those controls exactly like it clears any other content — no
+   edit-specific padding has to be reserved on the Flutter side. */
+.message-section.editing .msg-footer {
+  row-gap: 8px;
+  min-height: 32px;
+  margin-bottom: 8px;
+}
+/* Bubble layout: the footer is a wrapping flex row whose width follows the
+   bubble, so a narrow bubble would squeeze the two buttons against the meta /
+   switcher columns. Give them a row of their own, aligned to the same side as
+   the rest of the footer (left for char, right for user). */
+.message-section.layout-bubble.editing .edit-buttons {
+  flex: 1 0 100%;
+  justify-content: inherit;
 }
 .edit-btn {
   width: 28px;

--- a/assets/chat_webview/useVirtualScroll.js
+++ b/assets/chat_webview/useVirtualScroll.js
@@ -1,3 +1,15 @@
+/* How close to the end of the list still counts as "resting at the end" for
+ * the streaming auto-follow. Deliberately tiny: the follow is meant to hold
+ * only while the newest text is fully in view, and to resume only once the
+ * user has scrolled all the way back down. */
+const BOTTOM_PIN_EPSILON = 8;
+
+/* How close the user has to get, while scrolling back *down*, for the follow to
+ * take over again. Wider than the epsilon above so returning to the newest
+ * message does not demand hitting the last pixel — but it only ever applies to
+ * a downward move, never to a list the user is scrolling away from. */
+const BOTTOM_PIN_RESUME = 100;
+
 class VirtualScrollHeightCache {
     constructor(getItemLength, getColumns, estimateHeight) {
         this.getItemLength = getItemLength;
@@ -161,13 +173,13 @@ class UseVirtualScroll {
         this.scrollRaf = null;
         this.mounted = true;
 
-        // Mirrors Vue ChatView's `showScrollButton` gate for `smartScroll`:
-        // tracks whether the user is parked near the bottom. Updated only on
-        // *user* scrolls (programmatic scrolls are ignored) so that streaming
-        // content growth — which fires no scroll event — keeps following the
-        // bottom while the user has not deliberately scrolled away. Defaults to
-        // true because chats open pinned to the bottom.
+        // Gate for `smartScroll`: tracks whether the list is resting at the end
+        // of the chat. Content growth fires no scroll event, so streaming keeps
+        // following the bottom while this holds. Defaults to true because chats
+        // open pinned to the bottom. Maintained by _onContainerScroll().
         this._pinnedToBottom = true;
+        this._lastScrollTop = 0;
+        this._selfPinTop = null;
         this._smartScrollUnlock = null;
         
         this.visibleIndices = new Set();
@@ -387,6 +399,11 @@ class UseVirtualScroll {
         if (this.items.length === 0) return;
         this.isProgrammaticScrolling = true;
         this.container.scrollTop = this.container.scrollHeight;
+        // Remember where the follow parked so the scroll event it queues is
+        // recognised as ours even if the next chunk grows the list before that
+        // event is dispatched — otherwise the follow would read its own pin as
+        // "the user moved away" and switch itself off mid-stream.
+        this._lastScrollTop = this._selfPinTop = this.container.scrollTop;
         clearTimeout(this._smartScrollUnlock);
         this._smartScrollUnlock = setTimeout(() => {
             this.isProgrammaticScrolling = false;
@@ -568,7 +585,12 @@ class UseVirtualScroll {
         this.cache.pruneStale();
 
         if (type === 'append') {
-            const wasAtBottom = this.isNearBottom(100);
+            // Only follow a newly appended message when the user is actually
+            // parked at the end — the same gate the streaming auto-follow uses,
+            // so a reader who scrolled up is not yanked back down. (A message
+            // the user just sent scrolls down through appendMessage() /
+            // pendingScrollToBottom, which is independent of this.)
+            const wasAtBottom = this._pinnedToBottom && this.isNearBottom(100);
             if (wasAtBottom || this._scrollToBottomPending) {
                 this.renderEnd = newLen;
                 const vh = this.container.clientHeight || 800;
@@ -746,14 +768,38 @@ class UseVirtualScroll {
 
     _onContainerScroll() {
         // Update the bottom-pin tracker on EVERY scroll event — including the
-        // ones our own programmatic scrolls fire. This mirrors Vue's separate
-        // `onScroll` handler updating `showScrollButton` unconditionally. It is
-        // essential during streaming: smartScroll keeps isProgrammaticScrolling
-        // continuously true, so gating this behind the early-return below would
-        // make it impossible for the user to scroll up and detach from the
-        // auto-follow. smartScroll re-pins to the exact bottom, so its own
-        // events keep this true; only a genuine user scroll-up flips it false.
-        this._pinnedToBottom = this.isNearBottom(100);
+        // ones our own programmatic scrolls fire. This is essential during
+        // streaming: smartScroll keeps isProgrammaticScrolling continuously
+        // true, so gating this behind the early-return below would make it
+        // impossible for the user to scroll up and detach from the auto-follow.
+        //
+        // The rule is directional, not a distance band: the follow only stays
+        // on while the list is *resting at the end*, and ANY upward move — a
+        // single wheel notch, a short finger drag — detaches it at once. The
+        // old `isNearBottom(100)` band made scrolling away during a stream
+        // impossible: anywhere inside those 100px the next chunk's smartScroll
+        // pinned the list straight back to the bottom, so the view snapped back
+        // before the user could get out of the band. Our own auto-follow lands
+        // exactly at the end (scrollTop clamps to the maximum), and so does the
+        // inset re-pin glide, so neither loses the pin by scrolling upward.
+        const scrollTop = this.container.scrollTop;
+        const movedUp = scrollTop < this._lastScrollTop - 1;
+        const movedDown = scrollTop > this._lastScrollTop + 1;
+        const isOwnPin = this._selfPinTop !== null &&
+            Math.abs(scrollTop - this._selfPinTop) <= 1;
+        if (!isOwnPin) this._selfPinTop = null;
+        this._lastScrollTop = scrollTop;
+        if (isOwnPin || this.isNearBottom(BOTTOM_PIN_EPSILON)) {
+            // Resting at the end (or parked there by the follow itself).
+            this._pinnedToBottom = true;
+        } else if (movedUp) {
+            this._pinnedToBottom = false;
+        } else if (movedDown && this.isNearBottom(BOTTOM_PIN_RESUME)) {
+            // Coming back down to the newest message — resume the follow
+            // without making the user land on the exact last pixel.
+            this._pinnedToBottom = true;
+        }
+
         if (this.isProgrammaticScrolling) return;
         this.isScrolling = true;
         clearTimeout(this.scrollTimeout);

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -1331,20 +1331,14 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
           1.0,
           targetPanelHeight / math.max(1.0, safeBottom),
         );
-        // While inline-editing a message, reserve extra scroll room at the
-        // bottom. The normal inset only matches the input bar + keyboard, so a
-        // message edited at the very end of the chat can scroll its body up to
-        // that boundary but no further — and in bubble mode the Save/Cancel
-        // footer wraps onto its own row *below* the bubble, landing behind the
-        // input bar where it can't be reached. The extra padding lets the whole
-        // edit footer clear the bottom overlays. Reclaimed automatically when
-        // editing ends (isEditingMessage flips back to false).
-        const editFooterScrollRoom = 96.0;
+        // Editing needs no inset of its own: the Save/Cancel row is laid out
+        // inside the edited message (see `.message-section.editing .msg-footer`
+        // in assets/chat_webview/styles.css), so the message's own height
+        // already carries it and this inset clears it like any other content.
         final webViewBottomInset =
             _inputBarHeight +
             targetPanelHeight +
-            (safeBottom * (1 - targetFactor)) +
-            (isEditingMessage ? editFooterScrollRoom : 0.0);
+            (safeBottom * (1 - targetFactor));
         _lastMessageListBottom = webViewBottomInset;
         final showScrollBtn =
             _showScrollToBottom &&

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -126,6 +126,33 @@ void main() {
       expect(virtualScrollJs, contains('if (!this._pinnedToBottom) return'));
     });
 
+    test('the streaming follow detaches on any upward scroll', () {
+      final body = _extractBlockBody(
+        virtualScrollJs,
+        virtualScrollJs.indexOf('_onContainerScroll() {'),
+      );
+      expect(
+        body,
+        contains('const movedUp = scrollTop < this._lastScrollTop - 1'),
+        reason:
+            'The pin has to be directional: with a plain isNearBottom(100) band '
+            'the next streamed chunk re-pinned the list before the user could '
+            'scroll out of those 100px, so scrolling up during generation was '
+            'impossible.',
+      );
+      expect(
+        body,
+        contains('this.isNearBottom(BOTTOM_PIN_EPSILON)'),
+        reason:
+            'The follow resumes only when the list rests at the very end of the '
+            'container, not anywhere inside a wide band above it.',
+      );
+      expect(
+        body,
+        isNot(contains('this._pinnedToBottom = this.isNearBottom(100)')),
+      );
+    });
+
     test('scroll-to-bottom resolves after its correction pass', () {
       final body = _extractBlockBody(
         virtualScrollJs,
@@ -1307,6 +1334,25 @@ void main() {
         reason:
             'Without overscroll-behavior:contain, reaching the end of the textarea '
             'causes the parent chat container to scroll',
+      );
+    });
+
+    test('the edit footer reserves its own room inside the message', () {
+      expect(
+        stylessCss,
+        contains('.message-section.editing .msg-footer {'),
+        reason:
+            'The Save/Cancel row must be sized inside the edited message so the '
+            'chat container clears it with its ordinary bottom inset — Flutter '
+            'no longer reserves edit-only scroll room (chat_screen.dart).',
+      );
+      expect(
+        stylessCss,
+        contains('.message-section.layout-bubble.editing .edit-buttons {'),
+        reason:
+            'In bubble layout the footer is a wrapping flex row that follows the '
+            'bubble width; the edit buttons need a row of their own or a narrow '
+            'bubble squeezes them against the meta/switcher columns.',
       );
     });
   });


### PR DESCRIPTION
## Edit controls reserve their own room

- Removed the `editFooterScrollRoom = 96.0` bottom inset `_ChatBodyState.build` added to the whole WebView container while a message was being edited (`lib/features/chat/chat_screen.dart`). The container inset is again just input bar + keyboard/drawer + leftover safe area.
- `.message-section.editing .msg-footer` (`assets/chat_webview/styles.css`) now carries the Save/Cancel row inside the edited message: its own row height, a `row-gap`, and a gap beneath it. The message measures taller while it is edited, so the ordinary bottom inset clears the controls exactly like any other content — no edit-specific padding on the Flutter side.
- In bubble layout the footer is a wrapping flex row that follows the bubble width, so `.message-section.layout-bubble.editing .edit-buttons` gets a row of its own (`flex: 1 0 100%`) aligned to the same side as the rest of the footer (left for char, right for user); a narrow bubble can no longer squeeze the two buttons against the meta / switcher columns.

## Scrolling during streaming

- `UseVirtualScroll._onContainerScroll` (`assets/chat_webview/useVirtualScroll.js`) tracked the bottom pin with a plain `isNearBottom(100)` band. Anywhere inside those 100px the next streamed chunk's `smartScroll()` pinned the list straight back to the bottom, so scrolling up during generation was impossible — the view snapped back before the user could leave the band. The rule is now directional: any upward move detaches the follow at once, and it holds only while the list rests at the end of the container (`BOTTOM_PIN_EPSILON`).
- The follow resumes on a *downward* move that lands near the end (`BOTTOM_PIN_RESUME`), so returning to the newest message does not require hitting the last pixel, and a stationary scroll event cannot silently re-pin a reader who scrolled away.
- `smartScroll()` records the offset it parked at, and a scroll event matching it counts as ours — otherwise a chunk that grows the list between the pin and its (async) scroll event would make the follow read its own pin as "the user moved away" and switch itself off mid-stream.
- `_onItemsChanged('append')` now scrolls to a newly appended message only when the same pin holds, instead of on the 100px band, so a reader who scrolled up is not yanked down when a message is appended. A message the user just sent still scrolls down through `Bridge.appendMessage` / `pendingScrollToBottom`, which is independent of this gate.

## Verification

- Added two static-analysis guards to `test/webview_assets_test.dart`: one asserting the edit footer / bubble edit-button rules exist in `styles.css`, one asserting `_onContainerScroll` is directional and no longer pins on `isNearBottom(100)`.
- The pin tracker was exercised headlessly in Node against a stubbed container (chunks growing `scrollHeight` + `smartScroll`): on the previous code a 30px scroll-up during streaming was undone by the next chunk (4290 → 4380), on this branch the list stays put, and scrolling back down near the end resumes the follow.
- `flutter analyze` and `flutter test` were **not** run: the agent session had no Flutter SDK available. Relying on CI for both.
- Runtime behavior in the WebView (edit footer layout on device, touch scrolling during a live generation) has not been verified by hand — the agent cannot drive `flutter run`. Note the assets under `assets/chat_webview/` changed, so a hot **restart** is required, not a hot reload.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiknjiWrUVNvYdTqmvtug4)_