### PR TITLE
fix(image-gen): correct the pending-block placeholder and its triggers

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -2,6 +2,7 @@
 
 import { GenTimer } from './gen_timer.js';
 import { ImgGenTimer } from './imggen_timer.js';
+import { refreshImgGenPlaceholderState } from '../renderer/imggen_placeholder.js';
 import { MessageUpdateBatcher } from './message_update_batcher.js';
 import { SelectionManager } from './selection_manager.js';
 import { EditController } from './edit_controller.js';
@@ -141,6 +142,17 @@ export class Bridge {
 
   setPostGenRunning(value) {
     this.isPostGenRunning = !!value;
+  }
+
+  // The image stage is the only thing that generates from an `[IMG:GEN…]` tag,
+  // so this flag is what tells a pending block apart from a running one
+  // (INV-IG1). The transition carries no re-render of its own — the reply's
+  // last chunk is already painted — so the placeholders are restamped here,
+  // and the ticker is woken for the clocks that just started.
+  setImageGenerating(value) {
+    this.isGeneratingImage = !!value;
+    refreshImgGenPlaceholderState();
+    this._imgGenTimer.ensureRunning();
   }
 
   _syncGenerationTimer() {

--- a/assets/chat_webview/bridge/imggen_timer.js
+++ b/assets/chat_webview/bridge/imggen_timer.js
@@ -38,15 +38,29 @@ export class ImgGenTimer {
     hosts.forEach((host) => {
       const root = host.shadowRoot;
       if (!root) return;
-      const timers = root.querySelectorAll('.imggen-loading-timer[data-start]');
-      timers.forEach((el) => {
-        found++;
-        const start = parseInt(el.dataset.start, 10);
-        if (!start) return;
-        el.textContent = ((now - start) / 1000).toFixed(1) + 's';
-      });
+      found += this._updateIn(root, now);
     });
     if (found === 0) this.stop();
+    return found;
+  }
+
+  // Updates every timer in one shadow tree, then in the placeholders' own.
+  //
+  // A loading block carries its content in a nested shadow root of its own
+  // (renderer/imggen_placeholder.js), so the timer is one boundary deeper than
+  // the message body it belongs to and a flat query over the message root
+  // never sees it.
+  _updateIn(root, now) {
+    let found = 0;
+    root.querySelectorAll('.imggen-loading-timer[data-start]').forEach((el) => {
+      found++;
+      const start = parseInt(el.dataset.start, 10);
+      if (!start) return;
+      el.textContent = ((now - start) / 1000).toFixed(1) + 's';
+    });
+    root.querySelectorAll('.imggen-loading').forEach((block) => {
+      if (block.shadowRoot) found += this._updateIn(block.shadowRoot, now);
+    });
     return found;
   }
 }

--- a/assets/chat_webview/bridge/imggen_timer.js
+++ b/assets/chat_webview/bridge/imggen_timer.js
@@ -59,6 +59,9 @@ export class ImgGenTimer {
       el.textContent = ((now - start) / 1000).toFixed(1) + 's';
     });
     root.querySelectorAll('.imggen-loading').forEach((block) => {
+      // A queued block is waiting for the reply to finish, not generating, so
+      // its clock is hidden and must not hold the interval open (INV-IG1).
+      if (block.classList.contains('imggen-queued')) return;
       if (block.shadowRoot) found += this._updateIn(block.shadowRoot, now);
     });
     return found;

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -758,7 +758,11 @@ export class Formatter {
         // The children are moved into a shadow root of the placeholder's own by
         // `isolateImgGenPlaceholders` right after insertion, which is what keeps
         // message CSS from restyling them (see renderer/imggen_placeholder.js).
-        return `<div class="imggen-loading" data-start="${start}" data-img-index="${at}"><span class="imggen-loading-hint">Generating image…</span><span class="imggen-loading-timer" data-start="${start}">0.0s</span><button class="imggen-stop-btn" type="button" data-action="img-stop" title="Stop image generation" aria-label="Stop image generation">${STOP_SVG}</button>${promptEl}</div>`;
+        // Two labels, one of which is hidden: the block is "queued" until the
+        // reply has finished streaming and post-gen actually reaches the image
+        // stage (INV-IG1), and only then does anything start elapsing or
+        // become stoppable. `refreshImgGenPlaceholderState` flips the class.
+        return `<div class="imggen-loading" data-start="${start}" data-img-index="${at}"><span class="imggen-loading-hint">Generating image…</span><span class="imggen-queued-hint">Image queued…</span><span class="imggen-loading-timer" data-start="${start}">0.0s</span><button class="imggen-stop-btn" type="button" data-action="img-stop" title="Stop image generation" aria-label="Stop image generation">${STOP_SVG}</button>${promptEl}</div>`;
       }
       if (block.type === 'error') {
         let errorMsg = 'Unknown error';

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -166,13 +166,18 @@ export class Formatter {
     this.cacheMaxSize = 500;
   }
 
-  format(text, isUser = false) {
-    const key = `${text}:${isUser}`;
+  // [inReasoning] formats a body that *is* a reasoning block — the split-out
+  // `message.reasoning`, which the renderer shows in its own panel. Dart never
+  // scans that field for image tags, so a tag in it must not render as a block
+  // here either (INV-IG11); the same flag covers a `<think>` block found inline
+  // in the message body, from step 17.
+  format(text, isUser = false, inReasoning = false) {
+    const key = `${text}:${isUser}:${inReasoning}`;
     if (this.cache.has(key)) return this.cache.get(key);
 
     let result;
     try {
-      result = this._processText(text, isUser);
+      result = this._processText(text, isUser, false, inReasoning);
     } catch (e) {
       console.error('Formatter error:', e);
       result = (text || '').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>');
@@ -196,7 +201,12 @@ export class Formatter {
     return `\x01${prefix}${isBlock ? 'BLOCK_' : ''}${i}\x01`;
   }
 
-  _processText(text, isUser, skipQuotes = false) {
+  // [inReasoning] marks the recursive pass over a `<think>…</think>` body. A
+  // model plans its images out loud there, and Glaze does not generate from a
+  // tag it finds in that plan (INV-IG11) — so the tag must not render as a
+  // block either: a placeholder whose picture is never coming, or an <img>
+  // with no loadable source, would both be a lie about what the app is doing.
+  _processText(text, isUser, skipQuotes = false, inReasoning = false) {
     if (!text) return '';
     text = expandMacros(text).replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
 
@@ -328,6 +338,15 @@ export class Formatter {
     // letting step 6 treat it as an ordinary HTML tag) is what gives it the
     // options button, the variant switcher and its `data-img-index`.
     const imgBlocks = [];
+    // Tags a reasoning block only talks about: kept as their own literal text,
+    // restored in step 19b. Inline (not a block placeholder) so a tag written
+    // mid-sentence does not break the sentence in two.
+    const inertImgTags = [];
+    const inertTag = (match) => {
+      const id = this._ph('IGT_', inertImgTags.length);
+      inertImgTags.push(match);
+      return id;
+    };
     html = html.replace(IIG_ELEMENT_REGEX, (match) => {
       const parsed = parseImageResultElement(match);
       if (!parsed) {
@@ -337,6 +356,7 @@ export class Formatter {
         // broken-image icon for the whole generation.
         const pending = parseImagePendingElement(match);
         if (!pending) return match;
+        if (inReasoning) return inertTag(match);
         const id = this._ph('IG_', imgBlocks.length, true);
         imgBlocks.push({ type: 'gen', instruction: pending.instruction });
         return '\n\n' + id + '\n\n';
@@ -358,11 +378,13 @@ export class Formatter {
     html = html.replace(IMG_SRC_GEN_ELEMENT_REGEX, (match) => {
       const pending = parseImagePendingElement(match);
       if (!pending) return match;
+      if (inReasoning) return inertTag(match);
       const id = this._ph('IG_', imgBlocks.length, true);
       imgBlocks.push({ type: 'gen', instruction: pending.instruction });
       return '\n\n' + id + '\n\n';
     });
     html = html.replace(/\[IMG:GEN(?::(.*?))?\]/g, (match, instruction) => {
+      if (inReasoning) return inertTag(match);
       const id = this._ph('IG_', imgBlocks.length, true);
       imgBlocks.push({ type: 'gen', instruction: instruction || '' });
       return '\n\n' + id + '\n\n';
@@ -474,7 +496,7 @@ export class Formatter {
       const seg = styledSegments[parseInt(i)];
       // skipQuotes defaults to true (preserve color markers' fills);
       // plain formatting (italic/bold/strike) opts out via the second arg.
-      return renderStyledSegment(seg, (innerRaw, skipQuotes = true) => this._processText(innerRaw, false, skipQuotes));
+      return renderStyledSegment(seg, (innerRaw, skipQuotes = true) => this._processText(innerRaw, false, skipQuotes, inReasoning));
     });
 
     // 10. Markdown Parsing
@@ -647,7 +669,7 @@ export class Formatter {
     // 17. Restore think blocks
     html = html.replace(/\x01TB_BLOCK_(\d+)\x01/g, (_, i) => {
       const content = thinkBlocks[parseInt(i)];
-      const formatted = this._processText(content, isUser);
+      const formatted = this._processText(content, isUser, false, true);
       return `<details class="reasoning-block"><summary class="reasoning-summary">💭 Reasoning</summary><div class="reasoning-content">${formatted}</div></details>`;
     });
 
@@ -657,7 +679,7 @@ export class Formatter {
     html = html.replace(/\x01FC_(\d+)\x01/g, (_, i) => {
       const block = fontBlocks[parseInt(i)];
       if (block.type === 'style') {
-        let formatted = this._processText(block.content, isUser, true);
+        let formatted = this._processText(block.content, isUser, true, inReasoning);
         formatted = formatted.replace(/^\s*<p>([\s\S]*?)<\/p>\s*$/i, '$1');
 
         // Propagate gradient / text-fill / clip styles down to the first nested inline element
@@ -685,7 +707,7 @@ export class Formatter {
 
         return `<span class="font-style-block" style="${block.style}">${formatted}</span>`;
       }
-      let formatted = this._processText(block.content, isUser, true);
+      let formatted = this._processText(block.content, isUser, true, inReasoning);
       formatted = formatted.replace(/^\s*<p>([\s\S]*?)<\/p>\s*$/i, '$1');
       return `<span class="font-color-block" style="color:${block.color}">${formatted}</span>`;
     });
@@ -754,6 +776,12 @@ export class Formatter {
       }
       return '';
     });
+
+    // 19b. Restore the tags a reasoning block only talked about, as the text
+    // the model wrote. Nothing here loads, spins or generates.
+    html = html.replace(/\x01IGT_(\d+)\x01/g, (_, i) =>
+      this._escapeHtml(inertImgTags[parseInt(i)]),
+    );
 
     html = html.replace(/\x01[A-Z_]+\d+\x01/g, '');
 

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -5,6 +5,11 @@ import { renderStyledSegment } from './text_format.js';
 const OPTIONS_SVG = '<svg viewBox="0 0 24 24"><path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>';
 const VARIANT_PREV_SVG = '<svg viewBox="0 0 24 24"><path d="M15.4 7.4 14 6l-6 6 6 6 1.4-1.4-4.6-4.6z"/></svg>';
 const VARIANT_NEXT_SVG = '<svg viewBox="0 0 24 24"><path d="M8.6 7.4 10 6l6 6-6 6-1.4-1.4 4.6-4.6z"/></svg>';
+// Stop icon for the loading placeholder. An SVG rather than the ⏹ character:
+// the glyph is a font-dependent emoji that renders at a different size (and in
+// colour) on every platform, while a path is the same square everywhere and
+// takes `fill: currentColor` from the button.
+const STOP_SVG = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="2"/></svg>';
 
 /** Separator between the images one block carries, mirroring the Dart codec. */
 const IMG_VARIANT_SEPARATOR = ';;';
@@ -37,12 +42,36 @@ export function parseImageResultPayload(payload) {
   return { paths, activeIndex, instruction };
 }
 
+/** Introduces the images a pending block carries, mirroring the Dart codec. */
+const IMG_PENDING_MARKER = '@';
+
+/**
+ * Splits an `[IMG:GEN:…]` payload into the images the block already holds and
+ * its instruction — the JS half of ImageBlockPayload.parsePending. Without the
+ * `@` marker the whole payload is the instruction, which is how every block
+ * written before regeneration carried its images is spelled.
+ */
+export function parseImagePendingPayload(payload) {
+  const raw = String(payload == null ? '' : payload);
+  if (!raw.startsWith(IMG_PENDING_MARKER)) {
+    return { paths: [], activeIndex: 0, instruction: raw };
+  }
+  return parseImageResultPayload(raw.substring(IMG_PENDING_MARKER.length));
+}
+
 /**
  * Matches one `<img …data-iig-instruction…>` element, the stored form of an
  * image block. Whether it is finished or still waiting is decided by its
  * `src` (see `parseImageResultElement`), not by the pattern.
  */
 const IIG_ELEMENT_REGEX = /<img\s[^>]*?data-iig-instruction\s*=\s*(?:"[^"]*"|'[^']*')[^>]*>/gi;
+
+/**
+ * Matches an `<img …src="[IMG:GEN…]">` element that carries no instruction
+ * attribute — the spelling a model writes by hand, where the payload lives in
+ * the `src`. Mirrors ImgGenPatterns.imgSrcGenRegex on the Dart side.
+ */
+const IMG_SRC_GEN_ELEMENT_REGEX = /<img\b[^>]*?\bsrc\s*=\s*["']\[IMG:GEN[^\]]*\]["'][^>]*>/gi;
 
 /** A paragraph holding only tag placeholders and whitespace (see step 11). */
 const ONLY_TAG_PLACEHOLDERS = /^(?:\x01T_(?:BLOCK_)?\d+\x01|\s)+$/;
@@ -105,6 +134,30 @@ export function parseImageResultElement(tag) {
   if (!(activeIndex >= 0)) activeIndex = 0;
   if (activeIndex > paths.length - 1) activeIndex = paths.length - 1;
   return { paths, activeIndex, instruction };
+}
+
+/**
+ * Reads the pending form of a stored image block: the same `<img data-iig-…>`
+ * element, but with no picture in its `src` yet (see `parseImageResultElement`,
+ * which is what decides between the two). Returns null for a finished block.
+ *
+ * Pulling this element out of the markup — instead of leaving it to render as
+ * an ordinary `<img>` — is what keeps a browser's broken-image icon off the
+ * screen while the picture is still being generated: the tag has no image to
+ * load, so the only thing it can paint is the failure glyph.
+ */
+export function parseImagePendingElement(tag) {
+  const attributes = imgAttributes(tag);
+  const src = unescapeAttribute(attributes.src || '').trim();
+  if (src && !src.startsWith('[IMG:GEN')) return null;
+  // The instruction attribute is the authoritative payload; a bare
+  // `<img src="[IMG:GEN:…]">` carries it inside the src instead.
+  let instruction = unescapeAttribute(attributes['data-iig-instruction'] || '');
+  if (!instruction && src) {
+    const inSrc = src.match(/^\[IMG:GEN(?::([\s\S]*))?\]$/);
+    if (inSrc) instruction = inSrc[1] || '';
+  }
+  return { instruction };
 }
 
 export class Formatter {
@@ -277,7 +330,17 @@ export class Formatter {
     const imgBlocks = [];
     html = html.replace(IIG_ELEMENT_REGEX, (match) => {
       const parsed = parseImageResultElement(match);
-      if (!parsed) return match;
+      if (!parsed) {
+        // Still waiting for its picture: render the loading placeholder in the
+        // element's place. Leaving the tag alone would put an <img> with no
+        // loadable source into the message, and the reader would watch a
+        // broken-image icon for the whole generation.
+        const pending = parseImagePendingElement(match);
+        if (!pending) return match;
+        const id = this._ph('IG_', imgBlocks.length, true);
+        imgBlocks.push({ type: 'gen', instruction: pending.instruction });
+        return '\n\n' + id + '\n\n';
+      }
       const id = this._ph('IG_', imgBlocks.length, true);
       imgBlocks.push({
         type: 'result',
@@ -286,6 +349,17 @@ export class Formatter {
         activeIndex: parsed.activeIndex,
         instruction: parsed.instruction,
       });
+      return '\n\n' + id + '\n\n';
+    });
+    // `<img src="[IMG:GEN…]">` with no instruction attribute: the whole element
+    // is the block, so it has to go before the bare-tag pass below — otherwise
+    // only the src payload is consumed and the empty <img> stays behind as a
+    // broken-image icon.
+    html = html.replace(IMG_SRC_GEN_ELEMENT_REGEX, (match) => {
+      const pending = parseImagePendingElement(match);
+      if (!pending) return match;
+      const id = this._ph('IG_', imgBlocks.length, true);
+      imgBlocks.push({ type: 'gen', instruction: pending.instruction });
       return '\n\n' + id + '\n\n';
     });
     html = html.replace(/\[IMG:GEN(?::(.*?))?\]/g, (match, instruction) => {
@@ -653,9 +727,16 @@ export class Formatter {
       }
       if (block.type === 'gen') {
         const start = Date.now();
-        const prompt = this._escapeHtml(this._imgPrompt(block.instruction));
+        // A pending block that carried images through a regeneration spells its
+        // payload `@paths|instruction`; reading it here keeps the prompt line
+        // showing the prompt instead of the path list in front of it.
+        const pending = parseImagePendingPayload(block.instruction);
+        const prompt = this._escapeHtml(this._imgPrompt(pending.instruction));
         const promptEl = prompt ? `<div class="imggen-loading-prompt">${prompt}</div>` : '';
-        return `<div class="imggen-loading" data-start="${start}" data-img-index="${at}"><span class="imggen-loading-hint">Generating image…</span><span class="imggen-loading-timer" data-start="${start}">0.0s</span><button class="imggen-stop-btn" type="button" data-action="img-stop" title="Stop image generation">⏹</button>${promptEl}</div>`;
+        // The children are moved into a shadow root of the placeholder's own by
+        // `isolateImgGenPlaceholders` right after insertion, which is what keeps
+        // message CSS from restyling them (see renderer/imggen_placeholder.js).
+        return `<div class="imggen-loading" data-start="${start}" data-img-index="${at}"><span class="imggen-loading-hint">Generating image…</span><span class="imggen-loading-timer" data-start="${start}">0.0s</span><button class="imggen-stop-btn" type="button" data-action="img-stop" title="Stop image generation" aria-label="Stop image generation">${STOP_SVG}</button>${promptEl}</div>`;
       }
       if (block.type === 'error') {
         let errorMsg = 'Unknown error';

--- a/assets/chat_webview/renderer/imggen_placeholder.js
+++ b/assets/chat_webview/renderer/imggen_placeholder.js
@@ -70,7 +70,8 @@ const PLACEHOLDER_CSS = `
     gap: 6px;
     padding: 12px 44px 0 12px;
   }
-  .imggen-loading-hint {
+  .imggen-loading-hint,
+  .imggen-queued-hint {
     font-size: 14px;
     font-weight: 600;
     opacity: 0.9;
@@ -81,6 +82,16 @@ const PLACEHOLDER_CSS = `
     opacity: 0.65;
     font-variant-numeric: tabular-nums;
   }
+  /* Queued: the reply is still streaming, or post-gen has not reached the
+     image stage yet, so nothing is generating (INV-IG1). Neither an elapsed
+     time nor a Stop button means anything here — the timer would count a wait
+     that is not the generation's, and the button would cancel a token that
+     does not exist yet. */
+  .imggen-queued-hint { display: none; }
+  :host(.imggen-queued) .imggen-loading-hint,
+  :host(.imggen-queued) .imggen-loading-timer,
+  :host(.imggen-queued) .imggen-stop-btn { display: none; }
+  :host(.imggen-queued) .imggen-queued-hint { display: inline; }
   .imggen-stop-btn {
     position: absolute;
     top: 8px;
@@ -174,7 +185,67 @@ const THEME_VARIABLE = '--text-color';
 const PINNED_FOREGROUND = '--imggen-fg';
 
 /** Children that belong on the placeholder's header row, in that order. */
-const HEAD_CLASSES = ['imggen-loading-hint', 'imggen-loading-timer'];
+const HEAD_CLASSES = [
+  'imggen-loading-hint',
+  'imggen-queued-hint',
+  'imggen-loading-timer',
+];
+
+/** Marks a block that is waiting its turn rather than generating. */
+const QUEUED_CLASS = 'imggen-queued';
+
+/**
+ * Whether a pending block is waiting rather than generating.
+ *
+ * `isGeneratingImage` is the image stage, and that stage is the only thing
+ * that ever generates from an `[IMG:GEN…]` tag: `ImageGenProcessor` raises the
+ * flag before it dispatches the first block of a message and drops it after
+ * the last, on the pipeline path and on every manual retry alike. So the block
+ * is live exactly while the flag is up — and queued for the whole reply
+ * stream, the post-gen work before the image stage (with Studio on the cleaner
+ * runs first and takes seconds), and any block simply left pending.
+ *
+ * Reading one flag rather than inferring from `isGenerating` also means there
+ * is no window between the stream ending and post-gen taking its hold where a
+ * block would flicker into a running state it is not in.
+ */
+function isQueued() {
+  const bridge = window.bridge;
+  if (!bridge) return false;
+  return !bridge.isGeneratingImage;
+}
+
+/**
+ * Re-reads the generation flags and restamps the placeholders on screen.
+ *
+ * Called by the bridge whenever a flag changes, because the transition can
+ * happen with no re-render at all: the reply's last chunk is already painted
+ * when the stream ends. The restamp matters as much as the class — `data-start`
+ * was written when the block was *rendered*, so a block that waited out a long
+ * reply would otherwise jump straight to "48.2s" the moment it goes live.
+ */
+export function refreshImgGenPlaceholderState() {
+  const queued = isQueued();
+  for (const host of document.querySelectorAll('.message-content')) {
+    const root = host.shadowRoot;
+    if (!root) continue;
+    for (const block of root.querySelectorAll('.imggen-loading')) {
+      const wasQueued = block.classList.contains(QUEUED_CLASS);
+      if (wasQueued === queued) continue;
+      block.classList.toggle(QUEUED_CLASS, queued);
+      if (!queued) restartTimer(block);
+    }
+  }
+}
+
+/** Starts the elapsed clock from now, so it measures the generation itself. */
+function restartTimer(block) {
+  const root = block.shadowRoot || block;
+  const timer = root.querySelector('.imggen-loading-timer');
+  if (!timer) return;
+  timer.dataset.start = String(Date.now());
+  timer.textContent = '0.0s';
+}
 
 /**
  * Moves every `.imggen-loading` placeholder under [root] into a shadow root of
@@ -228,6 +299,13 @@ function isolateOne(host) {
     host.style.setProperty(property, value, 'important');
   }
   pinForeground(host);
+  // A freshly rendered block starts in whichever state the flags describe; a
+  // render during streaming must not paint a running one for a frame.
+  if (isQueued()) {
+    host.classList.add(QUEUED_CLASS);
+  } else {
+    restartTimer(host);
+  }
 }
 
 function pinForeground(host) {

--- a/assets/chat_webview/renderer/imggen_placeholder.js
+++ b/assets/chat_webview/renderer/imggen_placeholder.js
@@ -1,0 +1,244 @@
+/* Isolates the "generating image" placeholder from message CSS.
+ *
+ * A message body is authored content: cards ship their own `<style>` blocks,
+ * and those rules land in the same shadow root as everything the formatter
+ * renders. A card that styles `div`, `button` or `*` therefore restyles the
+ * loading placeholder too — and because a card's rules can carry `!important`,
+ * no amount of specificity in `SHADOW_STYLE` wins that fight. The placeholder
+ * is app chrome, not part of the reply, so it must look the same in every chat.
+ *
+ * The fix is a boundary rather than a specificity war: each `.imggen-loading`
+ * becomes a shadow host of its own and its content moves inside, where message
+ * rules cannot reach. Two leaks are closed by hand:
+ *
+ *  - the host element itself still lives in the message tree, so the geometry
+ *    that keeps the block visible is pinned as inline `!important` (inline
+ *    `!important` outranks a stylesheet's);
+ *  - inherited properties (font, colour, spacing) cross a shadow boundary, so
+ *    the wrapper inside starts from `all: initial` and sets its own.
+ *
+ * The shadow root is open, which is what keeps the rest of the WebView working
+ * unchanged: click dispatch already walks `composedPath()` (it pierces shadow
+ * boundaries), and `ImgGenTimer` descends into the nested root for its ticker.
+ */
+
+/** Styles for the placeholder's own shadow tree. Message CSS cannot reach it. */
+const PLACEHOLDER_CSS = `
+  :host { display: block; }
+  .imggen-root {
+    /* Cuts every inherited property off at the boundary, so a card's
+       font-size / color / letter-spacing stops here. Custom properties are
+       exempt from \`all\`, which is what lets the pinned theme colour below
+       still reach in. */
+    all: initial;
+    display: block;
+    position: relative;
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 120px;
+    border-radius: 12px;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    font-size: 14px;
+    line-height: 1.4;
+    color: var(--imggen-fg, #e0e0e0);
+    text-align: left;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  /* Grey on grey rather than a white sheen: the same shimmer has to read on a
+     light theme and a dark one, and the block no longer inherits either. */
+  .imggen-surface {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    border-radius: inherit;
+    background-color: rgba(128, 128, 128, 0.12);
+    background-image: linear-gradient(90deg,
+      rgba(128, 128, 128, 0.00) 25%,
+      rgba(128, 128, 128, 0.16) 50%,
+      rgba(128, 128, 128, 0.00) 75%);
+    background-size: 200% 100%;
+    animation: imggen-shimmer 1.5s infinite linear;
+    pointer-events: none;
+  }
+  .imggen-head {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 12px 44px 0 12px;
+  }
+  .imggen-loading-hint {
+    font-size: 14px;
+    font-weight: 600;
+    opacity: 0.9;
+  }
+  .imggen-loading-timer {
+    font-size: 14px;
+    font-weight: 600;
+    opacity: 0.65;
+    font-variant-numeric: tabular-nums;
+  }
+  .imggen-stop-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 2;
+    width: 26px;
+    height: 26px;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.55);
+    color: #fff;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .imggen-stop-btn:active { background: rgba(0, 0, 0, 0.8); }
+  .imggen-stop-btn svg {
+    width: 14px;
+    height: 14px;
+    fill: currentColor;
+    pointer-events: none;
+  }
+  .imggen-loading-prompt {
+    position: absolute;
+    z-index: 1;
+    bottom: 10px;
+    left: 10px;
+    right: 10px;
+    font-size: 11px;
+    line-height: 1.4;
+    opacity: 0.6;
+    max-height: 2.8em;
+    overflow: hidden;
+    transition: max-height 0.25s ease;
+    word-break: break-word;
+  }
+  /* Tapping the block opens the full prompt; the class lands on the host. */
+  :host(.expanded) .imggen-loading-prompt {
+    top: 44px;
+    max-height: calc(100% - 54px);
+    overflow-y: auto;
+  }
+  @keyframes imggen-shimmer {
+    0% { background-position: 100% 0; }
+    100% { background-position: -100% 0; }
+  }
+`;
+
+/* Geometry pinned on the host, where message rules still apply. Inline
+ * `!important` is the one declaration a message stylesheet cannot outrank, so
+ * these are the properties a card must not be able to take away: the ones that
+ * would hide the block outright, and the box the shadow tree is laid out in.
+ * Painting is left to `.imggen-surface` inside, hence the transparent host. */
+const HOST_STYLE = [
+  ['display', 'block'],
+  ['position', 'relative'],
+  ['box-sizing', 'border-box'],
+  ['inset', 'auto'],
+  ['width', 'auto'],
+  ['max-width', '100%'],
+  ['height', 'auto'],
+  ['min-height', '120px'],
+  ['max-height', 'none'],
+  ['margin', '8px 0'],
+  ['padding', '0'],
+  ['border', '0'],
+  ['border-radius', '12px'],
+  ['overflow', 'hidden'],
+  ['background', 'transparent'],
+  ['box-shadow', 'none'],
+  ['animation', 'none'],
+  ['transform', 'none'],
+  ['filter', 'none'],
+  ['clip-path', 'none'],
+  ['mix-blend-mode', 'normal'],
+  ['float', 'none'],
+  ['opacity', '1'],
+  ['visibility', 'visible'],
+  ['pointer-events', 'auto'],
+  ['cursor', 'pointer'],
+];
+
+/* The one thing that *should* reach in: the app's own text colour, so the
+ * placeholder reads on a light theme as well as a dark one. Custom properties
+ * survive `all: initial`, and pinning the value the app set on the document
+ * keeps a card from redefining it out from under the block. */
+const THEME_VARIABLE = '--text-color';
+const PINNED_FOREGROUND = '--imggen-fg';
+
+/** Children that belong on the placeholder's header row, in that order. */
+const HEAD_CLASSES = ['imggen-loading-hint', 'imggen-loading-timer'];
+
+/**
+ * Moves every `.imggen-loading` placeholder under [root] into a shadow root of
+ * its own. Idempotent: a placeholder that already has one is left alone, so
+ * calling this after every render costs one query on an unchanged message.
+ */
+export function isolateImgGenPlaceholders(root) {
+  if (!root || !root.querySelectorAll) return;
+  for (const host of root.querySelectorAll('.imggen-loading')) {
+    if (host.shadowRoot) continue;
+    try {
+      isolateOne(host);
+    } catch (_) {
+      // attachShadow refuses a host that already has one, and older engines
+      // may refuse it outright. The block then renders from SHADOW_STYLE's
+      // fallback rules — plainer, but never missing.
+    }
+  }
+}
+
+function isolateOne(host) {
+  const shadow = host.attachShadow({ mode: 'open' });
+
+  const wrapper = host.ownerDocument.createElement('div');
+  wrapper.className = 'imggen-root';
+
+  const surface = host.ownerDocument.createElement('div');
+  surface.className = 'imggen-surface';
+  wrapper.appendChild(surface);
+
+  const head = host.ownerDocument.createElement('div');
+  head.className = 'imggen-head';
+  wrapper.appendChild(head);
+
+  // The formatter emits the hint, the timer, the stop button and the prompt as
+  // flat siblings; the header row is assembled here so the nested stylesheet
+  // has a box to lay the first two out in.
+  for (const child of Array.from(host.childNodes)) {
+    const className = child.nodeType === 1 ? child.className : '';
+    const inHead = typeof className === 'string' &&
+      HEAD_CLASSES.some((name) => className.split(/\s+/).includes(name));
+    (inHead ? head : wrapper).appendChild(child);
+  }
+
+  const style = host.ownerDocument.createElement('style');
+  style.textContent = PLACEHOLDER_CSS;
+  shadow.appendChild(style);
+  shadow.appendChild(wrapper);
+
+  for (const [property, value] of HOST_STYLE) {
+    host.style.setProperty(property, value, 'important');
+  }
+  pinForeground(host);
+}
+
+function pinForeground(host) {
+  let color = '';
+  try {
+    color = getComputedStyle(host.ownerDocument.documentElement)
+      .getPropertyValue(THEME_VARIABLE)
+      .trim();
+  } catch (_) {
+    // No computed style to read (a detached tree): the stylesheet's own
+    // fallback colour stands in.
+  }
+  if (color) host.style.setProperty(PINNED_FOREGROUND, color, 'important');
+}

--- a/assets/chat_webview/renderer/macros_in_message.js
+++ b/assets/chat_webview/renderer/macros_in_message.js
@@ -1,3 +1,3 @@
-export function formatMessageBody(formatter, text, isUser) {
-  return formatter.format(text || '', isUser);
+export function formatMessageBody(formatter, text, isUser, isReasoning = false) {
+  return formatter.format(text || '', isUser, isReasoning);
 }

--- a/assets/chat_webview/renderer/markdown.js
+++ b/assets/chat_webview/renderer/markdown.js
@@ -38,6 +38,7 @@ export function writeShadowContent({
   searchQuery,
   applySearchHighlight,
   allowMessageScripts = false,
+  isReasoning = false,
 }) {
   if (!host || !host.shadowRoot) return;
   const root = host.shadowRoot.querySelector('.glaze-message');
@@ -47,7 +48,7 @@ export function writeShadowContent({
       root.innerHTML = '';
       return;
     }
-    let formatted = formatMessageBody(formatter, text, isUser);
+    let formatted = formatMessageBody(formatter, text, isUser, isReasoning);
     if (searchQuery) formatted = applySearchHighlight(formatted);
     if (!allowMessageScripts && SCRIPT_TAG.test(formatted)) {
       notifyMessageScriptBlocked();

--- a/assets/chat_webview/renderer/markdown.js
+++ b/assets/chat_webview/renderer/markdown.js
@@ -1,6 +1,7 @@
 import { syncCodeBlockMetadata } from './code_highlight.js';
 import { formatMessageBody } from './macros_in_message.js';
 import { reportCssErrors } from './css_diagnostics.js';
+import { isolateImgGenPlaceholders } from './imggen_placeholder.js';
 import { sanitizeMessageHtml } from '../bridge/html_sanitizer.js';
 
 /** Cheap pre-sanitize probe for an embedded `<script>` in formatted HTML. */
@@ -58,6 +59,9 @@ export function writeShadowContent({
     root.innerHTML = sanitizeMessageHtml(formatted, {
       allowScripts: allowMessageScripts,
     });
+    // Before anything else touches the tree: the placeholder's content moves
+    // behind a shadow boundary, out of reach of the message's own CSS.
+    isolateImgGenPlaceholders(root);
     syncCodeBlockMetadata(root);
     // A reply still arriving is half a stylesheet, and every unclosed brace in
     // it is on its way to being closed — report only what the message settled

--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -1,6 +1,7 @@
 import { reportCssErrors } from './css_diagnostics.js';
 import { ICON } from './icon_library.js';
 import { createImageAttachment, setImageAttachmentHidden } from './image_embed.js';
+import { isolateImgGenPlaceholders } from './imggen_placeholder.js';
 import { writeShadowContent } from './markdown.js';
 import { sanitizeMessageHtml } from '../bridge/html_sanitizer.js';
 import {
@@ -1090,6 +1091,10 @@ if (messageData.isEditing) classes.push('editing');
               allowScripts: this.allowMessageScripts,
             });
             root.querySelectorAll('script').forEach(script => script.remove());
+            // The rewrite dropped the placeholders' shadow roots with the rest
+            // of the body; re-isolate so a search pass cannot expose them to
+            // the message stylesheet.
+            isolateImgGenPlaceholders(root);
             // The rewrite dropped the CSS report with the rest of the body;
             // put it back so searching does not hide a broken stylesheet.
             if (!window.bridge?.isGenerating) reportCssErrors(root);

--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -316,7 +316,7 @@ if (messageData.isEditing) classes.push('editing');
 
     const shadowHost = this._createContentContainer();
     inner.appendChild(shadowHost);
-    this._writeShadowContent(shadowHost, reasoning, isUser, false);
+    this._writeShadowContent(shadowHost, reasoning, isUser, false, true);
 
     wrap.appendChild(inner);
     content.appendChild(wrap);
@@ -650,12 +650,15 @@ if (messageData.isEditing) classes.push('editing');
     return host;
   }
 
-  _writeShadowContent(host, text, isUser, isTyping) {
+  // [isReasoning] marks the split-out `message.reasoning` panel: the same
+  // formatter, but image tags there stay text (INV-IG11).
+  _writeShadowContent(host, text, isUser, isTyping, isReasoning = false) {
     writeShadowContent({
       host,
       text,
       isUser,
       isTyping,
+      isReasoning,
       formatter: this.formatter,
       searchQuery: this.searchQuery,
       applySearchHighlight: (html) => this._applySearchHighlight(html),
@@ -688,7 +691,7 @@ if (messageData.isEditing) classes.push('editing');
             let reasoningEl = sectionEl.querySelector('.msg-reasoning');
             if (reasoningEl) {
               const rHost = reasoningEl.querySelector('.msg-reasoning-inner .message-content');
-              if (rHost) this._writeShadowContent(rHost, reasoning, isUser, false);
+              if (rHost) this._writeShadowContent(rHost, reasoning, isUser, false, true);
             }
           }
           return;
@@ -726,7 +729,7 @@ if (messageData.isEditing) classes.push('editing');
         contentStack.insertBefore(reasoningEl, contentStack.firstChild);
       } else {
         const host = reasoningEl.querySelector('.msg-reasoning-inner .message-content');
-        if (host) this._writeShadowContent(host, reasoning, isUser, false);
+        if (host) this._writeShadowContent(host, reasoning, isUser, false, true);
       }
     } else if (reasoningEl) {
       reasoningEl.remove();
@@ -1020,7 +1023,7 @@ if (messageData.isEditing) classes.push('editing');
 
       const reasoningHost = section.querySelector('.msg-reasoning-inner .message-content');
       if (reasoningHost) {
-        this._writeShadowContent(reasoningHost, section.dataset.reasoning || '', isUser, false);
+        this._writeShadowContent(reasoningHost, section.dataset.reasoning || '', isUser, false, true);
       }
 
       const bodyHost = section.querySelector('.msg-body .message-content');
@@ -1077,11 +1080,11 @@ if (messageData.isEditing) classes.push('editing');
       if (!section) return;
       const isUser = section.classList.contains('user');
       
-      const processHost = (host, rawText) => {
+      const processHost = (host, rawText, isReasoning = false) => {
         if (host && host.shadowRoot) {
           const root = host.shadowRoot.querySelector('.glaze-message');
           if (root) {
-            const formatted = this.formatter.format(rawText, isUser);
+            const formatted = this.formatter.format(rawText, isUser, isReasoning);
             const prevMatchIndex = globalState.matchIndex;
             const highlighted = this._applySearchHighlight(formatted, globalState);
             // Same policy as a normal render (see writeShadowContent), so a
@@ -1108,7 +1111,7 @@ if (messageData.isEditing) classes.push('editing');
 
       const reasoningHost = section.querySelector('.msg-reasoning-inner .message-content');
       if (reasoningHost) {
-        processHost(reasoningHost, section.dataset.reasoning || '');
+        processHost(reasoningHost, section.dataset.reasoning || '', true);
       }
 
       const bodyHost = section.querySelector('.msg-body .message-content');

--- a/assets/chat_webview/renderer/shadow_style.js
+++ b/assets/chat_webview/renderer/shadow_style.js
@@ -107,7 +107,11 @@ export const SHADOW_STYLE = `
   .glaze-message .janitor-options-btn svg,
   .glaze-message .imggen-options-btn svg { width: 16px; height: 16px; fill: #fff; pointer-events: none; }
 
-  /* ── Imagen: loading shimmer ── */
+  /* ── Imagen: loading shimmer ──
+     Fallback only. The placeholder moves its content into a shadow root of its
+     own right after insertion (renderer/imggen_placeholder.js), so message CSS
+     cannot restyle it; these rules are what paints the block on an engine that
+     refuses attachShadow. */
   .glaze-message .imggen-loading {
     display: block;
     max-width: 100%;
@@ -161,6 +165,7 @@ export const SHADOW_STYLE = `
     z-index: 3;
   }
   .glaze-message .imggen-stop-btn:active { background: rgba(0,0,0,0.8); }
+  .glaze-message .imggen-stop-btn svg { width: 14px; height: 14px; fill: currentColor; pointer-events: none; }
   .glaze-message .imggen-loading-prompt {
     position: absolute;
     bottom: 10px;

--- a/assets/chat_webview/renderer/shadow_style.js
+++ b/assets/chat_webview/renderer/shadow_style.js
@@ -165,6 +165,18 @@ export const SHADOW_STYLE = `
     z-index: 3;
   }
   .glaze-message .imggen-stop-btn:active { background: rgba(0,0,0,0.8); }
+  .glaze-message .imggen-queued-hint { display: none; }
+  .glaze-message .imggen-loading.imggen-queued .imggen-loading-hint,
+  .glaze-message .imggen-loading.imggen-queued .imggen-loading-timer,
+  .glaze-message .imggen-loading.imggen-queued .imggen-stop-btn { display: none; }
+  .glaze-message .imggen-loading.imggen-queued .imggen-queued-hint {
+    display: inline-block;
+    padding: 12px 0 0 12px;
+    font-size: 14px;
+    font-weight: 600;
+    color: rgba(255,255,255,0.9);
+    user-select: none;
+  }
   .glaze-message .imggen-stop-btn svg { width: 14px; height: 14px; fill: currentColor; pointer-events: none; }
   .glaze-message .imggen-loading-prompt {
     position: absolute;

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -161,7 +161,28 @@ A finished block is written by `ImageTagMarkup.encodeResultElement()` only:
   `scanPendingTags()` and `scanResultElements()` from ever claiming the same
   element (`ImgGenPatterns.isPendingIigElement`).
 * the WebView formatter parses the element with `parseImageResultElement()`,
-  the mirror of the Dart writer.
+  the mirror of the Dart writer, and a pending one with
+  `parseImagePendingElement()`. Both spellings of a pending element
+  (`<img data-iig-instruction… src="[IMG:GEN]">` and the bare
+  `<img src="[IMG:GEN:…]">`) are consumed **whole** and rendered as the loading
+  placeholder. Leaving the tag in the markup would put an `<img>` with no
+  loadable source into the message, and the reader would watch the browser's
+  broken-image icon for the length of the generation.
+
+### INV-IG10: The loading placeholder is sealed off from message CSS
+
+A message body is authored content — cards ship their own `<style>`, and those
+rules land in the same shadow root as everything the formatter renders. The
+`[IMG:GEN…]` placeholder is app chrome, so
+`renderer/imggen_placeholder.js` gives each `.imggen-loading` a shadow root of
+its own and moves its content inside, out of reach of message rules that a
+specificity war could never win (a card's `!important` beats any selector in
+`SHADOW_STYLE`). Two leaks are closed by hand: the host still lives in the
+message tree, so its geometry is pinned as inline `!important`; and inherited
+properties cross a shadow boundary, so the wrapper inside starts from
+`all: initial`. The nested root is **open** — `InteractionDispatch` finds the
+stop button through `composedPath()` and `ImgGenTimer` descends into it for the
+elapsed-time ticker, both of which a closed root would break.
 
 ### INV-IG7: Regenerating an image never adds a message swipe
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -82,7 +82,23 @@ runs against that committed result. With Studio enabled it awaits
 processes image tags, so images bind to the selected final/cleaned/partial
 swipe. It never runs concurrently with text generation. `continueMessage()`
 uses the same pipeline and post-generation coordinator, bound to the merged
-message — see INV-CM2.
+message — see INV-CM2. An errored stream returns before post-gen, and an abort
+bumps `AbortHandler`'s gen id so every stage bails, so neither reaches the
+image stage at all.
+
+The WebView says the same thing. `ChatState.isGeneratingImage` is raised by
+`ImageGenProcessor` before it dispatches the first block of a message and
+dropped after the last — on the pipeline path and on every manual retry — and
+it reaches the page through `bridge.setImageGenerating()`. A pending block is
+rendered *queued* whenever that flag is down: no elapsed clock (nothing is
+elapsing), no Stop button (there is no `_imgGenCancelToken` to cancel yet), and
+a label that says so. That covers the whole reply stream and the post-gen work
+before the image stage, which with Studio on runs the cleaner first and can
+take seconds. The flip carries no re-render of its own — the reply's last chunk
+is already painted — so `refreshImgGenPlaceholderState()` restamps the blocks
+on screen, and restamps `data-start` with them: the clock was stamped when the
+block was *rendered*, so without that a block that waited out a long reply
+would jump straight to "48.2s" the moment it went live.
 
 ### INV-IG2: Image generation has independent abort infrastructure
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -184,6 +184,32 @@ properties cross a shadow boundary, so the wrapper inside starts from
 stop button through `composedPath()` and `ImgGenTimer` descends into it for the
 elapsed-time ticker, both of which a closed root would break.
 
+### INV-IG11: A tag inside a reasoning block never generates
+
+A model plans its images out loud — "then I'll put `[IMG:GEN:…]` here" — and a
+tag it writes inside `<think>…</think>` is a note to itself, not a request.
+Generating from it produces a picture nobody asked for, in the middle of the
+model's own scratchpad.
+
+`ImgGenPatterns.reasoningSpans()` marks those spans and
+`ImageTagMarkup.scanPendingTags()` walks past them. That scan is the single
+gate every generation goes through — `hasImageGenTags`, `scanImageBlocks`, the
+replace/reset helpers and `ImageGenProcessor` all read a message through it —
+so a reasoning tag is never generated, never rewritten into an error or
+"disabled" card, and never counted in the block numbering.
+
+The WebView agrees on both halves, which is what keeps `data-img-index`
+addressing the same block on either side: `_processText` carries an
+`inReasoning` flag into the recursive pass over a think block, and the three
+pending spellings there are restored as the literal text the model wrote (step
+19b) instead of becoming an image block. Only a **closed** block counts as
+reasoning, on both sides — an unclosed `<think>` is not folded away by the
+formatter either, so a tag after one still generates.
+
+Finished `<img data-iig-…>` blocks are deliberately *not* filtered: they are
+pictures that already exist, and `scanResultElements()` is what keeps their
+paths resolving and strips them from a sync payload.
+
 ### INV-IG7: Regenerating an image never adds a message swipe
 
 `ImageRecoveryService` resets the retried blocks through

--- a/lib/core/constants/image_gen_patterns.dart
+++ b/lib/core/constants/image_gen_patterns.dart
@@ -66,6 +66,37 @@ class ImgGenPatterns {
     r'''|([^\s"'>]*))''',
   );
 
+  /// A folded-away reasoning block: `<think>…</think>` and
+  /// `<thinking>…</thinking>`, the shapes the WebView formatter matches (see
+  /// `formatter.js` step 1a). Only a *closed* block counts, exactly as it does
+  /// there — an unclosed tag is not yet a reasoning block on either side.
+  static final reasoningBlockRegex = RegExp(
+    r'<(think|thinking)\b[\s\S]*?<\/\1\b[^>]*(?:>|$)',
+    caseSensitive: false,
+  );
+
+  /// Cheap probe: most messages carry no reasoning at all, and the scan below
+  /// only has to run for the ones that do.
+  static final _reasoningProbe = RegExp('<think', caseSensitive: false);
+
+  /// Character spans of [text] covered by a reasoning block, in document order.
+  ///
+  /// A model plans its images out loud — "then I'll put [IMG:GEN:…] here" — and
+  /// a tag written inside its own reasoning is a note to itself, not a request.
+  /// Generating from it produces a picture nobody asked for, so every scan that
+  /// can start a generation walks past these spans (INV-IG11).
+  static List<(int, int)> reasoningSpans(String text) {
+    if (!_reasoningProbe.hasMatch(text)) return const [];
+    return [
+      for (final match in reasoningBlockRegex.allMatches(text))
+        (match.start, match.end),
+    ];
+  }
+
+  /// Whether `[start, end)` falls in any of [spans].
+  static bool overlapsSpan(List<(int, int)> spans, int start, int end) =>
+      spans.any((span) => start < span.$2 && span.$1 < end);
+
   /// Whether an `<img …data-iig-instruction…>` element is still waiting for its
   /// image: it has no `src`, or only the `[IMG:GEN…]` placeholder in it. The
   /// same element with a stored image path in its `src` is the finished form.

--- a/lib/features/chat/widgets/chat_webview_initializer.dart
+++ b/lib/features/chat/widgets/chat_webview_initializer.dart
@@ -224,7 +224,7 @@ class ChatWebViewInitializer {
         'if (window.bridge) { '
         'window.bridge.setGenerating(${input.isGenerating}); '
         'window.bridge.setPostGenRunning(${input.isPostGenRunning}); '
-        'window.bridge.isGeneratingImage = ${input.isGeneratingImage}; '
+        'window.bridge.setImageGenerating(${input.isGeneratingImage}); '
         '}',
       ),
     );

--- a/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
+++ b/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
@@ -442,7 +442,7 @@ class ChatWebViewSyncDispatcher {
       'if (window.bridge) { '
       'window.bridge.setGenerating(${current.isGenerating}); '
       'window.bridge.setPostGenRunning(${current.isPostGenRunning}); '
-      'window.bridge.isGeneratingImage = ${current.isGeneratingImage}; '
+      'window.bridge.setImageGenerating(${current.isGeneratingImage}); '
       '}',
     );
 

--- a/lib/features/image_gen/services/image_tag_markup.dart
+++ b/lib/features/image_gen/services/image_tag_markup.dart
@@ -256,11 +256,20 @@ class ImageTagMarkup {
   /// HTML forms win over the bare `[IMG:GEN…]` they wrap, so an
   /// `<img data-iig-instruction='…' src="[IMG:GEN]">` counts once and is
   /// replaced as a whole element.
+  ///
+  /// A tag inside a reasoning block is skipped (INV-IG11): the model writing
+  /// "then I'll put [IMG:GEN:…] here" while it thinks is planning aloud, not
+  /// asking for a picture. This is the single gate every generation goes
+  /// through — [hasImageGenTags], [scanImageBlocks], the replace/reset helpers
+  /// and `ImageGenProcessor` all read the message through it — so a reasoning
+  /// tag is not generated, not turned into an error card, and not counted in
+  /// the block numbering the WebView addresses.
   static List<PendingImageTag> scanPendingTags(String text) {
     if (!text.contains('[IMG:GEN') && !text.contains('data-iig-instruction')) {
       return const [];
     }
 
+    final reasoning = ImgGenPatterns.reasoningSpans(text);
     final tags = <PendingImageTag>[];
     bool overlapsExisting(int start, int end) =>
         tags.any((tag) => start < tag.end && tag.start < end);
@@ -272,6 +281,9 @@ class ImageTagMarkup {
     }) {
       for (final match in pattern.allMatches(text)) {
         if (overlapsExisting(match.start, match.end)) continue;
+        if (ImgGenPatterns.overlapsSpan(reasoning, match.start, match.end)) {
+          continue;
+        }
         if (accept != null && !accept(match.group(0)!)) continue;
         tags.add(
           PendingImageTag(match.start, match.end, payloadOf(match) ?? ''),

--- a/test/chat_webview_sync_dispatcher_test.dart
+++ b/test/chat_webview_sync_dispatcher_test.dart
@@ -372,6 +372,13 @@ void main() {
         expect(bridge.lastMessageIds, ['a1']);
         expect(bridge.evalCalls.single, contains('setGenerating(false)'));
         expect(bridge.evalCalls.single, contains('setPostGenRunning(true)'));
+        // The image stage flag goes through a setter, not a bare assignment:
+        // it is what tells a pending block apart from a running one, and the
+        // WebView has to restamp its placeholders when it flips (INV-IG1).
+        expect(
+          bridge.evalCalls.single,
+          contains('setImageGenerating(false)'),
+        );
       },
     );
 

--- a/test/image_gen_patterns_test.dart
+++ b/test/image_gen_patterns_test.dart
@@ -153,5 +153,42 @@ void main() {
         );
       });
     });
+
+    group('reasoningSpans', () {
+      test('covers <think> and <thinking>, whatever the case', () {
+        expect(ImgGenPatterns.reasoningSpans('a <think>x</think> b'), [
+          (2, 18),
+        ]);
+        expect(ImgGenPatterns.reasoningSpans('<thinking>x</thinking>'), [
+          (0, 22),
+        ]);
+        expect(ImgGenPatterns.reasoningSpans('<THINK>x</THINK>'), [(0, 16)]);
+      });
+
+      test('stops at the first close, so two blocks stay two', () {
+        expect(
+          ImgGenPatterns.reasoningSpans('<think>a</think> mid <think>b</think>'),
+          [(0, 16), (21, 37)],
+        );
+      });
+
+      test('an unclosed block is not a span', () {
+        // The WebView formatter folds a block only once it closes; a tag after
+        // an unterminated <think> still belongs to the message (INV-IG11).
+        expect(ImgGenPatterns.reasoningSpans('<think>drafting'), isEmpty);
+      });
+
+      test('text with no reasoning costs nothing', () {
+        expect(ImgGenPatterns.reasoningSpans('plain [IMG:GEN]'), isEmpty);
+      });
+
+      test('overlapsSpan is true for any intersection', () {
+        const spans = [(10, 20)];
+        expect(ImgGenPatterns.overlapsSpan(spans, 12, 15), isTrue);
+        expect(ImgGenPatterns.overlapsSpan(spans, 5, 12), isTrue);
+        expect(ImgGenPatterns.overlapsSpan(spans, 0, 10), isFalse);
+        expect(ImgGenPatterns.overlapsSpan(spans, 20, 25), isFalse);
+      });
+    });
   });
 }

--- a/test/image_gen_service_test.dart
+++ b/test/image_gen_service_test.dart
@@ -47,6 +47,48 @@ void main() {
       expect(ImageTagMarkup.hasImageGenTags(''), isFalse);
     });
 
+    test('ignores a tag inside a reasoning block', () {
+      // INV-IG11: a model planning "then I'll put [IMG:GEN:…] here" is talking
+      // to itself, not asking for a picture.
+      expect(
+        ImageTagMarkup.hasImageGenTags(
+          '<think>next I add [IMG:GEN:{"prompt":"cat"}] here</think>She smiled.',
+        ),
+        isFalse,
+      );
+      expect(
+        ImageTagMarkup.hasImageGenTags(
+          "<thinking>plan: <img data-iig-instruction='{\"prompt\":\"x\"}' "
+          'src="[IMG:GEN]"></thinking>Body.',
+        ),
+        isFalse,
+      );
+      expect(
+        ImageTagMarkup.hasImageGenTags(
+          '<THINK>maybe [IMG:GEN]</THINK> body',
+        ),
+        isFalse,
+      );
+    });
+
+    test('a tag outside the reasoning block still generates', () {
+      expect(
+        ImageTagMarkup.hasImageGenTags(
+          '<think>I will add one</think>Now: [IMG:GEN:{"prompt":"real"}]',
+        ),
+        isTrue,
+      );
+    });
+
+    test('an unclosed reasoning tag is not a reasoning block', () {
+      // The WebView formatter folds a block only once it closes, and the two
+      // sides have to agree on what counts as reasoning.
+      expect(
+        ImageTagMarkup.hasImageGenTags('<think>drafting [IMG:GEN]'),
+        isTrue,
+      );
+    });
+
     test('detects tag inside full HTML card', () {
       const html = """<div style="max-width:680px; padding:18px;">
   <img data-iig-instruction='{"style":"cinematic manga","prompt":"SCENE_PROMPT: test","aspect_ratio":"9:16","image_size":"1K"}' src="[IMG:GEN]" style="display:block; width:100%; border-radius:15px;">
@@ -485,6 +527,38 @@ void main() {
       );
       expect(result, contains('[IMG:RESULT:/one.png|{"prompt":"one"}]'));
       expect(result, contains('[IMG:GEN:{"prompt":"three"}]'));
+    });
+
+    test('a reasoning block is outside the numbering', () {
+      // The WebView renders a tag inside `<think>` as the text the model wrote
+      // and never allocates a data-img-index for it, so Dart must not count it
+      // either — otherwise a tap on the body's only picture addresses nothing.
+      const withReasoning =
+          '<think>first I will do [IMG:GEN:{"prompt":"planned"}]</think>'
+          'She smiled. [IMG:GEN:{"prompt":"real"}]';
+
+      final blocks = ImageTagMarkup.scanImageBlocks(withReasoning);
+      expect(blocks.map((b) => b.kind), [ImageBlockKind.pending]);
+      expect(blocks.single.asPendingTag, '[IMG:GEN:{"prompt":"real"}]');
+      expect(ImageTagMarkup.pendingImageGenTagCount(withReasoning), 1);
+    });
+
+    test('the reasoning block survives a generation untouched', () {
+      const withReasoning =
+          '<think>plan: [IMG:GEN:{"prompt":"planned"}]</think>'
+          'Body. [IMG:GEN:{"prompt":"real"}]';
+
+      final resolved = ImageTagMarkup.replaceImageBlockWithResult(
+        withReasoning,
+        0,
+        '/real.png',
+      );
+
+      expect(
+        resolved,
+        contains('<think>plan: [IMG:GEN:{"prompt":"planned"}]</think>'),
+      );
+      expect(resolved, contains('src="/real.png"'));
     });
 
     test('block numbering survives HTML tags that have not resolved yet', () {

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -1150,6 +1150,45 @@ void main() {
       expect(imgGenPlaceholderJs, contains('fill: currentColor'));
     });
 
+    test('a pending block reads as queued until the image stage runs', () {
+      // INV-IG1: generation starts only after the reply has finished
+      // streaming and post-gen reaches the image stage. Until then there is
+      // nothing to time and nothing to stop — a running placeholder would be
+      // a lie, and its Stop button would cancel a token that does not exist.
+      expect(formatterFormatterJs, contains('class="imggen-queued-hint"'));
+      expect(
+        imgGenPlaceholderJs,
+        contains('return !bridge.isGeneratingImage;'),
+        reason: 'the image stage flag is what makes a block live',
+      );
+      expect(
+        imgGenPlaceholderJs,
+        contains(':host(.imggen-queued) .imggen-loading-timer,'),
+      );
+      expect(
+        imgGenPlaceholderJs,
+        contains(':host(.imggen-queued) .imggen-stop-btn { display: none; }'),
+      );
+      // The clock has to measure the generation, not the wait before it: the
+      // block was stamped when it rendered, possibly a whole reply ago.
+      expect(
+        imgGenPlaceholderJs,
+        contains('function restartTimer(block)'),
+      );
+      expect(imgGenPlaceholderJs, contains("timer.dataset.start = String(Date.now())"));
+      // The flip carries no re-render of its own, so the bridge drives it.
+      expect(
+        bridgeControllerJs,
+        contains('refreshImgGenPlaceholderState()'),
+      );
+      expect(bridgeControllerJs, contains('setImageGenerating(value)'));
+      // A hidden clock must not hold the ticker's interval open.
+      expect(
+        imgGenTimerJs,
+        contains("block.classList.contains('imggen-queued')"),
+      );
+    });
+
     test('the loading placeholder is sealed off from message CSS', () {
       // A card ships its own <style>, and its rules — !important included —
       // land in the same shadow root as the placeholder. A boundary is the

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -1083,6 +1083,56 @@ void main() {
       expect(srcElementIdx, lessThan(bareTagIdx));
     });
 
+    test('a tag inside a reasoning block never becomes a block', () {
+      // INV-IG11: Dart does not generate from a tag the model wrote while
+      // thinking, so the WebView must not render a placeholder whose picture
+      // is never coming — nor allocate a data-img-index Dart does not count.
+      expect(
+        formatterFormatterJs,
+        contains('_processText(text, isUser, skipQuotes = false, '
+            'inReasoning = false)'),
+      );
+      // The reasoning body is the one recursive pass that sets the flag.
+      expect(
+        formatterFormatterJs,
+        contains('this._processText(content, isUser, false, true)'),
+      );
+      // All three pending spellings fall through to the inert text collector.
+      expect(
+        RegExp('if [(]inReasoning[)] return inertTag[(]match[)];')
+            .allMatches(formatterFormatterJs)
+            .length,
+        3,
+      );
+      // The split-out `message.reasoning` panel is reasoning too, and Dart
+      // never scans that field at all — so it renders with the same flag.
+      expect(
+        formatterFormatterJs,
+        contains(r'const key = `${text}:${isUser}:${inReasoning}`'),
+        reason: 'the format cache must not serve a body render to a '
+            'reasoning panel, or the other way round',
+      );
+      expect(
+        rendererMessageJs,
+        contains(
+          "this._writeShadowContent(shadowHost, reasoning, isUser, "
+          "false, true)",
+        ),
+      );
+      expect(
+        rendererJs,
+        contains('formatMessageBody(formatter, text, isUser, isReasoning)'),
+      );
+      // Restored as the literal text the model wrote, before the leak sweep.
+      final restoreIdx = formatterFormatterJs.indexOf(r'\x01IGT_(\d+)\x01');
+      final sweepIdx = formatterFormatterJs.indexOf(
+        r"html = html.replace(/\x01[A-Z_]+\d+\x01/g, '');",
+      );
+      expect(restoreIdx, isNonNegative);
+      expect(sweepIdx, isNonNegative);
+      expect(restoreIdx, lessThan(sweepIdx));
+    });
+
     test('the stop button is an SVG, not an emoji glyph', () {
       // ⏹ is a font-dependent emoji: a different size and colour on every
       // platform. A path takes `fill: currentColor` and stays put.

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -40,6 +40,8 @@ void main() {
   late String htmlSanitizerJs;
   late String cssDiagnosticsJs;
   late String cssSanitizerJs;
+  late String imgGenPlaceholderJs;
+  late String imgGenTimerJs;
   late String selectionManagerJs;
   late String swipeHandlerJs;
   late String glazeSdkJs;
@@ -68,6 +70,8 @@ void main() {
     interactionDispatchJs = _bridgeAsset('interaction_dispatch.js');
     panelHostJs = _bridgeAsset('panel_host.js');
     htmlSanitizerJs = _bridgeAsset('html_sanitizer.js');
+    imgGenPlaceholderJs = _rendererAsset('imggen_placeholder.js');
+    imgGenTimerJs = _bridgeAsset('imggen_timer.js');
     cssDiagnosticsJs = _rendererAsset('css_diagnostics.js');
     cssSanitizerJs = _bridgeAsset('css_sanitizer.js');
     selectionManagerJs = _bridgeAsset('selection_manager.js');
@@ -1048,6 +1052,91 @@ void main() {
       expect(rule, contains('height: 18px'));
       expect(rule, contains('opacity: 0.45'));
       expect(rule, contains('rgba(0, 0, 0, 0.38)'));
+    });
+
+    test('a block still waiting for its picture renders no <img>', () {
+      // An <img> whose src is the [IMG:GEN…] placeholder has nothing to load,
+      // so the only thing it can paint is the browser's broken-image glyph.
+      // Both stored spellings are pulled out as pending blocks instead.
+      expect(
+        formatterFormatterJs,
+        contains('export function parseImagePendingElement('),
+      );
+      expect(formatterFormatterJs, contains('IMG_SRC_GEN_ELEMENT_REGEX'));
+      expect(
+        RegExp(
+          r'html = html\.replace\(IIG_ELEMENT_REGEX[\s\S]*?'
+          r"imgBlocks\.push\(\{ type: 'gen'",
+        ).hasMatch(formatterFormatterJs),
+        isTrue,
+        reason: 'a pending stored element must render the loading placeholder',
+      );
+      // The bare `<img src="[IMG:GEN…]">` element has to be consumed whole,
+      // before the pass that would take only the payload out of its src.
+      final srcElementIdx =
+          formatterFormatterJs.indexOf('html.replace(IMG_SRC_GEN_ELEMENT_REGEX');
+      final bareTagIdx = formatterFormatterJs.indexOf(
+        r'html.replace(/\[IMG:GEN(?::(.*?))?\]/g',
+      );
+      expect(srcElementIdx, isNonNegative);
+      expect(bareTagIdx, isNonNegative);
+      expect(srcElementIdx, lessThan(bareTagIdx));
+    });
+
+    test('the stop button is an SVG, not an emoji glyph', () {
+      // ⏹ is a font-dependent emoji: a different size and colour on every
+      // platform. A path takes `fill: currentColor` and stays put.
+      expect(formatterFormatterJs, contains('const STOP_SVG ='));
+      expect(formatterFormatterJs, contains('<rect x="7" y="7"'));
+      final stopIdx = formatterFormatterJs.indexOf('class="imggen-stop-btn"');
+      expect(stopIdx, isNonNegative);
+      final button = formatterFormatterJs.substring(
+        stopIdx,
+        formatterFormatterJs.indexOf('</button>', stopIdx),
+      );
+      expect(button, contains(r'${STOP_SVG}'));
+      expect(button, isNot(contains('⏹')));
+      // The icon takes the button's colour instead of the font's.
+      expect(imgGenPlaceholderJs, contains('fill: currentColor'));
+    });
+
+    test('the loading placeholder is sealed off from message CSS', () {
+      // A card ships its own <style>, and its rules — !important included —
+      // land in the same shadow root as the placeholder. A boundary is the
+      // only thing that keeps app chrome looking like app chrome.
+      expect(
+        imgGenPlaceholderJs,
+        contains('export function isolateImgGenPlaceholders('),
+      );
+      expect(imgGenPlaceholderJs, contains("attachShadow({ mode: 'open' })"));
+      // Inherited properties cross a shadow boundary; `all: initial` stops
+      // them at the wrapper inside.
+      expect(imgGenPlaceholderJs, contains('all: initial'));
+      // The host still lives in the message tree, so its geometry is pinned
+      // with the one declaration a message stylesheet cannot outrank.
+      expect(
+        imgGenPlaceholderJs,
+        contains("host.style.setProperty(property, value, 'important')"),
+      );
+      // Both render paths re-isolate: a search pass rewrites innerHTML too.
+      expect(rendererJs, contains('isolateImgGenPlaceholders(root)'));
+      expect(
+        RegExp('isolateImgGenPlaceholders\\(root\\)')
+            .allMatches(rendererJs)
+            .length,
+        greaterThanOrEqualTo(2),
+      );
+    });
+
+    test('the elapsed timer reaches into the placeholder shadow root', () {
+      // The ticker's elements are one boundary deeper than the message body
+      // once the placeholder is isolated, so a flat query never sees them.
+      expect(imgGenTimerJs, contains('_updateIn(root, now)'));
+      expect(imgGenTimerJs, contains('block.shadowRoot'));
+      expect(
+        imgGenTimerJs,
+        contains(r"querySelectorAll('.imggen-loading')"),
+      );
     });
 
     test('a failed generated image re-requests itself', () {


### PR DESCRIPTION
Three independent fixes around the `[IMG:GEN…]` block in a message: what the placeholder looks like, what is allowed to start a generation, and when the block is allowed to claim it is generating.

## The loading placeholder is sealed off from message CSS

- Move each `.imggen-loading` into a shadow root of its own (new `renderer/imggen_placeholder.js`) and move its content inside. A card ships its own `<style>`, and those rules land in the same shadow root as everything the formatter renders — with `!important` on the card's side, no selector in `SHADOW_STYLE` can win. The placeholder is app chrome, so it needs a boundary, not more specificity.
- Close the two leaks a boundary does not: the host still lives in the message tree, so its geometry is pinned as inline `!important`; and inherited properties cross a shadow boundary, so the wrapper inside starts from `all: initial`.
- Keep the nested root **open** — `InteractionDispatch` finds the stop button through `composedPath()` and `ImgGenTimer` descends into it, both of which a closed root would break.
- Take the placeholder's text colour from the app's `--text-color` instead of hardcoded white, and shimmer in neutral grey, so the block reads on a light theme as well as a dark one.
- Render the stop button's icon as an SVG rect instead of the `⏹` glyph, which is a font-dependent emoji sized and coloured differently on every platform.
- Render a block still waiting for its picture as the placeholder in both stored spellings (``'&lt;img data-iig-instruction… src="[IMG:GEN]"&gt;'`` and the bare ``'&lt;img src="[IMG:GEN:…]"&gt;'``). Both used to survive into the message as an `<img>` with no loadable source, so the reader watched the browser's broken-image icon for the length of the generation.
- Read the `@paths|instruction` payload of a pending block that carried images through a regeneration, so its prompt line shows the prompt and not the path list in front of it.

## A tag inside a reasoning block never generates (INV-IG11)

- A model plans its images out loud — "then I'll put `[IMG:GEN:…]` here" — and that note to itself was being taken as a request, generating a picture nobody asked for in the middle of the model's own scratchpad.
- Mark reasoning spans (`ImgGenPatterns.reasoningSpans`) and walk past them in `ImageTagMarkup.scanPendingTags`. That scan is the single gate every generation goes through, so a reasoning tag is now never generated, never rewritten into an error or "disabled" card, and never counted in the block numbering the WebView addresses.
- Carry an `inReasoning` flag through the formatter so the WebView agrees on both halves: inside a `<think>` block and in the split-out reasoning panel, the pending spellings are restored as the literal text the model wrote instead of becoming an image block. Without this the reader would watch a placeholder whose picture is never coming, and taps would carry a `data-img-index` Dart does not count.
- Key the format cache on the flag, so a body render is never served to a reasoning panel or the other way round.
- Only a **closed** block counts as reasoning, matching what the formatter folds away. Finished ``'&lt;img data-iig-…&gt;'`` blocks stay unfiltered — they are pictures that already exist, and their paths still have to resolve and be stripped from a sync payload.

## A pending block reads as queued until the image stage runs (INV-IG1)

- The Dart side already started generation only after the stream: `ImageTagStage` is the only path that generates from a reply's tag, and `PostGenCoordinator` reaches it only after the stream ends and the message is committed. An errored stream returns earlier, an abort bumps the gen id so every stage bails, `continueMessage` merges and commits first, the ext-block image agent awaits its whole response, and the manual retries guard on `isGenerating` and wait out post-gen.
- The placeholder did not know any of that. As soon as the model had emitted a complete `[IMG:GEN:…]` — with the rest of the reply still streaming — the block rendered as running: shimmer, ticking clock, Stop button. Nothing was generating, and the Stop button was dead (`cancelImageGeneration()` cancels `_imgGenCancelToken`, which `ImageTagStage` only creates later).
- Render a pending block as queued whenever `bridge.isGeneratingImage` is down: no clock, no Stop button, an "Image queued…" label. That covers the reply stream and the post-gen work before the image stage, which with Studio on runs the cleaner first and can take seconds.
- Drive the flip from a new `bridge.setImageGenerating()`, replacing the bare property assignment Flutter used — the transition carries no re-render of its own, since the reply's last chunk is already painted.
- Restamp `data-start` when a block goes live, so the clock measures the generation. It was stamped when the block *rendered*, so a block that waited out a long reply would otherwise jump straight to "48.2s".
- Skip queued blocks in `ImgGenTimer`, so a hidden clock does not hold the interval open.

## Verification

**Flutter is not installed in the environment this was written in, so `flutter analyze` and `flutter test` were never run — CI is the gate for both.** What was run:

- `node --check` on every touched JS module.
- A Node harness over `Formatter.format`: both pending element spellings and the bare tag produce a placeholder with no `<img>` in the output; block indices still match the Dart document-ordered scan on a mixed message; a tag inside `<think>`, both element spellings inside it, a tag outside it (still a block, index 0), a finished image inside it (still shows), and the split-out reasoning panel; plus a format-cache cross-contamination check.
- A DOM-stub harness over `isolateImgGenPlaceholders` (tree shape, emptied host, pinned inline styles, idempotent on a second pass) and over the whole queued→live transition (rendered mid-stream: queued, clock untouched, ticker finds nothing; image stage starts: live, clock restamped to 0.0s, ticker finds it; image stage ends: queued again).
- The reasoning-span regex checked against the same offsets the new Dart tests assert.

Tests added: `test/image_gen_patterns_test.dart` (reasoning spans and overlap), `test/image_gen_service_test.dart` (reasoning tags are not generated, block numbering, a reasoning block survives a generation untouched), `test/webview_assets_test.dart` (no `<img>` for a pending block, SVG stop button, CSS isolation, timer descent, queued state), `test/chat_webview_sync_dispatcher_test.dart` (the new setter is what Flutter calls).

Docs: INV-IG1 gains the WebView half, INV-IG9 the pending-element rule, and a new INV-IG10 (placeholder isolation) and INV-IG11 (reasoning tags).

Note for testing: changes under `assets/chat_webview/` need a **hot restart** (`R`), not a hot reload.

---
_Generated by [Claude Code](https://claude.ai/code/session_012v833n8Yze2D9gNzpJLxSv)_