### PR TITLE
fix(chat): hide the triggered-entries panel with the chat header

### DIFF
--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -1867,31 +1867,66 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                 ),
               ),
             ),
-            // Memory activity card: floats under the header, over the chat.
+            // Triggered-entries panel: part of the chat header. It sits flush
+            // under the header and rides the header's own hide-on-scroll
+            // animation (same curve, same pixel travel — see
+            // [kGlazeHeaderHideDuration]), so the two slide away and come back
+            // as one unit. It cannot live inside GlazeScaffold's header itself:
+            // its measured height is what insets the top of the message list
+            // (see [_memoryCardHeight]), and that measurement belongs to this
+            // body. The animation wrappers stay OUTSIDE the size notifier so
+            // the reserved space is the panel's natural height — the reserve
+            // does not collapse while the header is hidden, exactly like the
+            // header's own reserved strip.
             if (showMemoryCard)
               Positioned(
                 top: messageListTop,
                 left: 12,
                 right: 12,
-                child: NotificationListener<SizeChangedLayoutNotification>(
-                  onNotification: (n) {
-                    WidgetsBinding.instance.addPostFrameCallback(
-                      (_) => _checkHeight(),
-                    );
-                    return true;
-                  },
-                  child: SizeChangedLayoutNotifier(
-                    child: Container(
-                      key: _memoryCardKey,
-                      child: MemoryActivityCard(
-                        activity: memoryActivity,
-                        expanded: _showMemoryActivity,
-                        sessionId: widget.state.session?.id,
-                        onToggle: () {
-                          setState(() {
-                            _showMemoryActivity = !_showMemoryActivity;
-                          });
+                child: IgnorePointer(
+                  ignoring: widget.isHeaderHidden,
+                  child: AnimatedSlide(
+                    offset: widget.isHeaderHidden
+                        ? Offset(
+                            0,
+                            -glazeHeaderHideSlideFor(
+                              // The panel is anchored right below the header,
+                              // so `messageListTop` (safe-area top + 10px
+                              // padding + the 56px app bar) IS the header
+                              // strip's height.
+                              headerHeight: messageListTop,
+                              overlayHeight: _memoryCardHeight,
+                            ),
+                          )
+                        : Offset.zero,
+                    duration: kGlazeHeaderHideDuration,
+                    curve: kGlazeHeaderHideCurve,
+                    child: AnimatedOpacity(
+                      opacity: widget.isHeaderHidden ? 0.0 : 1.0,
+                      duration: kGlazeHeaderHideDuration,
+                      curve: kGlazeHeaderHideCurve,
+                      child: NotificationListener<SizeChangedLayoutNotification>(
+                        onNotification: (n) {
+                          WidgetsBinding.instance.addPostFrameCallback(
+                            (_) => _checkHeight(),
+                          );
+                          return true;
                         },
+                        child: SizeChangedLayoutNotifier(
+                          child: Container(
+                            key: _memoryCardKey,
+                            child: MemoryActivityCard(
+                              activity: memoryActivity,
+                              expanded: _showMemoryActivity,
+                              sessionId: widget.state.session?.id,
+                              onToggle: () {
+                                setState(() {
+                                  _showMemoryActivity = !_showMemoryActivity;
+                                });
+                              },
+                            ),
+                          ),
+                        ),
                       ),
                     ),
                   ),

--- a/lib/shared/widgets/glaze_scaffold.dart
+++ b/lib/shared/widgets/glaze_scaffold.dart
@@ -9,6 +9,33 @@ import '../theme/app_colors.dart';
 import 'glass_surface.dart';
 import 'glaze_background.dart';
 
+/// Hide-on-scroll animation of the floating header. Exposed so overlays that
+/// belong TO the header but cannot live inside it (the chat's triggered-entries
+/// panel, which is measured by the chat body to inset the message list) can run
+/// the exact same curve and travel the exact same distance — header and panel
+/// then slide away and come back as one unit instead of drifting apart.
+const Duration kGlazeHeaderHideDuration = Duration(milliseconds: 300);
+const Curve kGlazeHeaderHideCurve = Curves.easeOutCubic;
+
+/// How far the header slides up when hidden, as a fraction of its own height.
+const double kGlazeHeaderHideSlideFactor = 1.5;
+
+/// Fractional [AnimatedSlide] offset for an overlay that hides *with* the
+/// header: the y-offset an overlay of [overlayHeight] needs so it travels the
+/// same number of PIXELS as a header of [headerHeight].
+///
+/// [AnimatedSlide] measures its offset in fractions of the child's own size, so
+/// reusing [kGlazeHeaderHideSlideFactor] directly would make a tall overlay
+/// shoot off proportionally faster than the header and the two would visibly
+/// come apart mid-animation. Falls back to the header's own factor until the
+/// overlay has been measured ([overlayHeight] still 0).
+double glazeHeaderHideSlideFor({
+  required double headerHeight,
+  required double overlayHeight,
+}) => overlayHeight <= 0
+    ? kGlazeHeaderHideSlideFactor
+    : (headerHeight * kGlazeHeaderHideSlideFactor) / overlayHeight;
+
 /// Scaffold with a floating glassmorphic header — use for screens OUTSIDE
 /// the shell (character editor, chat screen, etc.) that need a back button.
 ///
@@ -93,13 +120,15 @@ class GlazeScaffold extends StatelessWidget {
     );
 
     final animatedHeader = AnimatedSlide(
-      offset: hideHeader ? const Offset(0, -1.5) : Offset.zero,
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.easeOutCubic,
+      offset: hideHeader
+          ? const Offset(0, -kGlazeHeaderHideSlideFactor)
+          : Offset.zero,
+      duration: kGlazeHeaderHideDuration,
+      curve: kGlazeHeaderHideCurve,
       child: AnimatedOpacity(
         opacity: hideHeader ? 0.0 : 1.0,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeOutCubic,
+        duration: kGlazeHeaderHideDuration,
+        curve: kGlazeHeaderHideCurve,
         child: header,
       ),
     );

--- a/test/glaze_header_hide_test.dart
+++ b/test/glaze_header_hide_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/shared/widgets/glaze_scaffold.dart';
+
+/// The chat's triggered-entries panel is anchored under the header and hides
+/// with it, but it lives in the chat body (its measured height insets the top
+/// of the message list), so it cannot sit inside the header's own
+/// AnimatedSlide. These cover the shared travel math that keeps the two
+/// moving as one unit: an AnimatedSlide offset is a fraction of the CHILD's
+/// height, so the panel needs its own fraction to cover the header's pixels.
+void main() {
+  group('glazeHeaderHideSlideFor', () {
+    test('an overlay as tall as the header reuses the header factor', () {
+      expect(
+        glazeHeaderHideSlideFor(headerHeight: 90, overlayHeight: 90),
+        kGlazeHeaderHideSlideFactor,
+      );
+    });
+
+    test('a taller overlay slides a smaller fraction of itself', () {
+      // Same pixel travel as the header: 90 * 1.5 = 135px over a 270px panel.
+      expect(
+        glazeHeaderHideSlideFor(headerHeight: 90, overlayHeight: 270),
+        closeTo(0.5, 1e-9),
+      );
+    });
+
+    test('a shorter overlay slides a larger fraction of itself', () {
+      expect(
+        glazeHeaderHideSlideFor(headerHeight: 90, overlayHeight: 45),
+        closeTo(3.0, 1e-9),
+      );
+    });
+
+    test('travels the header distance in pixels at any overlay height', () {
+      const headerHeight = 90.0;
+      for (final overlayHeight in <double>[20, 45, 90, 180, 400]) {
+        final pixels =
+            glazeHeaderHideSlideFor(
+              headerHeight: headerHeight,
+              overlayHeight: overlayHeight,
+            ) *
+            overlayHeight;
+        expect(
+          pixels,
+          closeTo(headerHeight * kGlazeHeaderHideSlideFactor, 1e-9),
+          reason: 'overlay height $overlayHeight must not outrun the header',
+        );
+      }
+    });
+
+    test('falls back to the header factor before the overlay is measured', () {
+      expect(
+        glazeHeaderHideSlideFor(headerHeight: 90, overlayHeight: 0),
+        kGlazeHeaderHideSlideFactor,
+      );
+    });
+  });
+}


### PR DESCRIPTION
The panel listing the entries that fired (`MemoryActivityCard`) is anchored directly under the chat header, but it stayed put while the header slid away on scroll — leaving a card floating over the messages with no header attached to it. It now belongs to the header: same hide, same reveal, same motion.

## Changes

- `lib/shared/widgets/glaze_scaffold.dart`: lift the header's hide-on-scroll animation out of the inline literals in `GlazeScaffold.build` into `kGlazeHeaderHideDuration`, `kGlazeHeaderHideCurve` and `kGlazeHeaderHideSlideFactor`, so anything that hides *with* the header shares one definition.
- `lib/shared/widgets/glaze_scaffold.dart`: add `glazeHeaderHideSlideFor(headerHeight:overlayHeight:)`, which converts the header's pixel travel into the fractional `AnimatedSlide` offset another overlay needs. An `AnimatedSlide` offset is a fraction of the *child's* own height, so reusing the header's factor directly would make a tall expanded panel fly off several times faster than the header and visibly come apart mid-animation.
- `lib/features/chat/chat_screen.dart`: slide and fade the triggered-entries panel off the same `isHeaderHidden` flag the scaffold uses, through that helper, and wrap it in `IgnorePointer` while hidden so taps fall through to the chat underneath.
- `test/glaze_header_hide_test.dart`: new test for the travel math — equal, taller and shorter overlays, the pixel-travel invariant across heights, and the pre-measurement fallback.

## Notes on the approach

- The panel stays in the chat body instead of moving inside `GlazeScaffold`'s header widget: its measured height (`_memoryCardHeight`) is what insets the top of the message list, and that measurement belongs to `_ChatBodyState`. It behaves as part of the header without that state having to move up.
- Its reserved top space does **not** collapse while hidden, exactly like the header's own reserved strip. Collapsing it would push a new top inset into the chat WebView on every scroll-direction flip and relayout the whole message list.

## Verification

- `flutter analyze` — clean on this branch. The 3 issues it reports are pre-existing infos/warnings in `lib/core/utils/error_format.dart` and `lib/features/catalog/widgets/janitor_lorebook_capture_sheet.dart`, files this PR does not touch, and are non-fatal under CI's `--no-fatal-infos --no-fatal-warnings`.
- `flutter test test/glaze_header_hide_test.dart test/memory_activity_card_test.dart` — 9/9 passed (5 new travel-math tests, plus the 4 existing `MemoryActivityCard` tests still green).
- The full suite is covered by the CI gate on this PR.
- Not verified: how the animation looks in a running app. That needs `flutter run`, which the agent cannot drive.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnaxyA7uPx8D45ZsPZL4wi)_