### PR TITLE
fix(api): persist complete protocol endpoints

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1091,7 +1091,7 @@ lorebook execution, and finalization. Supporting ownership is split among
 
 ## 5. Database Layer
 
-`AppDatabase` is at schema **v130** and registers **56 tables**. The current
+`AppDatabase` is at schema **v131** and registers **56 tables**. The current
 source of truth is the `@DriftDatabase(tables: [...])` list in
 `lib/core/db/app_db.dart`; generated `app_db.g.dart` reflects that declaration.
 Do not maintain a hand-copied table-by-table inventory here.
@@ -1099,7 +1099,7 @@ Do not maintain a hand-copied table-by-table inventory here.
 `app_db.dart` is the composition root. Its implementation is split into
 `migrations/database_integrity.dart`, `migrations/studio_legacy.dart`,
 `migrations/upgrade_v2_v50.dart`, `migrations/upgrade_v51_v100.dart`,
-`migrations/upgrade_v101_v130.dart`, and `studio_preset_seed.dart`. The versioned
+`migrations/upgrade_v101_v131.dart`, and `studio_preset_seed.dart`. The versioned
 files preserve historical upgrades; current schema declarations live behind the
 `tables.dart` barrel in seven domain parts:
 

--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -83,14 +83,14 @@ integrity helpers are split into these `app_db.dart` parts:
 
 - `migrations/upgrade_v2_v50.dart`
 - `migrations/upgrade_v51_v100.dart`
-- `migrations/upgrade_v101_v130.dart`
+- `migrations/upgrade_v101_v131.dart`
 - `migrations/database_integrity.dart`
 - `migrations/studio_legacy.dart`
 
 All schema changes must update the registration/migration path in
 `app_db.dart`. Bump the schema version and add a guarded `from -> to` migration
 step; never modify existing column types without a migration. The current
-schema is **v130** with **56 registered tables**.
+schema is **v131** with **56 registered tables**.
 
 Migration history:
 - v18: added `characters.picksHash`
@@ -233,6 +233,8 @@ Migration history:
   operation revisions, rewrite evidence, and LLM request captures update-immutable.
 - v130: added local-only `ledger_reconciliation_leases` for durable per-session
   reconciliation mutual exclusion across processes.
+- v131: normalized saved LLM and embedding endpoints to their concrete request
+  URLs.
 
 ---
 

--- a/docs/rules/generation.md
+++ b/docs/rules/generation.md
@@ -115,19 +115,21 @@ provider disposal is not a cleanup path.
 
 ---
 
-## Endpoint URLs — never hand-build them
+## Endpoint URLs — normalize when persisting
 
-Every request URL comes from `EndpointNormalizer` (`core/llm/transport/endpoint_normalizer.dart`).
-Never concatenate `'$endpoint/chat/completions'` in a transport, service or provider:
-the field is free text and arrives as `api.openai.com`, `htp:/api…`, a pasted
-`…/v1/chat/compeltions`, or a URL wrapped in quotes.
+`ApiConfig.endpoint` stores the concrete generation URL. Normalize free-text
+input with `EndpointNormalizer.persistedLlmEndpoint` at every persistence
+boundary. Generation transports use the stored endpoint as-is and must not
+append operation routes or probe alternatives after a 404/405.
 
 | Need | Call |
 |------|------|
+| Persisted generation URL | `EndpointNormalizer.persistedLlmEndpoint(...)` |
+| Persisted embeddings URL | `EndpointNormalizer.persistedEmbeddingEndpoint(endpoint)` |
 | Chat Completions URL | `EndpointNormalizer.chatCompletionsUrl(endpoint)` |
 | Responses / Messages / Embeddings / Models | `responsesUrl` / `messagesUrl` / `embeddingsUrl` / `modelsUrl` |
 | OpenAI images | `EndpointNormalizer.imagesUrl(endpoint, 'generations' \| 'edits')` |
-| Gemini base (caller appends `/v1beta/models/…`) | `EndpointNormalizer.geminiBase(endpoint)` |
+| Gemini base for sibling routes such as model listing | `EndpointNormalizer.geminiBase(endpoint)` |
 | Base only | `EndpointNormalizer.baseUrl(endpoint)` |
 
 Rules:
@@ -135,12 +137,11 @@ Rules:
 - The normalizer repairs scheme, typos and version segments and rewrites the
   base path for hosts in `KnownApiHosts`. A pasted **complete** operation URL is
   honoured verbatim — that is the escape hatch for providers with an unusual base.
-- A transport must treat **404/405 as a wrong URL, not a failed request**: walk
-  `EndpointNormalizer.candidates(...)` (via `<route>Candidates`), then report the
-  **first** error, never the last — later candidates describe URLs the user never typed.
-- Record the winner with `EndpointResolutionCache.record` and start from
-  `EndpointResolutionCache.order` so the walk is paid once per process.
-- An unparseable endpoint fails fast through `onError` before any HTTP call.
+- Model-list and embedding calls derive sibling URLs through the normalizer.
+- Unsaved settings input is normalized temporarily before connection tests and
+  model listing.
+- Gemini stores the concrete model action URL; its transport only adds auth and
+  streaming query parameters.
 
 ---
 

--- a/lib/core/db/app_db.dart
+++ b/lib/core/db/app_db.dart
@@ -12,6 +12,7 @@ import '../models/studio_preset_codec.dart';
 import '../models/studio_agent_codec.dart';
 import '../models/studio_config.dart';
 import '../llm/studio_controller_ontology.dart';
+import '../llm/transport/endpoint_normalizer.dart';
 import '../utils/platform_paths.dart';
 import '../utils/time_helpers.dart';
 import 'tables.dart';
@@ -22,7 +23,7 @@ part 'migrations/studio_legacy.dart';
 part 'studio_preset_seed.dart';
 part 'migrations/upgrade_v2_v50.dart';
 part 'migrations/upgrade_v51_v100.dart';
