### PR TITLE
fix(api): make the endpoint field survive whatever the user types

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2632,5 +2632,8 @@
   "game_time_seed_date_label": "Date (DD.MM.YYYY)",
   "game_time_seed_confirm": "Start",
   "game_time_seed_invalid_time": "Enter the time as HH:MM (24-hour).",
-  "game_time_seed_invalid_date": "Enter the date as DD.MM.YYYY."
+  "game_time_seed_invalid_date": "Enter the date as DD.MM.YYYY.",
+  "settings_endpoint_resolves_to": "Request URL: {url}",
+  "settings_endpoint_invalid": "This does not look like a URL",
+  "settings_endpoint_autofixed": "Endpoint corrected to {url}"
 }

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -2661,5 +2661,8 @@
   "game_time_seed_date_label": "Дата (ДД.ММ.ГГГГ)",
   "game_time_seed_confirm": "Начать",
   "game_time_seed_invalid_time": "Введи время в формате ЧЧ:ММ (24 часа).",
-  "game_time_seed_invalid_date": "Введи дату в формате ДД.ММ.ГГГГ."
+  "game_time_seed_invalid_date": "Введи дату в формате ДД.ММ.ГГГГ.",
+  "settings_endpoint_resolves_to": "URL запроса: {url}",
+  "settings_endpoint_invalid": "Это не похоже на URL",
+  "settings_endpoint_autofixed": "Эндпоинт исправлен на {url}"
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -179,6 +179,10 @@ lib/
 │   │   ├── transport_factory.dart    # ApiConfig.protocol → ChatTransport (wraps in PostProcessingChatTransport + LoggingChatTransport)
 │   │   ├── llm_request_dump.dart     # Diagnostics: dump every outgoing LLM request to JSONL (off by default)
 │   │   ├── post_processing_chat_transport.dart # Applies ApiConfig.promptPostProcessing before the protocol converter
+│   │   ├── endpoint_normalizer.dart  # User-typed endpoint → real request URL (scheme/typo/version repair)
+│   │   ├── known_api_hosts.dart      # Canonical base path per provider host (openrouter → /api/v1, perplexity → root)
+│   │   ├── endpoint_resolution_cache.dart # Remembers which candidate URL answered
+│   │   ├── endpoint_preview.dart     # "this endpoint will call …" caption for the settings field
 │   │   ├── openai_chat_transport.dart
 │   │   ├── openai_responses_transport.dart # OpenAI Responses API (`/responses`)
 │   │   ├── anthropic_chat_transport.dart

--- a/docs/rules/generation.md
+++ b/docs/rules/generation.md
@@ -115,6 +115,35 @@ provider disposal is not a cleanup path.
 
 ---
 
+## Endpoint URLs — never hand-build them
+
+Every request URL comes from `EndpointNormalizer` (`core/llm/transport/endpoint_normalizer.dart`).
+Never concatenate `'$endpoint/chat/completions'` in a transport, service or provider:
+the field is free text and arrives as `api.openai.com`, `htp:/api…`, a pasted
+`…/v1/chat/compeltions`, or a URL wrapped in quotes.
+
+| Need | Call |
+|------|------|
+| Chat Completions URL | `EndpointNormalizer.chatCompletionsUrl(endpoint)` |
+| Responses / Messages / Embeddings / Models | `responsesUrl` / `messagesUrl` / `embeddingsUrl` / `modelsUrl` |
+| OpenAI images | `EndpointNormalizer.imagesUrl(endpoint, 'generations' \| 'edits')` |
+| Gemini base (caller appends `/v1beta/models/…`) | `EndpointNormalizer.geminiBase(endpoint)` |
+| Base only | `EndpointNormalizer.baseUrl(endpoint)` |
+
+Rules:
+
+- The normalizer repairs scheme, typos and version segments and rewrites the
+  base path for hosts in `KnownApiHosts`. A pasted **complete** operation URL is
+  honoured verbatim — that is the escape hatch for providers with an unusual base.
+- A transport must treat **404/405 as a wrong URL, not a failed request**: walk
+  `EndpointNormalizer.candidates(...)` (via `<route>Candidates`), then report the
+  **first** error, never the last — later candidates describe URLs the user never typed.
+- Record the winner with `EndpointResolutionCache.record` and start from
+  `EndpointResolutionCache.order` so the walk is paid once per process.
+- An unparseable endpoint fails fast through `onError` before any HTTP call.
+
+---
+
 ## Reasoning / thinking controls
 
 `requestReasoning=false` and/or `omitReasoning=true` mean Glaze should not ask

--- a/lib/core/llm/embedding_service.dart
+++ b/lib/core/llm/embedding_service.dart
@@ -4,6 +4,8 @@ import 'dart:collection';
 import 'package:dio/dio.dart';
 
 import 'embedding_request_gate.dart';
