### PR TITLE
fix(sync): merge Collector boundary identities

### DIFF
--- a/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
+++ b/lib/features/cloud_sync/adapters/ext_blocks_sync_stores.dart
@@ -1129,21 +1129,32 @@ class ReconciliationStateSyncStore implements SyncReconciliationStateStore {
       }
     }
     for (final row in rows) {
-      final existing =
+      final conflicts =
           await (_db.select(_db.cardEvolutionCollectorRuns)..where(
                 (table) =>
                     table.sessionId.equals(sessionId) &
-                    table.collectorOrdinal.equals(row.collectorOrdinal),
+                    (table.collectorOrdinal.equals(row.collectorOrdinal) |
+                        table.reconciliationRunId.equals(
+                          row.reconciliationRunId,
+                        )),
               ))
-              .getSingleOrNull();
-      if (existing != null && existing.status == 'claimed') {
+              .get();
+      final completed = conflicts
+          .where((existing) => existing.status == 'completed')
+          .toList();
+      for (final existing in completed) {
+        _requireExact(existing, row, normalize: _collectorForSync);
+      }
+      final replaceableIds = conflicts
+          .where((existing) => existing.status != 'completed')
+          .map((existing) => existing.id)
+          .toList();
+      if (replaceableIds.isNotEmpty) {
         await (_db.delete(
           _db.cardEvolutionCollectorRuns,
-        )..where((item) => item.id.equals(existing.id))).go();
+        )..where((item) => item.id.isIn(replaceableIds))).go();
       }
-      final completed = existing?.status == 'completed' ? existing : null;
-      _requireExact(completed, row, normalize: _collectorForSync);
-      if (completed == null) {
+      if (completed.isEmpty) {
         await _db
             .into(_db.cardEvolutionCollectorRuns)
             .insert(row.copyWith(ownerId: 'cloud-sync', leaseExpiresAt: 0));

--- a/test/reconciliation_state_sync_store_test.dart
+++ b/test/reconciliation_state_sync_store_test.dart
@@ -565,6 +565,47 @@ void main() {
     },
   );
 
+  test(
+    'incoming completed collector replaces failed boundary at another ordinal',
+    () async {
+      final sourceRuns = await _appendChain(sourceDb, 2);
+      final targetRuns = await _appendChain(targetDb, 2);
+      await _insertFailedCollectorPlaceholder(sourceDb);
+      final completed = await _completeCollector(sourceDb, sourceRuns);
+      final local = await _claimCollector(
+        targetDb,
+        targetRuns,
+        ownerId: 'local',
+      );
+      expect(
+        await CardEvolutionCollectorRunRepo(targetDb).markFailed(
+          id: local.id,
+          ownerId: 'local',
+          now: 12,
+          code: 'httpError',
+        ),
+        isTrue,
+      );
+      expect(local.collectorOrdinal, 1);
+      expect(completed.collectorOrdinal, 2);
+      expect(local.reconciliationRunId, completed.reconciliationRunId);
+
+      await targetStore.mergeBySessionId(
+        'session',
+        (await sourceStore.getBySessionId('session'))!,
+      );
+
+      final stored = await targetDb
+          .select(targetDb.cardEvolutionCollectorRuns)
+          .get();
+      expect(stored, hasLength(1));
+      expect(stored.single.id, completed.id);
+      expect(stored.single.collectorOrdinal, 2);
+      expect(stored.single.status, 'completed');
+      expect(stored.single.ownerId, 'cloud-sync');
+    },
+  );
+
   test('conflicting manifest entry evidence rolls back the merge', () async {
     await _appendChain(sourceDb, 1);
     await _appendChain(targetDb, 1);
@@ -788,6 +829,28 @@ Future<CardEvolutionCollectorRunRow> _completeCollector(
     db.cardEvolutionCollectorRuns,
   )..where((item) => item.id.equals(row.id))).getSingle();
 }
+
+Future<void> _insertFailedCollectorPlaceholder(AppDatabase db) => db
+    .into(db.cardEvolutionCollectorRuns)
+    .insert(
+      CardEvolutionCollectorRunsCompanion.insert(
+        id: 'failed-placeholder',
+        sessionId: 'session',
+        characterId: 'character',
+        collectorOrdinal: 1,
+        reconciliationRunId: 'obsolete-reconciliation',
+        reconciliationRunOrdinal: 1,
+        reconciliationChainHash: 'obsolete-chain',
+        rangeHash: 'obsolete-range',
+        inputHash: 'obsolete-input',
+        ownerId: 'owner',
+        status: 'failed',
+        leaseExpiresAt: 0,
+        failureCode: const Value('httpError'),
+        createdAt: 9,
+        failedAt: const Value(10),
+      ),
+    );
 
 Future<void> _insertManifestEvidence(
   AppDatabase db, {


### PR DESCRIPTION
## Summary
- resolve incoming completed Collector rows against both unique identities: collector ordinal and reconciliation boundary
- replace local claimed or failed conflicts before inserting the authoritative cloud completion
- preserve strict immutable equality checks for existing completed Collector rows

## Regression
Covers a failed local Collector at one ordinal and a completed cloud Collector at another ordinal for the same reconciliation boundary, which previously failed with SQLite constraint 2067 on (session_id, reconciliation_run_id) on phone pull.

## Verification
- lutter test test/reconciliation_state_sync_store_test.dart (21 passed)
- lutter test (3382 passed)
- focused analyzer: clean
- lutter analyze (only two pre-existing warnings in janitor_lorebook_capture_sheet.dart)