### PR TITLE
fix(chat): preserve ledger and rebound sessions

### DIFF
--- a/lib/core/db/repositories/character_repo.dart
+++ b/lib/core/db/repositories/character_repo.dart
@@ -204,6 +204,12 @@ class CharacterRepo implements SyncCharacterStore {
     return {for (final r in rows) r.charId: _toModel(r)};
   }
 
+  Future<void> setCurrentSessionIndex(String characterId, int index) async {
+    await (_db.update(_db.characters)
+          ..where((row) => row.charId.equals(characterId)))
+        .write(CharactersCompanion(currentSessionIndex: Value(index)));
+  }
+
   @override
   Future<void> put(Character character) async {
     // Cache the estimated token count on every write (import/save) so the UI

--- a/lib/core/db/repositories/chat_repo.dart
+++ b/lib/core/db/repositories/chat_repo.dart
@@ -143,6 +143,18 @@ class ChatRepo implements SyncChatStore {
         .insertOnConflictUpdate(_toCompanion(session));
   }
 
+  /// Inserts a newly allocated session without replacing an existing owner of
+  /// the same globally unique session id.
+  Future<bool> insertIfAbsent(ChatSession session) async {
+    final inserted = await _db
+        .into(_db.chatSessions)
+        .insertReturningOrNull(
+          _toCompanion(session),
+          mode: InsertMode.insertOrIgnore,
+        );
+    return inserted != null;
+  }
+
   /// Atomically appends a user message and clears the draft.
   ///
   /// This avoids the send path writing a whole stale session blob while the

--- a/lib/core/llm/ledger/ledger_turn_committer.dart
+++ b/lib/core/llm/ledger/ledger_turn_committer.dart
@@ -101,6 +101,7 @@ class LedgerTurnCommitter {
           token: request.token,
           isStillCurrent: request.isStillCurrent,
           target: target,
+          checkCanon: false,
         );
         await _opApplier.applyOp(
           op: op,
@@ -120,6 +121,7 @@ class LedgerTurnCommitter {
         token: request.token,
         isStillCurrent: request.isStillCurrent,
         target: target,
+        checkCanon: false,
       );
       await _knowledgeFactRepo.replaceTentativeAnchor(
         sessionId: request.sessionId,
@@ -135,6 +137,7 @@ class LedgerTurnCommitter {
           token: request.token,
           isStillCurrent: request.isStillCurrent,
           target: target,
+          checkCanon: false,
         );
         opsApplied += await _knowledgeFactRepo.applyReconciliationCleanup(
           sessionId: request.sessionId,

--- a/lib/features/chat/chat_session_service.dart
+++ b/lib/features/chat/chat_session_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/models/character.dart';
 import '../../core/models/chat_message.dart';
 import '../../core/models/persona.dart';
 import '../../core/state/active_selection_provider.dart';
@@ -65,7 +66,6 @@ class ChatSessionService {
   }
 
   Future<ChatSession> createInitialSession(String charId) async {
-    final repo = _ref.read(chatRepoProvider);
     final charRepo = _ref.read(characterRepoProvider);
     final personaRepo = _ref.read(personaRepoProvider);
     final activePersonaId = _ref.read(activePersonaIdProvider);
@@ -80,23 +80,12 @@ class ChatSessionService {
       connections,
     );
 
-    final sessionId = '${charId}_0';
-    final initialMessages = InitialMessageBuilder.build(
+    final session = await _insertNewSession(
+      charId: charId,
       character: character,
       persona: persona,
-      sessionId: sessionId,
+      stampUpdatedAt: false,
     );
-
-    final session = ChatSession(
-      id: sessionId,
-      characterId: charId,
-      sessionIndex: 0,
-      messages: initialMessages,
-    );
-    await repo.put(session);
-    // Publish the durable row: `_0` is the most recycled id there is, and a
-    // cache entry left over from a deleted session under the same id would be
-    // served to the next `switchToSession`.
     updateCache(session);
     return session;
   }
@@ -109,7 +98,7 @@ class ChatSessionService {
 
     final directId = '${charId}_$currentIdx';
     var session = await repo.getById(directId);
-    if (session != null) return session;
+    if (session?.characterId == charId) return session;
 
     final sessions = await repo.getByCharacterId(charId);
     if (sessions.isEmpty) return null;
@@ -128,7 +117,9 @@ class ChatSessionService {
     final cacheKey = '${charId}_$sessionIndex';
 
     final cached = _cache[cacheKey];
-    if (cached != null) {
+    if (cached != null &&
+        cached.characterId == charId &&
+        cached.sessionIndex == sessionIndex) {
       _touchCacheKey(cacheKey);
       await saveCurrentSessionIndex(charId, sessionIndex);
       _prefetchAdjacent(charId, sessionIndex);
@@ -137,7 +128,9 @@ class ChatSessionService {
 
     final repo = _ref.read(chatRepoProvider);
     final session = await repo.getById(cacheKey);
-    if (session == null) {
+    if (session == null ||
+        session.characterId != charId ||
+        session.sessionIndex != sessionIndex) {
       final sessions = await repo.getByCharacterId(charId);
       final target = sessions
           .where((s) => s.sessionIndex == sessionIndex)
@@ -196,12 +189,10 @@ class ChatSessionService {
   }
 
   Future<ChatSession> createNewSession(String charId) async {
-    final repo = _ref.read(chatRepoProvider);
     final charRepo = _ref.read(characterRepoProvider);
     final personaRepo = _ref.read(personaRepoProvider);
     final activePersonaId = _ref.read(activePersonaIdProvider);
     final connections = _ref.read(personaConnectionsProvider);
-    final nextIndex = await _nextSessionIndex(charId);
     final character = await charRepo.getById(charId);
     final personas = await personaRepo.getAll();
     final persona = getEffectivePersona(
@@ -211,28 +202,46 @@ class ChatSessionService {
       activePersonaId,
       connections,
     );
-    final sessionId = '${charId}_$nextIndex';
-    final initialMessages = InitialMessageBuilder.build(
+    final session = await _insertNewSession(
+      charId: charId,
       character: character,
       persona: persona,
-      sessionId: sessionId,
+      stampUpdatedAt: true,
     );
-    final session = ChatSession(
-      id: sessionId,
-      characterId: charId,
-      sessionIndex: nextIndex,
-      messages: initialMessages,
-      // Stamp creation time so the new chat carries a real "last activity"
-      // date for the session list (display + sorting) instead of 0.
-      updatedAt: currentTimestampSeconds(),
-    );
-    await repo.put(session);
-    // Post-commit publication. Without it a cache entry left behind by a
-    // deleted session under the same (recycled) id survives, and the next
-    // switch to this index serves the deleted chat instead of this one.
     updateCache(session);
-    await saveCurrentSessionIndex(charId, nextIndex);
     return session;
+  }
+
+  Future<ChatSession> _insertNewSession({
+    required String charId,
+    required Character? character,
+    required Persona? persona,
+    required bool stampUpdatedAt,
+  }) {
+    final repo = _ref.read(chatRepoProvider);
+    final charRepo = _ref.read(characterRepoProvider);
+    return repo.transaction(() async {
+      var index = await _nextSessionIndex(charId);
+      while (true) {
+        final sessionId = '${charId}_$index';
+        final session = ChatSession(
+          id: sessionId,
+          characterId: charId,
+          sessionIndex: index,
+          messages: InitialMessageBuilder.build(
+            character: character,
+            persona: persona,
+            sessionId: sessionId,
+          ),
+          updatedAt: stampUpdatedAt ? currentTimestampSeconds() : 0,
+        );
+        if (await repo.insertIfAbsent(session)) {
+          await charRepo.setCurrentSessionIndex(charId, index);
+          return session;
+        }
+        index++;
+      }
+    });
   }
 
   Future<ChatSession> branchSession(
@@ -467,10 +476,7 @@ class ChatSessionService {
     if (!_ref.mounted) return;
     final charRepo = _ref.read(characterRepoProvider);
     try {
-      final character = await charRepo.getById(charId);
-      if (character != null) {
-        await charRepo.put(character.copyWith(currentSessionIndex: index));
-      }
+      await charRepo.setCurrentSessionIndex(charId, index);
     } catch (e) {
       debugPrint('[ChatSessionService] saveCurrentSessionIndex error: $e');
     }

--- a/test/chat_session_rebind_collision_test.dart
+++ b/test/chat_session_rebind_collision_test.dart
@@ -1,0 +1,154 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/models/card_evolution_observation.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:glaze_flutter/features/chat/chat_session_service.dart';
+
+final _serviceProvider = Provider(ChatSessionService.new);
+
+void main() {
+  late AppDatabase db;
+  late ProviderContainer container;
+  late ChatSessionService service;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    service = container.read(_serviceProvider);
+    ChatSessionService.clearCache();
+
+    await container
+        .read(characterRepoProvider)
+        .put(
+          const Character(id: 'mother', name: 'Mother', currentSessionIndex: 0),
+        );
+    await container
+        .read(characterRepoProvider)
+        .put(
+          const Character(
+            id: 'variant',
+            name: 'Variant',
+            variantGroupId: 'mother',
+            variantOrder: 1,
+            currentSessionIndex: 0,
+          ),
+        );
+    await container
+        .read(chatRepoProvider)
+        .put(
+          ChatSession(
+            id: 'mother_0',
+            characterId: 'variant',
+            sessionIndex: 0,
+            messages: const [
+              ChatMessage(
+                id: 'old-message',
+                role: 'assistant',
+                content: 'Old variant session',
+              ),
+            ],
+          ),
+        );
+    await container
+        .read(cardEvolutionObservationRepoProvider)
+        .insertObservation(
+          const CardEvolutionObservation(
+            id: 'old-observation',
+            sessionId: 'mother_0',
+            characterId: 'mother',
+            runOrdinal: 1,
+            semanticScopeKey: 'character.preference.tea',
+            observedChange: 'Prefers tea',
+            evidenceClusters: [
+              ['old-message'],
+            ],
+            confidence: 0.8,
+            status: 'active',
+            firstSeenRun: 1,
+            createdAt: 1,
+            updatedAt: 1,
+          ),
+        );
+  });
+
+  tearDown(() async {
+    container.dispose();
+    ChatSessionService.clearCache();
+    await db.close();
+  });
+
+  test('new mother session preserves the rebound variant session', () async {
+    expect(await service.findExistingSession('mother'), isNull);
+
+    final created = await service.createInitialSession('mother');
+
+    expect(created.id, 'mother_1');
+    expect(created.characterId, 'mother');
+    expect(created.sessionIndex, 1);
+
+    final oldSession = await container
+        .read(chatRepoProvider)
+        .getById('mother_0');
+    expect(oldSession?.characterId, 'variant');
+    expect(oldSession?.messages.single.id, 'old-message');
+
+    final observations = await container
+        .read(cardEvolutionObservationRepoProvider)
+        .getBySessionId('mother_0');
+    expect(observations.map((row) => row.id), ['old-observation']);
+    expect(
+      await container
+          .read(cardEvolutionObservationRepoProvider)
+          .getBySessionId('mother_1'),
+      isEmpty,
+    );
+
+    expect((await service.findExistingSession('mother'))?.id, 'mother_1');
+    expect((await service.switchToSession('variant', 0)).id, 'mother_0');
+    expect(
+      (await container.read(characterRepoProvider).getById('mother'))
+          ?.currentSessionIndex,
+      1,
+    );
+  });
+
+  test('explicit new-session creation also skips rebound ids', () async {
+    final first = await service.createNewSession('mother');
+    final second = await service.createNewSession('mother');
+
+    expect(first.id, 'mother_1');
+    expect(second.id, 'mother_2');
+    expect(
+      (await container.read(chatRepoProvider).getById('mother_0'))?.characterId,
+      'variant',
+    );
+  });
+
+  test('concurrent creation allocates distinct ids', () async {
+    final sessions = await Future.wait([
+      service.createNewSession('mother'),
+      service.createNewSession('mother'),
+    ]);
+
+    expect(sessions.map((session) => session.id).toSet(), {
+      'mother_1',
+      'mother_2',
+    });
+    expect(
+      (await container.read(chatRepoProvider).getById('mother_0'))?.characterId,
+      'variant',
+    );
+    expect(
+      (await container.read(characterRepoProvider).getById('mother'))
+          ?.currentSessionIndex,
+      2,
+    );
+  });
+}

--- a/test/studio_ledger_transaction_test.dart
+++ b/test/studio_ledger_transaction_test.dart
@@ -15,6 +15,7 @@ import 'package:glaze_flutter/core/db/repositories/character_revision_repo.dart'
 import 'package:glaze_flutter/core/db/repositories/character_session_baseline_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/chat_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_debug_run_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/ledger_raw_tracker_state_reader.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_checkpoint_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_lease_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_run_repo.dart';
@@ -22,7 +23,6 @@ import 'package:glaze_flutter/core/db/repositories/memory_book_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/tracker_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/tracker_snapshot_repo.dart';
 import 'package:glaze_flutter/core/llm/aux_llm_client.dart';
-import 'package:glaze_flutter/core/llm/prompt/ledger_tracker_loader.dart';
 import 'package:glaze_flutter/core/llm/studio_ledger_reconciliation.dart';
 import 'package:glaze_flutter/core/llm/studio_ledger_service.dart';
 import 'package:glaze_flutter/core/models/character.dart';
@@ -129,20 +129,7 @@ void main() {
       factRepo: facts,
       transitionRepo: transitions,
       transitionFactRefRepo: CanonTransitionFactRefRepo(db),
-      loadRawTrackerState: (sessionId) async {
-        final committed = await snapshots.getLatestCommitted(sessionId);
-        final live = await trackers.getBySessionAndScope(sessionId, 'ledger');
-        return LedgerRawTrackerState(
-          committedTrackers:
-              committed?.trackers
-                  .where((tracker) => tracker.scope == 'ledger')
-                  .toList() ??
-              const [],
-          manualControls: live
-              .where((tracker) => tracker.name.startsWith('canon_'))
-              .toList(),
-        );
-      },
+      loadRawTrackerState: LedgerRawTrackerStateReader(db).read,
     );
     service = StudioLedgerService(
       llm: const AuxLlmClient(),
@@ -1165,6 +1152,48 @@ void main() {
       expect(fact.basisRevisionHash, tracker.basisRevisionHash);
     },
   );
+
+  test('first Ledger turn commits from the game-time seed', () async {
+    await trackers.seedInitialGameTime(
+      sessionId: 'session',
+      time: '00:30',
+      date: '2026-08-26',
+      day: '0',
+    );
+    final endpoint = await _serve(_response);
+    addTearDown(endpoint.close);
+
+    final result = await run(endpoint.url);
+
+    expect(result.status, 'ok');
+    expect(result.opsApplied, 1);
+    expect((await trackers.get('session', 'world:time'))?.value, '01:00');
+    expect((await trackers.get('session', 'world:date'))?.value, '2026-08-26');
+    expect((await trackers.get('session', 'world:day'))?.value, '0');
+    expect(
+      await facts.getBySourceAnchor(
+        sessionId: 'session',
+        messageId: 'a1',
+        swipeId: 0,
+        agentSwipeId: 0,
+      ),
+      hasLength(1),
+    );
+    final snapshot = await snapshots.getByAnchor(
+      sessionId: 'session',
+      messageId: 'a1',
+      swipeId: 0,
+      agentSwipeId: 0,
+    );
+    expect(snapshot, isNotNull);
+    expect(snapshot!.committed, isFalse);
+    expect(
+      snapshot.trackers
+          .singleWhere((tracker) => tracker.name == 'world:time')
+          .value,
+      '01:00',
+    );
+  });
 
   group('structured output recovery', () {
     const malformed = '''


### PR DESCRIPTION
## Summary

- keep the first Ledger turn from invalidating its own canon fence after replacing the game-time bootstrap state
- allocate new chat sessions with insert-only, globally collision-safe IDs so Card Rewriter rebound sessions and their session-scoped data are never overwritten
- validate session ownership on direct/cache lookups and update the current session index without rewriting the whole character

## Root causes

PR #323 made the initial game-time seed part of effective canon before the first committed snapshot. Ledger then stamped that seed during replaceLedgerState and treated its own write as a concurrent canon change, aborting an otherwise successful HTTP 200 turn.

Card Rewriter intentionally rebinds an existing mother-card session to a generated variant while preserving its session ID. A later mother-card session reused that globally occupied ID and insertOnConflictUpdate silently replaced the old chat row, leaving Collector and other session-scoped data attached to the new logical chat.

## Tests

- flutter test (3354 tests passed)
- focused session collision and switching tests passed
- focused Studio Ledger and raw tracker state tests passed
- focused flutter analyze passed
- full flutter analyze reports only two pre-existing unused-element warnings in janitor_lorebook_capture_sheet.dart