+import 'transport/endpoint_normalizer.dart';
+import 'transport/endpoint_resolution_cache.dart';
 
 class EmbeddingConfig {
   final String endpoint;
@@ -23,23 +25,12 @@ class EmbeddingConfig {
 
 /// Resolves a raw embedding endpoint into the concrete `/embeddings` URL.
 ///
-/// Mirrors the chat transport's `normalizeEndpoint`: trims whitespace and
-/// prepends `https://` when no scheme is present. Without the scheme a
-/// separate embedding endpoint entered as `api.host/v1` becomes a malformed
-/// scheme-less URL that iOS's HTTP stack rejects — which is why embeddings
-/// failed on iPhone whenever the vector endpoint differed from the (already
-/// schemed) chat endpoint, yet worked when both were shared.
-String resolveEmbeddingEndpoint(String endpoint) {
-  var normalized = endpoint.trim();
-  if (normalized.isEmpty) return normalized;
-  if (!normalized.startsWith(RegExp(r'https?://', caseSensitive: false))) {
-    normalized = 'https://$normalized';
-  }
-  if (RegExp(r'/embeddings/?$', caseSensitive: false).hasMatch(normalized)) {
-    return normalized;
-  }
-  return '${normalized.replaceFirst(RegExp(r'/+$'), '')}/embeddings';
-}
+/// Shares [EndpointNormalizer] with the chat transports, so the vector
+/// endpoint tolerates exactly what the chat endpoint tolerates: a missing
+/// scheme (which iOS's HTTP stack rejects outright), a missing or misspelled
+/// `/v1`, or a full `…/v1/embeddings` pasted from the provider's docs.
+String resolveEmbeddingEndpoint(String endpoint) =>
+    EndpointNormalizer.embeddingsUrl(endpoint);
 
 String embeddingModelSignature(EmbeddingConfig config) {
   final endpoint = config.endpoint.trim();
@@ -122,6 +113,8 @@ class _Entry {
 }
 
 class EmbeddingService {
+  static const String _embeddingsRoute = '/embeddings';
+
   final Dio _dio = Dio(
     BaseOptions(
       connectTimeout: const Duration(seconds: 30),
@@ -282,7 +275,14 @@ class EmbeddingService {
   }) async {
     if (texts.isEmpty) return [];
 
-    final url = resolveEmbeddingEndpoint(config.endpoint);
+    final urls = EndpointResolutionCache.order(
+      config.endpoint,
+      _embeddingsRoute,
+      EndpointNormalizer.embeddingsCandidates(config.endpoint),
+    );
+    if (urls.isEmpty) {
+      throw 'Embedding endpoint is empty or not a valid URL';
+    }
 
     final headers = <String, String>{'Content-Type': 'application/json'};
     if (config.apiKey.isNotEmpty) {
@@ -298,11 +298,12 @@ class EmbeddingService {
         config.requestsPerMinute,
         requestToken,
       );
-      final response = await _dio.post<Map<String, dynamic>>(
-        url,
-        data: {'model': config.model, 'input': texts},
-        options: Options(headers: headers),
-        cancelToken: requestToken,
+      final response = await _postEmbeddings(
+        urls: urls,
+        rawEndpoint: config.endpoint,
+        body: {'model': config.model, 'input': texts},
+        headers: headers,
+        requestToken: requestToken,
       );
 
       final data = response.data;
@@ -338,6 +339,42 @@ class EmbeddingService {
     } finally {
       EmbeddingRequestGate.endRequest(requestToken);
     }
+  }
+
+  /// POSTs to the first candidate URL that answers. A 404/405 means the base
+  /// path is wrong rather than the request, so the next candidate is tried
+  /// (see [EndpointNormalizer.candidates]); the winner is remembered.
+  Future<Response<Map<String, dynamic>>> _postEmbeddings({
+    required List<String> urls,
+    required String rawEndpoint,
+    required Map<String, dynamic> body,
+    required Map<String, String> headers,
+    required CancelToken requestToken,
+  }) async {
+    DioException? firstError;
+    for (var i = 0; i < urls.length; i++) {
+      try {
+        final response = await _dio.post<Map<String, dynamic>>(
+          urls[i],
+          data: body,
+          options: Options(headers: headers),
+          cancelToken: requestToken,
+        );
+        EndpointResolutionCache.record(rawEndpoint, _embeddingsRoute, urls[i]);
+        return response;
+      } on DioException catch (e) {
+        final reportable = firstError ?? e;
+        firstError = reportable;
+        final status = e.response?.statusCode;
+        if (i < urls.length - 1 &&
+            (status == 404 || status == 405) &&
+            !requestToken.isCancelled) {
+          continue;
+        }
+        throw reportable;
+      }
+    }
+    throw firstError!;
   }
 
   List<String> _chunkText(String text, int maxTokens) {

--- a/lib/core/llm/transport/anthropic_chat_transport.dart
+++ b/lib/core/llm/transport/anthropic_chat_transport.dart
@@ -10,6 +10,8 @@ import '../converters/cache_breakpoint_marker.dart';
 import '../converters/thinking_budget.dart';
 import 'chat_transport.dart';
 import 'chat_transport_request.dart';
+import 'endpoint_normalizer.dart';
+import 'endpoint_resolution_cache.dart';
 import 'extra_request_parameters.dart';
 
 /// Result of [AnthropicChatTransport.buildRequest] — body + headers + the
@@ -70,16 +72,11 @@ class AnthropicChatTransport implements ChatTransport {
             ),
           );
 
-  static String buildMessagesUrl(String endpoint) {
-    var base = endpoint.trim();
-    if (base.isEmpty) return '';
-    if (!base.startsWith(RegExp(r'https?://'))) base = 'https://$base';
-    while (base.endsWith('/')) {
-      base = base.substring(0, base.length - 1);
-    }
-    if (base.toLowerCase().endsWith('/messages')) return base;
-    return '$base/messages';
-  }
+  static const String _messagesRoute = '/messages';
+  static const String _modelsRoute = '/models';
+
+  static String buildMessagesUrl(String endpoint) =>
+      EndpointNormalizer.messagesUrl(endpoint);
 
   @override
   Future<void> stream({
@@ -94,52 +91,85 @@ class AnthropicChatTransport implements ChatTransport {
       return;
     }
 
-    for (var attempt = 0; attempt <= _maxRetries; attempt++) {
-      try {
-        final built = buildRequest(request);
-        final url = buildMessagesUrl(request.endpoint);
-        if (request.stream) {
-          await _streamResponse(
-            url,
-            built.headers,
-            built.body,
-            prefill: built.prefill,
-            cancelToken: cancelToken,
-            onUpdate: onUpdate,
-            onComplete: onComplete,
-            omitReasoning:
-                !(request.showNativeReasoning ?? !request.omitReasoning),
-            receiveTimeoutMs: request.receiveTimeoutMs,
-          );
-        } else {
-          await _oneShotResponse(
-            url,
-            built.headers,
-            built.body,
-            prefill: built.prefill,
-            cancelToken: cancelToken,
-            onComplete: onComplete,
-            omitReasoning:
-                !(request.showNativeReasoning ?? !request.omitReasoning),
-            receiveTimeoutMs: request.receiveTimeoutMs,
-          );
+    final urls = EndpointResolutionCache.order(
+      request.endpoint,
+      _messagesRoute,
+      EndpointNormalizer.messagesCandidates(request.endpoint),
+    );
+    if (urls.isEmpty) {
+      onError?.call(Exception('Endpoint is empty or not a valid URL'));
+      return;
+    }
+
+    final AnthropicBuiltRequest built;
+    try {
+      built = buildRequest(request);
+    } catch (e) {
+      onError?.call(e);
+      return;
+    }
+    final omitReasoning =
+        !(request.showNativeReasoning ?? !request.omitReasoning);
+
+    // A 404/405 means the base path is wrong, not the request — walk the
+    // remaining candidates before surfacing the (first) failure.
+    DioException? firstError;
+
+    for (var i = 0; i < urls.length; i++) {
+      final url = urls[i];
+      for (var attempt = 0; attempt <= _maxRetries; attempt++) {
+        try {
+          if (request.stream) {
+            await _streamResponse(
+              url,
+              built.headers,
+              built.body,
+              prefill: built.prefill,
+              cancelToken: cancelToken,
+              onUpdate: onUpdate,
+              onComplete: onComplete,
+              omitReasoning: omitReasoning,
+              receiveTimeoutMs: request.receiveTimeoutMs,
+            );
+          } else {
+            await _oneShotResponse(
+              url,
+              built.headers,
+              built.body,
+              prefill: built.prefill,
+              cancelToken: cancelToken,
+              onComplete: onComplete,
+              omitReasoning: omitReasoning,
+              receiveTimeoutMs: request.receiveTimeoutMs,
+            );
+          }
+          EndpointResolutionCache.record(request.endpoint, _messagesRoute, url);
+          return; // success — no retry needed
+        } on DioException catch (e) {
+          if (attempt < _maxRetries &&
+              e.response?.statusCode == 408 &&
+              cancelToken?.isCancelled != true) {
+            debugPrint(
+              '[Anthropic] HTTP 408 on attempt ${attempt + 1}/$_maxRetries — retrying',
+            );
+            await Future<void>.delayed(const Duration(seconds: 1));
+            continue;
+          }
+          final reportable = firstError ?? e;
+          firstError = reportable;
+          final status = e.response?.statusCode;
+          if (i < urls.length - 1 &&
+              (status == 404 || status == 405) &&
+              cancelToken?.isCancelled != true) {
+            debugPrint('[Anthropic] $status on $url — trying ${urls[i + 1]}');
+            break; // next candidate URL
+          }
+          onError?.call(await decodeStreamingError(reportable));
+          return;
+        } catch (e) {
+          onError?.call(e);
+          return;
         }
-        return; // success — no retry needed
-      } on DioException catch (e) {
-        if (attempt < _maxRetries &&
-            e.response?.statusCode == 408 &&
-            cancelToken?.isCancelled != true) {
-          debugPrint(
-            '[Anthropic] HTTP 408 on attempt ${attempt + 1}/$_maxRetries — retrying',
-          );
-          await Future<void>.delayed(const Duration(seconds: 1));
-          continue;
-        }
-        onError?.call(await decodeStreamingError(e));
-        return;
-      } catch (e) {
-        onError?.call(e);
-        return;
       }
     }
   }
@@ -538,23 +568,28 @@ class AnthropicChatTransport implements ChatTransport {
     required String apiKey,
   }) async {
     if (apiKey.isEmpty || endpoint.trim().isEmpty) return const [];
-    var base = endpoint.trim();
-    if (!base.startsWith(RegExp(r'https?://'))) base = 'https://$base';
-    while (base.endsWith('/')) {
-      base = base.substring(0, base.length - 1);
+    final urls = EndpointResolutionCache.order(
+      endpoint,
+      _modelsRoute,
+      EndpointNormalizer.modelsCandidates(endpoint),
+    );
+    for (final url in urls) {
+      try {
+        final response = await _dio.get<Map<String, dynamic>>(
+          url,
+          options: Options(
+            headers: {'x-api-key': apiKey, 'anthropic-version': _apiVersion},
+          ),
+        );
+        final data = response.data?['data'] as List?;
+        if (data == null) continue;
+        EndpointResolutionCache.record(endpoint, _modelsRoute, url);
+        return data.cast<Map<String, dynamic>>();
+      } catch (_) {
+        continue;
+      }
     }
-    try {
-      final response = await _dio.get<Map<String, dynamic>>(
-        '$base/models',
-        options: Options(
-          headers: {'x-api-key': apiKey, 'anthropic-version': _apiVersion},
-        ),
-      );
-      final data = response.data?['data'] as List?;
-      return data?.cast<Map<String, dynamic>>() ?? const [];
-    } catch (_) {
-      return const [];
-    }
+    return const [];
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────

--- a/lib/core/llm/transport/endpoint_normalizer.dart
+++ b/lib/core/llm/transport/endpoint_normalizer.dart
@@ -1,0 +1,543 @@
+import 'known_api_hosts.dart';
+
+/// A user-entered endpoint parsed into the pieces needed to build a request
+/// URL: `origin` (scheme + host + port), `path` (the API base path) and the
+/// query string, which is preserved because some deployments (Azure OpenAI)
+/// carry a mandatory `api-version` parameter.
+class NormalizedEndpoint {
+  /// `https://api.openai.com` — empty when the input could not be parsed.
+  final String origin;
+
+  /// `/v1` — leading slash, never a trailing one. Empty when the API lives at
+  /// the root of the host.
+  final String path;
+
+  /// `api-version=2024-02-01` — without the leading `?`. Usually empty.
+  final String query;
+
+  /// True when the input already ended in a known operation path
+  /// (`/chat/completions`, `/messages`, …). Such an input is treated as
+  /// "the user knows the exact URL", so no version segment is invented.
+  final bool hasExplicitRoute;
+
+  const NormalizedEndpoint({
+    required this.origin,
+    required this.path,
+    required this.query,
+    required this.hasExplicitRoute,
+  });
+
+  static const NormalizedEndpoint invalid = NormalizedEndpoint(
+    origin: '',
+    path: '',
+    query: '',
+    hasExplicitRoute: false,
+  );
+
+  bool get isValid => origin.isNotEmpty;
+
+  /// `https://api.openai.com/v1` — the base every route is appended to.
+  String get base => isValid ? '$origin$path' : '';
+
+  /// Appends an operation path (`/chat/completions`) to [base], re-attaching
+  /// the query string when there is one.
+  String join(String suffix) {
+    if (!isValid) return '';
+    final normalizedSuffix = suffix.isEmpty || suffix.startsWith('/')
+        ? suffix
+        : '/$suffix';
+    final url = '$base$normalizedSuffix';
+    return query.isEmpty ? url : '$url?$query';
+  }
+
+  /// The same endpoint with every version segment removed — used to build
+  /// fallback candidates for providers that serve at the host root.
+  NormalizedEndpoint withoutVersionSegments() {
+    if (!isValid || path.isEmpty) return this;
+    final kept = path
+        .split('/')
+        .where((s) => s.isNotEmpty && !EndpointNormalizer.looksLikeVersion(s))
+        .toList();
+    return NormalizedEndpoint(
+      origin: origin,
+      path: kept.isEmpty ? '' : '/${kept.join('/')}',
+      query: query,
+      hasExplicitRoute: hasExplicitRoute,
+    );
+  }
+}
+
+/// Turns whatever the user typed into the endpoint field into a URL that
+/// actually resolves.
+///
+/// The field is free text and gets everything: `api.openai.com`,
+/// `https://api.openai.com/v1/chat/completions`, `htp:/api.openai.com`,
+/// `api.openai.com/v1/chat/compeltions`, a URL wrapped in quotes, a URL with
+/// a trailing comma. Normalization is a pure, testable pipeline:
+///
+/// 1. strip invisible characters, whitespace, wrapping quotes/brackets and
+///    trailing punctuation;
+/// 2. repair the scheme (`htp://` → `http://`, `https//` → `https://`) or add
+///    one (`https://`, or `http://` for localhost / private addresses);
+/// 3. drop a trailing operation path — `/chat/completions`, `/responses`,
+///    `/messages`, `/embeddings`, `/models`, `…:generateContent` — including
+///    misspellings, so the base can be rebuilt cleanly;
+/// 4. repair a mistyped version segment (`vl` → `v1`);
+/// 5. rewrite the base path for hosts in [KnownApiHosts] (this is what fixes
+///    `openrouter.ai` → `/api/v1` and `api.perplexity.ai/v1` → root);
+/// 6. otherwise append the protocol's default version segment when the path
+///    has none and the user did not paste a complete operation URL.
+///
+/// What normalization cannot know — an unlisted provider with an unusual base
+/// path — is covered at request time by [candidates]: the transport walks the
+/// alternatives on 404/405 instead of surfacing the error.
+class EndpointNormalizer {
+  EndpointNormalizer._();
+
+  static const String defaultVersion = 'v1';
+
+  static final RegExp _invisible = RegExp(
+    r'[\u0000-\u0008\u000B-\u001F\u007F\u00A0\u200B-\u200F\u2028\u2029\uFEFF]',
+  );
+  static final RegExp _whitespace = RegExp(r'\s+');
+  static final RegExp _leadingWrappers = RegExp(r'''^[<"'`\[(]+''');
+  static final RegExp _trailingWrappers = RegExp(r'''[>"'`\])]+$''');
+  static final RegExp _trailingPunctuation = RegExp(r'[.,;:!]+$');
+  static final RegExp _leadingSlashes = RegExp(r'^/+');
+  static final RegExp _schemeWithSeparator = RegExp(
+    r'^([A-Za-z][A-Za-z0-9+.\-]*)[:;]+(/*)',
+  );
+  static final RegExp _schemeWithoutColon = RegExp(
+    r'^([A-Za-z][A-Za-z0-9+.\-]*)(//+)',
+  );
+  static final RegExp _versionSegment = RegExp(
+    r'^v\d+([a-z]+\d*)?$',
+    caseSensitive: false,
+  );
+  static final RegExp _mistypedVersion = RegExp(
+    r'^v[.\-_]?([0-9lLiI])(beta|alpha|preview)?$',
+    caseSensitive: false,
+  );
+  static final RegExp _privateIp = RegExp(
+    r'^(127\.|10\.|192\.168\.|169\.254\.|0\.0\.0\.0$|172\.(1[6-9]|2\d|3[01])\.)',
+  );
+  static final RegExp _nonLetters = RegExp(r'[^a-z]');
+
+  /// Operation segments that mark the end of a complete API URL.
+  static const List<String> _routeWords = [
+    'completions',
+    'responses',
+    'messages',
+    'embeddings',
+    'models',
+    'generatecontent',
+    'streamgeneratecontent',
+    'chatcompletions',
+    'generations',
+  ];
+
+  /// Singular / shorthand spellings that are too short for fuzzy matching.
+  static const List<String> _routeAliases = [
+    'completion',
+    'response',
+    'message',
+    'embedding',
+    'model',
+    'edits',
+    'generation',
+  ];
+
+  /// Parses [raw] into an endpoint ready to build URLs from.
+  ///
+  /// [version] is the version segment appended when the path has none
+  /// (`v1` for OpenAI-compatible and Anthropic). [insertVersion] disables that
+  /// step; [forceVersion] applies it even when the user pasted a complete
+  /// operation URL. [gemini] selects the Gemini native host table.
+  static NormalizedEndpoint parse(
+    String raw, {
+    String version = defaultVersion,
+    bool insertVersion = true,
+    bool forceVersion = false,
+    bool gemini = false,
+  }) {
+    final cleaned = _clean(raw);
+    if (cleaned.isEmpty) return NormalizedEndpoint.invalid;
+
+    final (withScheme, explicitScheme) = _withScheme(cleaned);
+    final Uri uri;
+    try {
+      uri = Uri.parse(withScheme);
+    } on FormatException {
+      return NormalizedEndpoint.invalid;
+    }
+    if (uri.host.isEmpty) return NormalizedEndpoint.invalid;
+    if (uri.scheme != 'http' && uri.scheme != 'https') {
+      return NormalizedEndpoint.invalid;
+    }
+    // `some random text` collapses into a bare word that Uri happily accepts
+    // as a host. Reject it — unless the user typed a scheme, which makes even
+    // an odd single-label host (a hosts-file alias) deliberate.
+    if (!explicitScheme && !_isPlausibleHost(uri)) {
+      return NormalizedEndpoint.invalid;
+    }
+
+    final host = uri.host.toLowerCase();
+    final bracketedHost = host.contains(':') && !host.startsWith('[')
+        ? '[$host]'
+        : host;
+    final userInfo = uri.userInfo.isEmpty ? '' : '${uri.userInfo}@';
+    final origin =
+        '${uri.scheme}://$userInfo$bracketedHost'
+        '${uri.hasPort ? ':${uri.port}' : ''}';
+    final query = uri.query;
+
+    final stripped = _stripRoute(
+      uri.path.split('/').where((s) => s.isNotEmpty).toList(),
+    );
+    var segments = stripped.segments
+        .map(_repairVersionSegment)
+        .toList(growable: true);
+
+    var versionResolved = false;
+    final knownPath = KnownApiHosts.basePathFor(host, gemini: gemini);
+    if (knownPath != null && _isReplaceablePath(segments, knownPath)) {
+      segments = knownPath.isEmpty
+          ? <String>[]
+          : knownPath.split('/').toList(growable: true);
+      versionResolved = true;
+    }
+
+    // Azure deployments carry their own path shape and a mandatory
+    // `api-version` query — never invent a version segment for them.
+    final azure =
+        host.endsWith('.openai.azure.com') ||
+        segments.any((s) => s.toLowerCase() == 'deployments');
+
+    final needsVersion =
+        insertVersion &&
+        !versionResolved &&
+        !azure &&
+        query.isEmpty &&
+        version.isNotEmpty &&
+        (forceVersion || !stripped.hasExplicitRoute) &&
+        !segments.any(looksLikeVersion);
+    if (needsVersion) {
+      segments.addAll(version.split('/').where((s) => s.isNotEmpty));
+    }
+
+    return NormalizedEndpoint(
+      origin: origin,
+      path: segments.isEmpty ? '' : '/${segments.join('/')}',
+      query: query,
+      hasExplicitRoute: stripped.hasExplicitRoute,
+    );
+  }
+
+  // ── URL builders ──────────────────────────────────────────────────────────
+
+  /// `{base}/chat/completions` — OpenAI Chat Completions.
+  static String chatCompletionsUrl(String raw) =>
+      parse(raw).join('/chat/completions');
+
+  /// `{base}/responses` — OpenAI Responses API.
+  static String responsesUrl(String raw) => parse(raw).join('/responses');
+
+  /// `{base}/messages` — Anthropic Messages API.
+  static String messagesUrl(String raw) => parse(raw).join('/messages');
+
+  /// `{base}/embeddings` — OpenAI-compatible embeddings.
+  static String embeddingsUrl(String raw) => parse(raw).join('/embeddings');
+
+  /// `{base}/models` — model listing for OpenAI-compatible and Anthropic.
+  static String modelsUrl(String raw) => parse(raw).join('/models');
+
+  /// `{base}/images/{action}` — OpenAI image generation (`generations`,
+  /// `edits`).
+  static String imagesUrl(String raw, String action) =>
+      parse(raw).join('/images/$action');
+
+  /// The cleaned base URL without any operation path.
+  static String baseUrl(String raw, {String version = defaultVersion}) =>
+      parse(raw, version: version).base;
+
+  /// Gemini's base: the version segment is added by the transport
+  /// (`/v1beta/models/…`), so it must not be part of the base.
+  static String geminiBase(String raw) =>
+      parse(raw, gemini: true, insertVersion: false)
+          .withoutVersionSegments()
+          .base;
+
+  /// Ordered URLs to try for [suffix]: the normalized one first, then the
+  /// plausible alternatives (version forced on / stripped off). Transports
+  /// walk this list on 404/405 so an unlisted provider with an unusual base
+  /// path still connects instead of failing.
+  static List<String> candidates(
+    String raw,
+    String suffix, {
+    String version = defaultVersion,
+  }) {
+    final urls = <String>[];
+    void add(NormalizedEndpoint endpoint) {
+      final url = endpoint.join(suffix);
+      if (url.isNotEmpty && !urls.contains(url)) urls.add(url);
+    }
+
+    final primary = parse(raw, version: version);
+    add(primary);
+    add(parse(raw, version: version, forceVersion: true));
+    add(parse(raw, version: version, insertVersion: false));
+    add(primary.withoutVersionSegments());
+    return urls;
+  }
+
+  static List<String> chatCompletionsCandidates(String raw) =>
+      candidates(raw, '/chat/completions');
+
+  static List<String> responsesCandidates(String raw) =>
+      candidates(raw, '/responses');
+
+  static List<String> messagesCandidates(String raw) =>
+      candidates(raw, '/messages');
+
+  static List<String> embeddingsCandidates(String raw) =>
+      candidates(raw, '/embeddings');
+
+  static List<String> modelsCandidates(String raw) =>
+      candidates(raw, '/models');
+
+  /// True for `v1`, `v1beta`, `v2`… — used to decide whether a version
+  /// segment still has to be appended.
+  static bool looksLikeVersion(String segment) =>
+      _versionSegment.hasMatch(segment);
+
+  // ── internals ─────────────────────────────────────────────────────────────
+
+  static String _clean(String raw) {
+    var s = raw.replaceAll(_invisible, '').replaceAll(_whitespace, '');
+    s = s.replaceFirst(_leadingWrappers, '');
+    // Pasted values mix wrappers, punctuation and slashes in any order
+    // (`"https://api.host/v1",`) — peel until nothing changes.
+    String previous;
+    do {
+      previous = s;
+      s = s.replaceFirst(_trailingWrappers, '');
+      s = s.replaceFirst(_trailingPunctuation, '');
+      while (s.endsWith('/')) {
+        s = s.substring(0, s.length - 1);
+      }
+    } while (s != previous);
+    return s;
+  }
+
+  /// Returns the input with a usable scheme, and whether the user supplied
+  /// one themselves (a typo still counts — they meant a URL).
+  static (String, bool) _withScheme(String input) {
+    final s = input.replaceAll('\\', '/');
+
+    final withSeparator = _schemeWithSeparator.firstMatch(s);
+    if (withSeparator != null) {
+      final word = withSeparator.group(1)!.toLowerCase();
+      final slashes = withSeparator.group(2)!;
+      final rest = s.substring(withSeparator.end);
+      if (word == 'http' || word == 'https') return ('$word://$rest', true);
+      if (slashes.isNotEmpty) {
+        final repaired = _repairHttpScheme(word);
+        if (repaired != null) {
+          // A mistyped scheme says nothing about http vs https, so fall back
+          // to what the host deserves — unless the typo carried the `s`.
+          final scheme = repaired == 'https' ? 'https' : _defaultScheme(rest);
+          return ('$scheme://$rest', true);
+        }
+        return (s, true); // ws://, ftp://… — rejected by the caller
+      }
+      // No slashes after the colon: this is `host:port`, not a scheme.
+    } else {
+      final withoutColon = _schemeWithoutColon.firstMatch(s);
+      if (withoutColon != null) {
+        final rest = s.substring(withoutColon.end);
+        final repaired = _repairHttpScheme(
+          withoutColon.group(1)!.toLowerCase(),
+        );
+        if (repaired != null) {
+          final scheme = repaired == 'https' ? 'https' : _defaultScheme(rest);
+          return ('$scheme://$rest', true);
+        }
+      }
+    }
+
+    final withoutLeadingSlashes = s.replaceFirst(_leadingSlashes, '');
+    return (
+      '${_defaultScheme(withoutLeadingSlashes)}://$withoutLeadingSlashes',
+      false,
+    );
+  }
+
+  /// A host is plausible when it is dotted (`api.host`), an IPv6 literal,
+  /// `localhost`, or carries an explicit port (`myserver:8080`).
+  static bool _isPlausibleHost(Uri uri) {
+    final host = uri.host.toLowerCase();
+    return host.contains('.') ||
+        host.contains(':') ||
+        host == 'localhost' ||
+        uri.hasPort;
+  }
+
+  /// Schemes that are real and simply not ours — never "repaired" into http.
+  static const Set<String> _foreignSchemes = {
+    'ftp',
+    'ftps',
+    'sftp',
+    'ssh',
+    'file',
+    'ws',
+    'wss',
+    'data',
+    'mailto',
+  };
+
+  /// Maps a misspelled scheme onto http/https; null when it is not one.
+  static String? _repairHttpScheme(String word) {
+    if (word == 'http' || word == 'https') return word;
+    if (_foreignSchemes.contains(word)) return null;
+    if (word.length < 3 || word.length > 7) return null;
+    final preferred = word.contains('s') ? 'https' : 'http';
+    if (_levenshtein(word, preferred) <= 2) return preferred;
+    final other = preferred == 'https' ? 'http' : 'https';
+    if (_levenshtein(word, other) <= 2) return other;
+    return null;
+  }
+
+  static String _defaultScheme(String rest) {
+    final authority = rest.split('/').first.split('?').first;
+    final hostPart = authority.contains('@')
+        ? authority.split('@').last
+        : authority;
+    final hostname =
+        (hostPart.startsWith('[')
+                ? hostPart.substring(1).split(']').first
+                : hostPart.split(':').first)
+            .toLowerCase();
+    if (hostname == 'localhost' ||
+        hostname == '::1' ||
+        hostname.endsWith('.local') ||
+        hostname.endsWith('.localhost') ||
+        _privateIp.hasMatch(hostname)) {
+      return 'http';
+    }
+    return 'https';
+  }
+
+  static _StrippedRoute _stripRoute(List<String> input) {
+    final segments = List<String>.from(input);
+    var hasExplicitRoute = false;
+    var changed = true;
+
+    while (changed && segments.isNotEmpty) {
+      changed = false;
+      final last = segments.last;
+
+      // `models/gemini-3-pro:generateContent`
+      if (last.contains(':')) {
+        segments.removeLast();
+        hasExplicitRoute = true;
+        changed = true;
+        continue;
+      }
+
+      final matched = _matchRouteWord(_canonicalWord(last));
+      if (matched == null) break;
+
+      segments.removeLast();
+      hasExplicitRoute = true;
+      changed = true;
+      // `chat` and `images` are operation segments only together with the
+      // `completions` / `generations` that was just stripped.
+      final owner = switch (matched) {
+        'completions' || 'completion' => 'chat',
+        'generations' || 'generation' || 'edits' => 'images',
+        _ => null,
+      };
+      if (owner != null &&
+          segments.isNotEmpty &&
+          _canonicalWord(segments.last) == owner) {
+        segments.removeLast();
+      }
+    }
+
+    return _StrippedRoute(segments, hasExplicitRoute);
+  }
+
+  static String _canonicalWord(String segment) =>
+      segment.toLowerCase().replaceAll(_nonLetters, '');
+
+  static String? _matchRouteWord(String word) {
+    if (word.isEmpty) return null;
+    for (final canonical in _routeWords) {
+      if (word == canonical) return canonical;
+    }
+    for (final alias in _routeAliases) {
+      if (word == alias) return alias;
+    }
+    // Misspellings: `compeltions`, `completons`, `embedings`.
+    for (final canonical in _routeWords) {
+      if (word.length < 6) continue;
+      if ((word.length - canonical.length).abs() > 2) continue;
+      if (_levenshtein(word, canonical) <= 2) return canonical;
+    }
+    return null;
+  }
+
+  static String _repairVersionSegment(String segment) {
+    if (_versionSegment.hasMatch(segment)) return segment.toLowerCase();
+    final match = _mistypedVersion.firstMatch(segment);
+    if (match == null) return segment;
+    final digit = match.group(1)!.toLowerCase();
+    final normalizedDigit = (digit == 'l' || digit == 'i') ? '1' : digit;
+    final suffix = match.group(2)?.toLowerCase() ?? '';
+    return 'v$normalizedDigit$suffix';
+  }
+
+  static bool _isReplaceablePath(List<String> segments, String knownPath) {
+    if (segments.isEmpty) return true;
+    if (segments.every(looksLikeVersion)) return true;
+    final known = knownPath.isEmpty ? const <String>[] : knownPath.split('/');
+    if (segments.length > known.length) return false;
+    for (var i = 0; i < segments.length; i++) {
+      if (segments[i].toLowerCase() != known[i].toLowerCase()) return false;
+    }
+    return true;
+  }
+
+  static int _levenshtein(String a, String b) {
+    if (a == b) return 0;
+    if (a.isEmpty) return b.length;
+    if (b.isEmpty) return a.length;
+
+    var previous = List<int>.generate(b.length + 1, (i) => i);
+    var current = List<int>.filled(b.length + 1, 0);
+
+    for (var i = 0; i < a.length; i++) {
+      current[0] = i + 1;
+      for (var j = 0; j < b.length; j++) {
+        final cost = a.codeUnitAt(i) == b.codeUnitAt(j) ? 0 : 1;
+        final deletion = previous[j + 1] + 1;
+        final insertion = current[j] + 1;
+        final substitution = previous[j] + cost;
+        var min = deletion < insertion ? deletion : insertion;
+        if (substitution < min) min = substitution;
+        current[j + 1] = min;
+      }
+      final swap = previous;
+      previous = current;
+      current = swap;
+    }
+    return previous[b.length];
+  }
+}
+
+class _StrippedRoute {
+  final List<String> segments;
+  final bool hasExplicitRoute;
+
+  const _StrippedRoute(this.segments, this.hasExplicitRoute);
+}

--- a/lib/core/llm/transport/endpoint_preview.dart
+++ b/lib/core/llm/transport/endpoint_preview.dart
@@ -1,0 +1,67 @@
+import 'endpoint_normalizer.dart';
+import 'llm_protocol.dart';
+
+/// What the endpoint field resolves to, ready to show under the input.
+class EndpointPreview {
+  /// The URL a request would be sent to, or an empty string when the input
+  /// cannot be parsed as a URL.
+  final String url;
+
+  /// True when the input is not a usable URL at all.
+  final bool isInvalid;
+
+  const EndpointPreview({required this.url, required this.isInvalid});
+
+  static const EndpointPreview none = EndpointPreview(
+    url: '',
+    isInvalid: false,
+  );
+
+  bool get isEmpty => url.isEmpty && !isInvalid;
+
+  /// Resolves what [rawEndpoint] will actually call for [protocol], so the
+  /// settings UI can show it before the user hits send. Mirrors exactly what
+  /// the transports build — both go through [EndpointNormalizer].
+  static EndpointPreview resolve({
+    required String rawEndpoint,
+    required String protocol,
+    bool useResponsesApi = false,
+    String model = '',
+  }) {
+    if (protocol == LlmProtocol.openrouter) {
+      return const EndpointPreview(
+        url: 'https://openrouter.ai/api/v1/chat/completions',
+        isInvalid: false,
+      );
+    }
+    if (rawEndpoint.trim().isEmpty) return none;
+
+    if (protocol == LlmProtocol.gemini) {
+      final base = EndpointNormalizer.geminiBase(rawEndpoint);
+      if (base.isEmpty) return const EndpointPreview(url: '', isInvalid: true);
+      final name = model.trim().isEmpty ? '{model}' : model.trim();
+      return EndpointPreview(
+        url: '$base/v1beta/models/$name:streamGenerateContent',
+        isInvalid: false,
+      );
+    }
+
+    final url = switch (protocol) {
+      LlmProtocol.anthropic => EndpointNormalizer.messagesUrl(rawEndpoint),
+      LlmProtocol.openaiResponses => EndpointNormalizer.responsesUrl(
+        rawEndpoint,
+      ),
+      _ => useResponsesApi
+          ? EndpointNormalizer.responsesUrl(rawEndpoint)
+          : EndpointNormalizer.chatCompletionsUrl(rawEndpoint),
+    };
+    return EndpointPreview(url: url, isInvalid: url.isEmpty);
+  }
+
+  /// The embeddings URL for the vector endpoint field.
+  static EndpointPreview resolveEmbedding(String rawEndpoint) {
+    if (rawEndpoint.trim().isEmpty) return none;
+    final url = EndpointNormalizer.embeddingsUrl(rawEndpoint);
+    return EndpointPreview(url: url, isInvalid: url.isEmpty);
+  }
+}

--- a/lib/core/llm/transport/endpoint_resolution_cache.dart
+++ b/lib/core/llm/transport/endpoint_resolution_cache.dart
@@ -1,0 +1,56 @@
+/// Remembers which candidate URL a stored endpoint actually resolved to.
+///
+/// [EndpointNormalizer.candidates] can offer several plausible URLs for one
+/// endpoint; the transport walks them on 404/405. Without a memory every
+/// request would pay that walk again, so the winning URL is kept for the
+/// lifetime of the process and tried first next time.
+///
+/// Deliberately in-memory only: nothing here is worth persisting, and a
+/// provider that changes its URL shape gets a clean slate on the next launch.
+class EndpointResolutionCache {
+  EndpointResolutionCache._();
+
+  static final Map<String, String> _resolved = <String, String>{};
+
+  static String _key(String rawEndpoint, String suffix) =>
+      '${rawEndpoint.trim()}|$suffix';
+
+  /// [candidates] with the previously successful URL moved to the front.
+  static List<String> order(
+    String rawEndpoint,
+    String suffix,
+    List<String> candidates,
+  ) {
+    final known = _resolved[_key(rawEndpoint, suffix)];
+    if (known == null || candidates.length < 2) return candidates;
+    final index = candidates.indexOf(known);
+    if (index <= 0) return candidates;
+    return [known, ...candidates.where((c) => c != known)];
+  }
+
+  /// Records that [url] answered for [rawEndpoint]. Only worth storing when
+  /// there was more than one candidate to choose from.
+  static void record(String rawEndpoint, String suffix, String url) {
+    if (url.isEmpty) return;
+    _resolved[_key(rawEndpoint, suffix)] = url;
+  }
+
+  /// The base URL (route suffix removed) that [rawEndpoint] resolved to, or
+  /// null when nothing was recorded. The settings screen uses it to write the
+  /// working URL back into the endpoint field after a successful test, so the
+  /// fallback is paid once instead of on every launch.
+  static String? resolvedBase(String rawEndpoint) {
+    final prefix = '${rawEndpoint.trim()}|';
+    for (final entry in _resolved.entries) {
+      if (!entry.key.startsWith(prefix)) continue;
+      final suffix = entry.key.substring(prefix.length);
+      final url = entry.value;
+      if (url.endsWith(suffix)) {
+        return url.substring(0, url.length - suffix.length);
+      }
+    }
+    return null;
+  }
+
+  static void clear() => _resolved.clear();
+}

--- a/lib/core/llm/transport/gemini_chat_transport.dart
+++ b/lib/core/llm/transport/gemini_chat_transport.dart
@@ -9,6 +9,7 @@ import '../converters/gemini_messages.dart';
 import '../converters/thinking_budget.dart';
 import 'chat_transport.dart';
 import 'chat_transport_request.dart';
+import 'endpoint_normalizer.dart';
 import 'extra_request_parameters.dart';
 
 /// Result of [GeminiChatTransport.buildRequest] — URL/body/headers ready to
@@ -72,15 +73,11 @@ class GeminiChatTransport implements ChatTransport {
             ),
           );
 
-  static String _normaliseBase(String endpoint) {
-    var base = endpoint.trim();
-    if (base.isEmpty) return '';
-    if (!base.startsWith(RegExp(r'https?://'))) base = 'https://$base';
-    while (base.endsWith('/')) {
-      base = base.substring(0, base.length - 1);
-    }
-    return base;
-  }
+  /// Gemini builds `{base}/v1beta/models/{model}:{action}` itself, so the base
+  /// must not carry a version segment — `EndpointNormalizer.geminiBase` strips
+  /// one the user may have pasted along with the URL.
+  static String _normaliseBase(String endpoint) =>
+      EndpointNormalizer.geminiBase(endpoint);
 
   static String buildGenerateUrl({
     required String endpoint,

--- a/lib/core/llm/transport/known_api_hosts.dart
+++ b/lib/core/llm/transport/known_api_hosts.dart
@@ -1,0 +1,54 @@
+/// Canonical base paths for providers we know the URL shape of.
+///
+/// The endpoint field is free text, so users paste anything: a bare host, a
+/// full `…/v1/chat/completions`, a typo. For a host in this table we know the
+/// real base path, so [KnownApiHosts.basePathFor] can rewrite whatever was
+/// typed into the shape the provider actually serves — including providers
+/// whose OpenAI-compatible surface is *not* `/v1`
+/// (Perplexity serves it at the root, Groq under `/openai/v1`).
+///
+/// Only hosts whose path shape is stable belong here. Everything else falls
+/// back to the generic rules in `EndpointNormalizer` plus the runtime
+/// candidate retry.
+class KnownApiHosts {
+  KnownApiHosts._();
+
+  /// Host (lowercase, no port) → base path without leading/trailing slash.
+  /// An empty value means "the API lives at the root" — no version segment.
+  static const Map<String, String> openAiCompatible = {
+    'api.openai.com': 'v1',
+    'api.deepseek.com': 'v1',
+    'api.mistral.ai': 'v1',
+    'api.x.ai': 'v1',
+    'api.together.xyz': 'v1',
+    'api.together.ai': 'v1',
+    'api.cerebras.ai': 'v1',
+    'api.moonshot.ai': 'v1',
+    'api.moonshot.cn': 'v1',
+    'api.lambdalabs.com': 'v1',
+    'integrate.api.nvidia.com': 'v1',
+    'api.anthropic.com': 'v1',
+    'openrouter.ai': 'api/v1',
+    'api.groq.com': 'openai/v1',
+    'api.fireworks.ai': 'inference/v1',
+    'api.deepinfra.com': 'v1/openai',
+    'api.novita.ai': 'v3/openai',
+    'generativelanguage.googleapis.com': 'v1beta/openai',
+    // Perplexity serves chat completions at the root — appending /v1 404s.
+    'api.perplexity.ai': '',
+  };
+
+  /// Hosts that speak the Gemini native API (`/v1beta/models/…`). The version
+  /// segment is added by the transport, so the base path is empty.
+  static const Set<String> geminiNative = {
+    'generativelanguage.googleapis.com',
+  };
+
+  /// Returns the canonical base path for [host], or `null` when the host is
+  /// unknown. [host] is matched case-insensitively, with any port stripped.
+  static String? basePathFor(String host, {bool gemini = false}) {
+    final key = host.toLowerCase();
+    if (gemini) return geminiNative.contains(key) ? '' : null;
+    return openAiCompatible[key];
+  }
+}

--- a/lib/core/llm/transport/openai_chat_transport.dart
+++ b/lib/core/llm/transport/openai_chat_transport.dart
@@ -8,6 +8,8 @@ import '../../utils/error_format.dart';
 import '../converters/reasoning_effort.dart';
 import 'chat_transport.dart';
 import 'chat_transport_request.dart';
+import 'endpoint_normalizer.dart';
+import 'endpoint_resolution_cache.dart';
 import 'extra_request_parameters.dart';
 import 'llm_protocol.dart';
 
@@ -44,24 +46,18 @@ class OpenAiChatTransport implements ChatTransport {
            ),
        _extraHeaders = extraHeaders ?? const {};
 
-  static String normalizeEndpoint(String endpoint) {
-    var normalized = endpoint.trim();
-    if (normalized.isEmpty) return '';
-    if (!normalized.startsWith(RegExp(r'https?://'))) {
-      normalized = 'https://$normalized';
-    }
-    while (normalized.endsWith('/')) {
-      normalized = normalized.substring(0, normalized.length - 1);
-    }
-    return normalized;
-  }
+  static const String _chatRoute = '/chat/completions';
+  static const String _modelsRoute = '/models';
 
-  static String buildChatUrl(String endpoint) {
-    final base = normalizeEndpoint(endpoint);
-    if (base.isEmpty) return '';
-    if (base.toLowerCase().endsWith('/chat/completions')) return base;
-    return '$base/chat/completions';
-  }
+  /// HTTP statuses that mean "wrong URL, not wrong request" — the endpoint is
+  /// retried against the next candidate instead of failing the generation.
+  static const Set<int> _routeMismatchStatuses = {404, 405};
+
+  static String normalizeEndpoint(String endpoint) =>
+      EndpointNormalizer.baseUrl(endpoint);
+
+  static String buildChatUrl(String endpoint) =>
+      EndpointNormalizer.chatCompletionsUrl(endpoint);
 
   @override
   Future<void> stream({
@@ -75,9 +71,76 @@ class OpenAiChatTransport implements ChatTransport {
       onError?.call(Exception('API key is empty'));
       return;
     }
-    final url = buildChatUrl(request.endpoint);
+    final urls = EndpointResolutionCache.order(
+      request.endpoint,
+      _chatRoute,
+      EndpointNormalizer.chatCompletionsCandidates(request.endpoint),
+    );
+    if (urls.isEmpty) {
+      onError?.call(Exception('Endpoint is empty or not a valid URL'));
+      return;
+    }
 
-    final body = buildBody(request, protocol: _protocol);
+    final Map<String, dynamic> body;
+    try {
+      body = buildBody(request, protocol: _protocol);
+    } catch (e) {
+      onError?.call(e);
+      return;
+    }
+
+    // The first failure is the one worth reporting: later candidates exist
+    // only to rescue a mistyped base path, and their errors describe a URL
+    // the user never entered.
+    DioException? firstError;
+
+    for (var i = 0; i < urls.length; i++) {
+      final url = urls[i];
+      try {
+        await _send(
+          url: url,
+          request: request,
+          body: body,
+          cancelToken: cancelToken,
+          onUpdate: onUpdate,
+          onComplete: onComplete,
+        );
+        EndpointResolutionCache.record(request.endpoint, _chatRoute, url);
+        return;
+      } on DioException catch (e) {
+        final reportable = firstError ?? e;
+        firstError = reportable;
+        final canFallBack =
+            i < urls.length - 1 &&
+            _routeMismatchStatuses.contains(e.response?.statusCode) &&
+            cancelToken?.isCancelled != true;
+        if (canFallBack) {
+          debugPrint(
+            '[OpenAI] ${e.response?.statusCode} on $url — '
+            'trying ${urls[i + 1]}',
+          );
+          continue;
+        }
+        onError?.call(await decodeStreamingError(reportable));
+        return;
+      } catch (e) {
+        onError?.call(e);
+        return;
+      }
+    }
+  }
+
+  /// One POST against [url], with the 408 retry that slow mobile uploads need.
+  Future<void> _send({
+    required String url,
+    required ChatTransportRequest request,
+    required Map<String, dynamic> body,
+    required CancelToken? cancelToken,
+    required ChatTransportOnUpdate? onUpdate,
+    required ChatTransportOnComplete? onComplete,
+  }) async {
+    final omitReasoning =
+        !(request.showNativeReasoning ?? !request.omitReasoning);
 
     for (var attempt = 0; attempt <= _maxRetries; attempt++) {
       try {
@@ -89,8 +152,7 @@ class OpenAiChatTransport implements ChatTransport {
             cancelToken,
             onUpdate,
             onComplete,
-            omitReasoning:
-                !(request.showNativeReasoning ?? !request.omitReasoning),
+            omitReasoning: omitReasoning,
             receiveTimeoutMs: request.receiveTimeoutMs,
           );
         } else {
@@ -100,12 +162,11 @@ class OpenAiChatTransport implements ChatTransport {
             body,
             cancelToken,
             onComplete,
-            omitReasoning:
-                !(request.showNativeReasoning ?? !request.omitReasoning),
+            omitReasoning: omitReasoning,
             receiveTimeoutMs: request.receiveTimeoutMs,
           );
         }
-        return; // success — no retry needed
+        return;
       } on DioException catch (e) {
         if (attempt < _maxRetries &&
             e.response?.statusCode == 408 &&
@@ -116,11 +177,7 @@ class OpenAiChatTransport implements ChatTransport {
           await Future<void>.delayed(const Duration(seconds: 1));
           continue;
         }
-        onError?.call(await decodeStreamingError(e));
-        return;
-      } catch (e) {
-        onError?.call(e);
-        return;
+        rethrow;
       }
     }
   }
@@ -556,18 +613,26 @@ class OpenAiChatTransport implements ChatTransport {
     required String endpoint,
     required String apiKey,
   }) async {
-    final base = normalizeEndpoint(endpoint);
-    final url = '$base/models';
+    final urls = EndpointResolutionCache.order(
+      endpoint,
+      _modelsRoute,
+      EndpointNormalizer.modelsCandidates(endpoint),
+    );
 
-    try {
-      final response = await _dio.get<Map<String, dynamic>>(
-        url,
-        options: Options(headers: {'Authorization': 'Bearer $apiKey'}),
-      );
-      final data = response.data?['data'] as List?;
-      return data?.cast<Map<String, dynamic>>() ?? [];
-    } catch (_) {
-      return [];
+    for (final url in urls) {
+      try {
+        final response = await _dio.get<Map<String, dynamic>>(
+          url,
+          options: Options(headers: {'Authorization': 'Bearer $apiKey'}),
+        );
+        final data = response.data?['data'] as List?;
+        if (data == null) continue;
+        EndpointResolutionCache.record(endpoint, _modelsRoute, url);
+        return data.cast<Map<String, dynamic>>();
+      } catch (_) {
+        continue;
+      }
     }
+    return [];
   }
 }

--- a/lib/core/llm/transport/openai_responses_transport.dart
+++ b/lib/core/llm/transport/openai_responses_transport.dart
@@ -7,6 +7,8 @@ import '../../utils/error_format.dart';
 import '../converters/reasoning_effort.dart';
 import 'chat_transport.dart';
 import 'chat_transport_request.dart';
+import 'endpoint_normalizer.dart';
+import 'endpoint_resolution_cache.dart';
 import 'extra_request_parameters.dart';
 import 'llm_protocol.dart';
 import 'openai_chat_transport.dart';
@@ -28,16 +30,10 @@ class OpenAiResponsesTransport implements ChatTransport {
             ),
           );
 
-  static String buildResponsesUrl(String endpoint) {
-    var base = OpenAiChatTransport.normalizeEndpoint(endpoint);
-    final lower = base.toLowerCase();
-    if (lower.endsWith('/chat/completions')) {
-      base = base.substring(0, base.length - '/chat/completions'.length);
-    } else if (lower.endsWith('/responses')) {
-      return base;
-    }
-    return base.isEmpty ? '' : '$base/responses';
-  }
+  static const String _responsesRoute = '/responses';
+
+  static String buildResponsesUrl(String endpoint) =>
+      EndpointNormalizer.responsesUrl(endpoint);
 
   static Map<String, dynamic> buildBody(ChatTransportRequest request) {
     final body = <String, dynamic>{
@@ -144,27 +140,52 @@ class OpenAiResponsesTransport implements ChatTransport {
       onError?.call(Exception('API key is empty'));
       return;
     }
-    try {
-      if (request.stream) {
-        await _streamResponse(
-          buildResponsesUrl(request.endpoint),
-          request,
-          cancelToken,
-          onUpdate,
-          onComplete,
+    final urls = EndpointResolutionCache.order(
+      request.endpoint,
+      _responsesRoute,
+      EndpointNormalizer.responsesCandidates(request.endpoint),
+    );
+    if (urls.isEmpty) {
+      onError?.call(Exception('Endpoint is empty or not a valid URL'));
+      return;
+    }
+
+    DioException? firstError;
+
+    for (var i = 0; i < urls.length; i++) {
+      try {
+        if (request.stream) {
+          await _streamResponse(
+            urls[i],
+            request,
+            cancelToken,
+            onUpdate,
+            onComplete,
+          );
+        } else {
+          await _oneShotResponse(urls[i], request, cancelToken, onComplete);
+        }
+        EndpointResolutionCache.record(
+          request.endpoint,
+          _responsesRoute,
+          urls[i],
         );
-      } else {
-        await _oneShotResponse(
-          buildResponsesUrl(request.endpoint),
-          request,
-          cancelToken,
-          onComplete,
-        );
+        return;
+      } on DioException catch (error) {
+        final reportable = firstError ?? error;
+        firstError = reportable;
+        final status = error.response?.statusCode;
+        if (i < urls.length - 1 &&
+            (status == 404 || status == 405) &&
+            cancelToken?.isCancelled != true) {
+          continue;
+        }
+        onError?.call(await decodeStreamingError(reportable));
+        return;
+      } catch (error) {
+        onError?.call(error);
+        return;
       }
-    } on DioException catch (error) {
-      onError?.call(await decodeStreamingError(error));
-    } catch (error) {
-      onError?.call(error);
     }
   }
 

--- a/lib/features/image_gen/services/gemini_image_provider.dart
+++ b/lib/features/image_gen/services/gemini_image_provider.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 
+import '../../../core/llm/transport/endpoint_normalizer.dart';
 import 'image_gen_http.dart';
 import 'image_prompt_builder.dart';
 
@@ -55,13 +56,12 @@ class GeminiImageProvider {
     return ImageGenHttp.base64ToBytes(_extractImageBase64(json));
   }
 
+  /// `geminiBase` strips whatever the user pasted down to scheme + host (+ a
+  /// proxy path), so the version and model path are always ours to build.
   String _generationUrl(String endpoint, String model) {
-    final normalized = endpoint.replaceFirst(RegExp(r'/+$'), '');
-    if (normalized.endsWith(':generateContent')) return normalized;
-    if (normalized.endsWith('/v1beta')) {
-      return '$normalized/models/$model:generateContent';
-    }
-    return '$normalized/v1beta/models/$model:generateContent';
+    final base = EndpointNormalizer.geminiBase(endpoint);
+    if (base.isEmpty) throw Exception('Image endpoint is not a valid URL');
+    return '$base/v1beta/models/$model:generateContent';
   }
 
   String _extractImageBase64(Map<String, dynamic> json) {

--- a/lib/features/image_gen/services/image_gen_connection_service.dart
+++ b/lib/features/image_gen/services/image_gen_connection_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 
+import '../../../core/llm/transport/endpoint_normalizer.dart';
 import '../image_gen_models.dart';
 
 /// Lightweight connectivity and model-discovery requests for the image-gen
@@ -294,24 +295,15 @@ class ImageGenConnectionService {
     return response.data;
   }
 
-  static String _openAiModelsUrl(String endpoint) {
-    final normalized = endpoint.replaceFirst(RegExp(r'/+$'), '');
-    if (normalized.endsWith('/v1/models')) return normalized;
-    if (normalized.endsWith('/v1/images/generations')) {
-      return normalized.replaceFirst(
-        RegExp(r'/images/generations$'),
-        '/models',
-      );
-    }
-    if (normalized.endsWith('/v1')) return '$normalized/models';
-    return '$normalized/v1/models';
-  }
+  /// Both probes reuse the chat transports' normalization, so an endpoint
+  /// typed without a scheme or without `/v1` is checked at the URL the
+  /// provider will actually be called on.
+  static String _openAiModelsUrl(String endpoint) =>
+      EndpointNormalizer.modelsUrl(endpoint);
 
   static String _geminiModelsUrl(String endpoint) {
-    final normalized = endpoint.replaceFirst(RegExp(r'/+$'), '');
-    if (normalized.endsWith('/v1beta/models')) return normalized;
-    if (normalized.endsWith('/v1beta')) return '$normalized/models';
-    return '$normalized/v1beta/models';
+    final base = EndpointNormalizer.geminiBase(endpoint);
+    return base.isEmpty ? '' : '$base/v1beta/models';
   }
 
   void dispose() => _dio.close();

--- a/lib/features/image_gen/services/openai_image_provider.dart
+++ b/lib/features/image_gen/services/openai_image_provider.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 
+import '../../../core/llm/transport/endpoint_normalizer.dart';
 import '../image_gen_capabilities.dart';
 import 'image_gen_http.dart';
 
@@ -168,15 +169,9 @@ class OpenaiImageProvider {
       base64Decode(ImageGenHttp.stripBase64Prefix(reference));
 
   /// Appends the images path unless the endpoint already points at one.
-  static String _imagesUrl(String endpoint, String action) {
-    var url = endpoint.replaceFirst(RegExp(r'/+$'), '');
-    if (url.contains('/images/generations') || url.contains('/images/edits')) {
-      return url.replaceFirst(
-        RegExp(r'/images/(generations|edits)$'),
-        '/images/$action',
-      );
-    }
-    if (!url.contains('/v1')) return '$url/v1/images/$action';
-    return '$url/images/$action';
-  }
+  /// Same normalization as the chat transports — the image endpoint field is
+  /// the same free text, so a missing scheme, a missing `/v1` or a pasted full
+  /// `…/images/generations` all resolve here instead of 404ing.
+  static String _imagesUrl(String endpoint, String action) =>
+      EndpointNormalizer.imagesUrl(endpoint, action);
 }

--- a/lib/features/settings/api_settings_screen.dart
+++ b/lib/features/settings/api_settings_screen.dart
@@ -7,6 +7,9 @@ import 'package:go_router/go_router.dart';
 
 import '../../core/llm/converters/reasoning_effort.dart';
 import '../../core/llm/converters/prompt_post_processing.dart';
+import '../../core/llm/transport/endpoint_normalizer.dart';
+import '../../core/llm/transport/endpoint_preview.dart';
+import '../../core/llm/transport/endpoint_resolution_cache.dart';
 import '../../core/llm/transport/llm_protocol.dart';
 import '../../core/llm/transport/transport_factory.dart';
 import '../../core/services/api_connection_tester.dart';
@@ -627,10 +630,23 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
           onTap: _openProtocolSelector,
         ),
         if (_protocol != LlmProtocol.openrouter)
-          MenuFieldItem(
-            label: 'onboarding_label_endpoint'.tr(),
-            controller: _endpointCtrl,
-            placeholder: 'https://your-endpoint.example',
+          ValueListenableBuilder<TextEditingValue>(
+            valueListenable: _endpointCtrl,
+            builder: (context, value, _) {
+              final preview = EndpointPreview.resolve(
+                rawEndpoint: value.text,
+                protocol: _protocol,
+                useResponsesApi: _useResponsesApi,
+                model: _modelCtrl.text,
+              );
+              return MenuFieldItem(
+                label: 'onboarding_label_endpoint'.tr(),
+                controller: _endpointCtrl,
+                placeholder: 'https://your-endpoint.example',
+                helper: _endpointHelper(preview),
+                helperIsError: preview.isInvalid,
+              );
+            },
           ),
         MenuFieldItem(
           label: 'onboarding_label_model'.tr(),
@@ -1039,10 +1055,20 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
                   },
                 ),
                 if (!_embeddingUseSame) ...[
-                  MenuFieldItem(
-                    label: 'settings_embedding_endpoint'.tr(),
-                    controller: _embEndpointCtrl,
-                    placeholder: 'http://127.0.0.1:11434/v1',
+                  ValueListenableBuilder<TextEditingValue>(
+                    valueListenable: _embEndpointCtrl,
+                    builder: (context, value, _) {
+                      final preview = EndpointPreview.resolveEmbedding(
+                        value.text,
+                      );
+                      return MenuFieldItem(
+                        label: 'settings_embedding_endpoint'.tr(),
+                        controller: _embEndpointCtrl,
+                        placeholder: 'http://127.0.0.1:11434/v1',
+                        helper: _endpointHelper(preview),
+                        helperIsError: preview.isInvalid,
+                      );
+                    },
                   ),
                   MenuFieldItem(
                     label: 'settings_embedding_model'.tr(),
@@ -1649,6 +1675,44 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
     );
   }
 
+  /// Caption under an endpoint field: the URL the request will actually go
+  /// to, or a warning when the text is not a URL at all.
+  String? _endpointHelper(EndpointPreview preview) {
+    if (preview.isInvalid) return 'settings_endpoint_invalid'.tr();
+    if (preview.isEmpty) return null;
+    return 'settings_endpoint_resolves_to'.tr(namedArgs: {'url': preview.url});
+  }
+
+  /// After a successful test, adopt the URL the transport actually reached.
+  ///
+  /// The candidate walk that rescued a wrong base path lives in memory only,
+  /// so writing the working URL back into the field makes the fix permanent —
+  /// a complete URL is used verbatim by the normalizer, no path guessing.
+  void _adoptResolvedEndpoint() {
+    final raw = _endpointCtrl.text.trim();
+    if (raw.isEmpty || _protocol == LlmProtocol.openrouter) return;
+    final resolvedBase = EndpointResolutionCache.resolvedBase(raw);
+    if (resolvedBase == null) return;
+    if (resolvedBase == EndpointNormalizer.parse(raw).base) return;
+
+    final route = switch (_protocol) {
+      LlmProtocol.anthropic => '/messages',
+      LlmProtocol.gemini => '',
+      _ => _useResponsesApi ? '/responses' : '/chat/completions',
+    };
+    if (route.isEmpty) return;
+
+    _endpointCtrl.text = '$resolvedBase$route';
+    if (mounted) {
+      GlazeToast.show(
+        context,
+        'settings_endpoint_autofixed'.tr(
+          namedArgs: {'url': _endpointCtrl.text},
+        ),
+      );
+    }
+  }
+
   Future<void> _fetchModels() async {
     final endpoint = _endpointCtrl.text.trim();
     final apiKey = _keyCtrl.text.trim();
@@ -1704,6 +1768,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
     switch (result) {
       case ApiTestSuccess(:final message):
         setState(() => _llmStatus = ApiConnectionStatus.connected);
+        _adoptResolvedEndpoint();
         GlazeToast.show(context, message);
       case ApiTestFailure(:final error):
         setState(() {

--- a/lib/shared/widgets/menu_group.dart
+++ b/lib/shared/widgets/menu_group.dart
@@ -447,6 +447,13 @@ class MenuFieldItem extends StatelessWidget {
   /// into the label itself.
   final String? description;
 
+  /// Small caption *under* the field — used to show what a value resolves to
+  /// (the endpoint field previews the URL that will actually be called).
+  final String? helper;
+
+  /// Renders [helper] as a warning instead of a neutral caption.
+  final bool helperIsError;
+
   const MenuFieldItem({
     super.key,
     required this.label,
@@ -461,6 +468,8 @@ class MenuFieldItem extends StatelessWidget {
     this.maxLines = 1,
     this.onExpand,
     this.description,
+    this.helper,
+    this.helperIsError = false,
   });
 
   @override
@@ -542,6 +551,19 @@ class MenuFieldItem extends StatelessWidget {
               isDense: true,
             ),
           ),
+          if (helper != null && helper!.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Text(
+              helper!,
+              style: TextStyle(
+                color: helperIsError
+                    ? context.cs.error
+                    : context.cs.onSurfaceVariant.withValues(alpha: 0.7),
+                fontSize: 11.5,
+                height: 1.3,
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/test/embedding_service_cache_test.dart
+++ b/test/embedding_service_cache_test.dart
@@ -52,7 +52,14 @@ void main() {
       );
       expect(
         resolveEmbeddingEndpoint('api.host/v1/embeddings/'),
-        'https://api.host/v1/embeddings/',
+        'https://api.host/v1/embeddings',
+      );
+    });
+
+    test('adds the missing /v1 instead of 404ing on the host root', () {
+      expect(
+        resolveEmbeddingEndpoint('https://api.openai.com'),
+        'https://api.openai.com/v1/embeddings',
       );
     });
 

--- a/test/llm/transport/anthropic_chat_transport_test.dart
+++ b/test/llm/transport/anthropic_chat_transport_test.dart
@@ -45,12 +45,12 @@ ChatTransportRequest _req({
 
 void main() {
   group('buildMessagesUrl', () {
-    // Endpoints are normalised without auto-inserting /v1/ (the user is
-    // responsible for the path). See commit aaa3425 "endpoints normalization".
-    test('default endpoint → /messages', () {
+    // Endpoints go through EndpointNormalizer: the Anthropic base is /v1, so
+    // a bare host no longer 404s on /messages.
+    test('bare host gets the /v1 base Anthropic actually serves', () {
       expect(
         AnthropicChatTransport.buildMessagesUrl('https://api.anthropic.com'),
-        'https://api.anthropic.com/messages',
+        'https://api.anthropic.com/v1/messages',
       );
     });
 
@@ -77,14 +77,14 @@ void main() {
     test('schemeless endpoint gets https prefix', () {
       expect(
         AnthropicChatTransport.buildMessagesUrl('proxy.example.com'),
-        'https://proxy.example.com/messages',
+        'https://proxy.example.com/v1/messages',
       );
     });
 
     test('trailing slash is stripped before appending /messages', () {
       expect(
         AnthropicChatTransport.buildMessagesUrl('https://api.anthropic.com/'),
-        'https://api.anthropic.com/messages',
+        'https://api.anthropic.com/v1/messages',
       );
     });
   });

--- a/test/llm/transport/endpoint_fallback_test.dart
+++ b/test/llm/transport/endpoint_fallback_test.dart
@@ -1,0 +1,167 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/transport/chat_transport_request.dart';
+import 'package:glaze_flutter/core/llm/transport/endpoint_resolution_cache.dart';
+import 'package:glaze_flutter/core/llm/transport/openai_chat_transport.dart';
+
+/// Answers only for [servedUrl]; every other URL 404s the way a provider does
+/// when the base path is wrong. Records what was tried, in order.
+class _RoutingAdapter implements HttpClientAdapter {
+  _RoutingAdapter({this.servedUrl});
+
+  final String? servedUrl;
+  final List<String> requested = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final url = options.uri.toString();
+    requested.add(url);
+    if (url != servedUrl) {
+      return ResponseBody.fromBytes(
+        utf8.encode(jsonEncode({'error': 'no such route: $url'})),
+        404,
+        headers: {
+          Headers.contentTypeHeader: ['application/json'],
+        },
+      );
+    }
+    return ResponseBody.fromBytes(
+      utf8.encode(
+        jsonEncode({
+          'choices': [
+            {
+              'index': 0,
+              'message': {'role': 'assistant', 'content': 'pong'},
+            },
+          ],
+        }),
+      ),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ChatTransportRequest _req(String endpoint) => ChatTransportRequest(
+  endpoint: endpoint,
+  apiKey: 'sk-test',
+  model: 'gpt-test',
+  messages: const [
+    {'role': 'user', 'content': 'ping'},
+  ],
+  maxTokens: 16,
+  temperature: 0.7,
+  topP: 0.9,
+  stream: false,
+);
+
+void main() {
+  setUp(EndpointResolutionCache.clear);
+  tearDown(EndpointResolutionCache.clear);
+
+  test('falls back to the version-less URL when /v1 404s', () async {
+    final adapter = _RoutingAdapter(
+      servedUrl: 'https://proxy.tld/chat/completions',
+    );
+    final dio = Dio()..httpClientAdapter = adapter;
+    final transport = OpenAiChatTransport(dio: dio);
+
+    String? completed;
+    Object? failed;
+    await transport.stream(
+      request: _req('https://proxy.tld'),
+      onComplete: (text, _, {rawResponseJson}) => completed = text,
+      onError: (e) => failed = e,
+    );
+
+    expect(failed, isNull);
+    expect(completed, 'pong');
+    expect(adapter.requested, [
+      'https://proxy.tld/v1/chat/completions',
+      'https://proxy.tld/chat/completions',
+    ]);
+  });
+
+  test('adds the missing /v1 when the pasted URL 404s', () async {
+    final adapter = _RoutingAdapter(
+      servedUrl: 'https://proxy.tld/v1/chat/completions',
+    );
+    final dio = Dio()..httpClientAdapter = adapter;
+    final transport = OpenAiChatTransport(dio: dio);
+
+    String? completed;
+    await transport.stream(
+      request: _req('https://proxy.tld/chat/completions'),
+      onComplete: (text, _, {rawResponseJson}) => completed = text,
+    );
+
+    expect(completed, 'pong');
+    expect(adapter.requested, [
+      'https://proxy.tld/chat/completions',
+      'https://proxy.tld/v1/chat/completions',
+    ]);
+  });
+
+  test('the resolved URL is reused, so the walk is paid once', () async {
+    final adapter = _RoutingAdapter(
+      servedUrl: 'https://proxy.tld/chat/completions',
+    );
+    final dio = Dio()..httpClientAdapter = adapter;
+    final transport = OpenAiChatTransport(dio: dio);
+
+    await transport.stream(request: _req('https://proxy.tld'));
+    adapter.requested.clear();
+    await transport.stream(request: _req('https://proxy.tld'));
+
+    expect(adapter.requested, ['https://proxy.tld/chat/completions']);
+  });
+
+  test('when every candidate 404s the first failure is reported', () async {
+    final adapter = _RoutingAdapter();
+    final dio = Dio()..httpClientAdapter = adapter;
+    final transport = OpenAiChatTransport(dio: dio);
+
+    Object? failed;
+    await transport.stream(
+      request: _req('https://proxy.tld'),
+      onError: (e) => failed = e,
+    );
+
+    expect(adapter.requested, [
+      'https://proxy.tld/v1/chat/completions',
+      'https://proxy.tld/chat/completions',
+    ]);
+    expect(failed, isA<DioException>());
+    expect(
+      (failed as DioException).requestOptions.uri.toString(),
+      'https://proxy.tld/v1/chat/completions',
+    );
+  });
+
+  test('an unparseable endpoint fails without any request', () async {
+    final adapter = _RoutingAdapter();
+    final dio = Dio()..httpClientAdapter = adapter;
+    final transport = OpenAiChatTransport(dio: dio);
+
+    Object? failed;
+    await transport.stream(
+      request: _req('not a url'),
+      onError: (e) => failed = e,
+    );
+
+    expect(adapter.requested, isEmpty);
+    expect(failed, isNotNull);
+  });
+}

--- a/test/llm/transport/endpoint_normalizer_test.dart
+++ b/test/llm/transport/endpoint_normalizer_test.dart
@@ -1,0 +1,361 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/transport/endpoint_normalizer.dart';
+
+void main() {
+  group('bare host → full chat URL', () {
+    test('adds scheme and the version the provider serves', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('api.openai.com'),
+        'https://api.openai.com/v1/chat/completions',
+      );
+    });
+
+    test('unknown host gets the default /v1', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('https://proxy.tld'),
+        'https://proxy.tld/v1/chat/completions',
+      );
+    });
+
+    test('trailing slashes are stripped', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('https://api.openai.com///'),
+        'https://api.openai.com/v1/chat/completions',
+      );
+    });
+
+    test('localhost defaults to http, not https', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('localhost:1234'),
+        'http://localhost:1234/v1/chat/completions',
+      );
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('127.0.0.1:5000'),
+        'http://127.0.0.1:5000/v1/chat/completions',
+      );
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('192.168.1.5:8080'),
+        'http://192.168.1.5:8080/v1/chat/completions',
+      );
+    });
+
+    test('IPv6 host keeps its brackets', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('http://[::1]:8080/v1'),
+        'http://[::1]:8080/v1/chat/completions',
+      );
+    });
+  });
+
+  group('the user forgot /v1', () {
+    test('known host: the missing version is restored', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl(
+          'https://api.openai.com/chat/completions',
+        ),
+        'https://api.openai.com/v1/chat/completions',
+      );
+    });
+
+    test('openrouter resolves to its /api/v1 base', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('openrouter.ai'),
+        'https://openrouter.ai/api/v1/chat/completions',
+      );
+    });
+
+    test('groq resolves to its /openai/v1 base', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('api.groq.com'),
+        'https://api.groq.com/openai/v1/chat/completions',
+      );
+    });
+
+    test('unknown host keeps the pasted URL, fallback covers the rest', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl(
+          'https://proxy.tld/chat/completions',
+        ),
+        'https://proxy.tld/chat/completions',
+      );
+      expect(
+        EndpointNormalizer.chatCompletionsCandidates(
+          'https://proxy.tld/chat/completions',
+        ),
+        [
+          'https://proxy.tld/chat/completions',
+          'https://proxy.tld/v1/chat/completions',
+        ],
+      );
+    });
+  });
+
+  group('providers whose base is not /v1', () {
+    test('perplexity serves at the root — no version is invented', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('api.perplexity.ai'),
+        'https://api.perplexity.ai/chat/completions',
+      );
+    });
+
+    test('a /v1 typed onto perplexity is corrected away', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('https://api.perplexity.ai/v1'),
+        'https://api.perplexity.ai/chat/completions',
+      );
+    });
+
+    test('deepinfra keeps its /v1/openai base', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('api.deepinfra.com'),
+        'https://api.deepinfra.com/v1/openai/chat/completions',
+      );
+    });
+
+    test('gemini via the OpenAI-compatible surface', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl(
+          'generativelanguage.googleapis.com',
+        ),
+        'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
+      );
+    });
+  });
+
+  group('typos', () {
+    test('misspelled operation path is corrected', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl(
+          'api.openai.com/v1/chat/compeltions',
+        ),
+        'https://api.openai.com/v1/chat/completions',
+      );
+      expect(
+        EndpointNormalizer.chatCompletionsUrl(
+          'https://proxy.tld/v1/chat/completion',
+        ),
+        'https://proxy.tld/v1/chat/completions',
+      );
+    });
+
+    test('misspelled scheme is repaired', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('htp:/api.openai.com/v1'),
+        'https://api.openai.com/v1/chat/completions',
+      );
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('https//api.mistral.ai'),
+        'https://api.mistral.ai/v1/chat/completions',
+      );
+      expect(
+        EndpointNormalizer.chatCompletionsUrl(r'https:\\proxy.tld\v1'),
+        'https://proxy.tld/v1/chat/completions',
+      );
+    });
+
+    test('an explicit http:// scheme is never silently upgraded', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('http://proxy.tld/v1'),
+        'http://proxy.tld/v1/chat/completions',
+      );
+    });
+
+    test('mistyped version segment is repaired', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('https://proxy.tld/vl'),
+        'https://proxy.tld/v1/chat/completions',
+      );
+    });
+
+    test('quotes, spaces and trailing punctuation are peeled off', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('  https://api.host/v1  '),
+        'https://api.host/v1/chat/completions',
+      );
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('"https://api.host/v1",'),
+        'https://api.host/v1/chat/completions',
+      );
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('<https://api.host/v1>'),
+        'https://api.host/v1/chat/completions',
+      );
+    });
+
+    test('uppercase input is normalized', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('HTTPS://API.X.AI/V1'),
+        'https://api.x.ai/v1/chat/completions',
+      );
+    });
+  });
+
+  group('a complete URL for another route', () {
+    test('an /embeddings or /models URL still yields the chat URL', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl(
+          'https://api.host/v1/embeddings',
+        ),
+        'https://api.host/v1/chat/completions',
+      );
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('https://api.host/v1/models'),
+        'https://api.host/v1/chat/completions',
+      );
+    });
+
+    test('a gemini generate URL collapses back to the base', () {
+      expect(
+        EndpointNormalizer.geminiBase(
+          'https://generativelanguage.googleapis.com/v1beta/models/'
+          'gemini-3-pro:streamGenerateContent',
+        ),
+        'https://generativelanguage.googleapis.com',
+      );
+    });
+  });
+
+  group('invalid input', () {
+    test('empty and blank resolve to nothing', () {
+      expect(EndpointNormalizer.chatCompletionsUrl(''), '');
+      expect(EndpointNormalizer.chatCompletionsUrl('   '), '');
+      expect(EndpointNormalizer.chatCompletionsCandidates(''), isEmpty);
+    });
+
+    test('free text is not accepted as a host', () {
+      expect(EndpointNormalizer.chatCompletionsUrl('not a url'), '');
+      expect(EndpointNormalizer.chatCompletionsUrl('chat/completions'), '');
+    });
+
+    test('non-http schemes are rejected instead of repaired', () {
+      expect(EndpointNormalizer.chatCompletionsUrl('ftp://host.tld/v1'), '');
+      expect(EndpointNormalizer.chatCompletionsUrl('ws://host.tld/v1'), '');
+    });
+
+    test('an explicit scheme makes a single-label host deliberate', () {
+      expect(
+        EndpointNormalizer.chatCompletionsUrl('http://llm-box:8080'),
+        'http://llm-box:8080/v1/chat/completions',
+      );
+    });
+  });
+
+  group('azure deployments', () {
+    const azure =
+        'https://contoso.openai.azure.com/openai/deployments/gpt4o'
+        '/chat/completions?api-version=2024-02-01';
+
+    test('path and mandatory api-version query survive intact', () {
+      expect(EndpointNormalizer.chatCompletionsUrl(azure), azure);
+    });
+
+    test('no version segment is invented for a deployment path', () {
+      expect(
+        EndpointNormalizer.baseUrl(azure),
+        'https://contoso.openai.azure.com/openai/deployments/gpt4o',
+      );
+    });
+  });
+
+  group('other routes', () {
+    test('anthropic messages', () {
+      expect(
+        EndpointNormalizer.messagesUrl('api.anthropic.com'),
+        'https://api.anthropic.com/v1/messages',
+      );
+      expect(
+        EndpointNormalizer.messagesUrl('https://api.anthropic.com/v1/messages'),
+        'https://api.anthropic.com/v1/messages',
+      );
+    });
+
+    test('responses API', () {
+      expect(
+        EndpointNormalizer.responsesUrl(
+          'https://api.openai.com/v1/chat/completions',
+        ),
+        'https://api.openai.com/v1/responses',
+      );
+      expect(
+        EndpointNormalizer.responsesUrl('https://api.openai.com/v1/responses'),
+        'https://api.openai.com/v1/responses',
+      );
+    });
+
+    test('embeddings', () {
+      expect(
+        EndpointNormalizer.embeddingsUrl('api.host/v1'),
+        'https://api.host/v1/embeddings',
+      );
+      expect(
+        EndpointNormalizer.embeddingsUrl('api.host/v1/embeddings/'),
+        'https://api.host/v1/embeddings',
+      );
+    });
+
+    test('image generations and edits', () {
+      expect(
+        EndpointNormalizer.imagesUrl('api.openai.com', 'generations'),
+        'https://api.openai.com/v1/images/generations',
+      );
+      expect(
+        EndpointNormalizer.imagesUrl(
+          'https://api.openai.com/v1/images/generations',
+          'edits',
+        ),
+        'https://api.openai.com/v1/images/edits',
+      );
+      expect(
+        EndpointNormalizer.imagesUrl(
+          'http://127.0.0.1:8080',
+          'generations',
+        ),
+        'http://127.0.0.1:8080/v1/images/generations',
+      );
+    });
+
+    test('gemini base never carries a version segment', () {
+      expect(
+        EndpointNormalizer.geminiBase(
+          'https://generativelanguage.googleapis.com/v1beta',
+        ),
+        'https://generativelanguage.googleapis.com',
+      );
+      expect(
+        EndpointNormalizer.geminiBase('proxy.tld/gemini/v1beta'),
+        'https://proxy.tld/gemini',
+      );
+    });
+  });
+
+  group('candidates', () {
+    test('a version-less base offers the /v1 variant as a fallback', () {
+      expect(EndpointNormalizer.chatCompletionsCandidates('api.openai.com'), [
+        'https://api.openai.com/v1/chat/completions',
+        'https://api.openai.com/chat/completions',
+      ]);
+    });
+
+    test('a /v1 base offers the root variant as a fallback', () {
+      expect(EndpointNormalizer.chatCompletionsCandidates('proxy.tld/v1'), [
+        'https://proxy.tld/v1/chat/completions',
+        'https://proxy.tld/chat/completions',
+      ]);
+    });
+
+    test('an unusual base path is tried both with and without /v1', () {
+      expect(
+        EndpointNormalizer.chatCompletionsCandidates('proxy.tld/openai-compat'),
+        [
+          'https://proxy.tld/openai-compat/v1/chat/completions',
+          'https://proxy.tld/openai-compat/chat/completions',
+        ],
+      );
+    });
+
+    test('the normalized URL always comes first', () {
+      final candidates = EndpointNormalizer.modelsCandidates('api.openai.com');
+      expect(candidates.first, 'https://api.openai.com/v1/models');
+    });
+  });
+}


