### PR TITLE
fix(chat): keep game clocks variant-scoped

### DIFF
--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -759,16 +759,20 @@ if (messageData.isEditing) classes.push('editing');
     // In-game clock: the ledger stamps the message after the turn, so the
     // element usually appears (or updates) via this live path rather than at
     // initial render.
-    if (msg.gameTime) {
-      const stack = sectionEl.querySelector('.msg-content-stack');
-      if (stack) {
-        let clock = stack.querySelector('.msg-game-time');
-        if (!clock) {
-          clock = this._createGameTimeBlock(msg.gameTime);
-          const wrapper = stack.querySelector('.msg-transition-wrapper');
-          stack.insertBefore(clock, wrapper || null);
+    const stack = sectionEl.querySelector('.msg-content-stack');
+    if (stack) {
+      let clock = stack.querySelector('.msg-game-time');
+      if (Object.prototype.hasOwnProperty.call(msg, 'gameTime')) {
+        if (msg.gameTime) {
+          if (!clock) {
+            clock = this._createGameTimeBlock(msg.gameTime);
+            const wrapper = stack.querySelector('.msg-transition-wrapper');
+            stack.insertBefore(clock, wrapper || null);
+          } else {
+            clock.textContent = `⏱ ${msg.gameTime}`;
+          }
         } else {
-          clock.textContent = `⏱ ${msg.gameTime}`;
+          clock?.remove();
         }
       }
     }

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2626,11 +2626,10 @@
   "card_rewriter_studio_stage_card_repair": "Card repair",
   "card_rewriter_studio_stage_lorebook_writer": "Lorebook writer",
   "game_time_seed_title": "Game clock start",
-  "game_time_seed_description": "Anchor the ledger game clock. The day always starts at 0. The date is optional.",
+  "game_time_seed_description": "Anchor the ledger game clock. The RP day always starts at 0. Enter the full date and time so memory timestamps stay deterministic.",
   "game_time_seed_time_label": "Time (HH:MM)",
-  "game_time_seed_date_label": "Date (DD.MM.YYYY, optional)",
-  "game_time_seed_skip": "Skip",
+  "game_time_seed_date_label": "Date (DD.MM.YYYY)",
   "game_time_seed_confirm": "Start",
   "game_time_seed_invalid_time": "Enter the time as HH:MM (24-hour).",
-  "game_time_seed_invalid_date": "Enter the date as DD.MM.YYYY or leave it empty."
+  "game_time_seed_invalid_date": "Enter the date as DD.MM.YYYY."
 }

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -2655,11 +2655,10 @@
   "card_rewriter_studio_stage_card_repair": "Исправление карточки",
   "card_rewriter_studio_stage_lorebook_writer": "Писатель лорбука",
   "game_time_seed_title": "Начало игрового времени",
-  "game_time_seed_description": "Задай точку отсчёта игровых часов леджера. День всегда начинается с 0. Дата необязательна.",
+  "game_time_seed_description": "Задай точку отсчёта игровых часов леджера. RP-день всегда начинается с 0. Укажи полную дату и время, чтобы временные метки памяти были однозначными.",
   "game_time_seed_time_label": "Время (ЧЧ:ММ)",
-  "game_time_seed_date_label": "Дата (ДД.ММ.ГГГГ, необязательно)",
-  "game_time_seed_skip": "Пропустить",
+  "game_time_seed_date_label": "Дата (ДД.ММ.ГГГГ)",
   "game_time_seed_confirm": "Начать",
   "game_time_seed_invalid_time": "Введи время в формате ЧЧ:ММ (24 часа).",
-  "game_time_seed_invalid_date": "Введи дату в формате ДД.ММ.ГГГГ или оставь поле пустым."
+  "game_time_seed_invalid_date": "Введи дату в формате ДД.ММ.ГГГГ."
 }

--- a/lib/core/db/repositories/chat_repo.dart
+++ b/lib/core/db/repositories/chat_repo.dart
@@ -847,6 +847,7 @@ class ChatRepo implements SyncChatStore {
                 reasoning: msg.reasoning,
                 genTime: msg.genTime,
                 tokens: msg.tokens,
+                time: msg.time,
                 studioOutputs: msg.studioOutputs,
               ),
             );
@@ -877,17 +878,19 @@ class ChatRepo implements SyncChatStore {
                     ? agentSwipes[parentSwipeId].studioOutputs
                     : const <Map<String, dynamic>>[]);
 