-part 'migrations/upgrade_v101_v130.dart';
+part 'migrations/upgrade_v101_v131.dart';
 
 @DriftDatabase(
   tables: [
@@ -90,7 +91,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 130;
+  int get schemaVersion => 131;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -125,7 +126,7 @@ class AppDatabase extends _$AppDatabase {
     onUpgrade: (Migrator m, int from, int to) async {
       await _upgradeV2ToV50(m, from);
       await _upgradeV51ToV100(m, from);
-      await _upgradeV101ToV130(m, from);
+      await _upgradeV101ToV131(m, from);
     },
   );
 

--- a/lib/core/db/migrations/upgrade_v101_v131.dart
+++ b/lib/core/db/migrations/upgrade_v101_v131.dart
@@ -1,7 +1,7 @@
 part of '../app_db.dart';
 
-extension _AppDatabaseUpgradeV101ToV130 on AppDatabase {
-  Future<void> _upgradeV101ToV130(Migrator m, int from) async {
+extension _AppDatabaseUpgradeV101ToV131 on AppDatabase {
+  Future<void> _upgradeV101ToV131(Migrator m, int from) async {
     if (from < 101) {
       await _retireStudioConfigProfiles();
     }
@@ -400,6 +400,39 @@ extension _AppDatabaseUpgradeV101ToV130 on AppDatabase {
     }
     if (from < 130) {
       await m.createTable(ledgerReconciliationLeases);
+    }
+    if (from < 131) {
+      final rows = await customSelect(
+        'SELECT config_id, protocol, endpoint, model, stream, '
+        'use_responses_api, embedding_endpoint FROM api_configs',
+      ).get();
+      for (final row in rows) {
+        final endpoint = row.readNullable<String>('endpoint') ?? '';
+        final embeddingEndpoint =
+            row.readNullable<String>('embedding_endpoint') ?? '';
+        final persistedEndpoint = EndpointNormalizer.persistedLlmEndpoint(
+          raw: endpoint,
+          protocol: row.read<String>('protocol'),
+          model: row.readNullable<String>('model') ?? '',
+          stream: row.read<int>('stream') != 0,
+          useResponsesApi: row.read<int>('use_responses_api') != 0,
+        );
+        final persistedEmbeddingEndpoint =
+            EndpointNormalizer.persistedEmbeddingEndpoint(embeddingEndpoint);
+        if (persistedEndpoint == endpoint &&
+            persistedEmbeddingEndpoint == embeddingEndpoint) {
+          continue;
+        }
+        await customStatement(
+          'UPDATE api_configs SET endpoint = ?, embedding_endpoint = ? '
+          'WHERE config_id = ?',
+          [
+            persistedEndpoint,
+            persistedEmbeddingEndpoint,
+            row.read<String>('config_id'),
+          ],
+        );
+      }
     }
   }
 }

--- a/lib/core/db/repositories/api_config_repo.dart
+++ b/lib/core/db/repositories/api_config_repo.dart
@@ -6,6 +6,7 @@ import '../app_db.dart';
 import '../../models/api_config.dart';
 import '../../application/sync_repo_interfaces.dart';
 import '../../models/extra_request_parameter.dart';
+import '../../llm/transport/endpoint_normalizer.dart';
 
 class ApiConfigRepo implements SyncApiConfigStore {
   final AppDatabase _db;
@@ -27,7 +28,21 @@ class ApiConfigRepo implements SyncApiConfigStore {
 
   @override
   Future<void> put(ApiConfig config) async {
-    await _db.into(_db.apiConfigs).insertOnConflictUpdate(_toCompanion(config));
+    final persisted = config.copyWith(
+      endpoint: EndpointNormalizer.persistedLlmEndpoint(
+        raw: config.endpoint,
+        protocol: config.protocol,
+        model: config.model,
+        stream: config.stream,
+        useResponsesApi: config.useResponsesApi,
+      ),
+      embeddingEndpoint: EndpointNormalizer.persistedEmbeddingEndpoint(
+        config.embeddingEndpoint,
+      ),
+    );
+    await _db
+        .into(_db.apiConfigs)
+        .insertOnConflictUpdate(_toCompanion(persisted));
   }
 
   @override

--- a/lib/core/llm/embedding_service.dart
+++ b/lib/core/llm/embedding_service.dart
@@ -33,7 +33,7 @@ String resolveEmbeddingEndpoint(String endpoint) =>
     EndpointNormalizer.embeddingsUrl(endpoint);
 
 String embeddingModelSignature(EmbeddingConfig config) {
-  final endpoint = config.endpoint.trim();
+  final endpoint = resolveEmbeddingEndpoint(config.endpoint);
   final model = config.model.trim();
   return '${endpoint.isEmpty ? '<endpoint>' : endpoint}|'
       '${model.isEmpty ? '<model>' : model}|chunks:${config.maxChunkTokens}';
@@ -50,7 +50,7 @@ Map<String, dynamic> embeddingMetadataForConfig(
   if (hints != null) metadata['hints'] = hints;
   if (chunks != null) metadata['chunks'] = chunks;
   metadata['embeddingModel'] = config.model.trim();
-  metadata['embeddingEndpoint'] = config.endpoint.trim();
+  metadata['embeddingEndpoint'] = resolveEmbeddingEndpoint(config.endpoint);
   metadata['embeddingSignature'] = embeddingModelSignature(config);
   metadata['embeddingDimension'] = vectors.isEmpty ? 0 : vectors.first.length;
   return metadata;
@@ -81,7 +81,8 @@ class _EmbeddingCache {
   final LinkedHashMap<String, _Entry> _store = LinkedHashMap();
 
   String _key(String text, EmbeddingConfig config) =>
-      '${config.endpoint}|${config.model}|${text.hashCode}|$text';
+      '${resolveEmbeddingEndpoint(config.endpoint)}|${config.model}|'
+      '${text.hashCode}|$text';
 
   List<double>? get(String text, EmbeddingConfig config) {
     final entry = _store[_key(text, config)];

--- a/lib/core/llm/transport/anthropic_chat_transport.dart
+++ b/lib/core/llm/transport/anthropic_chat_transport.dart
@@ -72,7 +72,6 @@ class AnthropicChatTransport implements ChatTransport {
             ),
           );
 
-  static const String _messagesRoute = '/messages';
   static const String _modelsRoute = '/models';
 
   static String buildMessagesUrl(String endpoint) =>
@@ -91,12 +90,8 @@ class AnthropicChatTransport implements ChatTransport {
       return;
     }
 
-    final urls = EndpointResolutionCache.order(
-      request.endpoint,
-      _messagesRoute,
-      EndpointNormalizer.messagesCandidates(request.endpoint),
-    );
-    if (urls.isEmpty) {
+    final url = request.endpoint.trim();
+    if (url.isEmpty) {
       onError?.call(Exception('Endpoint is empty or not a valid URL'));
       return;
     }
@@ -111,65 +106,48 @@ class AnthropicChatTransport implements ChatTransport {
     final omitReasoning =
         !(request.showNativeReasoning ?? !request.omitReasoning);
 
-    // A 404/405 means the base path is wrong, not the request — walk the
-    // remaining candidates before surfacing the (first) failure.
-    DioException? firstError;
-
-    for (var i = 0; i < urls.length; i++) {
-      final url = urls[i];
-      for (var attempt = 0; attempt <= _maxRetries; attempt++) {
-        try {
-          if (request.stream) {
-            await _streamResponse(
-              url,
-              built.headers,
-              built.body,
-              prefill: built.prefill,
-              cancelToken: cancelToken,
-              onUpdate: onUpdate,
-              onComplete: onComplete,
-              omitReasoning: omitReasoning,
-              receiveTimeoutMs: request.receiveTimeoutMs,
-            );
-          } else {
-            await _oneShotResponse(
-              url,
-              built.headers,
-              built.body,
-              prefill: built.prefill,
-              cancelToken: cancelToken,
-              onComplete: onComplete,
-              omitReasoning: omitReasoning,
-              receiveTimeoutMs: request.receiveTimeoutMs,
-            );
-          }
-          EndpointResolutionCache.record(request.endpoint, _messagesRoute, url);
-          return; // success — no retry needed
-        } on DioException catch (e) {
-          if (attempt < _maxRetries &&
-              e.response?.statusCode == 408 &&
-              cancelToken?.isCancelled != true) {
-            debugPrint(
-              '[Anthropic] HTTP 408 on attempt ${attempt + 1}/$_maxRetries — retrying',
-            );
-            await Future<void>.delayed(const Duration(seconds: 1));
-            continue;
-          }
-          final reportable = firstError ?? e;
-          firstError = reportable;
-          final status = e.response?.statusCode;
-          if (i < urls.length - 1 &&
-              (status == 404 || status == 405) &&
-              cancelToken?.isCancelled != true) {
-            debugPrint('[Anthropic] $status on $url — trying ${urls[i + 1]}');
-            break; // next candidate URL
-          }
-          onError?.call(await decodeStreamingError(reportable));
-          return;
-        } catch (e) {
-          onError?.call(e);
-          return;
+    for (var attempt = 0; attempt <= _maxRetries; attempt++) {
+      try {
+        if (request.stream) {
+          await _streamResponse(
+            url,
+            built.headers,
+            built.body,
+            prefill: built.prefill,
+            cancelToken: cancelToken,
+            onUpdate: onUpdate,
+            onComplete: onComplete,
+            omitReasoning: omitReasoning,
+            receiveTimeoutMs: request.receiveTimeoutMs,
+          );
+        } else {
+          await _oneShotResponse(
+            url,
+            built.headers,
+            built.body,
+            prefill: built.prefill,
+            cancelToken: cancelToken,
+            onComplete: onComplete,
+            omitReasoning: omitReasoning,
+            receiveTimeoutMs: request.receiveTimeoutMs,
+          );
         }
+        return;
+      } on DioException catch (e) {
+        if (attempt < _maxRetries &&
+            e.response?.statusCode == 408 &&
+            cancelToken?.isCancelled != true) {
+          debugPrint(
+            '[Anthropic] HTTP 408 on attempt ${attempt + 1}/$_maxRetries — retrying',
+          );
+          await Future<void>.delayed(const Duration(seconds: 1));
+          continue;
+        }
+        onError?.call(await decodeStreamingError(e));
+        return;
+      } catch (e) {
+        onError?.call(e);
+        return;
       }
     }
   }

--- a/lib/core/llm/transport/endpoint_normalizer.dart
+++ b/lib/core/llm/transport/endpoint_normalizer.dart
@@ -1,4 +1,5 @@
 import 'known_api_hosts.dart';
+import 'llm_protocol.dart';
 
 /// A user-entered endpoint parsed into the pieces needed to build a request
 /// URL: `origin` (scheme + host + port), `path` (the API base path) and the
@@ -262,10 +263,66 @@ class EndpointNormalizer {
 
   /// Gemini's base: the version segment is added by the transport
   /// (`/v1beta/models/…`), so it must not be part of the base.
-  static String geminiBase(String raw) =>
-      parse(raw, gemini: true, insertVersion: false)
-          .withoutVersionSegments()
-          .base;
+  static String geminiBase(String raw) => parse(
+    raw,
+    gemini: true,
+    insertVersion: false,
+  ).withoutVersionSegments().base;
+
+  /// Canonical URL stored in `ApiConfig.endpoint` for an LLM connection.
+  ///
+  /// Request transports consume this value as-is. Route completion belongs at
+  /// the persistence boundary so the endpoint shown to the user is the endpoint
+  /// that will actually receive generation requests.
+  static String persistedLlmEndpoint({
+    required String raw,
+    required String protocol,
+    required String model,
+    required bool stream,
+    bool useResponsesApi = false,
+  }) {
+    final trimmed = raw.trim();
+    if (protocol == LlmProtocol.openrouter) {
+      return 'https://openrouter.ai/api/v1/chat/completions';
+    }
+    if (trimmed.isEmpty) return '';
+
+    final resolved = switch (protocol) {
+      LlmProtocol.openaiResponses => responsesUrl(trimmed),
+      LlmProtocol.anthropic => messagesUrl(trimmed),
+      LlmProtocol.gemini => _geminiGenerationUrl(
+        trimmed,
+        model: model,
+        stream: stream,
+      ),
+      LlmProtocol.customChatCompletion when useResponsesApi => responsesUrl(
+        trimmed,
+      ),
+      _ => chatCompletionsUrl(trimmed),
+    };
+    return resolved.isEmpty ? trimmed : resolved;
+  }
+
+  /// Canonical URL stored in `ApiConfig.embeddingEndpoint`.
+  static String persistedEmbeddingEndpoint(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return '';
+    final resolved = embeddingsUrl(trimmed);
+    return resolved.isEmpty ? trimmed : resolved;
+  }
+
+  static String _geminiGenerationUrl(
+    String raw, {
+    required String model,
+    required bool stream,
+  }) {
+    final base = geminiBase(raw);
+    if (base.isEmpty) return '';
+    final modelName = model.trim();
+    if (modelName.isEmpty) return '$base/v1beta/models';
+    final action = stream ? 'streamGenerateContent' : 'generateContent';
+    return '$base/v1beta/models/$modelName:$action';
+  }
 
   /// Ordered URLs to try for [suffix]: the normalized one first, then the
   /// plausible alternatives (version forced on / stripped off). Transports

--- a/lib/core/llm/transport/gemini_chat_transport.dart
+++ b/lib/core/llm/transport/gemini_chat_transport.dart
@@ -81,17 +81,18 @@ class GeminiChatTransport implements ChatTransport {
 
   static String buildGenerateUrl({
     required String endpoint,
-    required String model,
     required String apiKey,
-    required bool stream,
   }) {
-    final base = _normaliseBase(endpoint);
-    final responseType = stream ? 'streamGenerateContent' : 'generateContent';
-    final params = <String>[
-      'key=${Uri.encodeQueryComponent(apiKey)}',
-      if (stream) 'alt=sse',
-    ];
-    return '$base/$_apiVersion/models/$model:$responseType?${params.join('&')}';
+    final uri = Uri.parse(endpoint.trim());
+    return uri
+        .replace(
+          queryParameters: {
+            ...uri.queryParameters,
+            'key': apiKey,
+            if (endpoint.contains(':streamGenerateContent')) 'alt': 'sse',
+          },
+        )
+        .toString();
   }
 
   /// Pure: build URL + body + headers from a [ChatTransportRequest]. Exposed
@@ -155,9 +156,7 @@ class GeminiChatTransport implements ChatTransport {
 
     final url = buildGenerateUrl(
       endpoint: request.endpoint,
-      model: request.model,
       apiKey: request.apiKey,
-      stream: request.stream,
     );
 
     return GeminiBuiltRequest(

--- a/lib/core/llm/transport/openai_chat_transport.dart
+++ b/lib/core/llm/transport/openai_chat_transport.dart
@@ -46,12 +46,7 @@ class OpenAiChatTransport implements ChatTransport {
            ),
        _extraHeaders = extraHeaders ?? const {};
 
-  static const String _chatRoute = '/chat/completions';
   static const String _modelsRoute = '/models';
-
-  /// HTTP statuses that mean "wrong URL, not wrong request" — the endpoint is
-  /// retried against the next candidate instead of failing the generation.
-  static const Set<int> _routeMismatchStatuses = {404, 405};
 
   static String normalizeEndpoint(String endpoint) =>
       EndpointNormalizer.baseUrl(endpoint);
@@ -71,12 +66,12 @@ class OpenAiChatTransport implements ChatTransport {
       onError?.call(Exception('API key is empty'));
       return;
     }
-    final urls = EndpointResolutionCache.order(
-      request.endpoint,
-      _chatRoute,
-      EndpointNormalizer.chatCompletionsCandidates(request.endpoint),
-    );
-    if (urls.isEmpty) {
+    final url = request.endpoint.trim();
+    final uri = Uri.tryParse(url);
+    if (url.isEmpty ||
+        uri == null ||
+        !uri.hasAuthority ||
+        (uri.scheme != 'http' && uri.scheme != 'https')) {
       onError?.call(Exception('Endpoint is empty or not a valid URL'));
       return;
     }
@@ -89,44 +84,19 @@ class OpenAiChatTransport implements ChatTransport {
       return;
     }
 
-    // The first failure is the one worth reporting: later candidates exist
-    // only to rescue a mistyped base path, and their errors describe a URL
-    // the user never entered.
-    DioException? firstError;
-
-    for (var i = 0; i < urls.length; i++) {
-      final url = urls[i];
-      try {
-        await _send(
-          url: url,
-          request: request,
-          body: body,
-          cancelToken: cancelToken,
-          onUpdate: onUpdate,
-          onComplete: onComplete,
-        );
-        EndpointResolutionCache.record(request.endpoint, _chatRoute, url);
-        return;
-      } on DioException catch (e) {
-        final reportable = firstError ?? e;
-        firstError = reportable;
-        final canFallBack =
-            i < urls.length - 1 &&
-            _routeMismatchStatuses.contains(e.response?.statusCode) &&
-            cancelToken?.isCancelled != true;
-        if (canFallBack) {
-          debugPrint(
-            '[OpenAI] ${e.response?.statusCode} on $url — '
-            'trying ${urls[i + 1]}',
-          );
-          continue;
-        }
-        onError?.call(await decodeStreamingError(reportable));
-        return;
-      } catch (e) {
-        onError?.call(e);
-        return;
-      }
+    try {
+      await _send(
+        url: url,
+        request: request,
+        body: body,
+        cancelToken: cancelToken,
+        onUpdate: onUpdate,
+        onComplete: onComplete,
+      );
+    } on DioException catch (e) {
+      onError?.call(await decodeStreamingError(e));
+    } catch (e) {
+      onError?.call(e);
     }
   }
 

--- a/lib/core/llm/transport/openai_responses_transport.dart
+++ b/lib/core/llm/transport/openai_responses_transport.dart
@@ -8,7 +8,6 @@ import '../converters/reasoning_effort.dart';
 import 'chat_transport.dart';
 import 'chat_transport_request.dart';
 import 'endpoint_normalizer.dart';
-import 'endpoint_resolution_cache.dart';
 import 'extra_request_parameters.dart';
 import 'llm_protocol.dart';
 import 'openai_chat_transport.dart';
@@ -29,8 +28,6 @@ class OpenAiResponsesTransport implements ChatTransport {
               receiveTimeout: const Duration(seconds: 120),
             ),
           );
-
-  static const String _responsesRoute = '/responses';
 
   static String buildResponsesUrl(String endpoint) =>
       EndpointNormalizer.responsesUrl(endpoint);
@@ -140,52 +137,22 @@ class OpenAiResponsesTransport implements ChatTransport {
       onError?.call(Exception('API key is empty'));
       return;
     }
-    final urls = EndpointResolutionCache.order(
-      request.endpoint,
-      _responsesRoute,
-      EndpointNormalizer.responsesCandidates(request.endpoint),
-    );
-    if (urls.isEmpty) {
+    final url = request.endpoint.trim();
+    if (url.isEmpty) {
       onError?.call(Exception('Endpoint is empty or not a valid URL'));
       return;
     }
 
-    DioException? firstError;
-
-    for (var i = 0; i < urls.length; i++) {
-      try {
-        if (request.stream) {
-          await _streamResponse(
-            urls[i],
-            request,
-            cancelToken,
-            onUpdate,
-            onComplete,
-          );
-        } else {
-          await _oneShotResponse(urls[i], request, cancelToken, onComplete);
-        }
-        EndpointResolutionCache.record(
-          request.endpoint,
-          _responsesRoute,
-          urls[i],
-        );
-        return;
-      } on DioException catch (error) {
-        final reportable = firstError ?? error;
-        firstError = reportable;
-        final status = error.response?.statusCode;
-        if (i < urls.length - 1 &&
-            (status == 404 || status == 405) &&
-            cancelToken?.isCancelled != true) {
-          continue;
-        }
-        onError?.call(await decodeStreamingError(reportable));
-        return;
-      } catch (error) {
-        onError?.call(error);
-        return;
+    try {
+      if (request.stream) {
+        await _streamResponse(url, request, cancelToken, onUpdate, onComplete);
+      } else {
+        await _oneShotResponse(url, request, cancelToken, onComplete);
       }
+    } on DioException catch (error) {
+      onError?.call(await decodeStreamingError(error));
+    } catch (error) {
+      onError?.call(error);
     }
   }
 

--- a/lib/core/llm/transport/openrouter_chat_transport.dart
+++ b/lib/core/llm/transport/openrouter_chat_transport.dart
@@ -21,7 +21,7 @@ import 'openai_chat_transport.dart';
 /// Streaming/parsing reuses [OpenAiChatTransport] verbatim — OR's SSE chunks
 /// are OpenAI-compatible.
 class OpenRouterChatTransport implements ChatTransport {
-  static const String baseUrl = 'https://openrouter.ai/api/v1';
+  static const String baseUrl = 'https://openrouter.ai/api/v1/chat/completions';
   static const String referer = 'https://github.com/hydall/Glaze';
   static const String title = 'Glaze';
 

--- a/lib/core/services/api_connection_tester.dart
+++ b/lib/core/services/api_connection_tester.dart
@@ -1,6 +1,7 @@
 import '../llm/embedding_service.dart';
 import '../llm/transport/chat_transport.dart';
 import '../llm/transport/chat_transport_request.dart';
+import '../llm/transport/endpoint_normalizer.dart';
 import '../llm/transport/llm_protocol.dart';
 import '../llm/transport/transport_factory.dart';
 
@@ -34,15 +35,22 @@ class ApiConnectionTester {
     try {
       final effectiveProtocol = _normalizedProtocol(protocol);
       final transport = _pickTransport(effectiveProtocol);
+      final requestEndpoint = EndpointNormalizer.persistedLlmEndpoint(
+        raw: endpoint,
+        protocol: effectiveProtocol,
+        model: model,
+        stream: false,
+        useResponsesApi: useResponsesApi,
+      );
       final models = await transport.fetchModels(
-        endpoint: endpoint,
+        endpoint: requestEndpoint,
         apiKey: apiKey,
       );
       if (models.isEmpty) {
         String? responseText;
         await transport.stream(
           request: ChatTransportRequest(
-            endpoint: endpoint,
+            endpoint: requestEndpoint,
             apiKey: apiKey,
             model: model,
             messages: const [

--- a/lib/core/services/backup/flutter_backup_importer.dart
+++ b/lib/core/services/backup/flutter_backup_importer.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../db/app_db.dart';
 import '../../db/repositories/session_lorebook_embedding_job_repo.dart';
+import '../../llm/transport/endpoint_normalizer.dart';
 import '../../models/studio_agent_codec.dart';
 import '../../models/studio_preset_codec.dart';
 import '../image_storage_service.dart';
@@ -308,7 +309,7 @@ class FlutterBackupImporter extends BackupHelpers {
           try {
             r = jsonDecode(line) as Map<String, dynamic>;
             _stageLegacyStudioRuntimeRow(tableName, r);
-            r = _canonicalizeStudioRow(tableName, r);
+            r = _canonicalizeRow(tableName, r);
           } catch (_) {
             continue;
           }
@@ -406,7 +407,7 @@ class FlutterBackupImporter extends BackupHelpers {
               if ((++i % _batchSize) == 0) _cancel.check();
               final source = Map<String, dynamic>.from(row as Map);
               _stageLegacyStudioRuntimeRow(tableName, source);
-              final r = _canonicalizeStudioRow(tableName, source);
+              final r = _canonicalizeRow(tableName, source);
               final columns = r.keys.where(knownCols.contains).toList();
               if (columns.isEmpty) continue;
               final placeholders = columns.map((_) => '?').join(', ');
@@ -434,11 +435,33 @@ class FlutterBackupImporter extends BackupHelpers {
     }
   }
 
-  Map<String, dynamic> _canonicalizeStudioRow(
+  Map<String, dynamic> _canonicalizeRow(
     String tableName,
     Map<String, dynamic> row,
   ) {
     try {
+      if (tableName == 'api_configs') {
+        bool readBool(String key, {required bool fallback}) {
+          final value = row[key];
+          if (value is bool) return value;
+          if (value is num) return value != 0;
+          return fallback;
+        }
+
+        return {
+          ...row,
+          'endpoint': EndpointNormalizer.persistedLlmEndpoint(
+            raw: row['endpoint']?.toString() ?? '',
+            protocol: row['protocol']?.toString() ?? 'openai',
+            model: row['model']?.toString() ?? '',
+            stream: readBool('stream', fallback: true),
+            useResponsesApi: readBool('use_responses_api', fallback: false),
+          ),
+          'embedding_endpoint': EndpointNormalizer.persistedEmbeddingEndpoint(
+            row['embedding_endpoint']?.toString() ?? '',
+          ),
+        };
+      }
       if (tableName == 'studio_preset_rows') {
         final blocks = row['blocks_json'];
         final source = blocks is String ? blocks : jsonEncode(blocks);

--- a/lib/core/services/backup/js_api_config_importer.dart
+++ b/lib/core/services/backup/js_api_config_importer.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../db/app_db.dart';
+import '../../llm/transport/endpoint_normalizer.dart';
 import '../../llm/transport/llm_protocol.dart';
 import '../image_storage_service.dart';
 import 'backup_helpers.dart';
@@ -273,7 +274,9 @@ class JsApiConfigImporter extends BackupHelpers {
             ApiConfigsCompanion(
               embeddingUseSame: const Value(false),
               embeddingEnabled: const Value(true),
-              embeddingEndpoint: Value(embEndpoint),
+              embeddingEndpoint: Value(
+                EndpointNormalizer.persistedEmbeddingEndpoint(embEndpoint),
+              ),
               embeddingApiKey: Value(embApiKey),
               embeddingModel: Value(embModel),
             ),
@@ -348,6 +351,12 @@ class JsApiConfigImporter extends BackupHelpers {
     String embeddingModel = '',
     int embeddingMaxChunkTokens = 512,
   }) async {
+    final useResponsesApi =
+        preset['useResponsesApi'] == true ||
+        preset['use_responses_api'] == true;
+    final endpoint = preset['endpoint'] as String?;
+    final model = preset['model'] as String? ?? '';
+    final stream = preset['stream'] as bool? ?? true;
     await db
         .into(db.apiConfigs)
         .insertOnConflictUpdate(
@@ -356,17 +365,22 @@ class JsApiConfigImporter extends BackupHelpers {
             name: preset['name'] as String? ?? '',
             providerId: const Value('custom_chat_completion'),
             protocol: const Value(LlmProtocol.customChatCompletion),
-            useResponsesApi: Value(
-              preset['useResponsesApi'] == true ||
-                  preset['use_responses_api'] == true,
-            ),
-            endpoint: preset['endpoint'] != null
-                ? Value(preset['endpoint'] as String)
+            useResponsesApi: Value(useResponsesApi),
+            endpoint: endpoint != null
+                ? Value(
+                    EndpointNormalizer.persistedLlmEndpoint(
+                      raw: endpoint,
+                      protocol: LlmProtocol.customChatCompletion,
+                      model: model,
+                      stream: stream,
+                      useResponsesApi: useResponsesApi,
+                    ),
+                  )
                 : const Value.absent(),
             apiKey: Value(
               preset['apiKey'] as String? ?? preset['key'] as String?,
             ),
-            model: Value(preset['model'] as String?),
+            model: Value(model),
             mode: Value(mode),
             maxTokens: Value(toInt(preset['max_tokens']) ?? 8000),
             contextSize: Value(toInt(preset['context']) ?? 32000),
@@ -377,7 +391,7 @@ class JsApiConfigImporter extends BackupHelpers {
               toDouble(preset['frequency_penalty']) ?? 0.0,
             ),
             presencePenalty: Value(toDouble(preset['presence_penalty']) ?? 0.0),
-            stream: Value(preset['stream'] as bool? ?? true),
+            stream: Value(stream),
             reasoningEffort: Value(
               preset['reasoningEffort'] as String? ??
                   preset['reasoning_effort'] as String? ??
@@ -408,7 +422,9 @@ class JsApiConfigImporter extends BackupHelpers {
             ),
             embeddingUseSame: Value(embeddingUseSame),
             embeddingEnabled: Value(embeddingEnabled),
-            embeddingEndpoint: Value(embeddingEndpoint),
+            embeddingEndpoint: Value(
+              EndpointNormalizer.persistedEmbeddingEndpoint(embeddingEndpoint),
+            ),
             embeddingApiKey: Value(embeddingApiKey),
             embeddingModel: Value(embeddingModel),
             embeddingMaxChunkTokens: Value(embeddingMaxChunkTokens),

--- a/lib/features/settings/api_settings_screen.dart
+++ b/lib/features/settings/api_settings_screen.dart
@@ -1723,9 +1723,16 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
     }
     setState(() => _isLoadingModels = true);
     try {
+      final persistedEndpoint = EndpointNormalizer.persistedLlmEndpoint(
+        raw: endpoint,
+        protocol: _protocol,
+        model: _modelCtrl.text,
+        stream: _stream,
+        useResponsesApi: _useResponsesApi,
+      );
       final models = await pickChatTransport(
         _protocol,
-      ).fetchModels(endpoint: endpoint, apiKey: apiKey);
+      ).fetchModels(endpoint: persistedEndpoint, apiKey: apiKey);
       if (!mounted) return;
       setState(() {
         _fetchedModels = models;

--- a/test/api_config_extra_parameters_test.dart
+++ b/test/api_config_extra_parameters_test.dart
@@ -4,6 +4,7 @@ import 'package:glaze_flutter/core/db/app_db.dart';
 import 'package:glaze_flutter/core/db/repositories/api_config_repo.dart';
 import 'package:glaze_flutter/core/models/api_config.dart';
 import 'package:glaze_flutter/core/models/extra_request_parameter.dart';
+import 'package:glaze_flutter/core/llm/transport/llm_protocol.dart';
 
 void main() {
   test('API config persists extra request parameters', () async {
@@ -25,5 +26,29 @@ void main() {
 
     final restored = await repo.getById('custom-api');
     expect(restored?.extraRequestParameters, parameters);
+  });
+
+  test('API config persists concrete request endpoints', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final repo = ApiConfigRepo(db);
+
+    await repo.put(
+      const ApiConfig(
+        id: 'responses-api',
+        protocol: LlmProtocol.customChatCompletion,
+        endpoint: 'example.com/v1/',
+        model: 'gpt-test',
+        useResponsesApi: true,
+        embeddingEndpoint: 'embeddings.example.com/v1',
+      ),
+    );
+
+    final restored = await repo.getById('responses-api');
+    expect(restored?.endpoint, 'https://example.com/v1/responses');
+    expect(
+      restored?.embeddingEndpoint,
+      'https://embeddings.example.com/v1/embeddings',
+    );
   });
 }

--- a/test/backup_importer_test.dart
+++ b/test/backup_importer_test.dart
@@ -71,7 +71,7 @@ void main() {
       expect(configs.length, 1);
       final c = configs.first;
       expect(c.name, equals('Default'));
-      expect(c.endpoint, equals('https://api.openai.com/v1'));
+      expect(c.endpoint, equals('https://api.openai.com/v1/chat/completions'));
       expect(c.apiKey, equals('sk-test123'));
       expect(c.model, equals('gpt-4'));
       expect(c.maxTokens, equals(4096));
@@ -123,10 +123,13 @@ void main() {
       final c = configs.first;
       expect(c.configId, equals('llm1'));
       expect(c.name, equals('My LLM'));
-      expect(c.endpoint, equals('https://llm.example.com'));
+      expect(c.endpoint, equals('https://llm.example.com/v1/chat/completions'));
       expect(c.embeddingEnabled, isTrue);
       expect(c.embeddingUseSame, isFalse);
-      expect(c.embeddingEndpoint, equals('https://emb.example.com'));
+      expect(
+        c.embeddingEndpoint,
+        equals('https://emb.example.com/v1/embeddings'),
+      );
       expect(c.embeddingApiKey, equals('sk-emb'));
       expect(c.embeddingModel, equals('text-embedding-3'));
     });
@@ -242,17 +245,26 @@ void main() {
       expect(names, containsAll(['GPT-4', 'Claude', 'Local LLM']));
 
       final gpt4 = configs.firstWhere((c) => c.configId == 'p1');
-      expect(gpt4.endpoint, equals('https://api.openai.com/v1'));
+      expect(
+        gpt4.endpoint,
+        equals('https://api.openai.com/v1/chat/completions'),
+      );
       expect(gpt4.maxTokens, equals(4096));
       expect(gpt4.contextSize, equals(16000));
 
       final claude = configs.firstWhere((c) => c.configId == 'p2');
-      expect(claude.endpoint, equals('https://api.anthropic.com/v1'));
+      expect(
+        claude.endpoint,
+        equals('https://api.anthropic.com/v1/chat/completions'),
+      );
       expect(claude.maxTokens, equals(8000));
       expect(claude.contextSize, equals(100000));
 
       final local = configs.firstWhere((c) => c.configId == 'p3');
-      expect(local.endpoint, equals('http://localhost:8080/v1'));
+      expect(
+        local.endpoint,
+        equals('http://localhost:8080/v1/chat/completions'),
+      );
       expect(local.apiKey, isEmpty);
     });
 
@@ -319,11 +331,17 @@ void main() {
         expect(llm1.name, equals('Main LLM'));
         expect(llm1.embeddingEnabled, isTrue);
         expect(llm1.embeddingUseSame, isFalse);
-        expect(llm1.embeddingEndpoint, equals('https://emb.example.com'));
+        expect(
+          llm1.embeddingEndpoint,
+          equals('https://emb.example.com/v1/embeddings'),
+        );
 
         final llm2 = configs.firstWhere((c) => c.configId == 'llm2');
         expect(llm2.name, equals('Secondary LLM'));
-        expect(llm2.endpoint, equals('https://backup.example.com'));
+        expect(
+          llm2.endpoint,
+          equals('https://backup.example.com/v1/chat/completions'),
+        );
         expect(llm2.model, equals('claude-3.5'));
         expect(llm2.maxTokens, equals(4096));
         expect(llm2.contextSize, equals(200000));
@@ -466,10 +484,16 @@ void main() {
 
         final llm1 = configs.firstWhere((c) => c.configId == 'llm1');
         expect(llm1.name, equals('Main LLM'));
-        expect(llm1.endpoint, equals('https://llm.example.com'));
+        expect(
+          llm1.endpoint,
+          equals('https://llm.example.com/v1/chat/completions'),
+        );
         expect(llm1.embeddingEnabled, isTrue);
         expect(llm1.embeddingUseSame, isFalse);
-        expect(llm1.embeddingEndpoint, equals('https://emb.example.com'));
+        expect(
+          llm1.embeddingEndpoint,
+          equals('https://emb.example.com/v1/embeddings'),
+        );
         expect(llm1.embeddingApiKey, equals('sk-emb'));
         expect(llm1.embeddingModel, equals('text-embedding-3'));
 

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -77,7 +77,7 @@ void main() {
 
       // user_version matches the Drift schema version (app_db.dart schemaVersion).
       // Update this constant whenever a new migration step is added.
-      expect(version, 130);
+      expect(version, 131);
     });
 
     test(
@@ -231,7 +231,7 @@ void main() {
         final version = await upgraded
             .customSelect('PRAGMA user_version')
             .get();
-        expect(version.first.read<int>('user_version'), 130);
+        expect(version.first.read<int>('user_version'), 131);
         expect(names, contains('variant_group_id'));
         expect(names, contains('hidden'));
       },
@@ -261,7 +261,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test(
@@ -610,7 +610,7 @@ void main() {
 
     test('current schema includes atomic character fact tables', () async {
       final version = await db.customSelect('PRAGMA user_version').getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
 
       final factColumns = await db
           .customSelect("PRAGMA table_info('character_knowledge_fact_rows')")
@@ -722,7 +722,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test(
@@ -832,7 +832,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v80 adds Responses API toggle defaulting to off', () async {
@@ -872,7 +872,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v81 adds composite embedding source index', () async {
@@ -906,7 +906,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v82 creates rewrite persistence schema and provenance columns', () async {
@@ -980,7 +980,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v83 rebuilds interim text revision columns without losing rows', () async {
@@ -1432,7 +1432,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
 
       // Rows and payloads survive; legacy statuses pass through or are
       // normalized fail-closed, and new columns carry neutral defaults.
@@ -1637,7 +1637,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
       final row = await upgraded
           .customSelect(
             'SELECT blocks_json FROM studio_preset_rows WHERE preset_id = ?',
@@ -1753,7 +1753,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
       final check = await upgraded.customSelect('PRAGMA integrity_check').get();
       expect(check.single.read<String>('integrity_check'), 'ok');
     });
@@ -2417,7 +2417,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test(
@@ -2514,7 +2514,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v118 adds prompt post-processing with none for every config', () async {
@@ -2706,7 +2706,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v120 adds the ledger debug journal to an older database', () async {
@@ -2792,7 +2792,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v121 adds the session canon timeline foundation', () async {
@@ -2852,7 +2852,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v122 adds the embedding request rate limit', () async {
@@ -2891,7 +2891,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v123 raises only the legacy Studio final history limit', () async {
@@ -2943,7 +2943,7 @@ void main() {
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v124 and v125 add LLM capture history and linkage', () async {
@@ -3017,7 +3017,7 @@ void main() {
           'idx_llm_call_event_call_attempt',
         ]),
       );
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v125 upgrades an existing v124 request capture table', () async {
@@ -3075,7 +3075,7 @@ void main() {
         contains('call_id'),
       );
       expect(eventColumns, isNotEmpty);
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v126 adds immutable reconciliation effects', () async {
@@ -3126,7 +3126,7 @@ void main() {
         indexes.map((row) => row.read<String>('name')),
         contains('idx_reconciliation_effect_session_created'),
       );
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test(
@@ -3204,7 +3204,7 @@ INSERT INTO card_evolution_collector_runs VALUES
         expect(row.id, 'collector');
         expect(row.status, 'claimed');
         expect(row.failureCode, isNull);
-        expect(version.read<int>('user_version'), 130);
+        expect(version.read<int>('user_version'), 131);
       },
     );
 
@@ -3296,7 +3296,7 @@ INSERT INTO card_evolution_claims VALUES
         writerIndexes.map((row) => row.read<String>('name')),
         contains('idx_card_evolution_writer_call_session_updated'),
       );
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
     });
 
     test('v129 adds active job and immutable audit guards', () async {
@@ -3373,7 +3373,7 @@ INSERT INTO card_evolution_claims VALUES
       final version = await upgraded
           .customSelect('PRAGMA user_version')
           .getSingle();
-      expect(version.read<int>('user_version'), 130);
+      expect(version.read<int>('user_version'), 131);
       await upgraded.customStatement(
         "INSERT INTO ledger_reconciliation_leases VALUES ('session', 'owner', 'normal', 2, 1)",
       );
@@ -3382,6 +3382,88 @@ INSERT INTO card_evolution_claims VALUES
           "INSERT INTO ledger_reconciliation_leases VALUES ('bad', '', 'other', 1, 1)",
         ),
         throwsA(anything),
+      );
+    });
+
+    test('v131 stores concrete API request endpoints', () async {
+      final file = File(
+        '${Directory.systemTemp.path}/glaze_mig_endpoints_${DateTime.now().microsecondsSinceEpoch}.db',
+      );
+      addTearDown(() async {
+        if (file.existsSync()) await file.delete();
+      });
+      final seeded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      await seeded.customSelect('SELECT 1').get();
+      for (final row in const [
+        ('chat', 'openai', 'https://api.openai.com/v1/', 'gpt-test', 1, 0),
+        (
+          'responses',
+          'custom_chat_completion',
+          'https://proxy.example/v1',
+          'gpt-test',
+          1,
+          1,
+        ),
+        (
+          'gemini',
+          'gemini',
+          'https://generativelanguage.googleapis.com',
+          'gemini-test',
+          0,
+          0,
+        ),
+        ('router', 'openrouter', '', 'router-test', 1, 0),
+      ]) {
+        await seeded.customStatement(
+          'INSERT INTO api_configs '
+          '(config_id, name, protocol, endpoint, model, stream, '
+          'use_responses_api, embedding_endpoint) '
+          'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+          [
+            row.$1,
+            row.$1,
+            row.$2,
+            row.$3,
+            row.$4,
+            row.$5,
+            row.$6,
+            'https://embeddings.example/v1',
+          ],
+        );
+      }
+      await seeded.customStatement('PRAGMA user_version = 130');
+      await seeded.close();
+
+      final upgraded = AppDatabase.forTesting(
+        NativeDatabase.createInBackground(file),
+      );
+      addTearDown(upgraded.close);
+      final rows = await upgraded
+          .customSelect(
+            'SELECT config_id, endpoint, embedding_endpoint FROM api_configs',
+          )
+          .get();
+      final endpoints = {
+        for (final row in rows)
+          row.read<String>('config_id'): row.read<String>('endpoint'),
+      };
+
+      expect(endpoints['chat'], 'https://api.openai.com/v1/chat/completions');
+      expect(endpoints['responses'], 'https://proxy.example/v1/responses');
+      expect(
+        endpoints['gemini'],
+        'https://generativelanguage.googleapis.com/v1beta/models/'
+        'gemini-test:generateContent',
+      );
+      expect(
+        endpoints['router'],
+        'https://openrouter.ai/api/v1/chat/completions',
+      );
+      expect(
+        rows.first.read<String>('embedding_endpoint'),
+        'https://embeddings.example/v1/embeddings',
       );
     });
 

--- a/test/embedding_service_cache_test.dart
+++ b/test/embedding_service_cache_test.dart
@@ -77,6 +77,27 @@ void main() {
   });
 
   group('EmbeddingConfig', () {
+    test('signature uses the effective embedding URL', () {
+      const base = EmbeddingConfig(
+        endpoint: 'https://api.openai.com/v1',
+        model: 'text-embedding-3-small',
+      );
+      const chat = EmbeddingConfig(
+        endpoint: 'https://api.openai.com/v1/chat/completions',
+        model: 'text-embedding-3-small',
+      );
+      const embeddings = EmbeddingConfig(
+        endpoint: 'https://api.openai.com/v1/embeddings',
+        model: 'text-embedding-3-small',
+      );
+
+      expect(embeddingModelSignature(chat), embeddingModelSignature(base));
+      expect(
+        embeddingModelSignature(embeddings),
+        embeddingModelSignature(base),
+      );
+    });
+
     test('defaults are sensible', () {
       const config = EmbeddingConfig(endpoint: 'https://x');
       expect(config.endpoint, 'https://x');

--- a/test/llm/transport/endpoint_fallback_test.dart
+++ b/test/llm/transport/endpoint_fallback_test.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glaze_flutter/core/llm/transport/chat_transport_request.dart';
-import 'package:glaze_flutter/core/llm/transport/endpoint_resolution_cache.dart';
 import 'package:glaze_flutter/core/llm/transport/openai_chat_transport.dart';
 
 /// Answers only for [servedUrl]; every other URL 404s the way a provider does
@@ -68,10 +67,7 @@ ChatTransportRequest _req(String endpoint) => ChatTransportRequest(
 );
 
 void main() {
-  setUp(EndpointResolutionCache.clear);
-  tearDown(EndpointResolutionCache.clear);
-
-  test('falls back to the version-less URL when /v1 404s', () async {
+  test('uses the persisted endpoint without appending a route', () async {
     final adapter = _RoutingAdapter(
       servedUrl: 'https://proxy.tld/chat/completions',
     );
@@ -81,73 +77,29 @@ void main() {
     String? completed;
     Object? failed;
     await transport.stream(
-      request: _req('https://proxy.tld'),
+      request: _req('https://proxy.tld/chat/completions'),
       onComplete: (text, _, {rawResponseJson}) => completed = text,
       onError: (e) => failed = e,
     );
 
     expect(failed, isNull);
     expect(completed, 'pong');
-    expect(adapter.requested, [
-      'https://proxy.tld/v1/chat/completions',
-      'https://proxy.tld/chat/completions',
-    ]);
-  });
-
-  test('adds the missing /v1 when the pasted URL 404s', () async {
-    final adapter = _RoutingAdapter(
-      servedUrl: 'https://proxy.tld/v1/chat/completions',
-    );
-    final dio = Dio()..httpClientAdapter = adapter;
-    final transport = OpenAiChatTransport(dio: dio);
-
-    String? completed;
-    await transport.stream(
-      request: _req('https://proxy.tld/chat/completions'),
-      onComplete: (text, _, {rawResponseJson}) => completed = text,
-    );
-
-    expect(completed, 'pong');
-    expect(adapter.requested, [
-      'https://proxy.tld/chat/completions',
-      'https://proxy.tld/v1/chat/completions',
-    ]);
-  });
-
-  test('the resolved URL is reused, so the walk is paid once', () async {
-    final adapter = _RoutingAdapter(
-      servedUrl: 'https://proxy.tld/chat/completions',
-    );
-    final dio = Dio()..httpClientAdapter = adapter;
-    final transport = OpenAiChatTransport(dio: dio);
-
-    await transport.stream(request: _req('https://proxy.tld'));
-    adapter.requested.clear();
-    await transport.stream(request: _req('https://proxy.tld'));
-
     expect(adapter.requested, ['https://proxy.tld/chat/completions']);
   });
 
-  test('when every candidate 404s the first failure is reported', () async {
+  test('does not probe alternative endpoints after a 404', () async {
     final adapter = _RoutingAdapter();
     final dio = Dio()..httpClientAdapter = adapter;
     final transport = OpenAiChatTransport(dio: dio);
 
     Object? failed;
     await transport.stream(
-      request: _req('https://proxy.tld'),
-      onError: (e) => failed = e,
+      request: _req('https://proxy.tld/chat/completions'),
+      onError: (error) => failed = error,
     );
 
-    expect(adapter.requested, [
-      'https://proxy.tld/v1/chat/completions',
-      'https://proxy.tld/chat/completions',
-    ]);
+    expect(adapter.requested, ['https://proxy.tld/chat/completions']);
     expect(failed, isA<DioException>());
-    expect(
-      (failed as DioException).requestOptions.uri.toString(),
-      'https://proxy.tld/v1/chat/completions',
-    );
   });
 
   test('an unparseable endpoint fails without any request', () async {

--- a/test/llm/transport/endpoint_normalizer_test.dart
+++ b/test/llm/transport/endpoint_normalizer_test.dart
@@ -1,7 +1,69 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:glaze_flutter/core/llm/transport/endpoint_normalizer.dart';
+import 'package:glaze_flutter/core/llm/transport/llm_protocol.dart';
 
 void main() {
+  group('persisted endpoints', () {
+    test('stores the concrete generation route for every protocol', () {
+      String endpoint(
+        String protocol, {
+        bool useResponsesApi = false,
+        bool stream = true,
+      }) => EndpointNormalizer.persistedLlmEndpoint(
+        raw: 'https://example.com/v1/',
+        protocol: protocol,
+        model: 'model-name',
+        stream: stream,
+        useResponsesApi: useResponsesApi,
+      );
+
+      expect(
+        endpoint(LlmProtocol.openai),
+        'https://example.com/v1/chat/completions',
+      );
+      expect(
+        endpoint(LlmProtocol.customChatCompletion, useResponsesApi: true),
+        'https://example.com/v1/responses',
+      );
+      expect(
+        endpoint(LlmProtocol.openaiResponses),
+        'https://example.com/v1/responses',
+      );
+      expect(
+        endpoint(LlmProtocol.anthropic),
+        'https://example.com/v1/messages',
+      );
+      expect(
+        endpoint(LlmProtocol.gemini),
+        'https://example.com/v1beta/models/model-name:streamGenerateContent',
+      );
+      expect(
+        endpoint(LlmProtocol.gemini, stream: false),
+        'https://example.com/v1beta/models/model-name:generateContent',
+      );
+      expect(
+        endpoint(LlmProtocol.openrouter),
+        'https://openrouter.ai/api/v1/chat/completions',
+      );
+    });
+
+    test('preserves invalid text and completes embedding routes', () {
+      expect(
+        EndpointNormalizer.persistedLlmEndpoint(
+          raw: '  not a url  ',
+          protocol: LlmProtocol.openai,
+          model: '',
+          stream: true,
+        ),
+        'not a url',
+      );
+      expect(
+        EndpointNormalizer.persistedEmbeddingEndpoint('example.com/v1'),
+        'https://example.com/v1/embeddings',
+      );
+    });
+  });
+
   group('bare host → full chat URL', () {
     test('adds scheme and the version the provider serves', () {
       expect(
@@ -193,9 +255,7 @@ void main() {
   group('a complete URL for another route', () {
     test('an /embeddings or /models URL still yields the chat URL', () {
       expect(
-        EndpointNormalizer.chatCompletionsUrl(
-          'https://api.host/v1/embeddings',
-        ),
+        EndpointNormalizer.chatCompletionsUrl('https://api.host/v1/embeddings'),
         'https://api.host/v1/chat/completions',
       );
       expect(
@@ -306,10 +366,7 @@ void main() {
         'https://api.openai.com/v1/images/edits',
       );
       expect(
-        EndpointNormalizer.imagesUrl(
-          'http://127.0.0.1:8080',
-          'generations',
-        ),
+        EndpointNormalizer.imagesUrl('http://127.0.0.1:8080', 'generations'),
         'http://127.0.0.1:8080/v1/images/generations',
       );
     });

--- a/test/llm/transport/gemini_chat_transport_test.dart
+++ b/test/llm/transport/gemini_chat_transport_test.dart
@@ -41,10 +41,10 @@ void main() {
   group('buildGenerateUrl', () {
     test('streaming URL has streamGenerateContent + alt=sse', () {
       final url = GeminiChatTransport.buildGenerateUrl(
-        endpoint: 'https://generativelanguage.googleapis.com',
-        model: 'gemini-2.5-flash',
+        endpoint:
+            'https://generativelanguage.googleapis.com/v1beta/models/'
+            'gemini-2.5-flash:streamGenerateContent',
         apiKey: 'k',
-        stream: true,
       );
       expect(
         url,
@@ -55,10 +55,10 @@ void main() {
 
     test('non-stream URL uses generateContent', () {
       final url = GeminiChatTransport.buildGenerateUrl(
-        endpoint: 'https://generativelanguage.googleapis.com',
-        model: 'gemini-2.5-pro',
+        endpoint:
+            'https://generativelanguage.googleapis.com/v1beta/models/'
+            'gemini-2.5-pro:generateContent',
         apiKey: 'k',
-        stream: false,
       );
       expect(
         url,
@@ -69,22 +69,23 @@ void main() {
 
     test('api key with special chars is URL-encoded', () {
       final url = GeminiChatTransport.buildGenerateUrl(
-        endpoint: 'https://generativelanguage.googleapis.com',
-        model: 'gemini-2.5-flash',
+        endpoint:
+            'https://generativelanguage.googleapis.com/v1beta/models/'
+            'gemini-2.5-flash:generateContent',
         apiKey: 'k/with+chars',
-        stream: false,
       );
       expect(url, contains('key=k%2Fwith%2Bchars'));
     });
 
-    test('schemeless endpoint gets https prefix', () {
+    test('existing query parameters are preserved', () {
       final url = GeminiChatTransport.buildGenerateUrl(
-        endpoint: 'example.com',
-        model: 'gemini-2.5-flash',
+        endpoint:
+            'https://example.com/v1beta/models/'
+            'gemini-2.5-flash:generateContent?region=eu',
         apiKey: 'k',
-        stream: false,
       );
-      expect(url.startsWith('https://example.com/'), isTrue);
+      expect(url, contains('region=eu'));
+      expect(url, contains('key=k'));
     });
   });
 

--- a/test/llm/transport/openai_responses_transport_test.dart
+++ b/test/llm/transport/openai_responses_transport_test.dart
@@ -20,7 +20,7 @@ ChatTransportRequest _request({
   String sessionIdMode = 'openrouter',
   String reasoningEffort = 'high',
 }) => ChatTransportRequest(
-  endpoint: 'https://api.rout.my/v1/chat/completions',
+  endpoint: 'https://api.rout.my/v1/responses',
   apiKey: 'test-key',
   model: 'openai/gpt-5.6-sol',
   messages: const [

--- a/test/lorebook_embedding_service_test.dart
+++ b/test/lorebook_embedding_service_test.dart
@@ -87,7 +87,7 @@ void main() {
       ],
       textHash: hash,
       retrievalMetadata: embeddingMetadataForConfig(
-        const EmbeddingConfig(endpoint: 'old', model: 'model'),
+        const EmbeddingConfig(endpoint: 'https://old.example', model: 'model'),
         const [
           [1, 0],
         ],
@@ -96,7 +96,7 @@ void main() {
 
     final result = await service.indexLorebookEntries('book', const [
       entry,
-    ], const EmbeddingConfig(endpoint: 'new', model: 'model'));
+    ], const EmbeddingConfig(endpoint: 'https://new.example', model: 'model'));
     expect(result.indexed, 1);
     expect(embeddingService.requestedTexts, ['content']);
   });

--- a/test/lorebook_vector_search_test.dart
+++ b/test/lorebook_vector_search_test.dart
@@ -321,7 +321,10 @@ void main() {
       repo,
       'book',
       entry,
-      config: const EmbeddingConfig(endpoint: 'old', model: 'model'),
+      config: const EmbeddingConfig(
+        endpoint: 'https://old.example',
+        model: 'model',
+      ),
     );
 
     final results = await search.search(
@@ -331,7 +334,7 @@ void main() {
         Lorebook(id: 'book', name: 'Book', entries: [entry]),
       ],
       const LorebookGlobalSettings(searchType: 'vector', vectorThreshold: 0),
-      const EmbeddingConfig(endpoint: 'new', model: 'model'),
+      const EmbeddingConfig(endpoint: 'https://new.example', model: 'model'),
     );
     expect(results, isEmpty);
     expect(embeddings.queries, isEmpty);

--- a/test/studio_turn_config_snapshot_test.dart
+++ b/test/studio_turn_config_snapshot_test.dart
@@ -284,7 +284,7 @@ void main() {
       final cleanerConfig = snapshot.resolveCleanerConfig(
         errorLabel: 'test-cleaner',
       );
-      expect(cleanerConfig.endpoint, 'https://old.example');
+      expect(cleanerConfig.endpoint, 'https://old.example/v1/chat/completions');
       expect(cleanerConfig.model, 'old-model');
     },
   );


### PR DESCRIPTION
## Changes
- Canonicalize complete generation and embedding URLs when API configurations are persisted, with protocol-specific routes for OpenAI, Responses, Anthropic, Gemini, and OpenRouter.
- Send generation requests to the stored endpoint directly while retaining endpoint derivation for model listing and unsaved connection tests.
- Add database migration v131 and normalize endpoints restored through both Flutter and legacy JS backups.
- Keep embedding signatures stable by deriving them from the effective embeddings URL, avoiding unnecessary vector rebuilds.
- Update endpoint, transport, backup, migration, and embedding tests together with the architecture and database documentation.

## Verification
- `flutter test` (3456 tests passed)
- `flutter test test/db_migration_test.dart` (61 tests passed)
- `flutter analyze` (no errors; 3 pre-existing non-fatal findings remain)
- `git diff --check`