### PR DESCRIPTION
The endpoint field is free text, and the transports simply appended `/chat/completions` to it. A bare host, a missing or misspelled `/v1`, or a provider whose base is not `/v1` all ended in a 404.

## Changes

- Add `EndpointNormalizer` — one pure pipeline every request URL goes through: cleans the input (invisible chars, whitespace, wrapping quotes, trailing punctuation), repairs the scheme (`htp:/`, `https//`, missing → `https`, `http` for localhost and private IPs), strips a trailing operation path including misspellings (`chat/compeltions`, `embedings`, `models/x:generateContent`), repairs a mistyped version segment (`vl` → `v1`), and appends the version the provider actually serves.
- Add `KnownApiHosts` — canonical base path per provider host, so `openrouter.ai` → `/api/v1`, `api.groq.com` → `/openai/v1`, `api.deepinfra.com` → `/v1/openai`, `generativelanguage.googleapis.com` → `/v1beta/openai`, and `api.perplexity.ai` → the root, where inventing a `/v1` would 404.
- Honour a pasted complete operation URL verbatim (the escape hatch for providers with an unusual base) and preserve the query string, so Azure deployments (`?api-version=`) keep working.
- Treat 404/405 as a wrong URL rather than a failed request: transports walk `EndpointNormalizer.candidates` (with and without the version segment), report the **first** error rather than the last — later candidates describe URLs the user never entered — and remember the winner in `EndpointResolutionCache`, so the walk is paid once per process.
- Route every URL builder through the normalizer: chat completions, Responses, Anthropic messages, embeddings, model listing, Gemini's base, OpenAI image `generations`/`edits`, and the image-gen connection probes.
- Show what the endpoint resolves to underneath the field (`Request URL: …`), or a warning when the text is not a URL; add `MenuFieldItem.helper` for that caption.
- Adopt the URL that actually answered after a successful connection test, so a rescued endpoint is fixed permanently instead of only in memory.
- Fail fast with a clear error on an unparseable endpoint instead of firing a malformed request.
- Document the rule in `docs/rules/generation.md`: never hand-build an endpoint URL.

## Verification

- New `test/llm/transport/endpoint_normalizer_test.dart` — bare hosts, localhost/IPv6, forgotten `/v1`, known-host bases, scheme and path typos, quotes/punctuation, Azure, invalid input, candidate ordering, and the other routes (messages, responses, embeddings, models, images, Gemini base).
- New `test/llm/transport/endpoint_fallback_test.dart` — the 404 walk in both directions, the resolution cache (the walk is paid once), first-error reporting, and no HTTP call at all for an unparseable endpoint.
- Updated `anthropic_chat_transport_test.dart` and `embedding_service_cache_test.dart`, which pinned the old "never insert `/v1`" behaviour.
- `flutter analyze` / `flutter test` were **not** run locally — no Flutter SDK in the session container; relying on this PR's CI for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119o1J6rQGp7gnmQzhyo2jz

---
_Generated by [Claude Code](https://claude.ai/code/session_0119o1J6rQGp7gnmQzhyo2jz)_