-          agentSwipes.add(
-            AgentSwipe(
-              content: content,
-              kind: kind,
-              reasoning: reasoning,
-              genTime: genTime,
-              tokens: tokens,
-              studioOutputs: effectiveStudioOutputs,
-              parentSwipeId: parentSwipeId,
-            ),
+          final appendedSwipe = AgentSwipe(
+            content: content,
+            kind: kind,
+            reasoning: reasoning,
+            genTime: genTime,
+            tokens: tokens,
+            time: kind == 'cleaned' && parentSwipeId != null
+                ? agentSwipes[parentSwipeId].time
+                : null,
+            studioOutputs: effectiveStudioOutputs,
+            parentSwipeId: parentSwipeId,
           );
+          agentSwipes.add(appendedSwipe);
 
           messages[i] = msg.copyWith(
             content: content,
@@ -900,6 +903,7 @@ class ChatRepo implements SyncChatStore {
             // applyCleanedText fallback path.
             genTime: genTime ?? msg.genTime,
             tokens: tokens ?? msg.tokens,
+            time: appendedSwipe.time,
             agentSwipes: agentSwipes,
             agentSwipeId: agentSwipes.length - 1,
             swipesMeta: _syncAgentSwipesToMeta(
@@ -1068,6 +1072,7 @@ class ChatRepo implements SyncChatStore {
           content: active.content,
           genTime: active.genTime,
           tokens: active.tokens,
+          time: active.time,
           agentSwipes: agentSwipes,
           agentSwipeId: newActiveId,
           swipesMeta: _syncAgentSwipesToMeta(

--- a/lib/core/db/repositories/ledger_raw_tracker_state_reader.dart
+++ b/lib/core/db/repositories/ledger_raw_tracker_state_reader.dart
@@ -1,4 +1,5 @@
 import '../../models/ledger_raw_tracker_state.dart';
+import '../../models/tracker.dart';
 import '../app_db.dart';
 import 'tracker_repo.dart';
 import 'tracker_snapshot_repo.dart';
@@ -19,12 +20,15 @@ final class LedgerRawTrackerStateReader {
   Future<LedgerRawTrackerState> read(String sessionId) async {
     final snapshot = await _snapshots.getLatestCommitted(sessionId);
     final controls = await _trackers.getLiveCanonControls(sessionId);
+    final bootstrap = snapshot == null
+        ? await _trackers.getInitialGameTimeSeed(sessionId)
+        : const <Tracker>[];
     return LedgerRawTrackerState(
       committedTrackers:
           snapshot?.trackers
               .where((tracker) => tracker.scope == 'ledger')
               .toList(growable: false) ??
-          const [],
+          bootstrap,
       manualControls: controls,
     );
   }

--- a/lib/core/db/repositories/tracker_repo.dart
+++ b/lib/core/db/repositories/tracker_repo.dart
@@ -83,6 +83,7 @@ class TrackerRepo {
     required String sessionId,
     required String time,
     required String date,
+    String day = '0',
     Map<String, String?> expectedValues = const {},
   }) {
     return db.transaction(() async {
@@ -95,7 +96,7 @@ class TrackerRepo {
       for (final entry in {
         'world:time': time,
         'world:date': date,
-        'world:day': '0',
+        'world:day': day,
       }.entries) {
         await upsertValue(
           sessionId,

--- a/lib/core/db/repositories/tracker_repo.dart
+++ b/lib/core/db/repositories/tracker_repo.dart
@@ -56,6 +56,59 @@ class TrackerRepo {
     );
   }
 
+  /// Returns the complete first-turn game-clock seed, if one exists.
+  ///
+  /// Ledger normally reads model-owned state from committed snapshots. A new
+  /// session has no snapshot yet, so this narrowly scoped bootstrap is the
+  /// only live model-owned state allowed into that initial committed base.
+  Future<List<Tracker>> getInitialGameTimeSeed(String sessionId) async {
+    const names = {'world:time', 'world:date', 'world:day'};
+    final trackers = await getBySessionAndScope(sessionId, 'ledger');
+    final seed = trackers
+        .where(
+          (tracker) =>
+              tracker.provenance == 'game_time_seed' &&
+              names.contains(tracker.name) &&
+              tracker.value.trim().isNotEmpty,
+        )
+        .toList(growable: false);
+    return seed.map((tracker) => tracker.name).toSet().length == names.length
+        ? seed
+        : const [];
+  }
+
+  /// Persists the complete first-turn clock atomically if its rows still match
+  /// the values observed before the seed dialog opened.
+  Future<bool> seedInitialGameTime({
+    required String sessionId,
+    required String time,
+    required String date,
+    Map<String, String?> expectedValues = const {},
+  }) {
+    return db.transaction(() async {
+      if (expectedValues.isNotEmpty) {
+        for (final name in const ['world:time', 'world:date', 'world:day']) {
+          final current = await get(sessionId, name);
+          if (current?.value != expectedValues[name]) return false;
+        }
+      }
+      for (final entry in {
+        'world:time': time,
+        'world:date': date,
+        'world:day': '0',
+      }.entries) {
+        await upsertValue(
+          sessionId,
+          entry.key,
+          entry.value,
+          scope: 'ledger',
+          provenance: 'game_time_seed',
+        );
+      }
+      return true;
+    });
+  }
+
   /// Atomic upsert by natural key (sessionId, name). If a tracker with the
   /// same name already exists for the session, its value/scope/provenance/
   /// updatedAt are overwritten. Safe under concurrent writes — Drift resolves

--- a/lib/core/db/studio_preset_seed.dart
+++ b/lib/core/db/studio_preset_seed.dart
@@ -700,7 +700,8 @@ ALLOWED CURRENT-STATE KEYS:
 
 GAME CLOCK:
 - Keep world:time as the current in-game time of day in 24h HH:MM and advance it when narrated events imply elapsed time.
-- The clock only moves FORWARD. Never rewind it; flashbacks and memories stay in prose. Past midnight, advance world:day (day 0 = the first story day) and world:date when a date is tracked.
+- Keep one complete tuple: world:date (DD.MM.YYYY), zero-based world:day, and world:time. Never guess a missing date or day.
+- The clock only moves FORWARD. Never rewind it; flashbacks and memories stay in prose. Past midnight, advance world:day (day 0 = the first story day) and world:date.
 - Do not invent time skips the narrative does not support; an immediately continuing scene moves time by only a few minutes.
 
 Return the mandatory <glaze_memory_export> JSON block followed by a compact diagnostic <studio_ledger> block. Never expose either in story prose.''';

--- a/lib/core/llm/auxiliary_timed_history.dart
+++ b/lib/core/llm/auxiliary_timed_history.dart
@@ -1,0 +1,10 @@
+import '../models/chat_message.dart';
+
+/// Adds the active variation's Ledger clock for auxiliary consumers such as
+/// Memory and Summary. Main-model chat history must use [ChatMessage.content]
+/// directly and must never call this helper.
+String auxiliaryTimedContent(ChatMessage message) {
+  final time = message.time?.trim();
+  if (time == null || time.isEmpty) return message.content;
+  return '[$time] ${message.content}';
+}

--- a/lib/core/llm/fallback_prompt_builder.dart
+++ b/lib/core/llm/fallback_prompt_builder.dart
@@ -32,16 +32,10 @@ PromptResult buildFallbackPrompt(PromptPayload payload) {
     (message) => !message.isHidden && !message.isTyping,
   )) {
     final macroResult = replaceMacros(msg.content, macroCtx);
-    final gameTime = msg.time?.trim();
-    final content = gameTime == null || gameTime.isEmpty
-        ? macroResult.text
-        : macroResult.text.isEmpty
-        ? '[$gameTime]'
-        : '[$gameTime]\n${macroResult.text}';
     history.add(
       PromptMessage(
         role: msg.role,
-        content: content,
+        content: macroResult.text,
         reasoningContent: msg.reasoning,
         isHistory: true,
         sourceMessageId: msg.id,

--- a/lib/core/llm/game_time.dart
+++ b/lib/core/llm/game_time.dart
@@ -4,7 +4,7 @@ import '../models/tracker.dart';
 ///
 /// The ledger maintains three keys:
 /// - `world:time` — current in-game time of day, `HH:MM` (24h);
-/// - `world:date` — optional in-game date, `DD.MM.YYYY`;
+/// - `world:date` — in-game date, `DD.MM.YYYY`;
 /// - `world:day` — zero-based in-game day counter (day 0 = the day the
 ///   story starts).
 ///
@@ -22,7 +22,7 @@ class GameTimeState {
   /// `HH:MM` in-game time of day, or null when the ledger has none yet.
   final String? time;
 
-  /// `DD.MM.YYYY` in-game date, or null when the story has no calendar.
+  /// `DD.MM.YYYY` in-game date, or null when the ledger has none yet.
   final String? date;
 
   /// Zero-based in-game day number, or null when unset.
@@ -46,22 +46,23 @@ class GameTimeState {
           day = int.tryParse(value);
       }
     }
-    return GameTimeState(time: time, date: date, day: day);
+    return GameTimeState(
+      time: time,
+      date: date,
+      day: day != null && day >= 0 ? day : null,
+    );
   }
 
-  /// Compact display string: `DD.MM.YYYY · День N · HH:MM` with the parts
-  /// that exist. Returns null when no clock part is known at all.
+  /// Canonical auxiliary/display stamp. A partial clock is not emitted because
+  /// consumers must not invent missing calendar context.
   String? format() {
-    if (time == null && date == null && day == null) return null;
-    final parts = <String>[?date, if (day != null) 'День $day', ?time];
-    return parts.join(' · ');
+    if (time == null || date == null || day == null) return null;
+    return '$date · RP_Day $day · $time';
   }
 
   /// English display variant used where localization is not available.
   String? formatEnglish() {
-    if (time == null && date == null && day == null) return null;
-    final parts = <String>[?date, if (day != null) 'Day $day', ?time];
-    return parts.join(' · ');
+    return format();
   }
 
   static String? _normalizeTime(String raw) {
@@ -74,11 +75,16 @@ class GameTimeState {
   }
 
   static String? _normalizeDate(String raw) {
-    final match = RegExp(r'(\d{2})\.(\d{2})\.(\d{4})').firstMatch(raw);
+    final match = RegExp(r'(\d{2})[.-](\d{2})[.-](\d{4})').firstMatch(raw);
     if (match == null) return null;
     final day = int.parse(match.group(1)!);
     final month = int.parse(match.group(2)!);
     if (day < 1 || day > 31 || month < 1 || month > 12) return null;
+    final year = int.parse(match.group(3)!);
+    final parsed = DateTime.utc(year, month, day);
+    if (parsed.year != year || parsed.month != month || parsed.day != day) {
+      return null;
+    }
     return '${match.group(1)}.${match.group(2)}.${match.group(3)}';
   }
 

--- a/lib/core/llm/history_assembler.dart
+++ b/lib/core/llm/history_assembler.dart
@@ -19,7 +19,7 @@ class HistoryAssembler {
       messages.add(
         PromptMessage(
           role: msg.role,
-          content: _withGameTime(normalized, msg),
+          content: normalized,
           reasoningContent: msg.reasoning,
           isHistory: true,
           sourceMessageId: msg.id,
@@ -31,16 +31,6 @@ class HistoryAssembler {
     }
 
     return messages;
-  }
-
-  /// The in-game clock travels with the chat history itself: every message
-  /// stamped by the ledger carries its full game time, so the model sees the
-  /// whole progression of the clock instead of a single current timestamp.
-  String _withGameTime(String content, ChatMessage msg) {
-    final time = msg.time?.trim();
-    if (time == null || time.isEmpty) return content;
-    if (content.isEmpty) return '[$time]';
-    return '[$time]\n$content';
   }
 }
 

--- a/lib/core/llm/ledger/ledger_prompt_factory.dart
+++ b/lib/core/llm/ledger/ledger_prompt_factory.dart
@@ -126,12 +126,13 @@ Allowed eventState: planned, suggested, threatened, attempted, completed, failed
 
 Game clock (world:time, world:date, world:day):
 - Maintain world:time as the current in-game time of day in 24h HH:MM format.
+- Keep one complete tuple: world:date (DD.MM.YYYY), zero-based world:day, and
+  world:time. Never guess a missing date or day.
 - When the final response or chat implies elapsed time, advance world:time to the
   new in-game time based on how much time the narrated events would take.
 - The game clock only moves FORWARD. Never rewind time; flashbacks and memories
   stay in prose without touching world:time. When time passes midnight, advance
-  world:day (day 0 is the first day of the story) and world:date when a calendar
-  date is tracked.
+  world:day (day 0 is the first day of the story) and world:date.
 - Do not invent time skips that the narrative does not support. When the scene
   clearly continues immediately, keep world:time unchanged or move it by only a
   few minutes.''';

--- a/lib/core/llm/studio_ledger_export_parser.dart
+++ b/lib/core/llm/studio_ledger_export_parser.dart
@@ -677,7 +677,7 @@ class StudioLedgerExportParser {
       }
     } else if (key.startsWith('world:')) {
       if (!RegExp(
-        r'^world:(location|time|date|active_threats|current_conditions)$',
+        r'^world:(location|time|date|day|active_threats|current_conditions)$',
       ).hasMatch(key)) {
         return 'unknown world key "$key"';
       }

--- a/lib/core/llm/studio_ledger_prompt.dart
+++ b/lib/core/llm/studio_ledger_prompt.dart
@@ -388,9 +388,11 @@ Rules:
 - Arc keys: arc:id.status, arc:id.summary, arc:id.do_not_reopen, arc:id.card_override
 - World/scene keys: world:location, world:time, world:date, world:day, world:active_threats, scene.present_entities, scene.absent_backstory_entities
 - Game clock: keep world:time in 24h HH:MM as the current in-game time of day and
+  keep it paired with world:date (DD.MM.YYYY) and zero-based world:day. Never
+  guess a missing date or day. When all three are established,
   advance it when narrated events imply elapsed time. The clock only moves
   FORWARD — never rewind it; flashbacks stay in prose. Past midnight, advance
-  world:day (day 0 = first story day) and world:date when a date is tracked.
+  world:day (day 0 = first story day) and world:date.
   Do not invent time skips the narrative does not support.''';
 
   static const String _legacyTurnOnlySystemPrompt =
@@ -413,5 +415,5 @@ Rules:
 - Relationship keys include trust, status, relationship, attitude, boundaries, and card_override.
 - Never write npc:*.knowledge or relationship:*.knowledge. Use knowledgeFacts.
 - Arc keys: arc:id.status, arc:id.summary, arc:id.do_not_reopen, arc:id.card_override.
-- World/scene keys: world:location, world:time, world:date, world:active_threats, scene.present_entities, scene.absent_backstory_entities.''';
+- World/scene keys: world:location, world:time, world:date, world:day, world:active_threats, scene.present_entities, scene.absent_backstory_entities.''';
 }

--- a/lib/core/llm/studio_ledger_reconciliation.dart
+++ b/lib/core/llm/studio_ledger_reconciliation.dart
@@ -269,7 +269,8 @@ old or absent from the review range.
 Game clock (world:time, world:date, world:day): advance world:time (24h HH:MM)
 through the review range according to how much in-game time the narrated events
 take, crossing midnight into the next world:day (day 0 = first story day) and
-world:date when tracked. The clock only moves FORWARD — never rewind it; treat
+world:date. Keep the complete DD.MM.YYYY / RP day / HH:MM tuple and never guess
+a missing date or day. The clock only moves FORWARD — never rewind it; treat
 flashbacks and memories as prose, not clock changes. When the range continues a
 scene immediately, advance time by only a few minutes.''';
   }

--- a/lib/core/llm/summary_service.dart
+++ b/lib/core/llm/summary_service.dart
@@ -3,6 +3,7 @@ import 'package:dio/dio.dart';
 import '../db/repositories/summary_repo.dart';
 import '../models/api_config.dart';
 import '../models/chat_message.dart';
+import 'auxiliary_timed_history.dart';
 import 'aux_llm_client.dart';
 import 'macro_engine.dart';
 import 'transport/llm_protocol.dart';
@@ -206,11 +207,7 @@ class SummaryService {
         final speaker = msg.role == 'user' ? 'User' : 'Character';
         // The ledger-stamped game clock travels with the transcript so the
         // summary stays time-anchored instead of teleporting across hours.
-        final gameTime = msg.time?.trim();
-        final timePrefix = gameTime == null || gameTime.isEmpty
-            ? ''
-            : '[$gameTime] ';
-        buf.writeln('$speaker: $timePrefix${msg.content}');
+        buf.writeln('$speaker: ${auxiliaryTimedContent(msg)}');
       }
     }
     return buf.toString();

--- a/lib/core/models/chat_message.dart
+++ b/lib/core/models/chat_message.dart
@@ -53,6 +53,7 @@ class AgentSwipe {
   final String? reasoning;
   final String? genTime;
   final int? tokens;
+  final String? time;
   final List<Map<String, dynamic>> studioOutputs;
   final int? parentSwipeId;
 
@@ -62,6 +63,7 @@ class AgentSwipe {
     this.reasoning,
     this.genTime,
     this.tokens,
+    this.time,
     this.studioOutputs = const [],
     this.parentSwipeId,
   });
@@ -72,6 +74,7 @@ class AgentSwipe {
     reasoning: json['reasoning'] as String?,
     genTime: json['genTime'] as String?,
     tokens: json['tokens'] as int?,
+    time: json['time'] as String?,
     studioOutputs:
         (json['studioOutputs'] as List?)
             ?.whereType<Map<dynamic, dynamic>>()
@@ -87,6 +90,7 @@ class AgentSwipe {
     'reasoning': reasoning,
     'genTime': genTime,
     'tokens': tokens,
+    'time': time,
     'studioOutputs': studioOutputs,
     'parentSwipeId': parentSwipeId,
   };
@@ -97,6 +101,7 @@ class AgentSwipe {
     String? reasoning,
     String? genTime,
     int? tokens,
+    String? time,
     List<Map<String, dynamic>>? studioOutputs,
     int? parentSwipeId,
   }) => AgentSwipe(
@@ -105,6 +110,7 @@ class AgentSwipe {
     reasoning: reasoning ?? this.reasoning,
     genTime: genTime ?? this.genTime,
     tokens: tokens ?? this.tokens,
+    time: time ?? this.time,
     studioOutputs: studioOutputs ?? this.studioOutputs,
     parentSwipeId: parentSwipeId ?? this.parentSwipeId,
   );

--- a/lib/core/state/card_rewriter_providers.dart
+++ b/lib/core/state/card_rewriter_providers.dart
@@ -111,10 +111,7 @@ final cardRewriteJobsBySessionProvider =
           .watchJobsBySessionId(sessionId);
     });
 
-final cardRewriteDebugRunsProvider =
-    FutureProvider.family<List<CardEvolutionDebugRunRow>, String>((
-      ref,
-      sessionId,
-    ) {
+final cardRewriteDebugRunsProvider = FutureProvider.autoDispose
+    .family<List<CardEvolutionDebugRunRow>, String>((ref, sessionId) {
       return ref.watch(cardEvolutionRepoProvider).readDebugRuns(sessionId);
     });

--- a/lib/features/card_rewrite/card_rewriter_recovery_view_service.dart
+++ b/lib/features/card_rewrite/card_rewriter_recovery_view_service.dart
@@ -42,10 +42,7 @@ final cardRewriterRecoveryViewServiceProvider =
       );
     });
 
-final cardRewriterRecoveryViewsProvider =
-    FutureProvider.family<List<CardRewriterRecoveryView>, String>((
-      ref,
-      sessionId,
-    ) {
+final cardRewriterRecoveryViewsProvider = FutureProvider.autoDispose
+    .family<List<CardRewriterRecoveryView>, String>((ref, sessionId) {
       return ref.watch(cardRewriterRecoveryViewServiceProvider).load(sessionId);
     });

--- a/lib/features/chat/abort_handler.dart
+++ b/lib/features/chat/abort_handler.dart
@@ -268,11 +268,20 @@ class AbortHandler {
                     'genTime': restoration.genTime,
                     'reasoning': restoration.reasoning,
                     'tokens': restoration.tokens,
+                    'time': restoration.time,
                   },
                 ],
         );
         keptSwipes.add(partialText);
-        keptSwipesMeta.add(<String, dynamic>{});
+        final partialAgentSwipe = AgentSwipe(
+          content: partialText,
+          reasoning: partialStreaming.reasoning,
+          parentSwipeId: keptSwipes.length - 1,
+        );
+        keptSwipesMeta.add(<String, dynamic>{
+          'agentSwipes': [partialAgentSwipe.toJson()],
+          'agentSwipeId': 0,
+        });
         final newSwipeId = keptSwipes.length - 1;
         final updated = target.copyWith(
           content: partialText,
@@ -282,6 +291,9 @@ class AbortHandler {
           reasoning: partialStreaming.reasoning,
           genTime: null,
           tokens: null,
+          time: null,
+          agentSwipes: [partialAgentSwipe],
+          agentSwipeId: 0,
           isTyping: false,
           // Partial text becomes a fresh (healthy) swipe; with nothing
           // streamed we put the pre-regen variation back untouched — an

--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -3,8 +3,10 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/llm/game_time.dart';
 import '../../core/llm/tokenizer.dart';
 import '../../core/models/chat_message.dart';
+import '../../core/models/tracker.dart';
 import '../../core/models/tracker_snapshot.dart';
 import '../../core/utils/time_helpers.dart';
 import '../../core/state/db_provider.dart';
@@ -237,10 +239,32 @@ class ChatMessageService {
         messageIds: invalidatedMessageIds,
       );
       await checkpointRepo.deleteForMessages(session.id, invalidatedMessageIds);
-      await trackerRepo.replaceLedgerState(
-        session.id,
-        fallbackSnapshot?.trackers ?? const [],
-      );
+      // Rolling back before the first committed snapshot wipes all
+      // model-owned Ledger rows — including the game clock. Preserve the
+      // current complete tuple as a bootstrap seed so the next generation
+      // (e.g. regenerating after deleting the assistant reply) still stamps
+      // the opening clock and the next Ledger run sees a valid baseline.
+      var committedBase = fallbackSnapshot?.trackers ?? const <Tracker>[];
+      if (fallbackSnapshot == null) {
+        final liveLedger = await trackerRepo.getBySessionAndScope(
+          session.id,
+          'ledger',
+        );
+        final clock = GameTimeState.fromTrackers(liveLedger);
+        final time = clock.time;
+        final date = clock.date;
+        final day = clock.day;
+        if (time != null && date != null && day != null) {
+          await trackerRepo.seedInitialGameTime(
+            sessionId: session.id,
+            time: time,
+            date: date,
+            day: '$day',
+          );
+          committedBase = await trackerRepo.getInitialGameTimeSeed(session.id);
+        }
+      }
+      await trackerRepo.replaceLedgerState(session.id, committedBase);
       await chatRepo.put(updated);
       final canonRollback = await _ref
           .read(sessionCanonRollbackRepoProvider)

--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -340,9 +340,18 @@ class ChatMessageService {
     // swipe's meta, then load (or seed) agentSwipes for the incoming swipe.
     // Save outgoing agentSwipes.
     if (msg.agentSwipes.isNotEmpty && msg.swipeId < swipesMeta.length) {
+      final outgoingAgentSwipes = List<AgentSwipe>.from(msg.agentSwipes);
+      if (msg.agentSwipeId >= 0 &&
+          msg.agentSwipeId < outgoingAgentSwipes.length &&
+          outgoingAgentSwipes[msg.agentSwipeId].time == null &&
+          msg.time != null) {
+        outgoingAgentSwipes[msg.agentSwipeId] =
+            outgoingAgentSwipes[msg.agentSwipeId].copyWith(time: msg.time);
+      }
       swipesMeta[msg.swipeId] = {
         ...swipesMeta[msg.swipeId],
-        'agentSwipes': msg.agentSwipes.map((e) => e.toJson()).toList(),
+        'time': msg.time,
+        'agentSwipes': outgoingAgentSwipes.map((e) => e.toJson()).toList(),
         'agentSwipeId': msg.agentSwipeId,
       };
     }
@@ -362,6 +371,7 @@ class ChatMessageService {
           reasoning: meta?['reasoning'] as String?,
           genTime: meta?['genTime'] as String?,
           tokens: meta?['tokens'] as int?,
+          time: meta?['time'] as String?,
           studioOutputs: _studioOutputsFromMeta(meta),
         ),
       ];
@@ -373,6 +383,9 @@ class ChatMessageService {
         ? nextAgentSwipes[nextAgentSwipeId.clamp(0, nextAgentSwipes.length - 1)]
               .content
         : msg.swipes[swipeId];
+    final activeAgentSwipe = nextAgentSwipes.isNotEmpty
+        ? nextAgentSwipes[nextAgentSwipeId.clamp(0, nextAgentSwipes.length - 1)]
+        : null;
 
     final updated = msg.copyWith(
       swipeId: swipeId,
@@ -406,6 +419,7 @@ class ChatMessageService {
                 )]
                 .tokens
           : meta?['tokens'] as int?,
+      time: activeAgentSwipe?.time,
       triggeredLorebooks: _triggeredFromMeta(meta, 'triggeredLorebooks'),
       triggeredMemories: _triggeredFromMeta(meta, 'triggeredMemories'),
       studioOutputs: nextAgentSwipes.isNotEmpty
@@ -467,11 +481,12 @@ class ChatMessageService {
         agentSwipeId >= msg.agentSwipes.length) {
       return session;
     }
-    final swipe = msg.agentSwipes[agentSwipeId];
+    final agentSwipes = _withActiveTime(msg);
+    final swipe = agentSwipes[agentSwipeId];
     final swipesMeta = _syncAgentSwipesToMeta(
       msg.swipesMeta,
       msg.swipeId,
-      msg.agentSwipes,
+      agentSwipes,
       agentSwipeId,
     );
     final updated = msg.copyWith(
@@ -482,7 +497,9 @@ class ChatMessageService {
       reasoning: swipe.reasoning,
       genTime: swipe.genTime,
       tokens: swipe.tokens,
+      time: swipe.time,
       studioOutputs: swipe.studioOutputs,
+      agentSwipes: agentSwipes,
       swipesMeta: swipesMeta,
     );
     final newMessages = List<ChatMessage>.from(session.messages);
@@ -783,6 +800,7 @@ class ChatMessageService {
               reasoning: nextMeta['reasoning'] as String?,
               genTime: nextMeta['genTime'] as String?,
               tokens: nextMeta['tokens'] as int?,
+              time: nextMeta['time'] as String?,
               studioOutputs: _studioOutputsFromMeta(nextMeta),
             ),
           ]
@@ -809,6 +827,7 @@ class ChatMessageService {
           active.content.isEmpty && (active.reasoning?.isNotEmpty ?? false),
       genTime: active.genTime,
       tokens: active.tokens,
+      time: active.time,
       studioOutputs: active.studioOutputs,
       isError: nextMeta['isError'] == true,
       triggeredLorebooks: _triggeredFromMeta(nextMeta, 'triggeredLorebooks'),
@@ -844,6 +863,7 @@ class ChatMessageService {
         reasoning: swipe.reasoning,
         genTime: swipe.genTime,
         tokens: swipe.tokens,
+        time: swipe.time,
         studioOutputs: swipe.studioOutputs,
         parentSwipeId: parent,
       );
@@ -873,6 +893,7 @@ class ChatMessageService {
           active.content.isEmpty && (active.reasoning?.isNotEmpty ?? false),
       genTime: active.genTime,
       tokens: active.tokens,
+      time: active.time,
       studioOutputs: active.studioOutputs,
       swipes: greenSwipes,
       swipesMeta: meta,
@@ -899,6 +920,20 @@ class ChatMessageService {
       'agentSwipeId': agentSwipeId,
     };
     return meta;
+  }
+
+  static List<AgentSwipe> _withActiveTime(ChatMessage message) {
+    final swipes = List<AgentSwipe>.from(message.agentSwipes);
+    if (message.time == null ||
+        message.agentSwipeId < 0 ||
+        message.agentSwipeId >= swipes.length ||
+        swipes[message.agentSwipeId].time != null) {
+      return swipes;
+    }
+    swipes[message.agentSwipeId] = swipes[message.agentSwipeId].copyWith(
+      time: message.time,
+    );
+    return swipes;
   }
 
   /// Parse the per-swipe triggered entries stored in [swipesMeta]. Each
@@ -1008,11 +1043,12 @@ class ChatMessageService {
       return const ChangeSwipeResult.noop();
     }
 
-    final swipe = msg.agentSwipes[newIndex];
+    final agentSwipes = _withActiveTime(msg);
+    final swipe = agentSwipes[newIndex];
     final swipesMeta = _syncAgentSwipesToMeta(
       msg.swipesMeta,
       msg.swipeId,
-      msg.agentSwipes,
+      agentSwipes,
       newIndex,
     );
     final updated = msg.copyWith(
@@ -1021,7 +1057,9 @@ class ChatMessageService {
       reasoning: swipe.reasoning,
       genTime: swipe.genTime,
       tokens: swipe.tokens,
+      time: swipe.time,
       studioOutputs: swipe.studioOutputs,
+      agentSwipes: agentSwipes,
       swipeDirection: animDir,
       swipesMeta: swipesMeta,
     );

--- a/lib/features/chat/chat_provider.dart
+++ b/lib/features/chat/chat_provider.dart
@@ -748,6 +748,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       isTyping: true,
       genTime: null,
       tokens: null,
+      time: null,
       isError: false,
       swipes: pendingSwipes,
       swipeId: pendingSwipes.length - 1,
@@ -875,20 +876,36 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
   }
 
   List<Map<String, dynamic>>? _previousSwipesMetaForRegen(ChatMessage message) {
-    if (message.swipesMeta.isNotEmpty) return message.swipesMeta;
     final swipes = message.swipes.isNotEmpty
         ? message.swipes
         : [message.content];
-    return List<Map<String, dynamic>>.generate(
+    final meta = List<Map<String, dynamic>>.generate(
       swipes.length,
-      (i) => i == message.swipeId
-          ? <String, dynamic>{
-              'genTime': message.genTime,
-              'reasoning': message.reasoning,
-              'tokens': message.tokens,
-            }
+      (i) => i < message.swipesMeta.length
+          ? Map<String, dynamic>.from(message.swipesMeta[i])
           : <String, dynamic>{},
     );
+    if (message.swipeId >= 0 && message.swipeId < meta.length) {
+      final active = meta[message.swipeId];
+      final nested = message.agentSwipes
+          .map((swipe) => swipe.toJson())
+          .toList();
+      if (message.agentSwipeId >= 0 &&
+          message.agentSwipeId < nested.length &&
+          nested[message.agentSwipeId]['time'] == null) {
+        nested[message.agentSwipeId]['time'] = message.time;
+      }
+      meta[message.swipeId] = <String, dynamic>{
+        ...active,
+        if (!active.containsKey('genTime')) 'genTime': message.genTime,
+        if (!active.containsKey('reasoning')) 'reasoning': message.reasoning,
+        if (!active.containsKey('tokens')) 'tokens': message.tokens,
+        if (!active.containsKey('time')) 'time': message.time,
+        if (nested.isNotEmpty) 'agentSwipes': nested,
+        if (nested.isNotEmpty) 'agentSwipeId': message.agentSwipeId,
+      };
+    }
+    return meta;
   }
 
   /// Extend the trailing assistant message with a fresh generation, then fold

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -932,10 +932,15 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
     try {
       final session = widget.state.session;
       if (session == null) return false;
+      bool isCurrentSession() =>
+          mounted &&
+          ref.read(chatProvider(widget.charId)).value?.session?.id ==
+              session.id;
       if (widget.state.messages.any((m) => m.role == 'user')) return true;
       final turnConfig = await ref
           .read(studioTurnConfigResolverProvider)
           .resolve(session.id);
+      if (!isCurrentSession()) return false;
       if (!turnConfig.enabled || !turnConfig.ledgerEnabled) return true;
       final trackerRepo = ref.read(trackerRepoProvider);
       final existing = await Future.wait([
@@ -943,6 +948,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
         trackerRepo.get(session.id, GameTimeState.dateKey),
         trackerRepo.get(session.id, GameTimeState.dayKey),
       ]);
+      if (!isCurrentSession()) return false;
       if (GameTimeState.fromTrackers(existing.nonNulls).format() != null) {
         return true;
       }
@@ -953,28 +959,18 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
         builder: (_) => const GameTimeSeedDialog(),
       );
       if (result == null) return false;
-      await trackerRepo.upsertValue(
-        session.id,
-        GameTimeState.timeKey,
-        result.time,
-        scope: 'ledger',
-        provenance: 'game_time_seed',
+      if (!isCurrentSession()) return false;
+      final seeded = await trackerRepo.seedInitialGameTime(
+        sessionId: session.id,
+        time: result.time,
+        date: result.date,
+        expectedValues: {
+          GameTimeState.timeKey: existing[0]?.value,
+          GameTimeState.dateKey: existing[1]?.value,
+          GameTimeState.dayKey: existing[2]?.value,
+        },
       );
-      await trackerRepo.upsertValue(
-        session.id,
-        GameTimeState.dateKey,
-        result.date,
-        scope: 'ledger',
-        provenance: 'game_time_seed',
-      );
-      await trackerRepo.upsertValue(
-        session.id,
-        GameTimeState.dayKey,
-        '0',
-        scope: 'ledger',
-        provenance: 'game_time_seed',
-      );
-      return true;
+      return seeded && isCurrentSession();
     } catch (_) {
       return false;
     }

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -926,27 +926,33 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
     );
   }
 
-  /// Before the first message of a Studio chat with the ledger enabled, offer
-  /// to anchor the ledger game clock (world:time / world:date / world:day).
-  /// Best-effort: any failure or a skipped dialog never blocks the send.
-  Future<void> _maybeSeedGameTime() async {
+  /// Before the first message of a Studio chat with Ledger enabled, require a
+  /// complete world:date/day/time tuple. Ordinary chats never enter this path.
+  Future<bool> _maybeSeedGameTime() async {
     try {
       final session = widget.state.session;
-      if (session == null) return;
-      if (widget.state.messages.any((m) => m.role == 'user')) return;
+      if (session == null) return false;
+      if (widget.state.messages.any((m) => m.role == 'user')) return true;
       final turnConfig = await ref
           .read(studioTurnConfigResolverProvider)
           .resolve(session.id);
-      if (!turnConfig.enabled || !turnConfig.ledgerEnabled) return;
+      if (!turnConfig.enabled || !turnConfig.ledgerEnabled) return true;
       final trackerRepo = ref.read(trackerRepoProvider);
-      final existing = await trackerRepo.get(session.id, GameTimeState.timeKey);
-      if (existing != null && existing.value.trim().isNotEmpty) return;
-      if (!mounted) return;
+      final existing = await Future.wait([
+        trackerRepo.get(session.id, GameTimeState.timeKey),
+        trackerRepo.get(session.id, GameTimeState.dateKey),
+        trackerRepo.get(session.id, GameTimeState.dayKey),
+      ]);
+      if (GameTimeState.fromTrackers(existing.nonNulls).format() != null) {
+        return true;
+      }
+      if (!mounted) return false;
       final result = await showDialog<GameTimeSeedResult>(
         context: context,
+        barrierDismissible: false,
         builder: (_) => const GameTimeSeedDialog(),
       );
-      if (result == null) return;
+      if (result == null) return false;
       await trackerRepo.upsertValue(
         session.id,
         GameTimeState.timeKey,
@@ -954,15 +960,13 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
         scope: 'ledger',
         provenance: 'game_time_seed',
       );
-      if (result.date != null) {
-        await trackerRepo.upsertValue(
-          session.id,
-          GameTimeState.dateKey,
-          result.date!,
-          scope: 'ledger',
-          provenance: 'game_time_seed',
-        );
-      }
+      await trackerRepo.upsertValue(
+        session.id,
+        GameTimeState.dateKey,
+        result.date,
+        scope: 'ledger',
+        provenance: 'game_time_seed',
+      );
       await trackerRepo.upsertValue(
         session.id,
         GameTimeState.dayKey,
@@ -970,8 +974,9 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
         scope: 'ledger',
         provenance: 'game_time_seed',
       );
+      return true;
     } catch (_) {
-      // Seeding is best-effort — never block the first send on it.
+      return false;
     }
   }
 
@@ -1509,6 +1514,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                               .agentSwipes
                                               .length >
                                           1,
+                                  beforeRegenerate: _maybeSeedGameTime,
                                 );
                               },
                           onSwipe: (id, direction) {
@@ -1540,8 +1546,9 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                 .read(chatProvider(widget.charId).notifier)
                                 .setGreeting(idx, dir);
                           },
-                          onRegenerate: (id, mode) {
-                            ref
+                          onRegenerate: (id, mode) async {
+                            if (!await _maybeSeedGameTime()) return;
+                            await ref
                                 .read(chatProvider(widget.charId).notifier)
                                 .regenerateLastAssistant();
                           },
@@ -1583,7 +1590,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                               );
                             }
                           },
-                          onGuidedSwipe: (id, guidanceText) {
+                          onGuidedSwipe: (id, guidanceText) async {
                             final idx = widget.state.messages.indexWhere(
                               (m) => m.id == id,
                             );
@@ -1593,7 +1600,8 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                 msg.role == 'assistant' &&
                                 idx == widget.state.messages.length - 1;
                             if (isLastAssistant) {
-                              ref
+                              if (!await _maybeSeedGameTime()) return;
+                              await ref
                                   .read(chatProvider(widget.charId).notifier)
                                   .regenerateLastAssistant(
                                     guidanceText: guidanceText,
@@ -1934,6 +1942,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                               DrawerPanel.quickReplies
                           ? QuickRepliesPanel(
                               charId: widget.charId,
+                              beforeGeneration: _maybeSeedGameTime,
                               onClose: () => widget.drawerCtrl.closeDrawer(),
                               disableEffects:
                                   batterySaver &&
@@ -2059,7 +2068,9 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                         if (text.trim().isEmpty) {
                                           return false;
                                         }
-                                        await _maybeSeedGameTime();
+                                        if (!await _maybeSeedGameTime()) {
+                                          return false;
+                                        }
                                         final accepted = await ref
                                             .read(
                                               chatProvider(
@@ -2077,7 +2088,9 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                         if (text.trim().isEmpty) {
                                           return false;
                                         }
-                                        await _maybeSeedGameTime();
+                                        if (!await _maybeSeedGameTime()) {
+                                          return false;
+                                        }
                                         final accepted = await ref
                                             .read(
                                               chatProvider(
@@ -2100,7 +2113,9 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                             guidanceText,
                                             imageDataUrl,
                                           ) async {
-                                            await _maybeSeedGameTime();
+                                            if (!await _maybeSeedGameTime()) {
+                                              return false;
+                                            }
                                             final accepted = await ref
                                                 .read(
                                                   chatProvider(

--- a/lib/features/chat/services/collector_view_service.dart
+++ b/lib/features/chat/services/collector_view_service.dart
@@ -131,7 +131,7 @@ final collectorViewServiceProvider = Provider<CollectorViewService>((ref) {
   );
 });
 
-final collectorViewProvider =
-    FutureProvider.family<CollectorViewSnapshot, String>((ref, sessionId) {
+final collectorViewProvider = FutureProvider.autoDispose
+    .family<CollectorViewSnapshot, String>((ref, sessionId) {
       return ref.watch(collectorViewServiceProvider).load(sessionId);
     });

--- a/lib/features/chat/services/continuation_message_merger.dart
+++ b/lib/features/chat/services/continuation_message_merger.dart
@@ -43,6 +43,7 @@ ChatMessage mergeContinuationMessage(
             reasoning: reasoning,
             genTime: generated.genTime,
             tokens: generated.tokens,
+            time: original.time,
             studioOutputs: generated.studioOutputs,
             parentSwipeId: swipeId,
           ),

--- a/lib/features/chat/services/current_ledger_injection_preview_service.dart
+++ b/lib/features/chat/services/current_ledger_injection_preview_service.dart
@@ -233,11 +233,11 @@ final currentLedgerInjectionPreviewServiceProvider =
       );
     });
 
-final currentLedgerInjectionPreviewProvider =
-    FutureProvider.family<
-      CurrentLedgerInjectionPreview,
-      CurrentLedgerInjectionPreviewKey
-    >((ref, key) {
+final currentLedgerInjectionPreviewProvider = FutureProvider.autoDispose
+    .family<CurrentLedgerInjectionPreview, CurrentLedgerInjectionPreviewKey>((
+      ref,
+      key,
+    ) {
       return ref
           .watch(currentLedgerInjectionPreviewServiceProvider)
           .load(sessionId: key.sessionId, expectedCharacterId: key.characterId);

--- a/lib/features/chat/services/game_time_message_stamp.dart
+++ b/lib/features/chat/services/game_time_message_stamp.dart
@@ -1,0 +1,74 @@
+import '../../../core/models/chat_message.dart';
+
+/// Stores a Ledger clock on the exact green/blue variation it describes.
+/// [ChatMessage.time] remains a denormalized projection of the active variant
+/// for the WebView and auxiliary consumers.
+ChatMessage stampGameTimeForVariation(
+  ChatMessage message, {
+  required int swipeId,
+  required int agentSwipeId,
+  required String time,
+}) {
+  if (swipeId < 0) return message;
+
+  final meta = List<Map<String, dynamic>>.generate(
+    message.swipes.length > swipeId ? message.swipes.length : swipeId + 1,
+    (index) => index < message.swipesMeta.length
+        ? Map<String, dynamic>.from(message.swipesMeta[index])
+        : <String, dynamic>{},
+  );
+  final targetMeta = meta[swipeId];
+  final isActiveGreen = message.swipeId == swipeId;
+  var agentSwipes = isActiveGreen
+      ? List<AgentSwipe>.from(message.agentSwipes)
+      : _agentSwipesFromMeta(targetMeta);
+
+  if (agentSwipes.isEmpty) {
+    final greenContent = swipeId < message.swipes.length
+        ? message.swipes[swipeId]
+        : isActiveGreen
+        ? message.content
+        : '';
+    agentSwipes = [
+      AgentSwipe(
+        content: greenContent,
+        reasoning: targetMeta['reasoning'] as String?,
+        genTime: targetMeta['genTime'] as String?,
+        tokens: targetMeta['tokens'] as int?,
+        studioOutputs: _studioOutputsFromMeta(targetMeta),
+      ),
+    ];
+  }
+  if (agentSwipeId < 0 || agentSwipeId >= agentSwipes.length) return message;
+
+  agentSwipes[agentSwipeId] = agentSwipes[agentSwipeId].copyWith(time: time);
+  targetMeta
+    ..['time'] = time
+    ..['agentSwipes'] = agentSwipes.map((swipe) => swipe.toJson()).toList()
+    ..['agentSwipeId'] = agentSwipeId;
+
+  final isActive = isActiveGreen && message.agentSwipeId == agentSwipeId;
+  return message.copyWith(
+    time: isActive ? time : message.time,
+    swipesMeta: meta,
+    agentSwipes: isActiveGreen ? agentSwipes : message.agentSwipes,
+  );
+}
+
+List<AgentSwipe> _agentSwipesFromMeta(Map<String, dynamic> meta) {
+  final raw = meta['agentSwipes'];
+  if (raw is! List) return <AgentSwipe>[];
+  return raw
+      .whereType<Map<dynamic, dynamic>>()
+      .map((value) => AgentSwipe.fromJson(Map<String, dynamic>.from(value)))
+      .toList();
+}
+
+List<Map<String, dynamic>> _studioOutputsFromMeta(Map<String, dynamic> meta) {
+  final raw = meta['studioOutputs'];
+  if (raw is! List) return const [];
+  return raw
+      .whereType<Map<dynamic, dynamic>>()
+      .map((value) => Map<String, dynamic>.from(value))
+      .toList();
+}

--- a/lib/features/chat/services/image_gen_processor.dart
+++ b/lib/features/chat/services/image_gen_processor.dart
@@ -380,12 +380,16 @@ class ImageGenProcessor {
       }
     }
     if (agentSwipes.isEmpty && swipes.isNotEmpty) {
+      final storedTime = swipeId >= 0 && swipeId < meta.length
+          ? meta[swipeId]['time'] as String?
+          : null;
       agentSwipes = [
         AgentSwipe(
           content: content,
           reasoning: message.reasoning,
           genTime: message.genTime,
           tokens: message.tokens,
+          time: isActiveSwipe ? message.time : storedTime,
           studioOutputs: message.studioOutputs,
         ),
       ];

--- a/lib/features/chat/services/prompt_capture_view_service.dart
+++ b/lib/features/chat/services/prompt_capture_view_service.dart
@@ -97,8 +97,8 @@ final promptCaptureViewServiceProvider = Provider<PromptCaptureViewService>(
   (ref) => PromptCaptureViewService(ref.watch(llmRequestCaptureRepoProvider)),
 );
 
-final promptCaptureViewsProvider =
-    FutureProvider.family<List<PromptCaptureView>, String>(
+final promptCaptureViewsProvider = FutureProvider.autoDispose
+    .family<List<PromptCaptureView>, String>(
       (ref, sessionId) =>
           ref.watch(promptCaptureViewServiceProvider).load(sessionId),
     );

--- a/lib/features/chat/services/reconciler_view_service.dart
+++ b/lib/features/chat/services/reconciler_view_service.dart
@@ -193,7 +193,7 @@ final reconcilerViewServiceProvider = Provider<ReconcilerViewService>((ref) {
   );
 });
 
-final reconcilerViewProvider =
-    FutureProvider.family<ReconcilerViewSnapshot, String>((ref, sessionId) {
+final reconcilerViewProvider = FutureProvider.autoDispose
+    .family<ReconcilerViewSnapshot, String>((ref, sessionId) {
       return ref.watch(reconcilerViewServiceProvider).load(sessionId);
     });

--- a/lib/features/chat/services/saved_message_writer.dart
+++ b/lib/features/chat/services/saved_message_writer.dart
@@ -159,6 +159,7 @@ class SavedMessageWriter {
           agentSwipes: agentSwipes,
           agentSwipeId: agentSwipeId,
           studioOutputs: studioOutputs,
+          time: null,
         );
         final updatedMessages = [...currentSession.messages];
         updatedMessages[idx] = updated;
@@ -311,6 +312,7 @@ class SavedMessageWriter {
           'genTime': original.genTime,
           'reasoning': original.reasoning,
           'tokens': original.tokens,
+          'time': original.time,
         });
       } else {
         priorMeta.add(<String, dynamic>{});
@@ -330,6 +332,7 @@ class SavedMessageWriter {
       reasoning: null,
       genTime: null,
       tokens: null,
+      time: null,
     );
     final finalMessages = [...saveSession.messages];
     finalMessages[idx] = updated;

--- a/lib/features/chat/services/saved_message_writer.dart
+++ b/lib/features/chat/services/saved_message_writer.dart
@@ -30,6 +30,7 @@ class SavedMessageWriter {
     String? genTime,
     int? tokens,
     String? rawResponse,
+    String? time,
     List<String>? previousSwipes,
     int previousSwipeId = 0,
     String? previousReasoning,
@@ -63,6 +64,10 @@ class SavedMessageWriter {
       'genTime': genTime,
       'reasoning': reasoning,
       'tokens': tokens,
+      // Opening game clock (Studio only): stamped at creation so the badge
+      // renders with the initial append instead of waiting for the
+      // post-turn Ledger update.
+      'time': ?time,
       if (studioOutputs.isNotEmpty) 'studioOutputs': studioOutputs,
       // Persist triggered entries per swipe so each variation shows its own
       // lorebook/memory activations (restored on swipe in ChatMessageService).
@@ -120,6 +125,7 @@ class SavedMessageWriter {
             reasoning: reasoning,
             genTime: genTime,
             tokens: tokens,
+            time: time,
             studioOutputs: studioOutputs,
           ),
         ];
@@ -159,7 +165,9 @@ class SavedMessageWriter {
           agentSwipes: agentSwipes,
           agentSwipeId: agentSwipeId,
           studioOutputs: studioOutputs,
-          time: null,
+          // Fresh variation carries the opening clock (may be null when no
+          // complete game-time tuple exists); Ledger restamps after the turn.
+          time: time,
         );
         final updatedMessages = [...currentSession.messages];
         updatedMessages[idx] = updated;
@@ -194,6 +202,7 @@ class SavedMessageWriter {
         reasoning: reasoning,
         genTime: genTime,
         tokens: tokens,
+        time: time,
         studioOutputs: studioOutputs,
       ),
     ];
@@ -206,6 +215,7 @@ class SavedMessageWriter {
       genTime: genTime,
       tokens: tokens,
       timestamp: DateTime.now().millisecondsSinceEpoch,
+      time: time,
       swipes: swipes,
       swipeId: swipeId,
       swipesMeta: swipesMeta,

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -172,6 +172,16 @@ class LedgerStage {
         return;
       }
 
+      // Project the seeded opening clock immediately. The Ledger call may be
+      // delayed by reconciliation or fail; a valid seed is still the current
+      // story time until Ledger advances it.
+      await _syncGameTimeToMessage(
+        sessionId: sessionId,
+        targetMessage: targetMessage,
+        isCurrent: isCurrent,
+      );
+      if (!isCurrent()) return;
+
       // Always resolve the dedicated Ledger slot from the immutable turn
       // snapshot. A cleaner config must never override an explicit Ledger slot.
       final AuxApiConfig ledgerConfig;

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -31,6 +31,7 @@ import '../../state/post_gen_status_provider.dart';
 import '../collector_view_service.dart';
 import '../current_ledger_injection_preview_service.dart';
 import '../pipeline_utils.dart';
+import '../game_time_message_stamp.dart';
 import '../prompt_capture_view_service.dart';
 import '../reconciler_view_service.dart';
 import 'stage_context.dart';
@@ -539,7 +540,7 @@ class LedgerStage {
           .read(trackerRepoProvider)
           .getBySessionAndScope(sessionId, 'ledger');
       final display = GameTimeState.fromTrackers(trackers).format();
-      if (display == null || display == targetMessage.time) return;
+      if (display == null) return;
       if (!isCurrent()) return;
 
       final updated = await ctx.ref
@@ -548,7 +549,12 @@ class LedgerStage {
             sessionId: sessionId,
             messageId: targetMessage.id,
             updatedAt: currentTimestampSeconds(),
-            mutate: (message) => message.copyWith(time: display),
+            mutate: (message) => stampGameTimeForVariation(
+              message,
+              swipeId: targetMessage.swipeId,
+              agentSwipeId: targetMessage.agentSwipeId,
+              time: display,
+            ),
           );
       if (updated == null) return;
       ChatSessionService.updateCache(updated);

--- a/lib/features/chat/services/stages/post_gen_coordinator.dart
+++ b/lib/features/chat/services/stages/post_gen_coordinator.dart
@@ -155,9 +155,10 @@ class PostGenCoordinator {
     );
     if (!ctx.ref.mounted || !ctx.abortHandler.isCurrentGen(genId)) return;
 
-    // Embed and auto-draft work is intentionally background work: neither
-    // changes the visible assistant turn nor needs to own the Send/Stop lock.
-    // Keep errors observable without letting a stalled auxiliary task block chat.
+    final studioEnabled = studioTurnConfig?.enabled == true;
+
+    // Embedding is independent of the Studio Ledger clock and can start from
+    // the committed response immediately.
     _runInBackground(
       () => embedStage.run(
         sessionId: sessionId,
@@ -167,20 +168,21 @@ class PostGenCoordinator {
       'chat embedding',
       notifService,
     );
-    _runInBackground(
-      () => draftStage.run(result.session),
-      'memory auto-draft',
-      notifService,
-    );
-    _runInBackground(
-      () => autoSummaryStage.run(result.session),
-      'auto-summary',
-      notifService,
-    );
+    if (!studioEnabled) {
+      _runInBackground(
+        () => draftStage.run(result.session),
+        'memory auto-draft',
+        notifService,
+      );
+      _runInBackground(
+        () => autoSummaryStage.run(result.session),
+        'auto-summary',
+        notifService,
+      );
+    }
 
     // Determine Studio status before acquiring the foreground post-gen hold.
     // A disabled/no-op ordinary path must not retain that hold.
-    final studioEnabled = studioTurnConfig?.enabled == true;
     if (!ctx.ref.mounted || !ctx.abortHandler.isCurrentGen(genId)) return;
 
     if (!studioEnabled) {
@@ -218,6 +220,33 @@ class PostGenCoordinator {
       studioTurnConfig: studioTurnConfig,
     );
     postGenFutures.add(cleanerTask);
+
+    // Studio auxiliary consumers need the clock stamped by Ledger, which runs
+    // inside CleanerStage. Re-read the durable session after that workflow so
+    // Memory and Summary never infer a missing time from the pre-Ledger copy.
+    postGenFutures.add(
+      cleanerTask.then((_) async {
+        if (!ctx.ref.mounted || !ctx.abortHandler.isCurrentGen(genId)) return;
+        final refreshed = await ctx.ref
+            .read(chatRepoProvider)
+            .getById(sessionId);
+        if (!ctx.ref.mounted ||
+            !ctx.abortHandler.isCurrentGen(genId) ||
+            refreshed == null) {
+          return;
+        }
+        _runInBackground(
+          () => draftStage.run(refreshed),
+          'memory auto-draft',
+          notifService,
+        );
+        _runInBackground(
+          () => autoSummaryStage.run(refreshed),
+          'auto-summary',
+          notifService,
+        );
+      }),
+    );
 
     // Stage 5: Image tags — on canonical text, after cleaner. Re-read
     // the session from DB so image tags bind to the cleaned swipe.

--- a/lib/features/chat/services/stages/regen_resolver.dart
+++ b/lib/features/chat/services/stages/regen_resolver.dart
@@ -78,6 +78,7 @@ class RegenResolver {
               'genTime': original.genTime,
               'reasoning': original.reasoning,
               'tokens': original.tokens,
+              'time': original.time,
             },
           ];
     final restored = restoreSession.messages[idx].copyWith(
@@ -87,6 +88,7 @@ class RegenResolver {
       reasoning: original.reasoning,
       genTime: original.genTime,
       tokens: original.tokens,
+      time: original.time,
       swipesMeta: rollbackSwipesMeta,
       swipeDirection: original.swipeDirection,
       isTyping: false,

--- a/lib/features/chat/services/stream_generation_service.dart
+++ b/lib/features/chat/services/stream_generation_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/llm/game_time.dart';
 import '../../../core/llm/history_assembler.dart';
 import '../../../core/llm/prompt_isolate.dart';
 import '../../../core/llm/prompt/main_model_context_snapshot.dart';
@@ -34,6 +35,7 @@ import '../../../core/models/pipeline_settings.dart';
 import '../../../core/services/model_usage_service.dart';
 import '../../../core/services/preset_defaults.dart';
 import '../../../core/state/active_selection_provider.dart';
+import '../../../core/state/db_provider.dart';
 import '../../../core/state/memory_agent_providers.dart';
 import '../chat_provider.dart';
 import '../chat_state.dart';
@@ -436,6 +438,16 @@ class StreamGenerationService {
             studioFinalMessages,
           ),
         );
+        // Opening game clock: read the current ledger trackers before the
+        // message is written so the badge travels with the initial append
+        // (the post-turn Ledger stamp refines it afterwards). Null when no
+        // complete date/day/time tuple exists — never a partial clock.
+        final openingTrackers = await _ref
+            .read(trackerRepoProvider)
+            .getBySessionAndScope(session.id, 'ledger');
+        final openingClock = GameTimeState.fromTrackers(
+          openingTrackers,
+        ).format();
         final finalState = _writer
             .writeAssistant(
               text: wrappedStudioText,
@@ -447,6 +459,7 @@ class StreamGenerationService {
               pendingSessionVars: beautyApplied.vars,
               genTime: '${(elapsed / 1000).toStringAsFixed(1)}s',
               tokens: estimateTokens(studioResult.response),
+              time: openingClock,
               rawResponse:
                   studioResult.rawResponseJson ?? studioResult.response,
               previousSwipes: previousSwipes,

--- a/lib/features/chat/state/magic_drawer_stats_cache.dart
+++ b/lib/features/chat/state/magic_drawer_stats_cache.dart
@@ -2,7 +2,9 @@ import 'package:flutter_riverpod/legacy.dart';
 
 import '../widgets/magic_drawer_models.dart';
 
-/// Last computed Quick Access stats, per character.
+typedef MagicDrawerStatsCacheKey = ({String charId, String? sessionId});
+
+/// Last computed Quick Access stats, per character session.
 ///
 /// The drawer panel is unmounted the moment the drawer closes (see
 /// `renderDrawer` in `chat_screen.dart`), so its widget state cannot survive
@@ -11,7 +13,9 @@ import '../widgets/magic_drawer_models.dart';
 /// snapshot alive at app scope: an open paints it immediately and the real
 /// recomputation lands on top a moment later (stale-while-revalidate).
 final magicDrawerStatsCacheProvider =
-    StateProvider.family<MagicDrawerStats?, String>((ref, _) => null);
+    StateProvider.family<MagicDrawerStats?, MagicDrawerStatsCacheKey>(
+      (ref, _) => null,
+    );
 
 /// Last resolved card layout (order + deleted ids). Not per-character — the
 /// layout is a single app-wide preference.

--- a/lib/features/chat/widgets/agentic_operations_log_dialog.dart
+++ b/lib/features/chat/widgets/agentic_operations_log_dialog.dart
@@ -6,6 +6,7 @@ import '../../../shared/widgets/glaze_tab_bar.dart';
 import '../../../shared/widgets/sheet_view.dart';
 import '../../../shared/widgets/swipe_tab_switcher.dart';
 import '../../card_rewrite/card_rewriter_studio_sheet.dart';
+import '../chat_provider.dart';
 import 'agentic_collector_tab.dart';
 import 'agentic_reconciler_tab.dart';
 import 'agentic_snapshots_tab.dart';
@@ -20,9 +21,9 @@ class AgenticOperationsLogDialog extends ConsumerStatefulWidget {
     this.characterId,
   });
 
-  /// Opens the dialog as an overlay. Caller passes the current [sessionId]
-  /// so the dialog can scope the list, or null to show operations across all
-  /// sessions.
+  /// Opens the dialog as an overlay. When [characterId] is available, the
+  /// dialog follows that chat's active session instead of retaining a stale
+  /// session captured when the sheet was opened.
   static Future<String?> show(
     BuildContext context, {
     String? sessionId,
@@ -57,7 +58,13 @@ class _AgenticOperationsLogDialogState
 
   @override
   Widget build(BuildContext context) {
-    final sessionId = widget.sessionId;
+    final characterId = widget.characterId;
+    final liveSessionId = characterId == null || characterId.isEmpty
+        ? null
+        : ref.watch(chatProvider(characterId)).value?.session?.id;
+    final sessionId = characterId == null || characterId.isEmpty
+        ? widget.sessionId
+        : liveSessionId;
     final children = sessionId == null || sessionId.isEmpty
         ? <Widget>[Center(child: Text('agent_ops_open_from_chat'.tr()))]
         : <Widget>[
@@ -94,9 +101,12 @@ class _AgenticOperationsLogDialogState
             index: _activeIndex,
             length: 4,
             onChanged: _selectTab,
-            child: AgenticSessionScope(
-              sessionId: sessionId,
-              child: IndexedStack(index: _activeIndex, children: children),
+            child: KeyedSubtree(
+              key: ValueKey(sessionId),
+              child: AgenticSessionScope(
+                sessionId: sessionId,
+                child: IndexedStack(index: _activeIndex, children: children),
+              ),
             ),
           );
     return SheetView(

--- a/lib/features/chat/widgets/game_time_seed_dialog.dart
+++ b/lib/features/chat/widgets/game_time_seed_dialog.dart
@@ -4,18 +4,18 @@ import 'package:flutter/services.dart';
 
 /// Result of the first-message game time seeding dialog.
 class GameTimeSeedResult {
-  const GameTimeSeedResult({required this.time, this.date});
+  const GameTimeSeedResult({required this.time, required this.date});
 
   /// `HH:MM` in-game time of day for message zero.
   final String time;
 
-  /// `DD.MM.YYYY` in-game date, or null when the story has no calendar.
-  final String? date;
+  /// `DD.MM.YYYY` in-game date.
+  final String date;
 }
 
 /// Shown before the first message of a Studio chat so the player can anchor
 /// the ledger game clock (world:time / world:date / world:day). The in-game
-/// day always starts at 0; only the time of day and the optional date are
+/// day always starts at 0; only the time of day and date are
 /// entered here.
 class GameTimeSeedDialog extends StatefulWidget {
   const GameTimeSeedDialog({super.key});
@@ -49,80 +49,84 @@ class _GameTimeSeedDialogState extends State<GameTimeSeedDialog> {
       return;
     }
     final dateRaw = _dateController.text.trim();
-    if (dateRaw.isNotEmpty && !_dateRe.hasMatch(dateRaw)) {
+    if (!_dateRe.hasMatch(dateRaw)) {
+      setState(() => _error = 'game_time_seed_invalid_date'.tr());
+      return;
+    }
+    final dateParts = dateRaw.split('.').map(int.parse).toList();
+    final parsedDate = DateTime.utc(dateParts[2], dateParts[1], dateParts[0]);
+    if (parsedDate.year != dateParts[2] ||
+        parsedDate.month != dateParts[1] ||
+        parsedDate.day != dateParts[0]) {
       setState(() => _error = 'game_time_seed_invalid_date'.tr());
       return;
     }
     final hour = int.parse(timeMatch.group(1)!).toString().padLeft(2, '0');
     final minute = timeMatch.group(2)!;
-    Navigator.of(context).pop(
-      GameTimeSeedResult(
-        time: '$hour:$minute',
-        date: dateRaw.isEmpty ? null : dateRaw,
-      ),
-    );
+    Navigator.of(
+      context,
+    ).pop(GameTimeSeedResult(time: '$hour:$minute', date: dateRaw));
   }
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    return AlertDialog(
-      title: Text('game_time_seed_title'.tr()),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text('game_time_seed_description'.tr()),
-          const SizedBox(height: 16),
-          TextField(
-            controller: _timeController,
-            decoration: InputDecoration(
-              labelText: 'game_time_seed_time_label'.tr(),
-              hintText: '09:00',
-              errorText: null,
-            ),
-            inputFormatters: [
-              FilteringTextInputFormatter.allow(RegExp(r'[0-9:]')),
-              LengthLimitingTextInputFormatter(5),
-            ],
-            keyboardType: TextInputType.datetime,
-            autofocus: true,
-            onSubmitted: (_) => _submit(),
-          ),
-          const SizedBox(height: 12),
-          TextField(
-            controller: _dateController,
-            decoration: InputDecoration(
-              labelText: 'game_time_seed_date_label'.tr(),
-              hintText: 'DD.MM.YYYY',
-            ),
-            inputFormatters: [
-              FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
-              LengthLimitingTextInputFormatter(10),
-            ],
-            keyboardType: TextInputType.datetime,
-            onSubmitted: (_) => _submit(),
-          ),
-          if (_error != null)
-            Padding(
-              padding: const EdgeInsets.only(top: 12),
-              child: Text(
-                _error!,
-                style: TextStyle(color: cs.error, fontSize: 13),
+    return PopScope(
+      canPop: false,
+      child: AlertDialog(
+        title: Text('game_time_seed_title'.tr()),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('game_time_seed_description'.tr()),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _timeController,
+              decoration: InputDecoration(
+                labelText: 'game_time_seed_time_label'.tr(),
+                hintText: '09:00',
+                errorText: null,
               ),
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[0-9:]')),
+                LengthLimitingTextInputFormatter(5),
+              ],
+              keyboardType: TextInputType.datetime,
+              autofocus: true,
+              onSubmitted: (_) => _submit(),
             ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _dateController,
+              decoration: InputDecoration(
+                labelText: 'game_time_seed_date_label'.tr(),
+                hintText: 'DD.MM.YYYY',
+              ),
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+                LengthLimitingTextInputFormatter(10),
+              ],
+              keyboardType: TextInputType.datetime,
+              onSubmitted: (_) => _submit(),
+            ),
+            if (_error != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: Text(
+                  _error!,
+                  style: TextStyle(color: cs.error, fontSize: 13),
+                ),
+              ),
+          ],
+        ),
+        actions: [
+          FilledButton(
+            onPressed: _submit,
+            child: Text('game_time_seed_confirm'.tr()),
+          ),
         ],
       ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text('game_time_seed_skip'.tr()),
-        ),
-        FilledButton(
-          onPressed: _submit,
-          child: Text('game_time_seed_confirm'.tr()),
-        ),
-      ],
     );
   }
 }

--- a/lib/features/chat/widgets/magic_drawer.dart
+++ b/lib/features/chat/widgets/magic_drawer.dart
@@ -185,6 +185,12 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
   final _scrollController = ScrollController();
   late final MagicDrawerStatsService _statsService;
 
+  MagicDrawerStatsCacheKey _statsCacheKey([String? sessionId]) => (
+    charId: widget.charId,
+    sessionId:
+        sessionId ?? ref.read(chatProvider(widget.charId)).value?.session?.id,
+  );
+
   @override
   void initState() {
     super.initState();
@@ -198,7 +204,9 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
       _itemIds.addAll(cachedLayout.itemIds);
       _deletedIds.addAll(cachedLayout.deletedIds);
     }
-    final cachedStats = ref.read(magicDrawerStatsCacheProvider(widget.charId));
+    final cachedStats = ref.read(
+      magicDrawerStatsCacheProvider(_statsCacheKey()),
+    );
     if (cachedStats != null) _stats = cachedStats;
     // The spinner is now only for the first open of an app run, when there is
     // genuinely nothing to show.
@@ -258,13 +266,31 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
 
   Future<void> _loadStats() async {
     final request = ++_statsRequest;
+    final requestedSessionId = ref
+        .read(chatProvider(widget.charId))
+        .value
+        ?.session
+        ?.id;
     final stats = await _statsService.computeStats(widget.charId);
-    if (request != _statsRequest) return;
+    final currentSessionId = ref
+        .read(chatProvider(widget.charId))
+        .value
+        ?.session
+        ?.id;
+    if (request != _statsRequest || currentSessionId != requestedSessionId) {
+      return;
+    }
     _stats = stats;
     // The drawer can be closed mid-load, which disposes this state and with it
     // `ref` — only touch the cache while still mounted.
     if (mounted) {
-      ref.read(magicDrawerStatsCacheProvider(widget.charId).notifier).state =
+      ref
+              .read(
+                magicDrawerStatsCacheProvider(
+                  _statsCacheKey(requestedSessionId),
+                ).notifier,
+              )
+              .state =
           stats;
     }
   }
@@ -290,7 +316,7 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
       return;
     }
     if (!mounted || request != _statsRequest) return;
-    ref.read(magicDrawerStatsCacheProvider(widget.charId).notifier).state =
+    ref.read(magicDrawerStatsCacheProvider(_statsCacheKey()).notifier).state =
         updated;
     setState(() {
       _stats = updated;
@@ -709,8 +735,18 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
     ref.listen(chatProvider(widget.charId), (prev, next) {
       final prevSession = prev?.value?.session;
       final nextSession = next.value?.session;
-      if (prevSession?.id != nextSession?.id ||
-          prevSession?.messages.length != nextSession?.messages.length ||
+      if (prevSession?.id != nextSession?.id) {
+        ++_statsRequest;
+        _debounceTimer?.cancel();
+        final cached = ref.read(
+          magicDrawerStatsCacheProvider(_statsCacheKey(nextSession?.id)),
+        );
+        setState(() {
+          _stats = cached ?? const MagicDrawerStats();
+          _loadingTokens = false;
+        });
+        unawaited(_refreshStats());
+      } else if (prevSession?.messages.length != nextSession?.messages.length ||
           prevSession?.messages.lastOrNull?.content !=
               nextSession?.messages.lastOrNull?.content) {
         _scheduleRefresh();

--- a/lib/features/chat/widgets/memory_sheet.dart
+++ b/lib/features/chat/widgets/memory_sheet.dart
@@ -116,6 +116,7 @@ class _MemorySheetState extends ConsumerState<MemorySheet> {
                     : const SizedBox.shrink(),
                 _visited.contains(MemoryTab.books)
                     ? MemoryBooksTab(
+                        key: ValueKey(session.id),
                         sessionId: session.id,
                         charId: widget.charId,
                         messages: session.messages,
@@ -131,11 +132,8 @@ class _MemorySheetState extends ConsumerState<MemorySheet> {
   /// preset so the toggle is not silently overridden by the active preset.
   SheetViewAction _summaryToggle(String sessionId) {
     final enabled = ref.watch(summaryEnabledProvider(sessionId)).value ?? true;
-    void setEnabled(bool value) => syncSummaryEnabled(
-      ref,
-      charId: widget.charId,
-      enabled: value,
-    );
+    void setEnabled(bool value) =>
+        syncSummaryEnabled(ref, charId: widget.charId, enabled: value);
     return SheetViewAction(
       icon: Switch(
         value: enabled,

--- a/lib/features/chat/widgets/message_actions.dart
+++ b/lib/features/chat/widgets/message_actions.dart
@@ -22,6 +22,7 @@ void showMessageContextMenu({
   required bool isHidden,
   required bool canDeleteSwipe,
   required bool canDeleteAgentSwipe,
+  Future<bool> Function()? beforeRegenerate,
 }) {
   // Notifier is read fresh inside each onTap callback instead of captured
   // here. If the provider is invalidated while the menu is open (e.g. by a
@@ -72,9 +73,12 @@ void showMessageContextMenu({
         BottomSheetItem(
           icon: Icons.refresh,
           label: 'Regenerate',
-          onTap: () {
+          onTap: () async {
             Navigator.of(context, rootNavigator: true).pop();
-            ref.read(chatProvider(charId).notifier).regenerateLastAssistant();
+            if (await beforeRegenerate?.call() == false) return;
+            await ref
+                .read(chatProvider(charId).notifier)
+                .regenerateLastAssistant();
           },
         ),
       if (isActivelyGenerating)

--- a/lib/features/chat/widgets/quick_replies_panel.dart
+++ b/lib/features/chat/widgets/quick_replies_panel.dart
@@ -15,11 +15,13 @@ class QuickRepliesPanel extends ConsumerStatefulWidget {
   final String charId;
   final bool disableEffects;
   final VoidCallback? onClose;
+  final Future<bool> Function()? beforeGeneration;
 
   const QuickRepliesPanel({
     super.key,
     required this.charId,
     this.onClose,
+    this.beforeGeneration,
     this.disableEffects = false,
   });
 
@@ -43,16 +45,18 @@ class _QuickRepliesPanelState extends ConsumerState<QuickRepliesPanel> {
     setState(() => _editing = !_editing);
   }
 
-  void _handleTap(QuickReply reply) {
+  Future<void> _handleTap(QuickReply reply) async {
     if (_editing) {
-      _showEditSheet(existing: reply);
+      await _showEditSheet(existing: reply);
       return;
     }
     final notifier = ref.read(chatProvider(widget.charId).notifier);
+    if (await widget.beforeGeneration?.call() == false) return;
+    if (!mounted) return;
     if (reply.isContinueAction) {
-      notifier.continueMessage();
+      await notifier.continueMessage();
     } else if (reply.text.trim().isNotEmpty) {
-      notifier.sendMessage(reply.text);
+      await notifier.sendMessage(reply.text);
     }
     widget.onClose?.call();
   }
@@ -344,9 +348,7 @@ class _QuickReplyEditFormState extends State<_QuickReplyEditForm> {
               const SizedBox(width: 8),
               FilledButton(
                 onPressed: _submit,
-                child: Text(
-                  widget.isNew ? 'action_add'.tr() : 'btn_save'.tr(),
-                ),
+                child: Text(widget.isNew ? 'action_add'.tr() : 'btn_save'.tr()),
               ),
             ],
           ),

--- a/lib/features/extensions/services/generation_dispatcher.dart
+++ b/lib/features/extensions/services/generation_dispatcher.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/llm/game_time.dart';
+import '../../../core/state/db_provider.dart';
+import '../../../core/state/studio_turn_config_resolver.dart';
 import '../../chat/chat_provider.dart';
 import '../../chat/chat_state.dart';
 import '../../chat/editing_message_provider.dart';
@@ -74,6 +77,36 @@ class GenerationDispatcher {
     final resolved = _resolveAuto(current, mode);
 
     try {
+      final checkedSessionId = current.session!.id;
+      if (!current.session!.messages.any((message) => message.role == 'user')) {
+        final turnConfig = await ref
+            .read(studioTurnConfigResolverProvider)
+            .resolve(checkedSessionId);
+        if (turnConfig.enabled && turnConfig.ledgerEnabled) {
+          final trackerRepo = ref.read(trackerRepoProvider);
+          final trackers = await Future.wait([
+            trackerRepo.get(checkedSessionId, GameTimeState.timeKey),
+            trackerRepo.get(checkedSessionId, GameTimeState.dateKey),
+            trackerRepo.get(checkedSessionId, GameTimeState.dayKey),
+          ]);
+          if (GameTimeState.fromTrackers(trackers.nonNulls).format() == null) {
+            return TriggerError(
+              message:
+                  'Studio Ledger requires a complete game date and time before generation.',
+              mode: resolved,
+            );
+          }
+        }
+      }
+
+      final latest = ref.read(chatProvider(charId)).value;
+      if (latest?.session?.id != checkedSessionId) {
+        return TriggerNoSession(mode: resolved);
+      }
+      if (latest!.isGenerating || latest.isPostGenRunning) {
+        return TriggerBusy(busyKind: 'chat', mode: resolved);
+      }
+
       switch (resolved) {
         case TriggerMode.continueGeneration:
           await notifier.continueMessage();

--- a/lib/features/memory/controllers/memory_draft_generation_controller.dart
+++ b/lib/features/memory/controllers/memory_draft_generation_controller.dart
@@ -4,6 +4,7 @@ import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/llm/auxiliary_timed_history.dart';
 import '../../../core/models/memory_book.dart';
 import '../../../core/models/pipeline_settings.dart';
 import '../../../core/state/memory_settings_provider.dart';
@@ -127,11 +128,7 @@ class MemoryDraftGenerationController {
         .map((m) {
           // Ledger-stamped game clock travels with the transcript so memory
           // entries stay time-anchored.
-          final gameTime = m.time?.trim();
-          final timePrefix = gameTime == null || gameTime.isEmpty
-              ? ''
-              : '[$gameTime] ';
-          return '${m.role}: $timePrefix${m.content}';
+          return '${m.role}: ${auxiliaryTimedContent(m)}';
         })
         .join('\n\n');
     final cancelToken = CancelToken();

--- a/test/abort_handler_post_gen_abort_test.dart
+++ b/test/abort_handler_post_gen_abort_test.dart
@@ -154,6 +154,73 @@ void main() {
   );
 
   test(
+    'partial regeneration starts a fresh untimed nested variation',
+    () async {
+      const restoration = ChatMessage(
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'Original',
+        swipes: ['Original'],
+        swipesMeta: [
+          {
+            'time': '01.01.2026 · RP_Day 0 · 14:12',
+            'agentSwipeId': 0,
+            'agentSwipes': [
+              {
+                'content': 'Original',
+                'kind': 'final',
+                'time': '01.01.2026 · RP_Day 0 · 14:12',
+              },
+            ],
+          },
+        ],
+        agentSwipes: [
+          AgentSwipe(
+            content: 'Original',
+            time: '01.01.2026 · RP_Day 0 · 14:12',
+          ),
+        ],
+        time: '01.01.2026 · RP_Day 0 · 14:12',
+      );
+      final initialState = ChatState(
+        session: _session([restoration]),
+        isGenerating: true,
+        regenTargetId: restoration.id,
+      );
+      final harnessProvider = _abortHarnessProvider(initialState);
+      final container = ProviderContainer(
+        overrides: [
+          extensionPostGenServiceProvider.overrideWith(
+            (ref) => _RecordingExtensionPostGenService(ref),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final harness = container.read(harnessProvider);
+      harness.handler.restorationMessage = restoration;
+      container.read(streamingStateProvider('char-1').notifier).state =
+          const StreamingState(text: 'Partial', reasoning: 'Reasoning');
+
+      await harness.handler.abortGeneration();
+
+      final message = harness.durableSession!.messages.single;
+      expect(message.content, 'Partial');
+      expect(message.time, isNull);
+      expect(message.agentSwipeId, 0);
+      expect(message.agentSwipes, hasLength(1));
+      expect(message.agentSwipes.single.content, 'Partial');
+      expect(message.agentSwipes.single.time, isNull);
+      final stored = message.swipesMeta.last['agentSwipes'] as List<dynamic>;
+      expect(
+        AgentSwipe.fromJson(
+          Map<String, dynamic>.from(stored.single as Map<dynamic, dynamic>),
+        ).time,
+        isNull,
+      );
+    },
+  );
+
+  test(
     'post-gen Stop restores the snapshot without re-enabling generation flags',
     () async {
       final initialState = ChatState(

--- a/test/auxiliary_timed_history_test.dart
+++ b/test/auxiliary_timed_history_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/auxiliary_timed_history.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+
+void main() {
+  test('adds a Studio Ledger stamp for auxiliary consumers', () {
+    const message = ChatMessage(
+      id: 'a1',
+      role: 'assistant',
+      content: 'She waits.',
+      time: '12.05.2027 · RP_Day 2 · 14:15',
+    );
+
+    expect(
+      auxiliaryTimedContent(message),
+      '[12.05.2027 · RP_Day 2 · 14:15] She waits.',
+    );
+  });
+
+  test('ordinary messages remain unchanged when Ledger time is absent', () {
+    const message = ChatMessage(
+      id: 'a1',
+      role: 'assistant',
+      content: 'She waits.',
+    );
+
+    expect(auxiliaryTimedContent(message), 'She waits.');
+  });
+}

--- a/test/chat_atomic_message_mutation_test.dart
+++ b/test/chat_atomic_message_mutation_test.dart
@@ -162,6 +162,37 @@ void main() {
     expect(message.content, 'new active');
   });
 
+  test('image update does not copy the active clock to an inactive swipe', () {
+    const message = ChatMessage(
+      id: 'image',
+      role: 'assistant',
+      content: 'active',
+      swipes: ['[IMG:GEN]', 'active'],
+      swipesMeta: [
+        {'time': '01.01.2026 · RP_Day 0 · 14:12'},
+        {'time': '01.01.2026 · RP_Day 0 · 14:15'},
+      ],
+      swipeId: 1,
+      time: '01.01.2026 · RP_Day 0 · 14:15',
+    );
+
+    final updated = ImageGenProcessor.replaceImageContentAt(
+      message,
+      '[IMG:RESULT:/new.png]',
+      swipeId: 0,
+      agentSwipeId: 0,
+    );
+
+    final stored = updated.swipesMeta.first['agentSwipes'] as List<dynamic>;
+    expect(
+      AgentSwipe.fromJson(
+        Map<String, dynamic>.from(stored.single as Map<dynamic, dynamic>),
+      ).time,
+      '01.01.2026 · RP_Day 0 · 14:12',
+    );
+    expect(updated.time, '01.01.2026 · RP_Day 0 · 14:15');
+  });
+
   test(
     'author note mutation preserves concurrent draft and messages',
     () async {

--- a/test/chat_bulk_delete_test.dart
+++ b/test/chat_bulk_delete_test.dart
@@ -15,6 +15,69 @@ final _messageServiceProvider = Provider(ChatMessageService.new);
 
 void main() {
   test(
+    'deleting the last assistant message preserves the game clock as a seed',
+    () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      final container = ProviderContainer(
+        overrides: [appDbProvider.overrideWithValue(db)],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await db.close();
+      });
+
+      final session = ChatSession(
+        id: 's1',
+        characterId: 'c1',
+        sessionIndex: 0,
+        messages: const [
+          ChatMessage(id: 'u1', role: 'user', content: 'hi', timestamp: 1),
+          ChatMessage(
+            id: 'a1',
+            role: 'assistant',
+            content: 'reply',
+            timestamp: 2,
+          ),
+        ],
+      );
+      await container.read(chatRepoProvider).put(session);
+      // A complete clock tuple from a previous Ledger run — no committed
+      // tracker snapshot exists yet.
+      final trackerRepo = container.read(trackerRepoProvider);
+      for (final entry in {
+        'world:time': '14:15',
+        'world:date': '01.01.2027',
+        'world:day': '2',
+      }.entries) {
+        await trackerRepo.upsertValue(
+          's1',
+          entry.key,
+          entry.value,
+          scope: 'ledger',
+          provenance: 'studio_ledger',
+        );
+      }
+
+      await container.read(_messageServiceProvider).deleteMessages(session, {
+        1,
+      });
+
+      // The rollback-to-empty path must keep a complete bootstrap tuple so a
+      // following regeneration still stamps the opening clock.
+      final seed = await trackerRepo.getInitialGameTimeSeed('s1');
+      expect(seed.map((t) => t.name).toSet(), {
+        'world:time',
+        'world:date',
+        'world:day',
+      });
+      final byName = {for (final t in seed) t.name: t.value};
+      expect(byName['world:time'], '14:15');
+      expect(byName['world:date'], '01.01.2027');
+      expect(byName['world:day'], '2');
+    },
+  );
+
+  test(
     'bulk delete persists final state and clears raw-message index',
     () async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());

--- a/test/chat_webview_sync_dispatcher_test.dart
+++ b/test/chat_webview_sync_dispatcher_test.dart
@@ -59,6 +59,26 @@ void main() {
       expect(completed, isTrue);
     });
 
+    test('sends a time-only metadata update to the WebView', () async {
+      final bridge = _FakeBridge();
+      final oldMessage = _assistant('a1');
+      final updated = oldMessage.copyWith(
+        time: '12.05.2027 · RP_Day 2 · 14:15',
+      );
+
+      await const ChatMessageSync().sync(
+        bridge: bridge,
+        oldMsgs: [oldMessage],
+        newMsgs: [updated],
+        visibleStartIndex: 0,
+        isGenerating: false,
+        sessionSwitching: false,
+      );
+
+      expect(bridge.updatedMessages, [updated]);
+      expect(bridge.appendedMessages, isEmpty);
+    });
+
     test('appends streaming placeholder after persisted user append', () async {
       final userAppend = Completer<void>();
       final calls = <String>[];
@@ -195,7 +215,9 @@ void main() {
 
     test('pushes the search as soon as the query changes', () {
       final bridge = _FakeBridge();
-      final dispatcher = ChatWebViewSyncDispatcher(state: ChatWebViewSyncState());
+      final dispatcher = ChatWebViewSyncDispatcher(
+        state: ChatWebViewSyncState(),
+      );
 
       final result = dispatcher.dispatch(
         bridge: bridge,
@@ -221,7 +243,9 @@ void main() {
     test('defers the highlight pass when the messages changed under a '
         'search', () {
       final bridge = _FakeBridge();
-      final dispatcher = ChatWebViewSyncDispatcher(state: ChatWebViewSyncState());
+      final dispatcher = ChatWebViewSyncDispatcher(
+        state: ChatWebViewSyncState(),
+      );
       final edited = _assistant('a1').copyWith(content: 'edited');
 
       final result = dispatcher.dispatch(
@@ -256,7 +280,9 @@ void main() {
 
     test('re-numbers without scrolling on the deferred pass', () {
       final bridge = _FakeBridge();
-      final dispatcher = ChatWebViewSyncDispatcher(state: ChatWebViewSyncState());
+      final dispatcher = ChatWebViewSyncDispatcher(
+        state: ChatWebViewSyncState(),
+      );
 
       dispatcher.applySearch(
         bridge: bridge,

--- a/test/game_time_message_stamp_test.dart
+++ b/test/game_time_message_stamp_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/features/chat/services/game_time_message_stamp.dart';
+
+void main() {
+  test('stamps only the addressed nested variation', () {
+    const message = ChatMessage(
+      id: 'a1',
+      role: 'assistant',
+      content: 'second',
+      swipes: ['green'],
+      agentSwipes: [
+        AgentSwipe(content: 'first'),
+        AgentSwipe(content: 'second', kind: 'cleaned'),
+      ],
+      agentSwipeId: 1,
+    );
+
+    final stamped = stampGameTimeForVariation(
+      message,
+      swipeId: 0,
+      agentSwipeId: 1,
+      time: '12.05.2027 · RP_Day 2 · 14:15',
+    );
+
+    expect(stamped.time, '12.05.2027 · RP_Day 2 · 14:15');
+    expect(stamped.agentSwipes[0].time, isNull);
+    expect(stamped.agentSwipes[1].time, stamped.time);
+    final stored = stamped.swipesMeta.single['agentSwipes'] as List<dynamic>;
+    expect((stored[0] as Map<String, dynamic>)['time'], isNull);
+    expect((stored[1] as Map<String, dynamic>)['time'], stamped.time);
+  });
+
+  test('does not project a non-active variation clock onto the message', () {
+    const message = ChatMessage(
+      id: 'a1',
+      role: 'assistant',
+      content: 'first',
+      time: '12.05.2027 · RP_Day 2 · 14:12',
+      swipes: ['first', 'second'],
+      swipeId: 0,
+      agentSwipes: [
+        AgentSwipe(content: 'first', time: '12.05.2027 · RP_Day 2 · 14:12'),
+      ],
+    );
+
+    final stamped = stampGameTimeForVariation(
+      message,
+      swipeId: 1,
+      agentSwipeId: 0,
+      time: '12.05.2027 · RP_Day 2 · 14:15',
+    );
+
+    expect(stamped.time, message.time);
+    final nested = stamped.swipesMeta[1]['agentSwipes'] as List<dynamic>;
+    expect((nested.single as Map<String, dynamic>)['time'], contains('14:15'));
+  });
+}

--- a/test/game_time_test.dart
+++ b/test/game_time_test.dart
@@ -18,7 +18,7 @@ void main() {
       expect(state.time, '09:05');
       expect(state.date, '03.04.2027');
       expect(state.day, 2);
-      expect(state.format(), '03.04.2027 · День 2 · 09:05');
+      expect(state.format(), '03.04.2027 · RP_Day 2 · 09:05');
     });
 
     test('rejects out-of-range values and ignores empty rows', () {
@@ -34,10 +34,43 @@ void main() {
       expect(state.format(), isNull);
     });
 
-    test('formats with only the parts that exist', () {
-      expect(GameTimeState(time: '12:30').format(), '12:30');
-      expect(GameTimeState(time: '12:30', day: 0).format(), 'День 0 · 12:30');
-      expect(GameTimeState(day: 4).formatEnglish(), 'Day 4');
+    test('requires a complete date, RP day, and time for a stamp', () {
+      expect(GameTimeState(time: '12:30').format(), isNull);
+      expect(GameTimeState(time: '12:30', day: 0).format(), isNull);
+      expect(
+        const GameTimeState(
+          time: '12:30',
+          date: '03.04.2027',
+          day: 0,
+        ).formatEnglish(),
+        '03.04.2027 · RP_Day 0 · 12:30',
+      );
+    });
+
+    test('normalizes dashed ledger dates to the display contract', () {
+      final state = GameTimeState.fromTrackers([
+        tracker(GameTimeState.timeKey, '14:15'),
+        tracker(GameTimeState.dateKey, '26-08-2026'),
+        tracker(GameTimeState.dayKey, '7'),
+      ]);
+
+      expect(state.format(), '26.08.2026 · RP_Day 7 · 14:15');
+    });
+
+    test('rejects impossible dates and negative RP days', () {
+      final impossibleDate = GameTimeState.fromTrackers([
+        tracker(GameTimeState.timeKey, '12:00'),
+        tracker(GameTimeState.dateKey, '31.02.2026'),
+        tracker(GameTimeState.dayKey, '0'),
+      ]);
+      final negativeDay = GameTimeState.fromTrackers([
+        tracker(GameTimeState.timeKey, '12:00'),
+        tracker(GameTimeState.dateKey, '01.02.2026'),
+        tracker(GameTimeState.dayKey, '-1'),
+      ]);
+
+      expect(impossibleDate.format(), isNull);
+      expect(negativeDay.format(), isNull);
     });
   });
 

--- a/test/history_game_time_test.dart
+++ b/test/history_game_time_test.dart
@@ -14,20 +14,23 @@ void main() {
     sessionId: 'session',
   );
 
-  test('history assembler prefixes ledger-stamped game time', () {
-    final history = HistoryAssembler(macroCtx).assemble([
-      const ChatMessage(id: 'u1', role: 'user', content: 'Hello'),
-      const ChatMessage(
-        id: 'a1',
-        role: 'assistant',
-        content: 'She looks up.',
-        time: '12.05.2027 · День 0 · 09:15',
-      ),
-    ]);
+  test(
+    'history assembler keeps display-only game time out of chat history',
+    () {
+      final history = HistoryAssembler(macroCtx).assemble([
+        const ChatMessage(id: 'u1', role: 'user', content: 'Hello'),
+        const ChatMessage(
+          id: 'a1',
+          role: 'assistant',
+          content: 'She looks up.',
+          time: '12.05.2027 · День 0 · 09:15',
+        ),
+      ]);
 
-    expect(history[0].content, 'Hello');
-    expect(history[1].content, '[12.05.2027 · День 0 · 09:15]\nShe looks up.');
-  });
+      expect(history[0].content, 'Hello');
+      expect(history[1].content, 'She looks up.');
+    },
+  );
 
   test('history assembler leaves unstamped messages untouched', () {
     final history = HistoryAssembler(
@@ -37,7 +40,7 @@ void main() {
     expect(history[0].content, 'Hello');
   });
 
-  test('fallback prompt builder carries the game time into history', () {
+  test('fallback prompt builder keeps game time out of chat history', () {
     final payload = PromptPayload(
       character: const Character(id: 'character', name: 'Alison'),
       history: const [
@@ -57,6 +60,6 @@ void main() {
       (m) => m.sourceMessageId == 'a1',
     );
 
-    expect(historyMessage.content, '[День 2 · 18:30]\nHi.');
+    expect(historyMessage.content, 'Hi.');
   });
 }

--- a/test/ledger_raw_tracker_state_reader_test.dart
+++ b/test/ledger_raw_tracker_state_reader_test.dart
@@ -62,4 +62,117 @@ void main() {
       ]);
     },
   );
+
+  test('uses a complete game-time seed before the first snapshot', () async {
+    await trackers.seedInitialGameTime(
+      sessionId: 'session',
+      time: '14:12',
+      date: '26.08.2026',
+    );
+
+    final state = await db.transaction(() => reader.read('session'));
+
+    expect(
+      {
+        for (final tracker in state.committedTrackers)
+          tracker.name: tracker.value,
+      },
+      {'world:time': '14:12', 'world:date': '26.08.2026', 'world:day': '0'},
+    );
+  });
+
+  test(
+    'zero-op first Ledger replacement preserves the game-time seed',
+    () async {
+      await trackers.seedInitialGameTime(
+        sessionId: 'session',
+        time: '14:12',
+        date: '26.08.2026',
+      );
+      final bootstrap = await db.transaction(() => reader.read('session'));
+
+      await trackers.replaceLedgerState('session', bootstrap.committedTrackers);
+
+      final live = await trackers.getBySessionAndScope('session', 'ledger');
+      expect(
+        {for (final tracker in live) tracker.name: tracker.value},
+        {'world:time': '14:12', 'world:date': '26.08.2026', 'world:day': '0'},
+      );
+    },
+  );
+
+  test('stale seed dialog cannot overwrite a changed clock', () async {
+    await trackers.upsertValue(
+      'session',
+      'world:time',
+      '14:15',
+      scope: 'ledger',
+      provenance: 'source=studio_ledger',
+    );
+
+    final seeded = await trackers.seedInitialGameTime(
+      sessionId: 'session',
+      time: '14:12',
+      date: '26.08.2026',
+      expectedValues: const {
+        'world:time': null,
+        'world:date': null,
+        'world:day': null,
+      },
+    );
+
+    expect(seeded, isFalse);
+    expect((await trackers.get('session', 'world:time'))?.value, '14:15');
+    expect(await trackers.get('session', 'world:date'), isNull);
+    expect(await trackers.get('session', 'world:day'), isNull);
+  });
+
+  test('ignores a partial or unrelated live Ledger bootstrap', () async {
+    await trackers.upsertValue(
+      'session',
+      'world:time',
+      '14:12',
+      scope: 'ledger',
+      provenance: 'game_time_seed',
+    );
+    await trackers.upsertValue(
+      'session',
+      'world:date',
+      '26.08.2026',
+      scope: 'ledger',
+      provenance: 'other',
+    );
+
+    final state = await db.transaction(() => reader.read('session'));
+
+    expect(state.committedTrackers, isEmpty);
+  });
+
+  test('committed snapshot supersedes the live game-time seed', () async {
+    await trackers.seedInitialGameTime(
+      sessionId: 'session',
+      time: '14:12',
+      date: '26.08.2026',
+    );
+    await snapshots.upsertTrackers(
+      sessionId: 'session',
+      messageId: 'message',
+      swipeId: 0,
+      agentSwipeId: 0,
+      committed: true,
+      trackers: const [
+        Tracker(
+          sessionId: 'session',
+          name: 'world:time',
+          value: '14:15',
+          scope: 'ledger',
+        ),
+      ],
+    );
+
+    final state = await db.transaction(() => reader.read('session'));
+
+    expect(state.committedTrackers, hasLength(1));
+    expect(state.committedTrackers.single.value, '14:15');
+  });
 }

--- a/test/magic_drawer_refresh_test.dart
+++ b/test/magic_drawer_refresh_test.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:glaze_flutter/features/chat/state/magic_drawer_stats_cache.dart';
+import 'package:glaze_flutter/features/chat/widgets/magic_drawer_models.dart';
 
 void main() {
   group('Quick Access refresh contract', () {
@@ -75,6 +78,30 @@ void main() {
         source.substring(refreshStart, refreshEnd),
         contains('if (!mounted) return;'),
       );
+    });
+
+    test('keeps cached stats isolated between sessions of one character', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      const first = (charId: 'character', sessionId: 'session-a');
+      const second = (charId: 'character', sessionId: 'session-b');
+
+      container.read(magicDrawerStatsCacheProvider(first).notifier).state =
+          const MagicDrawerStats(memoryEntryCount: 13);
+
+      expect(
+        container.read(magicDrawerStatsCacheProvider(first))?.memoryEntryCount,
+        13,
+      );
+      expect(container.read(magicDrawerStatsCacheProvider(second)), isNull);
+    });
+
+    test('keys the MemoryBook controller subtree by active session', () {
+      final source = File(
+        'lib/features/chat/widgets/memory_sheet.dart',
+      ).readAsStringSync();
+
+      expect(source, contains('key: ValueKey(session.id)'));
     });
   });
 }

--- a/test/message_timestamp_refresh_test.dart
+++ b/test/message_timestamp_refresh_test.dart
@@ -86,4 +86,90 @@ void main() {
     expect(updated.messages.last.timestamp, greaterThan(2));
     expect(updated.messages.first.timestamp, 1);
   });
+
+  test('switching green variations restores each game-time stamp', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+    final service = container.read(_messageServiceProvider);
+    final session = ChatSession(
+      id: 's1',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: [
+        ChatMessage(
+          id: 'a1',
+          role: 'assistant',
+          content: 'first',
+          time: '12.05.2027 · RP_Day 2 · 14:12',
+          swipes: const ['first', 'second'],
+          swipeId: 0,
+          swipesMeta: [
+            <String, dynamic>{},
+            <String, dynamic>{
+              'time': '12.05.2027 · RP_Day 2 · 14:15',
+              'agentSwipes': [
+                const AgentSwipe(
+                  content: 'second',
+                  time: '12.05.2027 · RP_Day 2 · 14:15',
+                ).toJson(),
+              ],
+            },
+          ],
+          agentSwipes: const [AgentSwipe(content: 'first')],
+        ),
+      ],
+    );
+
+    final second = service.setSwipe(session, 0, 1);
+    expect(second.messages.single.time, contains('14:15'));
+
+    final first = service.setSwipe(second, 0, 0);
+    expect(first.messages.single.time, contains('14:12'));
+  });
+
+  test('switching nested variations restores each game-time stamp', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+    final service = container.read(_messageServiceProvider);
+    const session = ChatSession(
+      id: 's1',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: [
+        ChatMessage(
+          id: 'a1',
+          role: 'assistant',
+          content: 'first',
+          time: '12.05.2027 · RP_Day 2 · 14:12',
+          swipes: ['green'],
+          agentSwipes: [
+            AgentSwipe(content: 'first', time: '12.05.2027 · RP_Day 2 · 14:12'),
+            AgentSwipe(
+              content: 'second',
+              kind: 'cleaned',
+              time: '12.05.2027 · RP_Day 2 · 14:15',
+            ),
+          ],
+        ),
+      ],
+    );
+
+    final second = service.setAgentSwipe(session, 0, 1);
+    expect(second.messages.single.time, contains('14:15'));
+
+    final first = service.setAgentSwipe(second, 0, 0);
+    expect(first.messages.single.time, contains('14:12'));
+  });
 }

--- a/test/message_timestamp_refresh_test.dart
+++ b/test/message_timestamp_refresh_test.dart
@@ -49,6 +49,101 @@ void main() {
     expect(messages.first.timestamp, 1);
   });
 
+  test('writeAssistant stamps the opening clock on the new variation', () {
+    const writer = SavedMessageWriter();
+    const clock = '01.01.2027 · RP_Day 0 · 09:00';
+    final session = ChatSession(
+      id: 's1',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: [
+        const ChatMessage(id: 'u1', role: 'user', content: 'hi', timestamp: 1),
+      ],
+    );
+
+    final state = writer.writeAssistant(
+      text: 'hello',
+      reasoning: null,
+      currentSession: session,
+      isAborted: () => false,
+      time: clock,
+    );
+
+    final message = state.session!.messages.last;
+    expect(message.time, clock);
+    expect(message.agentSwipes.single.time, clock);
+    expect(message.swipesMeta.single['time'], clock);
+  });
+
+  test(
+    'writeAssistant stamps the opening clock on a regenerated variation',
+    () {
+      const writer = SavedMessageWriter();
+      const clock = '01.01.2027 · RP_Day 0 · 09:00';
+      final session = ChatSession(
+        id: 's1',
+        characterId: 'c1',
+        sessionIndex: 0,
+        messages: [
+          const ChatMessage(
+            id: 'u1',
+            role: 'user',
+            content: 'hi',
+            timestamp: 1,
+          ),
+          const ChatMessage(
+            id: 'a1',
+            role: 'assistant',
+            content: 'old',
+            timestamp: 2,
+            time: '01.01.2027 · RP_Day 0 · 08:00',
+            swipes: ['old'],
+          ),
+        ],
+      );
+
+      final state = writer.writeAssistant(
+        text: 'new',
+        reasoning: null,
+        currentSession: session,
+        isAborted: () => false,
+        previousSwipes: const ['old'],
+        previousSwipeId: 0,
+        regenTargetId: 'a1',
+        time: clock,
+      );
+
+      final message = state.session!.messages.last;
+      expect(message.time, clock);
+      expect(message.agentSwipes.single.time, clock);
+      expect(message.swipesMeta.last['time'], clock);
+    },
+  );
+
+  test('writeAssistant without a clock leaves the variation unstamped', () {
+    const writer = SavedMessageWriter();
+    final session = ChatSession(
+      id: 's1',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: [
+        const ChatMessage(id: 'u1', role: 'user', content: 'hi', timestamp: 1),
+      ],
+    );
+
+    final state = writer.writeAssistant(
+      text: 'hello',
+      reasoning: null,
+      currentSession: session,
+      isAborted: () => false,
+    );
+
+    final message = state.session!.messages.last;
+    expect(message.time, isNull);
+    expect(message.agentSwipes.single.time, isNull);
+    expect(message.swipesMeta.single.containsKey('time'), isFalse);
+  });
+
   test('switching variation restamps the message but keeps its slot', () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     final container = ProviderContainer(

--- a/test/nested_swipes_test.dart
+++ b/test/nested_swipes_test.dart
@@ -13,6 +13,7 @@ void main() {
         reasoning: 'thought',
         genTime: '1.5s',
         tokens: 42,
+        time: '12.05.2027 · RP_Day 2 · 14:12',
         studioOutputs: [
           {'id': 'out1', 'content': 'brief'},
         ],
@@ -25,6 +26,7 @@ void main() {
       expect(restored.reasoning, 'thought');
       expect(restored.genTime, '1.5s');
       expect(restored.tokens, 42);
+      expect(restored.time, '12.05.2027 · RP_Day 2 · 14:12');
       expect(restored.parentSwipeId, 0);
       expect(restored.studioOutputs.length, 1);
       expect(restored.studioOutputs[0]['id'], 'out1');
@@ -42,11 +44,16 @@ void main() {
     });
 
     test('copyWith creates a modified copy', () {
-      const original = AgentSwipe(content: 'a', kind: 'final');
+      const original = AgentSwipe(
+        content: 'a',
+        kind: 'final',
+        time: '12.05.2027 · RP_Day 2 · 14:12',
+      );
       final modified = original.copyWith(content: 'b', kind: 'cleaned');
       expect(modified.content, 'b');
       expect(modified.kind, 'cleaned');
       expect(modified.reasoning, isNull);
+      expect(modified.time, original.time);
     });
   });
 
@@ -285,6 +292,7 @@ void main() {
                 kind: 'cleaned',
                 reasoning: 'last reasoning',
                 tokens: 17,
+                time: '12.05.2027 · RP_Day 2 · 14:15',
               ).toJson(),
             ],
           },
@@ -306,6 +314,7 @@ void main() {
       expect(result.content, 'last cleaned');
       expect(result.reasoning, 'last reasoning');
       expect(result.tokens, 17);
+      expect(result.time, '12.05.2027 · RP_Day 2 · 14:15');
       expect(result.isError, isTrue);
     });
 
@@ -327,9 +336,22 @@ void main() {
         swipes: const ['final 2'],
         swipesMeta: const [<String, dynamic>{}],
         agentSwipes: const [
-          AgentSwipe(content: 'final 1', kind: 'final'),
-          AgentSwipe(content: 'final 2', kind: 'final'),
-          AgentSwipe(content: 'cleaned', kind: 'cleaned', parentSwipeId: 1),
+          AgentSwipe(
+            content: 'final 1',
+            kind: 'final',
+            time: '12.05.2027 · RP_Day 1 · 13:00',
+          ),
+          AgentSwipe(
+            content: 'final 2',
+            kind: 'final',
+            time: '12.05.2027 · RP_Day 1 · 14:00',
+          ),
+          AgentSwipe(
+            content: 'cleaned',
+            kind: 'cleaned',
+            parentSwipeId: 1,
+            time: '12.05.2027 · RP_Day 1 · 14:00',
+          ),
         ],
         agentSwipeId: 1,
       );
@@ -341,6 +363,7 @@ void main() {
       expect(result.content, 'cleaned');
       expect(result.swipes, ['final 1']);
       expect(result.agentSwipes[1].parentSwipeId, 0);
+      expect(result.time, '12.05.2027 · RP_Day 1 · 14:00');
       expect(result.swipesMeta[0]['agentSwipeId'], 1);
     });
 

--- a/test/studio_ledger_test.dart
+++ b/test/studio_ledger_test.dart
@@ -997,6 +997,28 @@ Ledger text.
       expect(result.wasRejected, isTrue);
     });
 
+    test('accepts the documented world day clock key', () {
+      const raw = '''
+<glaze_memory_export>
+{
+  "ops": [
+    {
+      "op": "set",
+      "key": "world:day",
+      "value": "2",
+      "evidence": "The story crossed midnight twice.",
+      "eventState": "completed"
+    }
+  ]
+}
+</glaze_memory_export>''';
+
+      final result = parser.parse(raw);
+
+      expect(result.wasRejected, isFalse);
+      expect(result.export!.ops.single.key, 'world:day');
+    });
+
     test('rejects model-owned tracker and arc state for the focal user', () {
       const raw = '''
 <glaze_memory_export>

--- a/test/summary_service_test.dart
+++ b/test/summary_service_test.dart
@@ -212,7 +212,7 @@ void main() {
           id: '2',
           role: 'assistant',
           content: 'She nods.',
-          time: '12.05.2027 · День 0 · 09:15',
+          time: '12.05.2027 · RP_Day 0 · 09:15',
         ),
       ],
       apiConfig: const ApiConfig(
@@ -225,7 +225,7 @@ void main() {
     );
 
     expect(llm.prompt, contains('User: Morning.'));
-    expect(llm.prompt, contains('[12.05.2027 · День 0 · 09:15] She nods.'));
+    expect(llm.prompt, contains('[12.05.2027 · RP_Day 0 · 09:15] She nods.'));
   });
 
   test('accepts an OpenRouter config with no endpoint', () async {

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -94,6 +94,18 @@ void main() {
   });
 
   group('memory badge and virtual-scroll settling', () {
+    test('game-time metadata can be added, updated, and removed live', () {
+      final body = _extractBlockBody(
+        rendererMessageJs,
+        rendererMessageJs.indexOf('updateMessageMeta(sectionEl, msg)'),
+      );
+      expect(body, contains("querySelector('.msg-game-time')"));
+      expect(body, contains(r'clock.textContent = `⏱ ${msg.gameTime}`'));
+      expect(body, contains('clock?.remove()'));
+      expect(body, contains("hasOwnProperty.call(msg, 'gameTime')"));
+      expect(body, contains("hasOwnProperty.call(msg, 'gameTime')"));
+    });
+
     test('late memory state patches metadata without a full render', () {
       final body = _extractBlockBody(
         bridgeControllerJs,
@@ -509,17 +521,12 @@ void main() {
     test('startEdit prefers sourceText over rawText', () {
       expect(
         editControllerJs,
-        contains(
-          'section.dataset.sourceText ?? section.dataset.rawText',
-        ),
+        contains('section.dataset.sourceText ?? section.dataset.rawText'),
       );
     });
 
     test('an update without sourceText clears a stale one', () {
-      expect(
-        bridgeControllerJs,
-        contains('delete section.dataset.sourceText'),
-      );
+      expect(bridgeControllerJs, contains('delete section.dataset.sourceText'));
     });
   });
 
@@ -703,8 +710,14 @@ void main() {
       // The count is `variants.length > 1` on both the switcher and the data
       // attributes, so a single-image block keeps its historical markup.
       expect(formatterFormatterJs, contains('imggen-variants'));
-      expect(formatterFormatterJs, contains("data-action=\"img-variant-prev\""));
-      expect(formatterFormatterJs, contains("data-action=\"img-variant-next\""));
+      expect(
+        formatterFormatterJs,
+        contains("data-action=\"img-variant-prev\""),
+      );
+      expect(
+        formatterFormatterJs,
+        contains("data-action=\"img-variant-next\""),
+      );
       expect(
         RegExp(r'variants\.length > 1').allMatches(formatterFormatterJs).length,
         greaterThanOrEqualTo(3),
@@ -756,8 +769,10 @@ void main() {
       );
       expect(
         bridgeControllerJs,
-        contains("import { parseImageResultElement } from "
-            "'../formatter/formatter.js';"),
+        contains(
+          "import { parseImageResultElement } from "
+          "'../formatter/formatter.js';",
+        ),
       );
     });
 
@@ -767,10 +782,7 @@ void main() {
       expect(interactionDispatchJs, contains("'img-variant-next'"));
       // The lightbox and the download button read data-src, so it moves too.
       expect(interactionDispatchJs, contains('img.dataset.src = src'));
-      expect(
-        interactionDispatchJs,
-        contains("_sendToFlutter('onImgVariant'"),
-      );
+      expect(interactionDispatchJs, contains("_sendToFlutter('onImgVariant'"));
     });
 
     test('the switcher is small and see-through', () {
@@ -1529,7 +1541,10 @@ void main() {
         contains('container.scrollHeight - container.clientHeight > 50'),
       );
       expect(helper, contains('this._headerHidden = false'));
-      expect(helper, contains("this._sendToFlutter('onHeaderScroll', [false])"));
+      expect(
+        helper,
+        contains("this._sendToFlutter('onHeaderScroll', [false])"),
+      );
     });
 
     test('a trimmed message re-checks that the header is reachable', () {


### PR DESCRIPTION
## Summary
- keep Studio Ledger clocks on the exact green/blue response variation and update/remove badges live
- keep display clocks out of main-model history while exposing complete stamps to Memory and Summary after Studio Ledger
- require and validate a complete first-turn Studio clock, including non-composer generation paths
- accept the documented world:day key and tighten date/day validation
- bootstrap the first-turn seed into the Ledger committed base so the first run sees and preserves it; isolate Agentic Ops tabs per live session (autoDispose view providers, live session watch)
- isolate Quick Access Memory stats per (charId, sessionId) and re-key the Memory Books tab on session change
- stamp the opening clock at message creation (studio writer + regen variation) so the badge renders with the initial append
- preserve the complete game-clock tuple as a bootstrap seed when a pre-snapshot message deletion would otherwise wipe it

## Verification
- dart run easy_localization:generate -S assets/translations -f keys -o locale_keys.g.dart
- dart run build_runner build --delete-conflicting-outputs
- flutter analyze --no-fatal-infos --no-fatal-warnings (only two pre-existing Janitor unused-element warnings)
- flutter test (full suite green; focused gates: variant clocks, seed bootstrap, deletion seed preservation, message-creation stamping, quick-access isolation)
