### PR TITLE
fix(chat): stop display-only regexes from overwriting message source

### DIFF
--- a/assets/chat_webview/bridge.legacy.js
+++ b/assets/chat_webview/bridge.legacy.js
@@ -255,7 +255,10 @@ class EditController {
     const scrollPos = scrollTopFn();
     section.classList.add('editing');
 
-    const rawText = (section.dataset.rawText || '').replace(/^<think\b[^>]*>[\s\S]*?<\/think>\s*/, '');
+    // Mirrors bridge/edit_controller.js: edit the stored text, never the
+    // rendered one, so a display-only regex is not saved over its own source.
+    const editSource = section.dataset.sourceText ?? section.dataset.rawText ?? '';
+    const rawText = editSource.replace(/^<think\b[^>]*>[\s\S]*?<\/think>\s*/, '');
     const reasoning = section.dataset.reasoning || '';
     let editText = rawText;
     if (reasoning) editText = '<' + 'think>\n' + reasoning + '\n</' + 'think>\n' + rawText;
@@ -1195,6 +1198,8 @@ class Bridge {
     else if (msg.reasoning === null || msg.reasoning === '') delete section.dataset.reasoning;
 
     if (msg.text != null) section.dataset.rawText = msg.text;
+    if (msg.sourceText != null) section.dataset.sourceText = msg.sourceText;
+    else if (msg.text != null) delete section.dataset.sourceText;
 
     if (msg.isError !== undefined) section.classList.toggle('error', !!msg.isError);
 

--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -577,6 +577,12 @@ export class Bridge {
 
     if (msg.text != null) section.dataset.rawText = msg.text;
 
+    // Kept in step with rawText: an update that carries text but no sourceText
+    // means the stored text and the rendered one are identical again, so a
+    // stale source from an earlier update must not survive into the editor.
+    if (msg.sourceText != null) section.dataset.sourceText = msg.sourceText;
+    else if (msg.text != null) delete section.dataset.sourceText;
+
     if (msg.isError !== undefined) section.classList.toggle('error', !!msg.isError);
 
     const isUser = section.classList.contains('user');

--- a/assets/chat_webview/bridge/edit_controller.js
+++ b/assets/chat_webview/bridge/edit_controller.js
@@ -30,7 +30,13 @@ export class EditController {
     const scrollPos = scrollTopFn();
     section.classList.add('editing');
 
-    const rawText = (section.dataset.rawText || '').replace(/^<think\b[^>]*>[\s\S]*?<\/think>\s*/, '');
+    // Edit the stored text, not the rendering. `rawText` holds the display
+    // form — macros expanded and display regexes applied — so saving from it
+    // would persist the rendered output over the source (a `markdownOnly`
+    // card regex would eat its own `{TRK|…}` marker). `sourceText` is sent
+    // whenever the two differ; without it they are the same string.
+    const editSource = section.dataset.sourceText ?? section.dataset.rawText ?? '';
+    const rawText = editSource.replace(/^<think\b[^>]*>[\s\S]*?<\/think>\s*/, '');
     const reasoning = section.dataset.reasoning || '';
     let editText = rawText;
     if (reasoning) editText = '<' + 'think>\n' + reasoning + '\n</' + 'think>\n' + rawText;

--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -95,6 +95,12 @@ export class Renderer {
     const section = document.createElement('div');
     section.dataset.messageId = id;
     section.dataset.rawText = text || '';
+    // Present only when the stored text differs from what is rendered (macros
+    // expanded, display regexes applied). The editor opens this instead of
+    // rawText so a display-only rewrite is never saved over the source.
+    if (messageData.sourceText != null) {
+      section.dataset.sourceText = messageData.sourceText;
+    }
     if (reasoning) section.dataset.reasoning = reasoning;
     if (isLast && this._roleKey(role) === 'char') section.dataset.isLast = 'true';
     if (messageData.personaName) section.dataset.personaName = messageData.personaName;

--- a/lib/features/chat/bridge/chat_message_mapper.dart
+++ b/lib/features/chat/bridge/chat_message_mapper.dart
@@ -124,10 +124,22 @@ class ChatMessageMapper {
       memoryStatus = 'DRAFT';
     }
 
+    // What the editor must show. `text` below carries the *display* form —
+    // macros expanded, display regexes applied — and the WebView keeps it in
+    // `dataset.rawText`. Feeding that into the edit textarea would let a
+    // display-only rewrite be saved back over the message: a `markdownOnly`
+    // regex that turns `{TRK|…}` into a styled HTML card would replace the
+    // marker in storage, and the next render would have nothing left to match.
+    // The stored content rides along whenever it differs so `startEdit` can
+    // open the source instead of the rendering.
+    final displayText = stripThinkTags(content);
+    final sourceText = stripThinkTags(m.content);
+
     return {
       'id': m.id,
       'role': m.role,
-      'text': stripThinkTags(content),
+      'text': displayText,
+      if (sourceText != displayText) 'sourceText': sourceText,
       'timestamp': m.timestamp,
       'isUser': isUser,
       'isAssistant': isAssistant,

--- a/lib/features/chat/controllers/chat_message_ops_controller.dart
+++ b/lib/features/chat/controllers/chat_message_ops_controller.dart
@@ -123,13 +123,18 @@ class ChatMessageOpsController {
     );
     final depth = session.messages.length - 1 - index;
     final ctx = RegexApplyContext(char: char, persona: persona, depth: depth);
+    // `isMarkdown: false` on purpose: this pass writes its result back into the
+    // session, and a `markdownOnly` script ("Only Format Display" in ST) must
+    // never touch stored text. Running it here baked the rendered output into
+    // the message — a card-rendering regex replaced its own `{TRK|…}` marker,
+    // so after one edit there was nothing left for it to match.
     final content = applyRegexes(
       msg.content,
       placement,
       1,
       editScripts,
       ctx,
-      isMarkdown: true,
+      isMarkdown: false,
     );
     if (content == msg.content) return session;
     final newMessages = List<ChatMessage>.from(session.messages);

--- a/test/display_regex_edit_source_test.dart
+++ b/test/display_regex_edit_source_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/regex_service.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/models/preset.dart';
+import 'package:glaze_flutter/features/chat/bridge/chat_message_mapper.dart';
+
+/// A display-only card renderer, the shape that broke: it consumes the very
+/// marker it renders, so persisting its output leaves nothing to match on the
+/// next pass.
+const _cardRegex = PresetRegex(
+  id: 'trk',
+  name: 'Tracker',
+  regex: r'/\{\s*TRK\s*\|\s*([^|}]*?)\s*\}/gi',
+  replacement: '<div class="tk">\$1</div>',
+  markdownOnly: true,
+  runOnEdit: true,
+);
+
+void main() {
+  const ctx = ChatMessageMapperContext(isGenerating: false);
+
+  ChatMessage makeMsg(String content) =>
+      ChatMessage(id: 'm1', role: 'assistant', content: content);
+
+  group('ChatMessageMapper sourceText', () {
+    test('carries the stored text when a display regex rewrites it', () {
+      final map = ChatMessageMapper.toMap(
+        makeMsg('Она вошла.\n\n{TRK | Дача}'),
+        ctx,
+        displayRegexes: const [_cardRegex],
+      );
+
+      expect(map['text'], 'Она вошла.\n\n<div class="tk">Дача</div>');
+      expect(map['sourceText'], 'Она вошла.\n\n{TRK | Дача}');
+    });
+
+    test('omitted when the rendering equals the stored text', () {
+      final map = ChatMessageMapper.toMap(
+        makeMsg('Просто текст.'),
+        ctx,
+        displayRegexes: const [_cardRegex],
+      );
+
+      expect(map['text'], 'Просто текст.');
+      expect(map.containsKey('sourceText'), isFalse);
+    });
+
+    test('omitted when no display regexes are configured', () {
+      final map = ChatMessageMapper.toMap(makeMsg('{TRK | Дача}'), ctx);
+
+      expect(map['text'], '{TRK | Дача}');
+      expect(map.containsKey('sourceText'), isFalse);
+    });
+  });
+
+  group('run-on-edit pass', () {
+    // Mirrors ChatMessageOpsController._applyRunOnEditRegexes, which persists
+    // its result and therefore runs with isMarkdown: false.
+    test('markdownOnly script never rewrites stored text', () {
+      final out = applyRegexes(
+        '{TRK | Дача}',
+        2,
+        1,
+        const [_cardRegex],
+        const RegexApplyContext(),
+        isMarkdown: false,
+      );
+
+      expect(out, '{TRK | Дача}');
+    });
+
+    test('a plain runOnEdit script still rewrites stored text', () {
+      const plain = PresetRegex(
+        id: 'plain',
+        name: 'Plain',
+        regex: '/foo/g',
+        replacement: 'bar',
+        runOnEdit: true,
+      );
+
+      final out = applyRegexes(
+        'foo',
+        2,
+        1,
+        const [plain],
+        const RegexApplyContext(),
+        isMarkdown: false,
+      );
+
+      expect(out, 'bar');
+    });
+  });
+}

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -498,6 +498,31 @@ void main() {
     });
   });
 
+  group('edit opens the stored text, not the rendering', () {
+    test('section carries sourceText when Dart sends one', () {
+      expect(
+        rendererMessageJs,
+        contains('section.dataset.sourceText = messageData.sourceText'),
+      );
+    });
+
+    test('startEdit prefers sourceText over rawText', () {
+      expect(
+        editControllerJs,
+        contains(
+          'section.dataset.sourceText ?? section.dataset.rawText',
+        ),
+      );
+    });
+
+    test('an update without sourceText clears a stale one', () {
+      expect(
+        bridgeControllerJs,
+        contains('delete section.dataset.sourceText'),
+      );
+    });
+  });
+
   group('bridge ES module layout', () {
     test('module entrypoint exports and bootstraps Bridge', () {
       expect(


### PR DESCRIPTION
A `markdownOnly` regex is a rendering pass, but its output was reaching storage by two routes. A card-rendering script that consumes its own marker (`{TRK|…}` → styled HTML) therefore lost that marker for good after one edit: the next render had nothing left to match, so the card came back as plain unstyled text, and the message source in the editor was a wall of generated HTML.

## Changes

- `chat_message_mapper.dart` — send `sourceText` (the stored content) alongside `text` (the display form) whenever the two differ, so the editor has a source to open.
- `message_renderer.js` — park it on the section as `data-source-text`.
- `edit_controller.js` — `startEdit` opens `sourceText ?? rawText`. `rawText` holds the display form (macros expanded, display regexes applied, `[IMG:RESULT:…]` resolved), and saving from it persisted the rendering over the source.
- `chat_bridge_controller.js` — an update carrying `text` but no `sourceText` clears a stale source, so the editor never opens a rendering left over from an earlier update.
- `chat_message_ops_controller.dart` — `_applyRunOnEditRegexes` persists its result, so it runs with `isMarkdown: false`: `runOnEdit` scripts still rewrite stored text, `markdownOnly` ones no longer do (ST's "Only Format Display" never touches storage).
- `bridge.legacy.js` — mirrored the two edit-path changes into the inert fallback snapshot so it does not carry the bug.

## Verification

- New `test/display_regex_edit_source_test.dart`: `sourceText` present when a display regex rewrites the text, absent when the rendering equals the source and when no display regexes are configured; the run-on-edit pass skips a `markdownOnly` script and still applies a plain one.
- `test/webview_assets_test.dart`: three static assertions pinning the WebView wiring (renderer writes `sourceText`, `startEdit` prefers it, an update without it clears the stale one).
- CI (`flutter analyze` + `flutter test`) green on the branch: run 32967512069.
- The reported regex itself was run against its real input, and its output through `formatter.js` + `html_sanitizer.js`/`css_sanitizer.js` in Chromium — the card renders and keeps its CSS, confirming the pattern and the render path were never the fault.

---
_Generated by [Claude Code](https://claude.ai/code/session_019jPToE6ub6hQGmAsh7Exmu)_