### PR TITLE
refactor(webview): parse the message before formatting its text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,34 @@ jobs:
       - name: Test
         run: flutter test --reporter expanded
 
+  webview-render:
+    name: WebView render tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: test/webview_js/package-lock.json
+
+      - name: Install dependencies
+        working-directory: test/webview_js
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: test/webview_js
+        run: npx playwright install --with-deps chromium
+
+      # Renders the card corpus in a real browser and asserts on the DOM, the
+      # resolved CSS and what a click does — the checks the Dart asset tests
+      # cannot make, because they only read the sources as strings.
+      - name: Test
+        working-directory: test/webview_js
+        run: npm test
+
   bug-triage:
     name: Bug-triage agent (unit tests)
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,12 @@ opencode.jsonc
 # Python bytecode (tools/bug_triage)
 __pycache__/
 *.pyc
+
+# WebView asset browser tests (test/webview_js)
+test/webview_js/node_modules/
+test/webview_js/test-results/
+test/webview_js/playwright-report/
+# The Node manifests above are ignored repo-wide (a leftover of the Vue app).
+# This one is a committed test project, so it opts back in.
+!test/webview_js/package.json
+!test/webview_js/package-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 | Drift reads/writes, repositories | `docs/rules/database.md` |
 | Architecture details, full flow | `docs/ARCHITECTURE.md` |
 | Formal invariants with code references | `docs/INVARIANTS.md` |
-| Message rendering — `assets/chat_webview/formatter/`, `renderer/` | `docs/rules/message-rendering.md` |
+| Message rendering — `assets/chat_webview/formatter/`, `renderer/` | `docs/rules/message-rendering.md` + `docs/INVARIANTS.md` (INV-MR1–8) |
 | Custom `==...==` markdown markers | `docs/markdown-markers.md` |
 | Windows/build failures, dependency overrides | `docs/BUILD_NOTES.md` |
 | Class/file organization, decomposition | `docs/CODE_STYLE.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 - **Feature branches are always based on `nightly`** — `stable` is the default branch, so a fresh clone starts there; check the base first, and `git rebase origin/nightly` a branch that was cut from the wrong one before opening the PR.
 - Open PRs only against upstream repository `hydall/Glaze` (base: `hydall/Glaze:nightly`), not against fork repos.
 - PR title and body are **in English**, and the body lists the changes as bullets (one bullet per change, `##` headings when a PR carries several independent fixes) plus how it was verified. Full rules: `docs/WORKFLOW.md` § PR title and body.
-- PRs are squash-merged and gated on CI (`.github/workflows/ci.yml` — `flutter analyze` + `flutter test`); a red check blocks the merge.
+- PRs are squash-merged and gated on CI (`.github/workflows/ci.yml` — `flutter analyze` + `flutter test` + the WebView render suite in `test/webview_js`); a red check blocks the merge.
 - Release branches are `nightly` → `staging` → `stable`, one per build channel; features enter at `nightly` and are promoted by merge. Channel semantics: `docs/RELEASE_CHANNELS.md`.
 - Run `dart run build_runner build` after changing any freezed/drift model.
 - Single responsibility: split a class before it grows past ~200-250 lines (thin orchestrators, fat specialists, constructor injection). Details: `docs/CODE_STYLE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,8 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 | Drift reads/writes, repositories | `docs/rules/database.md` |
 | Architecture details, full flow | `docs/ARCHITECTURE.md` |
 | Formal invariants with code references | `docs/INVARIANTS.md` |
-| Custom `==...==` markdown markers, message rendering | `docs/markdown-markers.md` |
+| Message rendering — `assets/chat_webview/formatter/`, `renderer/` | `docs/rules/message-rendering.md` |
+| Custom `==...==` markdown markers | `docs/markdown-markers.md` |
 | Windows/build failures, dependency overrides | `docs/BUILD_NOTES.md` |
 | Class/file organization, decomposition | `docs/CODE_STYLE.md` |
 | Any screen, sheet or dialog — which widget to reach for | `docs/UI_KIT.md` |

--- a/assets/chat_webview/bridge/selection_manager.js
+++ b/assets/chat_webview/bridge/selection_manager.js
@@ -1,5 +1,7 @@
 ﻿/* Extracted from ../bridge.legacy.js. Keep public behavior stable. */
 
+import { appBody } from '../renderer/message_document.js';
+
 export class SelectionManager {
   constructor(sendToFlutter, getOrderedIds) {
     this._sendToFlutter = sendToFlutter;
@@ -157,7 +159,9 @@ export class SelectionManager {
       content.appendChild(selection.getRangeAt(i).cloneContents());
     }
     shadow.appendChild(content);
-    document.body.appendChild(host);
+    // appBody(), not document.body: this runs from a click that may have come
+    // out of a message, where `document.body` is that message's overlay.
+    appBody().appendChild(host);
     const text = content.innerText.trim();
     host.remove();
     return text;
@@ -178,7 +182,7 @@ export class SelectionManager {
         this._hideSelectionBar();
         window.getSelection().removeAllRanges();
       });
-      document.body.appendChild(bar);
+      appBody().appendChild(bar);
       this._barCreated = true;
     }
     this._selectedText = text;

--- a/assets/chat_webview/formatter/block_syntax.js
+++ b/assets/chat_webview/formatter/block_syntax.js
@@ -1,0 +1,176 @@
+// Block markdown: what a line of a message can be.
+//
+// Runs over one run of text, line by line. A construct is recognised only at
+// the start of a line, which is what markdown means by "block", and the text
+// it wraps goes through the inline pass. Elements are opaque placeholders
+// here too, so a list item can hold a `<b>` and a table cell can hold a card
+// without either pass reaching into the other.
+
+import { SENTINEL } from './protect.js';
+
+/**
+ * A line that carries nothing but protected regions — never a paragraph.
+ * Only `P_`: a style marker is inline content and belongs in a paragraph like
+ * any other word.
+ */
+const ONLY_REGIONS = new RegExp(`^(?:${SENTINEL}P_\\d+${SENTINEL}|\\s)+$`);
+
+const HEADING = /^(#{1,6})[ \t]+(.+?)[ \t]*#*$/;
+const RULE = /^(_{3,}|-{3,}|\*{3,})$/;
+const BULLET = /^([ \t]*)[-*] (.*)$/;
+const NUMBERED = /^\d+\. (.*)$/;
+const QUOTED = /^>[ \t]?(.*)$/;
+const TABLE_ROW = /^[ \t]*\|.*\|[ \t]*$/;
+const TABLE_SEPARATOR = /^[ \t]*\|[ \t:|-]+\|[ \t]*$/;
+
+function renderList(items, inline) {
+  // An indented item belongs to the list above it. Splitting the run at the
+  // first indented line left it stranded as its own paragraph between two
+  // lists; nesting it keeps the run one list.
+  let out = '';
+  let nested = false;
+  let open = false;
+  for (const item of items) {
+    if (item.depth) {
+      // The sub-list lives inside the item above it, which stays open until
+      // the run ends or the next top-level item starts.
+      if (!nested) { out += '<ul class="chat-list">'; nested = true; }
+      out += `<li>${inline(item.text)}</li>`;
+      continue;
+    }
+    if (nested) { out += '</ul>'; nested = false; }
+    if (open) out += '</li>';
+    out += `<li>${inline(item.text)}`;
+    open = true;
+  }
+  if (nested) out += '</ul>';
+  if (open) out += '</li>';
+  return `<ul class="chat-list">${out}</ul>`;
+}
+
+function renderTable(rows, inline) {
+  const cells = (row) => row.trim().replace(/^\||\|$/g, '').split('|').map((c) => c.trim());
+  const head = cells(rows[0]).map((c) => `<th>${inline(c)}</th>`).join('');
+  const body = rows.slice(2)
+    .map((row) => `<tr>${cells(row).map((c) => `<td>${inline(c)}</td>`).join('')}</tr>`)
+    .join('');
+  return `<table class="chat-table"><thead><tr>${head}</tr></thead>` +
+    `${body ? `<tbody>${body}</tbody>` : ''}</table>`;
+}
+
+/**
+ * Renders one run of text.
+ *
+ * [paragraphs] wraps loose text in `<p>`. It is set only at the top level of a
+ * message: inside markup the author wrote, a `<p>` of ours would reparent
+ * their elements, and a card built on `#toggle:checked ~ .overlay` stops
+ * working the moment its two halves stop being siblings.
+ */
+export function applyBlockSyntax(text, { inline, paragraphs }) {
+  const lines = text.split('\n');
+  const out = [];
+  let pending = [];
+
+  const flush = () => {
+    while (pending.length && !pending[0].trim()) pending.shift();
+    while (pending.length && !pending[pending.length - 1].trim()) pending.pop();
+    if (!pending.length) return;
+    const body = pending.map((line) => (line.trim() ? inline(line) : '')).join('<br>');
+    const bare = pending.every((line) => ONLY_REGIONS.test(line) || !line.trim());
+    out.push(paragraphs && !bare ? `<p>${body}</p>` : body);
+    pending = [];
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (!line.trim()) {
+      // A blank line ends a paragraph. Where nothing is wrapped in `<p>` it is
+      // just another line break, and keeping it preserves the author's spacing.
+      if (paragraphs) flush();
+      else pending.push('');
+      continue;
+    }
+
+    if (ONLY_REGIONS.test(line)) {
+      // A protected region stands on its own: a `<p>` around an image block or
+      // a code block is a `<p>` the browser immediately throws back out.
+      flush();
+      out.push(line.trim());
+      continue;
+    }
+
+    const heading = HEADING.exec(line);
+    if (heading) {
+      flush();
+      const level = heading[1].length;
+      out.push(`<h${level} class="chat-heading">${inline(heading[2])}</h${level}>`);
+      continue;
+    }
+
+    if (RULE.test(line.trim())) {
+      flush();
+      out.push('<hr>');
+      continue;
+    }
+
+    // A table needs its separator row: that is what tells a table from a line
+    // of prose that happens to use pipes.
+    if (TABLE_ROW.test(line) && TABLE_SEPARATOR.test(lines[i + 1] || '')) {
+      flush();
+      const rows = [line, lines[i + 1]];
+      let j = i + 2;
+      while (j < lines.length && TABLE_ROW.test(lines[j])) rows.push(lines[j++]);
+      out.push(renderTable(rows, inline));
+      i = j - 1;
+      continue;
+    }
+
+    if (BULLET.test(line)) {
+      flush();
+      const items = [];
+      let j = i;
+      let match;
+      while (j < lines.length && (match = BULLET.exec(lines[j])) !== null) {
+        items.push({ depth: match[1].length ? 1 : 0, text: match[2] });
+        j++;
+      }
+      out.push(renderList(items, inline));
+      i = j - 1;
+      continue;
+    }
+
+    if (NUMBERED.test(line)) {
+      flush();
+      const items = [];
+      let j = i;
+      let match;
+      while (j < lines.length && (match = NUMBERED.exec(lines[j])) !== null) {
+        items.push(`<li>${inline(match[1])}</li>`);
+        j++;
+      }
+      out.push(`<ol class="chat-list">${items.join('')}</ol>`);
+      i = j - 1;
+      continue;
+    }
+
+    if (QUOTED.test(line)) {
+      flush();
+      const quoted = [];
+      let j = i;
+      let match;
+      while (j < lines.length && (match = QUOTED.exec(lines[j])) !== null) {
+        quoted.push(inline(match[1]));
+        j++;
+      }
+      out.push(`<blockquote class="chat-blockquote">${quoted.join('<br>')}</blockquote>`);
+      i = j - 1;
+      continue;
+    }
+
+    pending.push(line);
+  }
+
+  flush();
+  return out.join('');
+}

--- a/assets/chat_webview/formatter/dom_format.js
+++ b/assets/chat_webview/formatter/dom_format.js
@@ -1,0 +1,238 @@
+// Phase B: markdown over the parsed message, text node by text node.
+//
+// Phase A handed us a tree. Nothing in this file guesses at structure — the
+// parser already decided what is an element, which elements nest and where an
+// unclosed tag ends. What is left is to format the *text* between those
+// elements, and to do it without moving any of them.
+//
+// Two rules carry most of the weight:
+//
+//   * markdown is applied to a run of text and inline elements, with the
+//     elements masked out. A `*` inside an attribute is unreachable, and a
+//     `<b>` in the middle of an italic run stays where the author put it.
+//   * `<p>` is only ever added at the top level of a message, and never
+//     between an element and a block sibling it might be styled against. A
+//     paragraph wrapped around someone's card is what breaks `~` and `+`.
+
+import { isKnownElement, RAW_TEXT_ELEMENTS } from './html_scan.js';
+import { SENTINEL } from './protect.js';
+import { applyBlockSyntax } from './block_syntax.js';
+import { applyInlineSyntax, escapeText } from './inline_syntax.js';
+
+/** Elements that flow with the text around them, so they join its run. */
+const PHRASING = new Set([
+  'a', 'abbr', 'audio', 'b', 'bdi', 'bdo', 'big', 'br', 'button', 'canvas',
+  'cite', 'code', 'data', 'datalist', 'del', 'dfn', 'em', 'embed', 'font',
+  'i', 'iframe', 'img', 'input', 'ins', 'kbd', 'label', 'map', 'mark', 'math',
+  'meter', 'nobr', 'object', 'output', 'picture', 'progress', 'q', 'ruby',
+  's', 'samp', 'select', 'slot', 'small', 'span', 'strike', 'strong', 'sub',
+  'sup', 'svg', 'textarea', 'time', 'tt', 'u', 'var', 'video', 'wbr',
+]);
+
+/** Elements whose content is flow content, where a list or table may start. */
+const FLOW_CONTAINERS = new Set([
+  'article', 'aside', 'blockquote', 'center', 'dd', 'details', 'div',
+  'fieldset', 'figcaption', 'figure', 'footer', 'form', 'header', 'li',
+  'main', 'nav', 'section', 'td', 'th',
+]);
+
+/** Elements this pass never reaches inside: their content is not prose. */
+const OPAQUE = new Set([...RAW_TEXT_ELEMENTS, 'svg', 'math', 'template']);
+
+function isElement(node) {
+  return node && node.nodeType === 1;
+}
+
+function isPhrasing(node) {
+  return isElement(node) && PHRASING.has(node.localName);
+}
+
+/** A custom element is a card's own container, so it may hold blocks too. */
+function canHoldBlocks(name) {
+  return FLOW_CONTAINERS.has(name) || !isKnownElement(name);
+}
+
+function isBlank(node) {
+  return node.nodeType === 3 && !node.data.trim();
+}
+
+/** Whitespace between two nodes that contains a blank line detaches them. */
+function hasBlankLine(node) {
+  return node.nodeType === 3 && /\n[ \t]*\n/.test(node.data);
+}
+
+/**
+ * True when the run sits right against a block element the author wrote.
+ *
+ * This is the CSS-only card: `<input id="t1"><label>…</label><div class="ov">`
+ * with `#t1:checked ~ .ov` in the card's `<style>`. Wrapping the run in a
+ * paragraph moves the checkbox into it, the two stop being siblings, and the
+ * card's button goes dead while the checkbox itself still toggles. Prose
+ * separated from a card by a blank line is not touching it and still gets its
+ * paragraphs.
+ */
+function touchesBlockSibling(run) {
+  const first = run.find((node) => !isBlank(node));
+  const last = [...run].reverse().find((node) => !isBlank(node));
+  if (!isElement(first) && !isElement(last)) return false;
+
+  const before = run[0].previousSibling;
+  const after = run[run.length - 1].nextSibling;
+  const leadingGap = isBlank(run[0]) ? run[0] : null;
+  const trailingGap = isBlank(run[run.length - 1]) ? run[run.length - 1] : null;
+
+  const tightBefore = isElement(first) && isElement(before) &&
+    !(leadingGap && hasBlankLine(leadingGap));
+  const tightAfter = isElement(last) && isElement(after) &&
+    !(trailingGap && hasBlankLine(trailingGap));
+  return tightBefore || tightAfter;
+}
+
+/**
+ * Replaces every `PREFIX_n` placeholder in [root]'s text with what [resolve]
+ * returns for it: a node, a list of nodes, or null to leave it alone.
+ */
+export function replacePlaceholders(root, prefix, resolve) {
+  const pattern = new RegExp(`${SENTINEL}${prefix}_(\\d+)${SENTINEL}`, 'g');
+  const document_ = root.ownerDocument || document;
+  const walker = document_.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const pending = [];
+  while (walker.nextNode()) {
+    pattern.lastIndex = 0;
+    if (pattern.test(walker.currentNode.data)) pending.push(walker.currentNode);
+  }
+  for (const node of pending) {
+    const parts = node.data.split(new RegExp(`${SENTINEL}${prefix}_(\\d+)${SENTINEL}`));
+    const fragment = document_.createDocumentFragment();
+    for (let i = 0; i < parts.length; i++) {
+      if (i % 2 === 0) {
+        if (parts[i]) fragment.appendChild(document_.createTextNode(parts[i]));
+        continue;
+      }
+      const resolved = resolve(parts[i]);
+      if (resolved == null) {
+        fragment.appendChild(document_.createTextNode(
+          `${SENTINEL}${prefix}_${parts[i]}${SENTINEL}`,
+        ));
+      } else if (Array.isArray(resolved)) {
+        for (const child of resolved) fragment.appendChild(child);
+      } else {
+        fragment.appendChild(resolved);
+      }
+    }
+    node.replaceWith(fragment);
+  }
+}
+
+/** Turns an HTML string into nodes, in the message's own document. */
+export function parseHtml(html, document_) {
+  const template = document_.createElement('template');
+  template.innerHTML = html;
+  return template.content;
+}
+
+function formatRun(run, container, context) {
+  const document_ = container.ownerDocument || document;
+  const kept = [];
+  const masked = run.map((node) => {
+    if (node.nodeType === 3) return escapeText(node.data);
+    if (isElement(node)) {
+      kept.push(node);
+      return `${SENTINEL}E_${kept.length - 1}${SENTINEL}`;
+    }
+    return '';
+  }).join('');
+
+  if (!masked.trim()) return;
+
+  const inline = (line) => applyInlineSyntax(line, context.inlineContext);
+  const html = context.allowBlocks
+    ? applyBlockSyntax(masked, { inline, paragraphs: context.paragraphs })
+    : inline(masked).replace(/\n/g, '<br>');
+
+  // Detach the run before the formatted tree is built: the elements it kept
+  // are moved into that tree, and removing "what the run used to be"
+  // afterwards would take them straight back out again.
+  const anchor = document_.createTextNode('');
+  container.insertBefore(anchor, run[0]);
+  for (const node of run) node.remove();
+
+  const formatted = parseHtml(html, document_);
+  replacePlaceholders(formatted, 'E', (index) => kept[Number(index)] || null);
+  anchor.replaceWith(formatted);
+}
+
+/**
+ * Formats the text inside one container: first its element children (each in
+ * its own context), then the runs of text between them.
+ */
+export function formatContainer(container, { isRoot, allowBlocks, inlineContext }) {
+  for (const child of Array.from(container.children)) {
+    const name = child.localName;
+    if (OPAQUE.has(name)) continue;
+    formatContainer(child, {
+      isRoot: false,
+      allowBlocks: canHoldBlocks(name),
+      inlineContext,
+    });
+  }
+
+  const runs = [];
+  let run = [];
+  for (const node of Array.from(container.childNodes)) {
+    if (isElement(node) && !isPhrasing(node)) {
+      if (run.length) runs.push(run);
+      run = [];
+      continue;
+    }
+    if (node.nodeType === 8) continue;
+    run.push(node);
+  }
+  if (run.length) runs.push(run);
+
+  for (const current of runs) {
+    formatRun(current, container, {
+      allowBlocks,
+      paragraphs: isRoot && !touchesBlockSibling(current),
+      inlineContext,
+    });
+  }
+}
+
+/**
+ * `<font>` is the one element the message CSS restyles rather than renders.
+ *
+ * A gradient fill written as `<font style="background-clip:text">` has nothing
+ * to clip when the visible text sits in a nested `<span style="transform:…">`,
+ * which is how models write it. The fill properties are copied down to that
+ * first child so the text takes the gradient instead of disappearing.
+ */
+export function convertFontElements(root) {
+  for (const font of Array.from(root.querySelectorAll('font'))) {
+    const span = (root.ownerDocument || document).createElement('span');
+    const color = font.getAttribute('color');
+    const style = font.getAttribute('style');
+    if (style) {
+      span.className = 'font-style-block';
+      span.setAttribute('style', style);
+    } else if (color) {
+      span.className = 'font-color-block';
+      span.setAttribute('style', `color:${color}`);
+    } else {
+      span.className = 'font-color-block';
+    }
+    while (font.firstChild) span.appendChild(font.firstChild);
+    font.replaceWith(span);
+
+    const fill = /(?:-webkit-)?background-clip\s*:\s*text|-webkit-text-fill-color\s*:\s*transparent/i;
+    if (!style || !fill.test(style)) continue;
+    const inner = span.firstElementChild;
+    if (!inner) continue;
+    const carried = (style.match(
+      /(?:background-image|-webkit-background-clip|-webkit-text-fill-color|-webkit-text-stroke|filter)\s*:\s*[^;]+/gi,
+    ) || []).join('; ');
+    if (!carried) continue;
+    const own = (inner.getAttribute('style') || '').replace(/;?\s*$/, '');
+    inner.setAttribute('style', own ? `${own}; ${carried}` : carried);
+  }
+}

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -1,163 +1,52 @@
+// The message renderer, in two phases.
+//
+//   Phase A — parse. The message is handed to the browser's own HTML parser.
+//     What is an element, how elements nest, and where an unclosed tag ends
+//     are the parser's answers, not ours. That is what makes a card render as
+//     a card from its first streamed chunk instead of flickering as raw tags,
+//     and it is why there is no list of block tags and no "orphan" counter
+//     here any more.
+//
+//   Phase B — format the text. Markdown is applied to text nodes, never to a
+//     string with live markup in it. Attributes, `<style>`, `<script>`, `<pre>`
+//     and `<code>` are out of reach by construction, and a `<p>` of ours is
+//     only ever added at the top level of the message — never inside markup
+//     the author wrote.
+//
+// Around those two: `protect.js` takes out the regions that are not markup
+// (code, image tags, a `<think>` panel) before parsing, and puts them back
+// afterwards. See docs/rules/message-rendering.md.
+
 import { expandMacros } from './macros.js';
-import { renderStyledSegment } from './text_format.js';
+import { escapeProseTags } from './html_scan.js';
+import {
+  ANY_PLACEHOLDER,
+  createStore,
+  extractMarkers,
+  maskCodeElements,
+  protectRegions,
+} from './protect.js';
+import {
+  convertFontElements,
+  formatContainer,
+  parseHtml,
+  replacePlaceholders,
+} from './dom_format.js';
+import { formatInlineRaw } from './inline_syntax.js';
+import { renderImageBlock } from './image_blocks.js';
 
-// Vertical 3-dot "options" icon (ported from Glaze useMessageImageGen.js).
-const OPTIONS_SVG = '<svg viewBox="0 0 24 24"><path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>';
-const VARIANT_PREV_SVG = '<svg viewBox="0 0 24 24"><path d="M15.4 7.4 14 6l-6 6 6 6 1.4-1.4-4.6-4.6z"/></svg>';
-const VARIANT_NEXT_SVG = '<svg viewBox="0 0 24 24"><path d="M8.6 7.4 10 6l6 6-6 6-1.4-1.4 4.6-4.6z"/></svg>';
-// Stop icon for the loading placeholder. An SVG rather than the ⏹ character:
-// the glyph is a font-dependent emoji that renders at a different size (and in
-// colour) on every platform, while a path is the same square everywhere and
-// takes `fill: currentColor` from the button.
-const STOP_SVG = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="2"/></svg>';
+export {
+  parseImageResultPayload,
+  parseImageResultElement,
+  parseImagePendingPayload,
+  parseImagePendingElement,
+} from './image_blocks.js';
 
-/** Separator between the images one block carries, mirroring the Dart codec. */
-const IMG_VARIANT_SEPARATOR = ';;';
-
-/** Marks the image on screen inside a multi-image payload. */
-const IMG_VARIANT_ACTIVE_MARKER = '*';
-
-/**
- * Splits an `[IMG:RESULT:…]` payload into its images, the one on screen and
- * the instruction — the JS half of ImageBlockPayload in image_tag_markup.dart.
- * A single-image block keeps the historical `path|instruction` spelling, so
- * messages written before block variants existed parse unchanged.
- */
-export function parseImageResultPayload(payload) {
-  const raw = String(payload == null ? '' : payload);
-  const pipeIdx = raw.indexOf('|');
-  const head = pipeIdx === -1 ? raw : raw.substring(0, pipeIdx);
-  const instruction = pipeIdx === -1 ? '' : raw.substring(pipeIdx + 1);
-  const paths = [];
-  let activeIndex = 0;
-  for (const entry of head.split(IMG_VARIANT_SEPARATOR)) {
-    if (!entry) continue;
-    if (entry.startsWith(IMG_VARIANT_ACTIVE_MARKER)) {
-      activeIndex = paths.length;
-      paths.push(entry.substring(IMG_VARIANT_ACTIVE_MARKER.length));
-    } else {
-      paths.push(entry);
-    }
-  }
-  return { paths, activeIndex, instruction };
-}
-
-/** Introduces the images a pending block carries, mirroring the Dart codec. */
-const IMG_PENDING_MARKER = '@';
-
-/**
- * Splits an `[IMG:GEN:…]` payload into the images the block already holds and
- * its instruction — the JS half of ImageBlockPayload.parsePending. Without the
- * `@` marker the whole payload is the instruction, which is how every block
- * written before regeneration carried its images is spelled.
- */
-export function parseImagePendingPayload(payload) {
-  const raw = String(payload == null ? '' : payload);
-  if (!raw.startsWith(IMG_PENDING_MARKER)) {
-    return { paths: [], activeIndex: 0, instruction: raw };
-  }
-  return parseImageResultPayload(raw.substring(IMG_PENDING_MARKER.length));
-}
-
-/**
- * Matches one `<img …data-iig-instruction…>` element, the stored form of an
- * image block. Whether it is finished or still waiting is decided by its
- * `src` (see `parseImageResultElement`), not by the pattern.
- */
-const IIG_ELEMENT_REGEX = /<img\s[^>]*?data-iig-instruction\s*=\s*(?:"[^"]*"|'[^']*')[^>]*>/gi;
-
-/**
- * Matches an `<img …src="[IMG:GEN…]">` element that carries no instruction
- * attribute — the spelling a model writes by hand, where the payload lives in
- * the `src`. Mirrors ImgGenPatterns.imgSrcGenRegex on the Dart side.
- */
-const IMG_SRC_GEN_ELEMENT_REGEX = /<img\b[^>]*?\bsrc\s*=\s*["']\[IMG:GEN[^\]]*\]["'][^>]*>/gi;
-
-/** A paragraph holding only tag placeholders and whitespace (see step 11). */
-const ONLY_TAG_PLACEHOLDERS = /^(?:\x01T_(?:BLOCK_)?\d+\x01|\s)+$/;
-
-const ATTRIBUTE_PAIR_REGEX = /([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]*))/g;
-
-/** Attributes of one `<img …>` element, lower-cased names to raw values. */
-function imgAttributes(tag) {
-  const body = String(tag == null ? '' : tag).replace(/^<\s*[A-Za-z][-A-Za-z0-9]*/i, '');
-  // Null-prototype: an attribute called `constructor` or `toString` must not
-  // read as already present, and must not reach an inherited value.
-  const attributes = Object.create(null);
-  ATTRIBUTE_PAIR_REGEX.lastIndex = 0;
-  let match;
-  while ((match = ATTRIBUTE_PAIR_REGEX.exec(body)) !== null) {
-    const name = match[1].toLowerCase();
-    if (name in attributes) continue;
-    const value = match[2] !== undefined ? match[2]
-      : match[3] !== undefined ? match[3]
-      : match[4] !== undefined ? match[4] : '';
-    attributes[name] = value;
-  }
-  return attributes;
-}
-
-function unescapeAttribute(value) {
-  const raw = String(value == null ? '' : value);
-  if (raw.indexOf('&') === -1) return raw;
-  return raw
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&#39;/g, "'")
-    .replace(/&apos;/g, "'")
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, '&');
-}
-
-/**
- * Reads the stored `<img data-iig-…>` form of a finished image block — the JS
- * half of ImageTagMarkup.encodeResultElement in image_tag_markup.dart. The
- * visible image is the element's `src`, the block's other images ride along in
- * `data-iig-variants`. Returns null while the block is still waiting for its
- * picture (no `src`, or the `[IMG:GEN…]` placeholder in it), which the caller
- * reads as "not a result".
- */
-export function parseImageResultElement(tag) {
-  const attributes = imgAttributes(tag);
-  const src = unescapeAttribute(attributes.src || '').trim();
-  if (!src || src.startsWith('[IMG:GEN')) return null;
-  const instruction = unescapeAttribute(attributes['data-iig-instruction'] || '');
-  const variants = unescapeAttribute(attributes['data-iig-variants'] || '');
-  const paths = [];
-  for (const entry of variants.split(IMG_VARIANT_SEPARATOR)) {
-    if (entry) paths.push(entry);
-  }
-  if (!paths.length) paths.push(src);
-  const declared = parseInt(attributes['data-iig-index'], 10);
-  const fallback = paths.indexOf(src);
-  let activeIndex = Number.isNaN(declared) ? fallback : declared;
-  if (!(activeIndex >= 0)) activeIndex = 0;
-  if (activeIndex > paths.length - 1) activeIndex = paths.length - 1;
-  return { paths, activeIndex, instruction };
-}
-
-/**
- * Reads the pending form of a stored image block: the same `<img data-iig-…>`
- * element, but with no picture in its `src` yet (see `parseImageResultElement`,
- * which is what decides between the two). Returns null for a finished block.
- *
- * Pulling this element out of the markup — instead of leaving it to render as
- * an ordinary `<img>` — is what keeps a browser's broken-image icon off the
- * screen while the picture is still being generated: the tag has no image to
- * load, so the only thing it can paint is the failure glyph.
- */
-export function parseImagePendingElement(tag) {
-  const attributes = imgAttributes(tag);
-  const src = unescapeAttribute(attributes.src || '').trim();
-  if (src && !src.startsWith('[IMG:GEN')) return null;
-  // The instruction attribute is the authoritative payload; a bare
-  // `<img src="[IMG:GEN:…]">` carries it inside the src instead.
-  let instruction = unescapeAttribute(attributes['data-iig-instruction'] || '');
-  if (!instruction && src) {
-    const inSrc = src.match(/^\[IMG:GEN(?::([\s\S]*))?\]$/);
-    if (inSrc) instruction = inSrc[1] || '';
-  }
-  return { instruction };
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 export class Formatter {
@@ -170,23 +59,23 @@ export class Formatter {
   // `message.reasoning`, which the renderer shows in its own panel. Dart never
   // scans that field for image tags, so a tag in it must not render as a block
   // here either (INV-IG11); the same flag covers a `<think>` block found inline
-  // in the message body, from step 17.
+  // in the message body.
   format(text, isUser = false, inReasoning = false) {
     const key = `${text}:${isUser}:${inReasoning}`;
     if (this.cache.has(key)) return this.cache.get(key);
 
     let result;
     try {
-      result = this._processText(text, isUser, false, inReasoning);
+      result = this._render(text, isUser, inReasoning);
     } catch (e) {
       console.error('Formatter error:', e);
-      result = (text || '').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>');
+      result = escapeHtml(text || '').replace(/\n/g, '<br>');
     }
 
-    const leaked = result.match(/\x01[A-Z_]+\d+\x01/g);
+    const leaked = result.match(ANY_PLACEHOLDER);
     if (leaked) {
       console.error('Formatter LEAK:', leaked, 'text:', text?.substring(0, 100));
-      result = result.replace(/\x01[A-Z_]+\d+\x01/g, '');
+      result = result.replace(ANY_PLACEHOLDER, '');
     }
 
     if (this.cache.size >= this.cacheMaxSize) {
@@ -197,652 +86,82 @@ export class Formatter {
     return result;
   }
 
-  _ph(prefix, i, isBlock) {
-    return `\x01${prefix}${isBlock ? 'BLOCK_' : ''}${i}\x01`;
-  }
-
-  // [inReasoning] marks the recursive pass over a `<think>…</think>` body. A
-  // model plans its images out loud there, and Glaze does not generate from a
-  // tag it finds in that plan (INV-IG11) — so the tag must not render as a
-  // block either: a placeholder whose picture is never coming, or an <img>
-  // with no loadable source, would both be a lie about what the app is doing.
-  _processText(text, isUser, skipQuotes = false, inReasoning = false) {
+  _render(text, isUser, inReasoning) {
     if (!text) return '';
-    text = expandMacros(text).replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+    const source = expandMacros(text)
+      .replace(/\r\n/g, '\n')
+      .replace(/\r/g, '\n')
+      .trim();
 
-    let html = text;
+    const regions = createStore('P');
+    const markers = createStore('S');
 
-    // 1a. Extract <think...</think...> reasoning blocks
-    const thinkBlocks = [];
-    html = html.replace(/<think\b[^>]*>([\s\S]*?)<\/think\b[^>]*>/gi, (match, content) => {
-      const id = this._ph('TB_', thinkBlocks.length, true);
-      thinkBlocks.push(content.trim());
-      return '\n\n' + id + '\n\n';
+    let staged = protectRegions(source, { store: regions, inReasoning });
+    // Style markers come out before the parse, because html_to_markdown writes
+    // rich content inside them and a parsed marker is two text nodes with an
+    // element between. `<style>`/`<script>` bodies are hidden for that scan:
+    // a `*` in a selector is not an italic marker.
+    const code = maskCodeElements(staged);
+    staged = code.unmask(extractMarkers(code.masked, markers));
+
+    const tree = parseHtml(escapeProseTags(staged), document);
+
+    formatContainer(tree, {
+      isRoot: true,
+      allowBlocks: true,
+      inlineContext: {
+        markers,
+        inner: (raw, skipQuotes = true) => formatInlineRaw(raw, { skipQuotes }),
+      },
     });
 
-    html = html.replace(/<think\b([^>]*?)(?:>|\n)([\s\S]*?)<\/think\b/gi, (match, attrs, content) => {
-      const id = this._ph('TB_', thinkBlocks.length, true);
-      thinkBlocks.push(content.trim());
-      return '\n\n' + id + '\n\n';
-    });
-
-    html = html.replace(/<thinking\b[^>]*>([\s\S]*?)<\/thinking\b[^>]*>/gi, (match, content) => {
-      const id = this._ph('TB_', thinkBlocks.length, true);
-      thinkBlocks.push(content.trim());
-      return '\n\n' + id + '\n\n';
-    });
-
-    html = html.replace(/<thinking\b([^>]*?)(?:>|\n)([\s\S]*?)<\/thinking\b/gi, (match, attrs, content) => {
-      const id = this._ph('TB_', thinkBlocks.length, true);
-      thinkBlocks.push(content.trim());
-      return '\n\n' + id + '\n\n';
-    });
-
-    // 1b. Extract <style>...</style> blocks
-    const styleBlocks = [];
-    html = html.replace(/<style\b[^>]*>([\s\S]*?)<\/style>/gi, (match, content) => {
-      const id = this._ph('STY_', styleBlocks.length, true);
-      styleBlocks.push(match);
-      return '\n\n' + id + '\n\n';
-    });
-
-    // 1c. Extract <script>...</script> blocks
-    const scriptBlocks = [];
-    html = html.replace(/<script\b[^>]*>([\s\S]*?)<\/script>/gi, (match, content) => {
-      const id = this._ph('SCR_', scriptBlocks.length, true);
-      scriptBlocks.push(match);
-      return '\n\n' + id + '\n\n';
-    });
-
-    // 2. Extract Code Blocks
-    const codeBlocks = [];
-    html = html.replace(/```(\w*)\n?([\s\S]*?)(?:```|$)/g, (match, lang, code) => {
-      const id = this._ph('CB_', codeBlocks.length);
-      codeBlocks.push({ lang, code });
-      return id;
-    });
-
-    // 2b. Extract inline code spans, before the tag pass can read what is
-    //     inside them as HTML. `Пиши `<div>`` is prose about a tag, not a tag.
-    const inlineCode = [];
-    html = html.replace(/`([^`\n]+)`/g, (match, code) => {
-      const id = this._ph('IC_', inlineCode.length);
-      inlineCode.push(code);
-      return id;
-    });
-
-    // 3. Extract CSS comments inside code blocks are already protected
-    //    Extract standalone CSS comments (outside code blocks)
-    const cssComments = [];
-    html = html.replace(/\/\*([\s\S]*?)\*\//g, (match) => {
-      const id = this._ph('CC_', cssComments.length);
-      cssComments.push(match);
-      return id;
-    });
-
-    // 4. Fix escaped HTML line breaks
-    html = html.replace(/&lt;br\s*\/?&gt;/gi, '<br>');
-
-    // 5. Extract <font color="..."> blocks before quote processing
-    const fontBlocks = [];
-    html = html.replace(/<font\s+color=["']?(#[0-9a-fA-F]{3,8})["']?\s*>([\s\S]*?)<\/font>/gi, (match, color, content) => {
-      const id = this._ph('FC_', fontBlocks.length);
-      fontBlocks.push({ type: 'color', color, content });
-      return id;
-    });
-    // font style with double-quoted attribute value
-    html = html.replace(/<font\s+style\s*=\s*"([^"]*)"['"]*\s*>([\s\S]*?)<\/font>/gi, (match, style, content) => {
-      const id = this._ph('FC_', fontBlocks.length);
-      fontBlocks.push({ type: 'style', style, content });
-      return id;
-    });
-    // font style with single-quoted attribute value
-    html = html.replace(/<font\s+style\s*=\s*'([^']*)'\s*>([\s\S]*?)<\/font>/gi, (match, style, content) => {
-      const id = this._ph('FC_', fontBlocks.length);
-      fontBlocks.push({ type: 'style', style, content });
-      return id;
-    });
-
-    // 5b. Janitor images: ![alt](url) → <span class="janitor-img-wrapper"> with options button
-    //
-    // The card is stashed as ONE atomic placeholder and restored at the very
-    // end (step 12c). Emitting its raw HTML here instead would hand it to the
-    // tag extraction in step 6, which classifies <img>/<svg>/<path> as *block*
-    // tags — step 11 then isolates every block placeholder in its own
-    // paragraph, so `<span class="janitor-img-wrapper">`, the `<img>` and the
-    // options `<button>` end up in three different <p> elements. The button
-    // would lose its positioned wrapper and its `position: absolute` would
-    // resolve against the message container, pinning the 3-dot menu to the top
-    // of the whole message instead of the top of the image.
-    const mdImages = [];
-    html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (match, alt, url) => {
-      // `![alt](url =100x50)` — the dimension suffix is markdown, not part of
-      // the address; leaving it in `src` requests a URL that cannot resolve.
-      const sized = url.match(/^(.*?)\s+=(\d+)?x(\d+)?$/);
-      const size = sized
-        ? `${sized[2] ? ` width="${sized[2]}"` : ''}` +
-          `${sized[3] ? ` height="${sized[3]}"` : ''}`
-        : '';
-      const safeUrl = this._escapeHtml(
-        this._normalizeMdUrl(sized ? sized[1] : url),
-      );
-      const id = this._ph('MI_', mdImages.length);
-      mdImages.push(`<span class="janitor-img-wrapper"><img${size} src="${safeUrl}" alt="${this._escapeHtml(alt)}" class="janitor-img" loading="lazy" data-action="image-click" data-src="${safeUrl}"><button class="janitor-options-btn" type="button" data-action="img-options" data-src="${safeUrl}" title="Options">${OPTIONS_SVG}</button></span>`);
-      return id;
-    });
-
-    // 5c. Glaze image gen tags
-    //
-    // The stored `<img data-iig-…>` element comes first: it is the form every
-    // finished block is written in, and pulling it out here (rather than
-    // letting step 6 treat it as an ordinary HTML tag) is what gives it the
-    // options button, the variant switcher and its `data-img-index`.
-    const imgBlocks = [];
-    // Tags a reasoning block only talks about: kept as their own literal text,
-    // restored in step 19b. Inline (not a block placeholder) so a tag written
-    // mid-sentence does not break the sentence in two.
-    const inertImgTags = [];
-    const inertTag = (match) => {
-      const id = this._ph('IGT_', inertImgTags.length);
-      inertImgTags.push(match);
-      return id;
-    };
-    html = html.replace(IIG_ELEMENT_REGEX, (match) => {
-      const parsed = parseImageResultElement(match);
-      if (!parsed) {
-        // Still waiting for its picture: render the loading placeholder in the
-        // element's place. Leaving the tag alone would put an <img> with no
-        // loadable source into the message, and the reader would watch a
-        // broken-image icon for the whole generation.
-        const pending = parseImagePendingElement(match);
-        if (!pending) return match;
-        if (inReasoning) return inertTag(match);
-        const id = this._ph('IG_', imgBlocks.length, true);
-        imgBlocks.push({ type: 'gen', instruction: pending.instruction });
-        return '\n\n' + id + '\n\n';
+    let imageIndex = 0;
+    replacePlaceholders(tree, 'P', (index) => {
+      const region = regions.get(index);
+      if (!region) return null;
+      if (region.kind === 'image') {
+        // Document order: the blocks are numbered the way
+        // ImageTagMarkup.scanImageBlocks() numbers them on the Dart side, so
+        // `data-img-index` addresses one image and not the whole message.
+        return Array.from(
+          parseHtml(renderImageBlock(region.block, imageIndex++), document).childNodes,
+        );
       }
-      const id = this._ph('IG_', imgBlocks.length, true);
-      imgBlocks.push({
-        type: 'result',
-        path: parsed.paths[parsed.activeIndex] || parsed.paths[0] || '',
-        paths: parsed.paths,
-        activeIndex: parsed.activeIndex,
-        instruction: parsed.instruction,
-      });
-      return '\n\n' + id + '\n\n';
-    });
-    // `<img src="[IMG:GEN…]">` with no instruction attribute: the whole element
-    // is the block, so it has to go before the bare-tag pass below — otherwise
-    // only the src payload is consumed and the empty <img> stays behind as a
-    // broken-image icon.
-    html = html.replace(IMG_SRC_GEN_ELEMENT_REGEX, (match) => {
-      const pending = parseImagePendingElement(match);
-      if (!pending) return match;
-      if (inReasoning) return inertTag(match);
-      const id = this._ph('IG_', imgBlocks.length, true);
-      imgBlocks.push({ type: 'gen', instruction: pending.instruction });
-      return '\n\n' + id + '\n\n';
-    });
-    html = html.replace(/\[IMG:GEN(?::(.*?))?\]/g, (match, instruction) => {
-      if (inReasoning) return inertTag(match);
-      const id = this._ph('IG_', imgBlocks.length, true);
-      imgBlocks.push({ type: 'gen', instruction: instruction || '' });
-      return '\n\n' + id + '\n\n';
-    });
-    html = html.replace(/\[IMG:RESULT:(.*?)\]/g, (match, payload) => {
-      const id = this._ph('IG_', imgBlocks.length, true);
-      const parsed = parseImageResultPayload(payload);
-      imgBlocks.push({
-        type: 'result',
-        path: parsed.paths[parsed.activeIndex] || parsed.paths[0] || '',
-        paths: parsed.paths,
-        activeIndex: parsed.activeIndex,
-        instruction: parsed.instruction,
-      });
-      return '\n\n' + id + '\n\n';
-    });
-    html = html.replace(/\[IMG:ERROR:(.*?)\]/g, (match, data) => {
-      const id = this._ph('IG_', imgBlocks.length, true);
-      imgBlocks.push({ type: 'error', data });
-      return '\n\n' + id + '\n\n';
+      return Array.from(parseHtml(this._regionHtml(region, isUser), document).childNodes);
     });
 
-    // 6. Extract HTML Tags — distinguish block vs inline
-    //    Skip orphan tags (no matching pair) so they render as visible text
-    //    instead of being interpreted as real HTML elements.
-    const tagBlocks = [];
-    const blockTags = new Set(['div','p','style','pre','table','ul','ol','li','h1','h2','h3','h4','h5','h6','blockquote','section','article','header','footer','hr','details','summary','figure','figcaption','svg','path','math','canvas','video','audio','form','fieldset','nav','aside','main','img','loomledger']);
-    const TAG_REGEX = /<(?:[^"'>]|"[^"]*"|'[^']*')*>/g;
+    convertFontElements(tree);
+    return this._serialize(tree);
+  }
 
-    const allTagMatches = [...html.matchAll(TAG_REGEX)];
-    const tagCounts = new Map();
-    for (const m of allTagMatches) {
-      const nameMatch = m[0].match(/^<\/?(\w+)/);
-      if (nameMatch) {
-        const name = nameMatch[1].toLowerCase();
-        tagCounts.set(name, (tagCounts.get(name) || 0) + 1);
+  _regionHtml(region, isUser) {
+    switch (region.kind) {
+      case 'code': {
+        const langAttr = region.lang ? ` class="language-${region.lang}"` : '';
+        const langLabel = region.lang ? `<span class="code-lang">${region.lang}</span>` : '';
+        return `<div class="code-block-wrapper">${langLabel}` +
+          `<pre><code${langAttr}>${escapeHtml(region.code)}</code></pre></div>`;
       }
+      case 'inline-code':
+        // Escaped: a tag written inside backticks is shown, not rendered.
+        return `<code>${escapeHtml(region.code)}</code>`;
+      case 'think':
+        return '<details class="reasoning-block">' +
+          '<summary class="reasoning-summary">💭 Reasoning</summary>' +
+          `<div class="reasoning-content">${this._render(region.content, isUser, true)}</div>` +
+          '</details>';
+      case 'html':
+        return region.html;
+      case 'text':
+        return escapeHtml(region.text);
+      default:
+        return '';
     }
-
-    html = html.replace(TAG_REGEX, (match) => {
-      const tagMatch = match.match(/^<\/?(\w+)/);
-      if (!tagMatch) return match;
-      const name = tagMatch[1].toLowerCase();
-      const count = tagCounts.get(name) || 0;
-      // Self-closing tags (br, hr, img) and paired tags are fine;
-      // single occurrence of a non-self-closing tag is orphan — escape it.
-      // Every HTML void element: it is written once, with no closing tag, so
-      // the orphan rule below would turn `<source>` inside a `<video>` into
-      // visible `&lt;source&gt;` text.
-      const selfClosing = new Set([
-        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link',
-        'meta', 'param', 'source', 'track', 'wbr',
-      ]);
-      const isExplicitSelfClosing = /\/\s*>$/.test(match);
-      if (count === 1 && !selfClosing.has(name) && !isExplicitSelfClosing) {
-        return match.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-      }
-      const isBlock = blockTags.has(name);
-      const id = this._ph('T_', tagBlocks.length, isBlock);
-      tagBlocks.push(match);
-      return id;
-    });
-
-    // 7. Extract Glaze custom markers BEFORE quotes
-    const styledSegments = [];
-    const styledRegex = /(==hc:#[0-9a-fA-F]{3,8}==.+?==|==glow:#[0-9a-fA-F]{3,8},\d+==.+?==|==cg:#[0-9a-fA-F]{3,8},#[0-9a-fA-F]{3,8},\d+==.+?==|==grad:#[0-9a-fA-F]{3,8}(?:,#[0-9a-fA-F]{3,8})+==.+?==|==bg:#[0-9a-fA-F]{3,8}==.+?==|==mark==.+?==|==active==.+?==|==accent==.+?==|\*\*[^*\n]+?\*\*|(?<!\*)\*(?=[^*\n]*[^ \t*\n])[^*\n]+?\*(?!\*)|__[^_\n]+?__|(?<!\w)_[^_\n]+?_(?!\w)|~~[^~\n]+?~~)/gs;
-
-    html = html.replace(styledRegex, (match) => {
-      const id = this._ph('S_', styledSegments.length);
-      styledSegments.push(match);
-      return id;
-    });
-    // Models occasionally emit `».* *action*`: the first `*` is an orphan
-    // marker, not an empty italic segment. Drop it once the real action is
-    // safely stashed, otherwise it steals that action's opening marker.
-    html = html.replace(/\*([ \t]+)(?=\x01S_\d+\x01)/g, '$1');
-
-    // 8. Quote formatting — with unclosed quote handling for streaming
-    if (!skipQuotes) {
-      const phGroup = '\x01[A-Z_]+\\d+\x01';
-      // Never let a malformed outer « quote consume a styled-segment
-      // placeholder while looking for its closing ». Each placeholder is
-      // restored independently in step 9.
-      const quoteRegex = new RegExp(`(${phGroup})|(=[ \\t]*"(?:[^"]|\\\\")*?")|(")((?:[^"]|\\\\")*?)(")|(«)([^»\x01]*?(?:«[^»\x01]*?»[^»\x01]*?)*?)(»)|(")((?:[^"]*)$)`, 'gm');
-      html = html.replace(quoteRegex, (match, placeholder, skipQuote, openQ, closedContent, closeQ, openG, guillemetContent, closeG, openU, unclosedContent) => {
-        if (placeholder) return placeholder;
-        if (skipQuote) return skipQuote;
-        if (openQ !== undefined) return `<span class="chat-quote">${openQ}</span><span class="chat-quote-text">${closedContent}</span><span class="chat-quote">${closeQ}</span>`;
-        if (openG !== undefined) {
-          // Nested «outer «inner» more outer» — split at inner «» so the
-          // inner quote renders with default (narration) color, while the
-          // outer text keeps the quote color. Inner «» are literal chars,
-          // not separately colored.
-          const parts = guillemetContent.split(/(«[^»]*?»)/);
-          const rendered = parts.map(p => {
-            if (!p) return '';
-            if (/^«[^»]*?»$/.test(p)) return p;
-            return `<span class="chat-quote-text">${p}</span>`;
-          }).join('');
-          return `<span class="chat-quote">${openG}</span>${rendered}<span class="chat-quote">${closeG}</span>`;
-        }
-        if (openU !== undefined) return `<span class="chat-quote">${openU}</span><span class="chat-quote-text">${unclosedContent}</span>`;
-        return match;
-      });
-    }
-
-    // 9. Restore styled segments with Glaze marker rendering
-    html = html.replace(/\x01S_(\d+)\x01/g, (_, i) => {
-      const seg = styledSegments[parseInt(i)];
-      // skipQuotes defaults to true (preserve color markers' fills);
-      // plain formatting (italic/bold/strike) opts out via the second arg.
-      return renderStyledSegment(seg, (innerRaw, skipQuotes = true) => this._processText(innerRaw, false, skipQuotes, inReasoning));
-    });
-
-    // 10. Markdown Parsing
-    html = html.replace(/^>\s?(.*)$/gm, '<blockquote class="chat-blockquote">$1</blockquote>');
-    html = html.replace(/<\/blockquote>\n*<blockquote class="chat-blockquote">/g, '<br>');
-    html = html.replace(/^(_{3,}|-{3,}|\*{3,})$/gm, () => {
-      // A raw `<hr>` here would be plain text to step 11 and end up inside a
-      // paragraph; as a tag placeholder it keeps its own line.
-      tagBlocks.push('<hr>');
-      return `\n\n${this._ph('T_', tagBlocks.length - 1, true)}\n\n`;
-    });
-    html = html.replace(/~~([^~\n]+?)~~/g, '<del>$1</del>');
-    html = html.replace(/\*\*\*([^*\n]+?)\*\*\*/g, '<strong><em>$1</em></strong>');
-    html = html.replace(/\*\*([^*\n]+?)\*\*/g, '<strong>$1</strong>');
-    // Never let an unmatched marker consume text from a later line.
-    html = html.replace(/\*([^*\n]+?)\*/g, '<em>$1</em>');
-    html = html.replace(/<em>/g, '<em class="chat-italic">');
-
-    html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
-
-    // 10a0. Markdown tables — header row, a `---` separator, then body rows.
-    //       The separator is what tells a table from a line of prose that
-    //       happens to use pipes, so it is required.
-    const TABLE_RUN =
-      /(?:^|\n)([ \t]*\|[^\n]*\|[ \t]*\n[ \t]*\|[ \t:|-]+\|[ \t]*(?:\n[ \t]*\|[^\n]*\|[ \t]*)*)/g;
-    html = html.replace(TABLE_RUN, (match, run) => {
-      const rows = run.trim().split('\n').map(line => line.trim());
-      const cells = row => row.replace(/^\||\|$/g, '').split('|').map(c => c.trim());
-      const head = cells(rows[0]).map(c => `<th>${c}</th>`).join('');
-      const body = rows.slice(2)
-        .map(row => `<tr>${cells(row).map(c => `<td>${c}</td>`).join('')}</tr>`)
-        .join('');
-      tagBlocks.push(
-        `<table class="chat-table"><thead><tr>${head}</tr></thead>` +
-        `${body ? `<tbody>${body}</tbody>` : ''}</table>`,
-      );
-      return `\n\n${this._ph('T_', tagBlocks.length - 1, true)}\n\n`;
-    });
-
-    // 10a. Headings — `#` through `######`, the way every markdown renderer
-    //      spells them. Left as text they show up as literal hashes.
-    html = html.replace(/^(#{1,6})[ \t]+(.+?)[ \t]*#*$/gm, (match, hashes, body) => {
-      const level = hashes.length;
-      tagBlocks.push(`<h${level} class="chat-heading">${body}</h${level}>`);
-      return `\n\n${this._ph('T_', tagBlocks.length - 1, true)}\n\n`;
-    });
-
-    // 10b. Markdown lists
-    const listBlocks = [];
-    html = html.replace(/((?:^|\n)((?:[ \t]*[-*] .+(?:\n|$))+))/g, (match) => {
-      const id = this._ph('LB_', listBlocks.length, true);
-      // An indented item belongs to the list above it. Splitting the run at
-      // the first indented line left it stranded as its own paragraph between
-      // two lists; nesting it keeps the run one list.
-      const items = match.trim().split('\n')
-        .filter(line => /^[ \t]*[-*] /.test(line))
-        .map(line => ({
-          depth: /^[ \t]+/.test(line) ? 1 : 0,
-          text: line.replace(/^[ \t]*[-*] /, ''),
-        }));
-      let rendered = '';
-      let nested = false;
-      let open = false;
-      for (const item of items) {
-        if (item.depth) {
-          // The sub-list lives inside the item above it, which stays open
-          // until the run ends or the next top-level item starts.
-          if (!nested) { rendered += '<ul class="chat-list">'; nested = true; }
-          rendered += `<li>${item.text}</li>`;
-          continue;
-        }
-        if (nested) { rendered += '</ul>'; nested = false; }
-        if (open) rendered += '</li>';
-        rendered += `<li>${item.text}`;
-        open = true;
-      }
-      if (nested) rendered += '</ul>';
-      if (open) rendered += '</li>';
-      listBlocks.push(`<ul class="chat-list">${rendered}</ul>`);
-      return '\n\n' + id + '\n\n';
-    });
-    html = html.replace(/((?:^|\n)((?:\d+\. .+(?:\n|$))+))/g, (match) => {
-      const id = this._ph('LB_', listBlocks.length, true);
-      const items = match.trim().split('\n')
-        .filter(line => line.match(/^\d+\. /))
-        .map(line => `<li>${line.replace(/^\d+\. /, '')}</li>`)
-        .join('');
-      listBlocks.push(`<ol class="chat-list">${items}</ol>`);
-      return '\n\n' + id + '\n\n';
-    });
-
-    // 11. Paragraphs — isolate block placeholders, don't wrap in <p>
-    const blockPh = '\x01T_BLOCK_\\d+\x01';
-    const codePh = '\x01CB_\\d+\x01';
-    const stylePh = '\x01STY_BLOCK_\\d+\x01';
-    const scriptPh = '\x01SCR_BLOCK_\\d+\x01';
-    const listPh = '\x01LB_BLOCK_\\d+\x01';
-    const imgPh = '\x01IG_BLOCK_\\d+\x01';
-    const allBlockPh = `${codePh}|${blockPh}|${stylePh}|${scriptPh}|${listPh}|${imgPh}`;
-    html = html.replace(new RegExp(`\\n?(${allBlockPh})\\n?`, 'g'), '\n\n$1\n\n');
-
-    const paragraphs = html.split(/\n\n+/);
-    html = paragraphs
-      .map(p => {
-        let trimmed = p.trim();
-        if (!trimmed) return '';
-
-        if (new RegExp(`^(${allBlockPh})$`).test(trimmed)) return trimmed;
-
-        // A paragraph made of nothing but HTML tags — a bare `<input>` on its
-        // own line, say — is left unwrapped. A `<p>` around it would reparent
-        // the tag, and CSS-only cards are built on exactly that adjacency:
-        // `#toggle:checked ~ .overlay` stops matching the moment the checkbox
-        // and its target stop being siblings, so the card's button goes dead
-        // while the checkbox itself still toggles.
-        if (ONLY_TAG_PLACEHOLDERS.test(trimmed)) {
-          return trimmed.replace(/\s*\n\s*/g, '');
-        }
-
-        const startsWithBlock = new RegExp(`^(${blockPh}|${stylePh}|${scriptPh})`).test(trimmed);
-        trimmed = trimmed.replace(new RegExp(`(\x01T_(?:BLOCK_)?\\d+\x01)\\s*\\n\\s*`, 'g'), '$1 ');
-        trimmed = trimmed.replace(new RegExp(`\\s*\\n\\s*(\x01T_(?:BLOCK_)?\\d+\x01)`, 'g'), ' $1');
-        trimmed = trimmed.replace(/\n/g, '<br>');
-        return startsWithBlock ? trimmed : `<p>${trimmed}</p>`;
-      })
-      .filter(p => p !== '')
-      .join('');
-
-    // 12. Restore HTML Tags
-    html = html.replace(/\x01T_(?:BLOCK_)?(\d+)\x01/g, (_, i) => tagBlocks[parseInt(i)]);
-    html = html.replace(/(<svg\b[^>]*>)\s*<p>([\s\S]*?)<\/p>\s*(<\/svg>)/gi, '$1$2$3');
-
-    // 12b. Restore list blocks
-    html = html.replace(/\x01LB_BLOCK_(\d+)\x01/g, (_, i) => listBlocks[parseInt(i)]);
-
-    // 12c. Restore markdown image cards — kept whole so the options button
-    //      stays inside its positioned .janitor-img-wrapper (see step 5b).
-    html = html.replace(/\x01MI_(\d+)\x01/g, (_, i) => mdImages[parseInt(i)]);
-
-    // 12d. Restore inline code — escaped, so a tag written inside backticks
-    //      is shown, not rendered.
-    html = html.replace(/\x01IC_(\d+)\x01/g, (_, i) => {
-      const code = inlineCode[parseInt(i)];
-      return `<code>${this._escapeHtml(code)}</code>`;
-    });
-
-    // 13. Restore CSS comments
-    html = html.replace(/\x01CC_(\d+)\x01/g, (_, i) => cssComments[parseInt(i)]);
-
-    // 14. Restore style blocks
-    html = html.replace(/\x01STY_BLOCK_(\d+)\x01/g, (_, i) => styleBlocks[parseInt(i)]);
-
-    // 15. Restore script blocks (will be executed by renderer via DOM API)
-    html = html.replace(/\x01SCR_BLOCK_(\d+)\x01/g, (_, i) => {
-      return scriptBlocks[parseInt(i)];
-    });
-
-    // 16. Restore Code Blocks
-    html = html.replace(/\x01CB_(\d+)\x01/g, (_, i) => {
-      const block = codeBlocks[parseInt(i)];
-      const escapedCode = block.code
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
-      const langAttr = block.lang ? ` class="language-${block.lang}"` : '';
-      const langLabel = block.lang ? `<span class="code-lang">${block.lang}</span>` : '';
-      return `<div class="code-block-wrapper">${langLabel}<pre><code${langAttr}>${escapedCode}</code></pre></div>`;
-    });
-
-    // 17. Restore think blocks
-    html = html.replace(/\x01TB_BLOCK_(\d+)\x01/g, (_, i) => {
-      const content = thinkBlocks[parseInt(i)];
-      const formatted = this._processText(content, isUser, false, true);
-      return `<details class="reasoning-block"><summary class="reasoning-summary">💭 Reasoning</summary><div class="reasoning-content">${formatted}</div></details>`;
-    });
-
-    // 18. Restore font color/style blocks
-    // skipQuotes=true: quotes inside styled spans keep their visual style intact
-    // (chat-quote color would override gradient/color fills)
-    html = html.replace(/\x01FC_(\d+)\x01/g, (_, i) => {
-      const block = fontBlocks[parseInt(i)];
-      if (block.type === 'style') {
-        let formatted = this._processText(block.content, isUser, true, inReasoning);
-        formatted = formatted.replace(/^\s*<p>([\s\S]*?)<\/p>\s*$/i, '$1');
-
-        // Propagate gradient / text-fill / clip styles down to the first nested inline element
-        // when the LLM put the visible text inside <span style="transform..."> inside the <font>.
-        // Without this the background-clip:text on the outer span has no text to clip.
-        const hasGradientClip = /background-clip\s*:\s*text/i.test(block.style) ||
-                                /-webkit-background-clip\s*:\s*text/i.test(block.style) ||
-                                /-webkit-text-fill-color\s*:\s*transparent/i.test(block.style);
-        if (hasGradientClip) {
-          const toMerge = [];
-          const bg = block.style.match(/background-image\s*:\s*[^;]+/i);
-          const clip = block.style.match(/-webkit-background-clip\s*:\s*[^;]+/i);
-          const fill = block.style.match(/-webkit-text-fill-color\s*:\s*[^;]+/i);
-          const stroke = block.style.match(/-webkit-text-stroke\s*:\s*[^;]+/i);
-          const filter = block.style.match(/filter\s*:\s*[^;]+/i);
-          for (const m of [bg, clip, fill, stroke, filter]) if (m) toMerge.push(m[0]);
-          if (toMerge.length) {
-            const extra = toMerge.join('; ');
-            formatted = formatted.replace(/^(\s*<span)(\s+style=")([^"]*)(")/i, (m, tagOpen, styleOpen, inner, styleClose) => {
-              const merged = (inner || '').replace(/;?\s*$/, '') + '; ' + extra;
-              return `${tagOpen}${styleOpen}${merged}${styleClose}`;
-            });
-          }
-        }
-
-        return `<span class="font-style-block" style="${block.style}">${formatted}</span>`;
-      }
-      let formatted = this._processText(block.content, isUser, true, inReasoning);
-      formatted = formatted.replace(/^\s*<p>([\s\S]*?)<\/p>\s*$/i, '$1');
-      return `<span class="font-color-block" style="color:${block.color}">${formatted}</span>`;
-    });
-
-    // 19. Restore image gen blocks (Imagen UI ported from Glaze ShadowContent.vue)
-    //
-    // The placeholders sit where their tags were, so this pass walks the blocks
-    // in document order — the same order ImageTagMarkup.scanImageBlocks() sees
-    // on the Dart side. `data-img-index` carries that position back with every
-    // tap, which is what makes an action apply to one image and not the whole
-    // message.
-    let imgBlockIndex = 0;
-    html = html.replace(/\x01IG_BLOCK_(\d+)\x01/g, (_, i) => {
-      const block = imgBlocks[parseInt(i)];
-      const at = imgBlockIndex++;
-      if (block.type === 'result') {
-        const src = this._imageSrc(block.path);
-        const encInstr = encodeURIComponent(block.instruction || '');
-        const variants = (block.paths || []).map((p) => this._imageSrc(p));
-        const activeIndex = variants.length > 1 ? (block.activeIndex || 0) : 0;
-        // The switcher only exists once the block holds a second image, so a
-        // single-image block renders exactly as it always did.
-        const switcher = variants.length > 1
-          ? `<span class="imggen-variants"><button class="imggen-variant-btn" type="button" data-action="img-variant-prev" data-img-index="${at}" title="Previous image">${VARIANT_PREV_SVG}</button><span class="imggen-variant-count">${activeIndex + 1}/${variants.length}</span><button class="imggen-variant-btn" type="button" data-action="img-variant-next" data-img-index="${at}" title="Next image">${VARIANT_NEXT_SVG}</button></span>`
-          : '';
-        // The whole list rides along on the wrapper so paging through the
-        // block swaps the picture in place, with no round trip to Flutter.
-        const variantAttrs = variants.length > 1
-          ? ` data-variants="${this._escapeHtml(variants.join(IMG_VARIANT_SEPARATOR))}" data-variant-index="${activeIndex}"`
-          : '';
-        // loading="eager" (not "lazy"): a just-generated image lands at the
-        // bottom edge of the WebView, where Android/iOS keep resizing the
-        // viewport around the input bar. A lazy image there can be evaluated
-        // while the row is still off-screen and never come back for it, and
-        // the picture the user just waited for shows as a broken tag. These
-        // are local files, so eager loading costs nothing — same reasoning as
-        // _renderExtBlockImageHtml in the bridge controller.
-        return `<span class="imggen-result-wrapper"${variantAttrs}><img src="${src}" class="imggen-result" loading="eager" decoding="async" data-action="image-click" data-src="${src}"><button class="imggen-options-btn" type="button" data-action="img-options" data-src="${src}" data-instruction="${encInstr}" data-img-index="${at}" title="Options">${OPTIONS_SVG}</button>${switcher}</span>`;
-      }
-      if (block.type === 'gen') {
-        const start = Date.now();
-        // A pending block that carried images through a regeneration spells its
-        // payload `@paths|instruction`; reading it here keeps the prompt line
-        // showing the prompt instead of the path list in front of it.
-        const pending = parseImagePendingPayload(block.instruction);
-        const prompt = this._escapeHtml(this._imgPrompt(pending.instruction));
-        const promptEl = prompt ? `<div class="imggen-loading-prompt">${prompt}</div>` : '';
-        // The children are moved into a shadow root of the placeholder's own by
-        // `isolateImgGenPlaceholders` right after insertion, which is what keeps
-        // message CSS from restyling them (see renderer/imggen_placeholder.js).
-        // Two labels, one of which is hidden: the block is "queued" until the
-        // reply has finished streaming and post-gen actually reaches the image
-        // stage (INV-IG1), and only then does anything start elapsing or
-        // become stoppable. `refreshImgGenPlaceholderState` flips the class.
-        return `<div class="imggen-loading" data-start="${start}" data-img-index="${at}"><span class="imggen-loading-hint">Generating image…</span><span class="imggen-queued-hint">Image queued…</span><span class="imggen-loading-timer" data-start="${start}">0.0s</span><button class="imggen-stop-btn" type="button" data-action="img-stop" title="Stop image generation" aria-label="Stop image generation">${STOP_SVG}</button>${promptEl}</div>`;
-      }
-      if (block.type === 'error') {
-        let errorMsg = 'Unknown error';
-        let instruction = '';
-        try {
-          const parsed = JSON.parse(block.data);
-          errorMsg = parsed.error || errorMsg;
-          instruction = parsed.instruction || '';
-        } catch(_) {}
-        const encInstr = encodeURIComponent(instruction);
-        if (errorMsg === 'Image generation disabled') {
-          return `<div class="imggen-error imggen-disabled" data-instruction="${encInstr}" data-img-index="${at}"><span class="imggen-error-icon">🖼</span><span class="imggen-error-msg">Image generation disabled</span><div class="imggen-error-actions"><button class="imggen-error-retry" type="button" data-action="img-enable-retry" data-instruction="${encInstr}" data-img-index="${at}">Enable and generate</button></div></div>`;
-        }
-        return `<div class="imggen-error" data-instruction="${encInstr}" data-img-index="${at}"><span class="imggen-error-icon">⚠</span><span class="imggen-error-msg">${this._escapeHtml(errorMsg)}</span><div class="imggen-error-actions"><button class="imggen-error-retry" type="button" data-action="img-retry" data-instruction="${encInstr}" data-img-index="${at}">↻ Regenerate</button><button class="imggen-error-options" type="button" data-action="img-options" data-instruction="${encInstr}" data-img-index="${at}" title="Options">${OPTIONS_SVG}</button></div></div>`;
-      }
-      return '';
-    });
-
-    // 19b. Restore the tags a reasoning block only talked about, as the text
-    // the model wrote. Nothing here loads, spins or generates.
-    html = html.replace(/\x01IGT_(\d+)\x01/g, (_, i) =>
-      this._escapeHtml(inertImgTags[parseInt(i)]),
-    );
-
-    html = html.replace(/\x01[A-Z_]+\d+\x01/g, '');
-
-    return html;
   }
 
-  _renderStyledSegment(seg) {
-    return renderStyledSegment(seg, (innerRaw) => this._processText(innerRaw, false, true));
-  }
-
-  _imageSrc(path) {
-    if (!path) return '';
-    if (path.startsWith('data:') || path.startsWith('http://') || path.startsWith('https://') || path.startsWith('file://')) {
-      return path;
-    }
-    const normalized = path.replace(/\\/g, '/');
-    return normalized.startsWith('/') ? `file://${normalized}` : `file:///${normalized}`;
-  }
-
-  // Normalizes the destination of a markdown image/link.
-  //
-  // The raw capture is everything between the parens, which for CommonMark can
-  // carry padding, an <…> wrapper and a title: `![a]( <u> "cap" )`. A browser
-  // trims and re-encodes most of that when it loads the <img>, so the picture
-  // still appears in the message — but the same raw string handed to Flutter
-  // (via data-src) is not a valid URL there, and the full-screen viewer opens
-  // onto nothing. Normalize once, so both sides see the same URL.
-  _normalizeMdUrl(url) {
-    let out = String(url == null ? '' : url).trim();
-    // Trailing title: `url "caption"` / `url 'caption'` / `url (caption)`.
-    const titled = out.match(/^(\S+)\s+(?:"[^"]*"|'[^']*'|\([^)]*\))$/);
-    if (titled) out = titled[1];
-    if (out.startsWith('<') && out.endsWith('>')) out = out.slice(1, -1).trim();
-    return out;
-  }
-
-  _escapeHtml(value) {
-    return String(value == null ? '' : value)
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;');
-  }
-
-  // Extract a human-readable prompt from an IMG:GEN instruction payload.
-  // The payload may be a JSON object ({prompt, caption, ...}) or raw text.
-  _imgPrompt(instruction) {
-    const raw = (instruction || '').trim();
-    if (!raw) return '';
-    try {
-      const json = JSON.parse(raw);
-      if (json && typeof json === 'object') {
-        const p = (json.prompt || json.caption || '').replace(/^SCENE_PROMPT:\s*/, '');
-        return p || '';
-      }
-    } catch (_) { /* fall through to raw */ }
-    return raw;
+  _serialize(tree) {
+    const template = document.createElement('template');
+    template.content.appendChild(tree);
+    return template.innerHTML;
   }
 }

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -18,7 +18,7 @@
 // afterwards. See docs/rules/message-rendering.md.
 
 import { expandMacros } from './macros.js';
-import { escapeProseTags } from './html_scan.js';
+import { escapeProseTags, styledElementNames } from './html_scan.js';
 import {
   ANY_PLACEHOLDER,
   createStore,
@@ -97,14 +97,18 @@ export class Formatter {
     const markers = createStore('S');
 
     let staged = protectRegions(source, { store: regions, inReasoning });
+    // `<style>` and `<script>` bodies are code, and both string passes below
+    // would read them as prose: a `*` in a selector is not an italic marker,
+    // and `i<n; i++) { if (i>` in a script is not a tag. They are masked for
+    // the length of both, and put back for the parser.
+    const styled = styledElementNames(staged);
+    const code = maskCodeElements(staged);
     // Style markers come out before the parse, because html_to_markdown writes
     // rich content inside them and a parsed marker is two text nodes with an
-    // element between. `<style>`/`<script>` bodies are hidden for that scan:
-    // a `*` in a selector is not an italic marker.
-    const code = maskCodeElements(staged);
-    staged = code.unmask(extractMarkers(code.masked, markers));
+    // element between them.
+    staged = extractMarkers(code.masked, markers);
 
-    const tree = parseHtml(escapeProseTags(staged), document);
+    const tree = parseHtml(code.unmask(escapeProseTags(staged, styled)), document);
 
     formatContainer(tree, {
       isRoot: true,

--- a/assets/chat_webview/formatter/html_scan.js
+++ b/assets/chat_webview/formatter/html_scan.js
@@ -73,7 +73,7 @@ export const RAW_TEXT_ELEMENTS = new Set([
 ]);
 
 /** Element names a `<style>` block in the message uses as a type selector. */
-function styledElementNames(text) {
+export function styledElementNames(text) {
   const names = new Set();
   const styles = text.match(/<style\b[^>]*>[\s\S]*?(?:<\/style>|$)/gi) || [];
   for (const block of styles) {
@@ -98,9 +98,14 @@ function styledElementNames(text) {
 /**
  * Escapes the tags in [text] that are prose rather than markup, and leaves
  * every other character untouched. The result is what gets parsed.
+ *
+ * [styledNames] is the set of element names the message's CSS styles. The
+ * caller passes it in when `<style>` and `<script>` bodies are masked out of
+ * [text] — which they must be, because `i<n; i++) { if (i>` inside a script is
+ * a tag to this scan, and escaping it corrupts the script.
  */
-export function escapeProseTags(text) {
-  const styled = styledElementNames(text);
+export function escapeProseTags(text, styledNames) {
+  const styled = styledNames || styledElementNames(text);
   const opened = new Set();
   const closed = new Set();
   TAG_REGEX.lastIndex = 0;

--- a/assets/chat_webview/formatter/html_scan.js
+++ b/assets/chat_webview/formatter/html_scan.js
@@ -1,0 +1,145 @@
+// What in a message is markup, and what is a reader writing about markup.
+//
+// This is the only guess the renderer still makes, and it is a small one: the
+// browser parses everything, so the question is not "is this tag block or
+// inline" (the parser knows) or "is this tag closed" (the parser closes it) —
+// only "did the author mean an element here at all". A model writing
+// `он прошептал <вздох>` means the word, not an element.
+//
+// The rule, in order:
+//   1. a name the HTML/SVG/MathML vocabulary defines is markup, always;
+//   2. any other name is markup if the message's own CSS styles it (that is
+//      how `<loomledger>` and friends declare themselves), or if it appears as
+//      a matched open/close pair;
+//   3. anything else is text, and its angle brackets are escaped.
+//
+// What this replaces: the "orphan" counter (a tag was text if its name
+// occurred exactly once in the message) and the hand-kept `blockTags` list.
+
+/** One tag, with quoted attribute values that may contain `>`. */
+export const TAG_REGEX = /<(?:[^"'>]|"[^"]*"|'[^']*')*>/g;
+
+/** The tag's name, lower-cased, or '' for a comment / doctype / stray `<`. */
+export function tagName(tag) {
+  const match = /^<\/?([A-Za-z][A-Za-z0-9-]*)/.exec(tag);
+  return match ? match[1].toLowerCase() : '';
+}
+
+export function isClosingTag(tag) {
+  return /^<\//.test(tag);
+}
+
+// Every element name the HTML, SVG and MathML vocabularies define, including
+// the deprecated ones a model still writes (`<font>`, `<center>`, `<marquee>`).
+// A name in this set is markup whatever the message does with it.
+const HTML_ELEMENTS = new Set(`
+a abbr acronym address applet area article aside audio b base basefont bdi bdo
+big blink blockquote body br button canvas caption center cite code col colgroup
+data datalist dd del details dfn dialog dir div dl dt em embed fieldset
+figcaption figure font footer form frame frameset h1 h2 h3 h4 h5 h6 head header
+hgroup hr html i iframe img input ins kbd label legend li link main map mark
+marquee menu meta meter nav nobr noscript object ol optgroup option output p
+param picture plaintext pre progress q rb rp rt rtc ruby s samp script search
+section select slot small source spacer span strike strong style sub summary
+sup table tbody td template textarea tfoot th thead time title tr track tt u ul
+var video wbr xmp
+`.trim().split(/\s+/));
+
+const SVG_ELEMENTS = new Set(`
+svg altglyph animate animatemotion animatetransform circle clippath defs desc
+ellipse feblend fecolormatrix fecomponenttransfer fecomposite feconvolvematrix
+fediffuselighting fedisplacementmap fedropshadow feflood fefunca fefuncb
+fefuncg fefuncr fegaussianblur feimage femerge femergenode femorphology
+feoffset fepointlight fespecularlighting fespotlight fetile feturbulence
+filter foreignobject g image line lineargradient marker mask metadata mpath
+path pattern polygon polyline radialgradient rect set stop switch symbol text
+textpath tspan use view
+`.trim().split(/\s+/));
+
+const MATHML_ELEMENTS = new Set(`
+math maction menclose merror mfenced mfrac mglyph mi mlabeledtr mmultiscripts
+mn mo mover mpadded mphantom mroot mrow ms mspace msqrt mstyle msub msubsup
+msup mtable mtd mtext mtr munder munderover semantics annotation
+`.trim().split(/\s+/));
+
+export function isKnownElement(name) {
+  return HTML_ELEMENTS.has(name) || SVG_ELEMENTS.has(name) ||
+    MATHML_ELEMENTS.has(name);
+}
+
+/** Elements whose content is raw text: markdown never reaches inside them. */
+export const RAW_TEXT_ELEMENTS = new Set([
+  'script', 'style', 'pre', 'code', 'textarea', 'title', 'xmp', 'plaintext',
+]);
+
+/** Element names a `<style>` block in the message uses as a type selector. */
+function styledElementNames(text) {
+  const names = new Set();
+  const styles = text.match(/<style\b[^>]*>[\s\S]*?(?:<\/style>|$)/gi) || [];
+  for (const block of styles) {
+    const selectors = block
+      // Declarations carry property names that would otherwise read as
+      // element names (`background`, `filter`, `mask`).
+      .replace(/\{[^}]*\}?/g, ' ')
+      // At-rule preludes name fonts, urls and media features, not elements.
+      .replace(/@[^;{]*/g, ' ')
+      // A class, id, attribute or pseudo is not a type selector.
+      .replace(/\[[^\]]*\]/g, ' ')
+      .replace(/[.#:][A-Za-z0-9_-]+(?:\([^)]*\))?/g, ' ');
+    const TYPE_SELECTOR = /(?:^|[\s,>+~])([A-Za-z][A-Za-z0-9-]*)/g;
+    let match;
+    while ((match = TYPE_SELECTOR.exec(selectors)) !== null) {
+      names.add(match[1].toLowerCase());
+    }
+  }
+  return names;
+}
+
+/**
+ * Escapes the tags in [text] that are prose rather than markup, and leaves
+ * every other character untouched. The result is what gets parsed.
+ */
+export function escapeProseTags(text) {
+  const styled = styledElementNames(text);
+  const opened = new Set();
+  const closed = new Set();
+  TAG_REGEX.lastIndex = 0;
+  let match;
+  while ((match = TAG_REGEX.exec(text)) !== null) {
+    const name = tagName(match[0]);
+    if (!name) continue;
+    (isClosingTag(match[0]) ? closed : opened).add(name);
+  }
+
+  return text.replace(TAG_REGEX, (tag) => {
+    const name = tagName(tag);
+    if (!name) return tag;
+    if (isKnownElement(name)) return tag;
+    if (styled.has(name)) return tag;
+    if (opened.has(name) && closed.has(name)) return tag;
+    return tag.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  });
+}
+
+/**
+ * Replaces every tag with an opaque placeholder and hands back the restore.
+ *
+ * Used where a string pass must not read inside a tag: markdown markers are
+ * matched across a message that still contains raw HTML, and `*` inside
+ * `<div style="a*b">` is not an italic marker. Markers that *span* tags
+ * (`==hc:#fff==<b>x</b>==`, which is how html_to_markdown writes rich colour)
+ * still match, because the tag is one opaque character run rather than a
+ * boundary.
+ */
+export function maskTags(text, sentinel) {
+  const tags = [];
+  const masked = text.replace(TAG_REGEX, (tag) => {
+    tags.push(tag);
+    return `${sentinel}TAG_${tags.length - 1}${sentinel}`;
+  });
+  const pattern = new RegExp(`${sentinel}TAG_(\\d+)${sentinel}`, 'g');
+  return {
+    masked,
+    unmask: (value) => String(value).replace(pattern, (_m, i) => tags[Number(i)]),
+  };
+}

--- a/assets/chat_webview/formatter/image_blocks.js
+++ b/assets/chat_webview/formatter/image_blocks.js
@@ -1,0 +1,336 @@
+// Image blocks: the stored forms an image tag is written in, and the markup
+// each one renders to.
+//
+// Split out of formatter.js when the formatter became a two-phase renderer.
+// Everything here works on the *raw* message text, before it is parsed: an
+// image tag is pulled out of the source and replaced with a placeholder, so
+// the parser never sees an `<img>` with no loadable source and the reader
+// never watches a broken-image icon while a picture is being generated.
+
+// Vertical 3-dot "options" icon (ported from Glaze useMessageImageGen.js).
+const OPTIONS_SVG = '<svg viewBox="0 0 24 24"><path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>';
+const VARIANT_PREV_SVG = '<svg viewBox="0 0 24 24"><path d="M15.4 7.4 14 6l-6 6 6 6 1.4-1.4-4.6-4.6z"/></svg>';
+const VARIANT_NEXT_SVG = '<svg viewBox="0 0 24 24"><path d="M8.6 7.4 10 6l6 6-6 6-1.4-1.4 4.6-4.6z"/></svg>';
+// Stop icon for the loading placeholder. An SVG rather than the ⏹ character:
+// the glyph is a font-dependent emoji that renders at a different size (and in
+// colour) on every platform, while a path is the same square everywhere and
+// takes `fill: currentColor` from the button.
+const STOP_SVG = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="2"/></svg>';
+
+/** Separator between the images one block carries, mirroring the Dart codec. */
+export const IMG_VARIANT_SEPARATOR = ';;';
+
+/** Marks the image on screen inside a multi-image payload. */
+const IMG_VARIANT_ACTIVE_MARKER = '*';
+
+/** Introduces the images a pending block carries, mirroring the Dart codec. */
+const IMG_PENDING_MARKER = '@';
+
+/**
+ * Matches one `<img …data-iig-instruction…>` element, the stored form of an
+ * image block. Whether it is finished or still waiting is decided by its
+ * `src` (see `parseImageResultElement`), not by the pattern.
+ */
+export const IIG_ELEMENT_REGEX = /<img\s[^>]*?data-iig-instruction\s*=\s*(?:"[^"]*"|'[^']*')[^>]*>/gi;
+
+/**
+ * Matches an `<img …src="[IMG:GEN…]">` element that carries no instruction
+ * attribute — the spelling a model writes by hand, where the payload lives in
+ * the `src`. Mirrors ImgGenPatterns.imgSrcGenRegex on the Dart side.
+ */
+export const IMG_SRC_GEN_ELEMENT_REGEX = /<img\b[^>]*?\bsrc\s*=\s*["']\[IMG:GEN[^\]]*\]["'][^>]*>/gi;
+
+const ATTRIBUTE_PAIR_REGEX = /([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]*))/g;
+
+/**
+ * Splits an `[IMG:RESULT:…]` payload into its images, the one on screen and
+ * the instruction — the JS half of ImageBlockPayload in image_tag_markup.dart.
+ * A single-image block keeps the historical `path|instruction` spelling, so
+ * messages written before block variants existed parse unchanged.
+ */
+export function parseImageResultPayload(payload) {
+  const raw = String(payload == null ? '' : payload);
+  const pipeIdx = raw.indexOf('|');
+  const head = pipeIdx === -1 ? raw : raw.substring(0, pipeIdx);
+  const instruction = pipeIdx === -1 ? '' : raw.substring(pipeIdx + 1);
+  const paths = [];
+  let activeIndex = 0;
+  for (const entry of head.split(IMG_VARIANT_SEPARATOR)) {
+    if (!entry) continue;
+    if (entry.startsWith(IMG_VARIANT_ACTIVE_MARKER)) {
+      activeIndex = paths.length;
+      paths.push(entry.substring(IMG_VARIANT_ACTIVE_MARKER.length));
+    } else {
+      paths.push(entry);
+    }
+  }
+  return { paths, activeIndex, instruction };
+}
+
+/**
+ * Splits an `[IMG:GEN:…]` payload into the images the block already holds and
+ * its instruction — the JS half of ImageBlockPayload.parsePending. Without the
+ * `@` marker the whole payload is the instruction, which is how every block
+ * written before regeneration carried its images is spelled.
+ */
+export function parseImagePendingPayload(payload) {
+  const raw = String(payload == null ? '' : payload);
+  if (!raw.startsWith(IMG_PENDING_MARKER)) {
+    return { paths: [], activeIndex: 0, instruction: raw };
+  }
+  return parseImageResultPayload(raw.substring(IMG_PENDING_MARKER.length));
+}
+
+/** Attributes of one `<img …>` element, lower-cased names to raw values. */
+function imgAttributes(tag) {
+  const body = String(tag == null ? '' : tag).replace(/^<\s*[A-Za-z][-A-Za-z0-9]*/i, '');
+  // Null-prototype: an attribute called `constructor` or `toString` must not
+  // read as already present, and must not reach an inherited value.
+  const attributes = Object.create(null);
+  ATTRIBUTE_PAIR_REGEX.lastIndex = 0;
+  let match;
+  while ((match = ATTRIBUTE_PAIR_REGEX.exec(body)) !== null) {
+    const name = match[1].toLowerCase();
+    if (name in attributes) continue;
+    const value = match[2] !== undefined ? match[2]
+      : match[3] !== undefined ? match[3]
+      : match[4] !== undefined ? match[4] : '';
+    attributes[name] = value;
+  }
+  return attributes;
+}
+
+function unescapeAttribute(value) {
+  const raw = String(value == null ? '' : value);
+  if (raw.indexOf('&') === -1) return raw;
+  return raw
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&');
+}
+
+/**
+ * Reads the stored `<img data-iig-…>` form of a finished image block — the JS
+ * half of ImageTagMarkup.encodeResultElement in image_tag_markup.dart. The
+ * visible image is the element's `src`, the block's other images ride along in
+ * `data-iig-variants`. Returns null while the block is still waiting for its
+ * picture (no `src`, or the `[IMG:GEN…]` placeholder in it), which the caller
+ * reads as "not a result".
+ */
+export function parseImageResultElement(tag) {
+  const attributes = imgAttributes(tag);
+  const src = unescapeAttribute(attributes.src || '').trim();
+  if (!src || src.startsWith('[IMG:GEN')) return null;
+  const instruction = unescapeAttribute(attributes['data-iig-instruction'] || '');
+  const variants = unescapeAttribute(attributes['data-iig-variants'] || '');
+  const paths = [];
+  for (const entry of variants.split(IMG_VARIANT_SEPARATOR)) {
+    if (entry) paths.push(entry);
+  }
+  if (!paths.length) paths.push(src);
+  const declared = parseInt(attributes['data-iig-index'], 10);
+  const fallback = paths.indexOf(src);
+  let activeIndex = Number.isNaN(declared) ? fallback : declared;
+  if (!(activeIndex >= 0)) activeIndex = 0;
+  if (activeIndex > paths.length - 1) activeIndex = paths.length - 1;
+  return { paths, activeIndex, instruction };
+}
+
+/**
+ * Reads the pending form of a stored image block: the same `<img data-iig-…>`
+ * element, but with no picture in its `src` yet (see `parseImageResultElement`,
+ * which is what decides between the two). Returns null for a finished block.
+ *
+ * Pulling this element out of the markup — instead of leaving it to render as
+ * an ordinary `<img>` — is what keeps a browser's broken-image icon off the
+ * screen while the picture is still being generated: the tag has no image to
+ * load, so the only thing it can paint is the failure glyph.
+ */
+export function parseImagePendingElement(tag) {
+  const attributes = imgAttributes(tag);
+  const src = unescapeAttribute(attributes.src || '').trim();
+  if (src && !src.startsWith('[IMG:GEN')) return null;
+  // The instruction attribute is the authoritative payload; a bare
+  // `<img src="[IMG:GEN:…]">` carries it inside the src instead.
+  let instruction = unescapeAttribute(attributes['data-iig-instruction'] || '');
+  if (!instruction && src) {
+    const inSrc = src.match(/^\[IMG:GEN(?::([\s\S]*))?\]$/);
+    if (inSrc) instruction = inSrc[1] || '';
+  }
+  return { instruction };
+}
+
+function escapeHtml(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function imageSrc(path) {
+  if (!path) return '';
+  if (path.startsWith('data:') || path.startsWith('http://') ||
+      path.startsWith('https://') || path.startsWith('file://')) {
+    return path;
+  }
+  const normalized = path.replace(/\\/g, '/');
+  return normalized.startsWith('/') ? `file://${normalized}` : `file:///${normalized}`;
+}
+
+// Extract a human-readable prompt from an IMG:GEN instruction payload.
+// The payload may be a JSON object ({prompt, caption, ...}) or raw text.
+function imgPrompt(instruction) {
+  const raw = (instruction || '').trim();
+  if (!raw) return '';
+  try {
+    const json = JSON.parse(raw);
+    if (json && typeof json === 'object') {
+      const p = (json.prompt || json.caption || '').replace(/^SCENE_PROMPT:\s*/, '');
+      return p || '';
+    }
+  } catch (_) { /* fall through to raw */ }
+  return raw;
+}
+
+/**
+ * The markup one image block renders to.
+ *
+ * [at] is the block's position in the message — the same order
+ * ImageTagMarkup.scanImageBlocks() sees on the Dart side. It rides back with
+ * every tap as `data-img-index`, which is what makes an action apply to one
+ * image and not the whole message (INV-IG6).
+ */
+export function renderImageBlock(block, at) {
+  if (block.type === 'result') return renderResult(block, at);
+  if (block.type === 'gen') return renderPending(block, at);
+  if (block.type === 'error') return renderError(block, at);
+  return '';
+}
+
+function renderResult(block, at) {
+  const src = imageSrc(block.path);
+  const encInstr = encodeURIComponent(block.instruction || '');
+  const variants = (block.paths || []).map((p) => imageSrc(p));
+  const activeIndex = variants.length > 1 ? (block.activeIndex || 0) : 0;
+  // The switcher only exists once the block holds a second image, so a
+  // single-image block renders exactly as it always did.
+  const switcher = variants.length > 1
+    ? `<span class="imggen-variants"><button class="imggen-variant-btn" type="button" data-action="img-variant-prev" data-img-index="${at}" title="Previous image">${VARIANT_PREV_SVG}</button><span class="imggen-variant-count">${activeIndex + 1}/${variants.length}</span><button class="imggen-variant-btn" type="button" data-action="img-variant-next" data-img-index="${at}" title="Next image">${VARIANT_NEXT_SVG}</button></span>`
+    : '';
+  // The whole list rides along on the wrapper so paging through the
+  // block swaps the picture in place, with no round trip to Flutter.
+  const variantAttrs = variants.length > 1
+    ? ` data-variants="${escapeHtml(variants.join(IMG_VARIANT_SEPARATOR))}" data-variant-index="${activeIndex}"`
+    : '';
+  // loading="eager" (not "lazy"): a just-generated image lands at the
+  // bottom edge of the WebView, where Android/iOS keep resizing the
+  // viewport around the input bar. A lazy image there can be evaluated
+  // while the row is still off-screen and never come back for it, and
+  // the picture the user just waited for shows as a broken tag. These
+  // are local files, so eager loading costs nothing — same reasoning as
+  // _renderExtBlockImageHtml in the bridge controller.
+  return `<span class="imggen-result-wrapper"${variantAttrs}><img src="${src}" class="imggen-result" loading="eager" decoding="async" data-action="image-click" data-src="${src}"><button class="imggen-options-btn" type="button" data-action="img-options" data-src="${src}" data-instruction="${encInstr}" data-img-index="${at}" title="Options">${OPTIONS_SVG}</button>${switcher}</span>`;
+}
+
+function renderPending(block, at) {
+  const start = Date.now();
+  // A pending block that carried images through a regeneration spells its
+  // payload `@paths|instruction`; reading it here keeps the prompt line
+  // showing the prompt instead of the path list in front of it.
+  const pending = parseImagePendingPayload(block.instruction);
+  const prompt = escapeHtml(imgPrompt(pending.instruction));
+  const promptEl = prompt ? `<div class="imggen-loading-prompt">${prompt}</div>` : '';
+  // The children are moved into a shadow root of the placeholder's own by
+  // `isolateImgGenPlaceholders` right after insertion, which is what keeps
+  // message CSS from restyling them (see renderer/imggen_placeholder.js).
+  // Two labels, one of which is hidden: the block is "queued" until the
+  // reply has finished streaming and post-gen actually reaches the image
+  // stage (INV-IG1), and only then does anything start elapsing or
+  // become stoppable. `refreshImgGenPlaceholderState` flips the class.
+  return `<div class="imggen-loading" data-start="${start}" data-img-index="${at}"><span class="imggen-loading-hint">Generating image…</span><span class="imggen-queued-hint">Image queued…</span><span class="imggen-loading-timer" data-start="${start}">0.0s</span><button class="imggen-stop-btn" type="button" data-action="img-stop" title="Stop image generation" aria-label="Stop image generation">${STOP_SVG}</button>${promptEl}</div>`;
+}
+
+function renderError(block, at) {
+  let errorMsg = 'Unknown error';
+  let instruction = '';
+  try {
+    const parsed = JSON.parse(block.data);
+    errorMsg = parsed.error || errorMsg;
+    instruction = parsed.instruction || '';
+  } catch (_) { /* keep the defaults */ }
+  const encInstr = encodeURIComponent(instruction);
+  if (errorMsg === 'Image generation disabled') {
+    return `<div class="imggen-error imggen-disabled" data-instruction="${encInstr}" data-img-index="${at}"><span class="imggen-error-icon">🖼</span><span class="imggen-error-msg">Image generation disabled</span><div class="imggen-error-actions"><button class="imggen-error-retry" type="button" data-action="img-enable-retry" data-instruction="${encInstr}" data-img-index="${at}">Enable and generate</button></div></div>`;
+  }
+  return `<div class="imggen-error" data-instruction="${encInstr}" data-img-index="${at}"><span class="imggen-error-icon">⚠</span><span class="imggen-error-msg">${escapeHtml(errorMsg)}</span><div class="imggen-error-actions"><button class="imggen-error-retry" type="button" data-action="img-retry" data-instruction="${encInstr}" data-img-index="${at}">↻ Regenerate</button><button class="imggen-error-options" type="button" data-action="img-options" data-instruction="${encInstr}" data-img-index="${at}" title="Options">${OPTIONS_SVG}</button></div></div>`;
+}
+
+/**
+ * Pulls every image tag out of the raw message text.
+ *
+ * Runs before the message is parsed, and in document order, so the blocks the
+ * renderer emits are numbered the way the Dart side numbers them. [hold] takes
+ * one block and returns the placeholder that stands in for it; [inert] takes a
+ * tag that must stay literal text (a tag inside a reasoning block never
+ * generates — INV-IG11).
+ */
+export function extractImageBlocks(text, { hold, inert, inReasoning }) {
+  let out = text;
+
+  out = out.replace(IIG_ELEMENT_REGEX, (match) => {
+    const parsed = parseImageResultElement(match);
+    if (!parsed) {
+      // Still waiting for its picture: render the loading placeholder in the
+      // element's place. Leaving the tag alone would put an <img> with no
+      // loadable source into the message, and the reader would watch a
+      // broken-image icon for the whole generation.
+      const pending = parseImagePendingElement(match);
+      if (!pending) return match;
+      if (inReasoning) return inert(match);
+      return hold({ type: 'gen', instruction: pending.instruction });
+    }
+    return hold({
+      type: 'result',
+      path: parsed.paths[parsed.activeIndex] || parsed.paths[0] || '',
+      paths: parsed.paths,
+      activeIndex: parsed.activeIndex,
+      instruction: parsed.instruction,
+    });
+  });
+
+  // `<img src="[IMG:GEN…]">` with no instruction attribute: the whole element
+  // is the block, so it has to go before the bare-payload pass below —
+  // otherwise only the src payload is consumed and the empty <img> stays
+  // behind as a broken-image icon.
+  out = out.replace(IMG_SRC_GEN_ELEMENT_REGEX, (match) => {
+    const pending = parseImagePendingElement(match);
+    if (!pending) return match;
+    if (inReasoning) return inert(match);
+    return hold({ type: 'gen', instruction: pending.instruction });
+  });
+
+  out = out.replace(/\[IMG:GEN(?::(.*?))?\]/g, (match, instruction) => {
+    if (inReasoning) return inert(match);
+    return hold({ type: 'gen', instruction: instruction || '' });
+  });
+
+  out = out.replace(/\[IMG:RESULT:(.*?)\]/g, (_match, payload) => {
+    const parsed = parseImageResultPayload(payload);
+    return hold({
+      type: 'result',
+      path: parsed.paths[parsed.activeIndex] || parsed.paths[0] || '',
+      paths: parsed.paths,
+      activeIndex: parsed.activeIndex,
+      instruction: parsed.instruction,
+    });
+  });
+
+  out = out.replace(/\[IMG:ERROR:(.*?)\]/g, (_match, data) => hold({ type: 'error', data }));
+
+  return out;
+}

--- a/assets/chat_webview/formatter/inline_syntax.js
+++ b/assets/chat_webview/formatter/inline_syntax.js
@@ -1,0 +1,128 @@
+// Inline markdown: what happens *inside* a line of a message.
+//
+// Everything here works on a string that is already known to be text — either
+// a text node the parser produced, or the inside of a style marker. Elements
+// around it are opaque placeholders, so no pass in this file can reach into a
+// tag, an attribute or a script. That is the whole point of the split: the
+// old formatter ran these same regexes over a string with live HTML in it,
+// and the markdown kept eating the markup.
+
+import { renderStyledSegment } from './text_format.js';
+import { maskTags } from './html_scan.js';
+import { SENTINEL, createStore, extractMarkers } from './protect.js';
+
+/**
+ * Text becomes markup only through this file, so what could open a tag is
+ * escaped first. `>` is deliberately left alone: it needs no escaping in text
+ * content, and escaping it would hide the `>` a blockquote line starts with
+ * from the block pass.
+ */
+export function escapeText(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;');
+}
+
+/** Any placeholder, as one alternative inside a larger pattern. */
+const PLACEHOLDER_GROUP = `${SENTINEL}[A-Z_]+\\d+${SENTINEL}`;
+
+// Quotes, with the unclosed case handled so a reply reads correctly while it
+// is still streaming. The first two alternatives are guards: a placeholder is
+// opaque, and `="…"` is an attribute value, not dialogue.
+const QUOTE_REGEX = new RegExp(
+  `(${PLACEHOLDER_GROUP})|(=[ \\t]*"(?:[^"]|\\\\")*?")|(")((?:[^"]|\\\\")*?)(")` +
+  `|(«)([^»\\u0001]*?(?:«[^»\\u0001]*?»[^»\\u0001]*?)*?)(»)|(")((?:[^"]*)$)`,
+  'gm',
+);
+
+function applyQuotes(text) {
+  return text.replace(QUOTE_REGEX, (
+    match, placeholder, attribute,
+    openQ, closedContent, closeQ,
+    openG, guillemetContent, closeG,
+    openU, unclosedContent,
+  ) => {
+    if (placeholder) return placeholder;
+    if (attribute) return attribute;
+    if (openQ !== undefined) {
+      return `<span class="chat-quote">${openQ}</span>` +
+        `<span class="chat-quote-text">${closedContent}</span>` +
+        `<span class="chat-quote">${closeQ}</span>`;
+    }
+    if (openG !== undefined) {
+      // Nested «outer «inner» more outer» — split at the inner «» so the inner
+      // quote renders with the narration colour while the outer text keeps the
+      // quote colour. Inner «» are literal characters, not a second quote.
+      const rendered = guillemetContent.split(/(«[^»]*?»)/).map((part) => {
+        if (!part) return '';
+        if (/^«[^»]*?»$/.test(part)) return part;
+        return `<span class="chat-quote-text">${part}</span>`;
+      }).join('');
+      return `<span class="chat-quote">${openG}</span>${rendered}` +
+        `<span class="chat-quote">${closeG}</span>`;
+    }
+    if (openU !== undefined) {
+      return `<span class="chat-quote">${openU}</span>` +
+        `<span class="chat-quote-text">${unclosedContent}</span>`;
+    }
+    return match;
+  });
+}
+
+function applyLinks(text) {
+  return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, url) => {
+    const href = url.trim().replace(/"/g, '&quot;');
+    return `<a href="${href}" target="_blank" rel="noopener">${label}</a>`;
+  });
+}
+
+/**
+ * Emphasis the marker scan could not take: a run that spans a line break, or
+ * one whose opening marker only became unambiguous after the quotes pass.
+ */
+function applyLooseEmphasis(text) {
+  return text
+    .replace(/~~([^~\n]+?)~~/g, '<del>$1</del>')
+    .replace(/\*\*\*([^*\n]+?)\*\*\*/g, '<strong><em class="chat-italic">$1</em></strong>')
+    .replace(/\*\*([^*\n]+?)\*\*/g, '<strong>$1</strong>')
+    // Never let an unmatched marker consume text from a later line.
+    .replace(/\*([^*\n]+?)\*/g, '<em class="chat-italic">$1</em>');
+}
+
+/**
+ * Formats one run of message text.
+ *
+ * [markers] holds the style markers pulled out before parsing; [inner] renders
+ * the content of one marker (it recurses back into this file). [skipQuotes]
+ * is set inside a colour marker, whose fill the quote colour would override.
+ */
+export function applyInlineSyntax(text, { markers, inner, skipQuotes = false }) {
+  let out = skipQuotes ? text : applyQuotes(text);
+  out = out.replace(new RegExp(`${SENTINEL}S_(\\d+)${SENTINEL}`, 'g'), (_m, i) => {
+    const segment = markers ? markers.get(i) : '';
+    return segment === undefined ? '' : renderStyledSegment(segment, inner);
+  });
+  out = applyLooseEmphasis(out);
+  return applyLinks(out);
+}
+
+/**
+ * Formats a raw fragment of message source as inline content: the inside of a
+ * style marker, which may carry its own tags and its own nested markers.
+ *
+ * Always inline — a marker is a `<span>`, and a `<p>` inside one is what the
+ * browser throws straight back out, leaving the marker empty on screen.
+ */
+export function formatInlineRaw(raw, { skipQuotes = false } = {}) {
+  if (!raw) return '';
+  const markers = createStore('S');
+  const held = extractMarkers(String(raw), markers);
+  const { masked, unmask } = maskTags(held, SENTINEL);
+  const formatted = applyInlineSyntax(escapeText(masked), {
+    markers,
+    skipQuotes,
+    inner: (nested, nestedSkipQuotes = true) =>
+      formatInlineRaw(nested, { skipQuotes: nestedSkipQuotes }),
+  });
+  return unmask(formatted);
+}

--- a/assets/chat_webview/formatter/protect.js
+++ b/assets/chat_webview/formatter/protect.js
@@ -1,0 +1,185 @@
+// Everything that has to leave the message text before it is parsed.
+//
+// Two kinds of region live here:
+//
+//   * regions that are *not* markup even though they look like it — a fenced
+//     code block, a span of inline code, the tag a reasoning block only talks
+//     about. Handing those to the parser would turn prose about a `<div>` into
+//     a `<div>`;
+//   * regions the renderer replaces with UI of its own — an image block, a
+//     `<think>` panel, a markdown image card. Those become one placeholder so
+//     nothing downstream can split them apart.
+//
+// Each region is swapped for a placeholder built out of a control character,
+// which survives HTML parsing as ordinary text and cannot appear in a message.
+
+import { extractImageBlocks } from './image_blocks.js';
+import { maskTags } from './html_scan.js';
+
+/** Wraps every placeholder. U+0001 is not writable in a chat message. */
+export const SENTINEL = '\u0001';
+
+/** A protected region, restored into the tree after formatting. */
+export const REGION_PATTERN = new RegExp(`${SENTINEL}P_(\\d+)${SENTINEL}`, 'g');
+
+/** A Glaze / markdown style marker, restored while formatting text. */
+export const MARKER_PATTERN = new RegExp(`${SENTINEL}S_(\\d+)${SENTINEL}`, 'g');
+
+/** Any placeholder at all — the sweep that proves none leaked. */
+export const ANY_PLACEHOLDER = new RegExp(`${SENTINEL}[A-Z_]+\\d+${SENTINEL}`, 'g');
+
+export function createStore(prefix) {
+  const entries = [];
+  return {
+    entries,
+    hold(entry) {
+      entries.push(entry);
+      return `${SENTINEL}${prefix}_${entries.length - 1}${SENTINEL}`;
+    },
+    get(index) {
+      return entries[Number(index)];
+    },
+  };
+}
+
+function escapeAttribute(value) {
+  return String(value == null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Normalizes the destination of a markdown image/link.
+//
+// The raw capture is everything between the parens, which for CommonMark can
+// carry padding, an <…> wrapper and a title: `![a]( <u> "cap" )`. A browser
+// trims and re-encodes most of that when it loads the <img>, so the picture
+// still appears in the message — but the same raw string handed to Flutter
+// (via data-src) is not a valid URL there, and the full-screen viewer opens
+// onto nothing. Normalize once, so both sides see the same URL.
+export function normalizeMdUrl(url) {
+  let out = String(url == null ? '' : url).trim();
+  // Trailing title: `url "caption"` / `url 'caption'` / `url (caption)`.
+  const titled = out.match(/^(\S+)\s+(?:"[^"]*"|'[^']*'|\([^)]*\))$/);
+  if (titled) out = titled[1];
+  if (out.startsWith('<') && out.endsWith('>')) out = out.slice(1, -1).trim();
+  return out;
+}
+
+const OPTIONS_SVG = '<svg viewBox="0 0 24 24"><path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>';
+
+/** The card a markdown image renders to: the picture and its options button. */
+function markdownImageCard(alt, url) {
+  // `![alt](url =100x50)` — the dimension suffix is markdown, not part of the
+  // address; leaving it in `src` requests a URL that cannot resolve.
+  const sized = url.match(/^(.*?)\s+=(\d+)?x(\d+)?$/);
+  const size = sized
+    ? `${sized[2] ? ` width="${sized[2]}"` : ''}${sized[3] ? ` height="${sized[3]}"` : ''}`
+    : '';
+  const safeUrl = escapeAttribute(normalizeMdUrl(sized ? sized[1] : url));
+  return `<span class="janitor-img-wrapper"><img${size} src="${safeUrl}" alt="${escapeAttribute(alt)}" class="janitor-img" loading="lazy" data-action="image-click" data-src="${safeUrl}"><button class="janitor-options-btn" type="button" data-action="img-options" data-src="${safeUrl}" title="Options">${OPTIONS_SVG}</button></span>`;
+}
+
+/**
+ * A block region is padded with blank lines so it lands in a block of its own:
+ * an image block or a code block is never part of the paragraph around it.
+ */
+function block(placeholder) {
+  return `\n\n${placeholder}\n\n`;
+}
+
+/**
+ * Pulls the protected regions out of [text] and returns what is left to parse.
+ *
+ * [store] collects the regions; the caller puts them back into the tree once
+ * the markdown passes are done.
+ */
+export function protectRegions(text, { store, inReasoning = false }) {
+  let out = text;
+
+  // `<think>` is the model's own panel, not part of the reply's flow. Both
+  // spellings, and both the closed and the still-streaming form.
+  const think = (content) => block(store.hold({ kind: 'think', content: content.trim() }));
+  out = out
+    .replace(/<think\b[^>]*>([\s\S]*?)<\/think\b[^>]*>/gi, (_m, content) => think(content))
+    .replace(/<think\b[^>]*?(?:>|\n)([\s\S]*?)<\/think\b/gi, (_m, content) => think(content))
+    .replace(/<thinking\b[^>]*>([\s\S]*?)<\/thinking\b[^>]*>/gi, (_m, content) => think(content))
+    .replace(/<thinking\b[^>]*?(?:>|\n)([\s\S]*?)<\/thinking\b/gi, (_m, content) => think(content));
+
+  // Fenced code first: everything else in this file must not read inside one.
+  out = out.replace(/```(\w*)\n?([\s\S]*?)(?:```|$)/g, (_match, lang, code) =>
+    block(store.hold({ kind: 'code', lang, code })));
+
+  // Inline code, before the tag scan can read what is inside it as HTML.
+  // `Пиши `<div>`` is prose about a tag, not a tag.
+  out = out.replace(/`([^`\n]+)`/g, (_match, code) =>
+    store.hold({ kind: 'inline-code', code }));
+
+  // A model writes `&lt;br&gt;` when it escapes its own output; the reader
+  // meant a line break.
+  out = out.replace(/&lt;br\s*\/?&gt;/gi, '<br>');
+
+  out = extractImageBlocks(out, {
+    inReasoning,
+    hold: (imageBlock) => block(store.hold({ kind: 'image', block: imageBlock })),
+    // Tags a reasoning block only talks about stay the text the model wrote:
+    // nothing here loads, spins or generates (INV-IG11).
+    inert: (raw) => store.hold({ kind: 'text', text: raw }),
+  });
+
+  out = out.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_match, alt, url) =>
+    store.hold({ kind: 'html', html: markdownImageCard(alt, url) }));
+
+  return out;
+}
+
+/**
+ * Hides `<style>` and `<script>` bodies for the duration of the marker scan.
+ *
+ * Their contents are code, not prose: a `*` in a CSS selector is not an italic
+ * marker and `**` in a script is not bold. They go back into the text before
+ * it is parsed, so both still reach the message as real elements.
+ */
+export function maskCodeElements(text) {
+  const bodies = [];
+  const masked = text.replace(
+    /<(style|script)\b[^>]*>[\s\S]*?(?:<\/\1\s*>|$)/gi,
+    (match) => {
+      bodies.push(match);
+      return `${SENTINEL}RAW_${bodies.length - 1}${SENTINEL}`;
+    },
+  );
+  const pattern = new RegExp(`${SENTINEL}RAW_(\\d+)${SENTINEL}`, 'g');
+  return {
+    masked,
+    unmask: (value) => String(value).replace(pattern, (_m, i) => bodies[Number(i)]),
+  };
+}
+
+/** Glaze colour markers and the markdown emphasis run that follows them. */
+const MARKER_REGEX = /(==hc:#[0-9a-fA-F]{3,8}==.+?==|==glow:#[0-9a-fA-F]{3,8},\d+==.+?==|==cg:#[0-9a-fA-F]{3,8},#[0-9a-fA-F]{3,8},\d+==.+?==|==grad:#[0-9a-fA-F]{3,8}(?:,#[0-9a-fA-F]{3,8})+==.+?==|==bg:#[0-9a-fA-F]{3,8}==.+?==|==mark==.+?==|==active==.+?==|==accent==.+?==|\*\*[^*\n]+?\*\*|(?<!\*)\*(?=[^*\n]*[^ \t*\n])[^*\n]+?\*(?!\*)|__[^_\n]+?__|(?<!\w)_[^_\n]+?_(?!\w)|~~[^~\n]+?~~)/gs;
+
+/**
+ * Pulls the style markers out of [text] before it is parsed.
+ *
+ * They have to come out here, not from the parsed tree: html_to_markdown puts
+ * rich content inside a colour marker (`==hc:#fff==<b>x</b>==`), and once that
+ * is parsed the marker's two halves live in two different text nodes with an
+ * element between them. Tags are masked for the scan so a `*` inside an
+ * attribute cannot open an emphasis run, while a marker that spans a tag still
+ * matches.
+ */
+export function extractMarkers(text, markers) {
+  const { masked, unmask } = maskTags(text, SENTINEL);
+  const held = masked.replace(MARKER_REGEX, (segment) =>
+    markers.hold(unmask(segment)));
+  // Models occasionally emit `».* *action*`: the first `*` is an orphan
+  // marker, not an empty italic segment. Drop it once the real action is
+  // safely stashed, otherwise it steals that action's opening marker.
+  return unmask(held.replace(
+    new RegExp(`\\*([ \\t]+)(?=${SENTINEL}S_\\d+${SENTINEL})`, 'g'),
+    '$1',
+  ));
+}

--- a/assets/chat_webview/formatter/text_format.js
+++ b/assets/chat_webview/formatter/text_format.js
@@ -1,3 +1,9 @@
+// One style marker, rendered.
+//
+// [processRichText] formats the marker's own content, and it is always an
+// *inline* pass: a marker is a `<span>`, and a `<p>` inside one is markup the
+// browser throws straight back out — which used to leave a coloured marker
+// showing as empty text on screen.
 export function renderStyledSegment(seg, processRichText) {
   // Variant C support: the captured inner content may contain raw HTML/Markdown
   // because html_to_markdown emits rich content inside ==hc:...== markers.
@@ -51,21 +57,7 @@ export function renderStyledSegment(seg, processRichText) {
   // dialogue inside *"..."* gets the quote color (colored italic), not the
   // gray italic default. Color markers above keep skipQuotes=true (default)
   // so chat-quote color does not override their fill.
-  const rq = (raw) => {
-    if (!processRichText) return raw;
-    const rich = processRichText(raw, false);
-    // _processText treats every standalone fragment as a paragraph. Styled
-    // markers are inline, though, so keeping that wrapper would produce
-    // invalid block-in-inline markup such as <em><p>action</p></em>. Browsers
-    // then lay every *action* out on its own line even when the source contains
-    // no newline. Unwrap only a single paragraph; preserve genuinely
-    // multi-paragraph content as-is.
-    const paragraph = rich.match(/^\s*<p>([\s\S]*)<\/p>\s*$/i);
-    if (paragraph && !/<\/?p(?:\s|>)/i.test(paragraph[1])) {
-      return paragraph[1];
-    }
-    return rich;
-  };
+  const rq = (raw) => (processRichText ? processRichText(raw, false) : raw);
   m = seg.match(/^\*\*\*(.+?)\*\*\*$/s);
   if (m) return `<strong><em>${rq(m[1])}</em></strong>`;
   m = seg.match(/^\*\*(.+?)\*\*$/s);

--- a/assets/chat_webview/renderer/css_diagnostics.js
+++ b/assets/chat_webview/renderer/css_diagnostics.js
@@ -145,6 +145,33 @@ function droppedRules(css, blocks) {
   return dropped;
 }
 
+/**
+ * At-rules the CSS policy drops before the message is rendered.
+ *
+ * `@import` is rejected on purpose (css_sanitizer.js: message CSS never
+ * reaches the network), and `@font-face` with it. The card author saw only a
+ * font that silently fell back, so the drop is reported instead of hidden.
+ * Read from the *pre-sanitize* source — by the time the style element exists,
+ * the rule is already gone.
+ */
+const BLOCKED_AT_RULE = /@(import|font-face|page|namespace)\b/gi;
+
+export function inspectBlockedAtRules(css) {
+  const source = String(css == null ? '' : css);
+  const found = [];
+  BLOCKED_AT_RULE.lastIndex = 0;
+  let match;
+  while ((match = BLOCKED_AT_RULE.exec(source)) !== null) {
+    const line = countNewlines(source, 0, match.index) + 1;
+    found.push(
+      `line ${line}: @${match[1].toLowerCase()} is not applied ` +
+      '(message CSS cannot load anything over the network)',
+    );
+    if (found.length >= MAX_REPORTED) break;
+  }
+  return found;
+}
+
 /** Problems in one `<style>` block, as lines ready to show. */
 export function inspectCss(css) {
   const source = String(css == null ? '' : css);
@@ -197,12 +224,12 @@ function buildReport(problems) {
  * from scratch — so a stale report cannot survive and the pass is a no-op for
  * the overwhelming majority of messages, which carry no `<style>` at all.
  */
-export function reportCssErrors(root) {
+export function reportCssErrors(root, extraProblems = []) {
   if (!root) return;
   const styles = root.querySelectorAll('style');
-  if (!styles.length) return;
+  if (!styles.length && !extraProblems.length) return;
 
-  const problems = [];
+  const problems = [...extraProblems];
   for (const style of styles) {
     problems.push(...inspectCss(style.textContent));
   }

--- a/assets/chat_webview/renderer/markdown.js
+++ b/assets/chat_webview/renderer/markdown.js
@@ -1,9 +1,9 @@
 import { syncCodeBlockMetadata } from './code_highlight.js';
 import { formatMessageBody } from './macros_in_message.js';
-import { reportCssErrors } from './css_diagnostics.js';
+import { inspectBlockedAtRules, reportCssErrors } from './css_diagnostics.js';
 import { isolateImgGenPlaceholders } from './imggen_placeholder.js';
 import { sanitizeMessageHtml } from '../bridge/html_sanitizer.js';
-import { rewriteTargetSelectors } from './target_toggle.js';
+import { installMessageDocument } from './message_document.js';
 
 /** Cheap pre-sanitize probe for an embedded `<script>` in formatted HTML. */
 const SCRIPT_TAG = /<script\b/i;
@@ -28,6 +28,26 @@ function notifyMessageScriptBlocked() {
   } catch (_) {
     // Bridge not wired yet — a later render notifies instead.
   }
+}
+
+/** `<style>` bodies as the message wrote them, before the CSS policy ran. */
+const STYLE_BLOCK = /<style\b[^>]*>([\s\S]*?)(?:<\/style\s*>|$)/gi;
+
+/**
+ * At-rules the CSS policy dropped, read off the formatted HTML.
+ *
+ * The sanitizer removes them, so by the time the message is in the DOM there
+ * is nothing left to notice — which is how a card's `@import`ed font came to
+ * fall back to `cursive` with no explanation anywhere.
+ */
+function blockedAtRules(formatted) {
+  const problems = [];
+  STYLE_BLOCK.lastIndex = 0;
+  let match;
+  while ((match = STYLE_BLOCK.exec(formatted)) !== null) {
+    problems.push(...inspectBlockedAtRules(match[1]));
+  }
+  return problems;
 }
 
 export function writeShadowContent({
@@ -61,10 +81,6 @@ export function writeShadowContent({
     root.innerHTML = sanitizeMessageHtml(formatted, {
       allowScripts: allowMessageScripts,
     });
-    // A fragment link cannot make an id inside a shadow root the document's
-    // target element, so the card's `:target` rules are re-keyed on the
-    // attribute the click dispatcher stamps instead.
-    rewriteTargetSelectors(root);
     // Before anything else touches the tree: the placeholder's content moves
     // behind a shadow boundary, out of reach of the message's own CSS.
     isolateImgGenPlaceholders(root);
@@ -72,8 +88,13 @@ export function writeShadowContent({
     // A reply still arriving is half a stylesheet, and every unclosed brace in
     // it is on its way to being closed — report only what the message settled
     // on. `isGenerating` covers the whole reply, `isTyping` its first chunks.
-    if (!isTyping && !window.bridge?.isGenerating) reportCssErrors(root);
-    executeInlineScripts(root, allowMessageScripts);
+    if (!isTyping && !window.bridge?.isGenerating) {
+      reportCssErrors(root, blockedAtRules(formatted));
+    }
+    // The message's document: `:target` re-keyed, the scoped `document.*`
+    // lookups installed for later events, and the card's own scripts run.
+    // See renderer/message_document.js and INV-MR1…INV-MR8.
+    installMessageDocument(root, { allowMessageScripts });
     fixDetailsSummaryArrows(root);
     retryFailedLocalImages(root);
   } catch (e) {
@@ -109,55 +130,6 @@ export function retryFailedLocalImages(root) {
         img.src = `${source}${separator}__glaze_retry=${attempt}`;
       }, LOCAL_IMAGE_RETRY_DELAY_MS * attempt);
     });
-  }
-}
-
-export function executeInlineScripts(root, allowMessageScripts = false) {
-  const scripts = Array.from(root.querySelectorAll('script'));
-  if (!allowMessageScripts) {
-    scripts.forEach(script => script.remove());
-    return;
-  }
-  for (const oldScript of scripts) {
-    // Inline scripts set via innerHTML are never executed by the browser.
-    // We run them manually with shimmed globals so ST-compatible regex
-    // scripts (BOOTS, HEADER, etc.) work inside shadow DOM:
-    //   - document.currentScript.previousElementSibling -> sibling in shadow root
-    //   - document.getElementById -> searches inside the shadow root first
-    //   - document.querySelector  -> searches inside the shadow root first
-    const prev = oldScript.previousElementSibling;
-    const src = oldScript.textContent || '';
-    try {
-      const shim = { previousElementSibling: prev, parentNode: prev ? prev.parentNode : null };
-      const csDesc = Object.getOwnPropertyDescriptor(Document.prototype, 'currentScript');
-      Object.defineProperty(document, 'currentScript', { value: shim, configurable: true });
-
-      const origGetById = document.getElementById.bind(document);
-      const origQS = document.querySelector.bind(document);
-      document.getElementById = function(id) {
-        const inShadow = root.querySelector('#' + CSS.escape(id));
-        return inShadow || origGetById(id);
-      };
-      document.querySelector = function(sel) {
-        const inShadow = root.querySelector(sel);
-        return inShadow || origQS(sel);
-      };
-
-      try {
-        new Function(src)();
-      } finally {
-        if (csDesc) {
-          Object.defineProperty(document, 'currentScript', csDesc);
-        } else {
-          delete document.currentScript;
-        }
-        document.getElementById = origGetById;
-        document.querySelector = origQS;
-      }
-    } catch (e) {
-      console.error('Inline script error:', e);
-    }
-    oldScript.remove();
   }
 }
 

--- a/assets/chat_webview/renderer/markdown.js
+++ b/assets/chat_webview/renderer/markdown.js
@@ -18,7 +18,7 @@ const LOCAL_IMAGE_RETRY_DELAY_MS = 350;
  * Tell Flutter that a message wanted to run JS while execution is off, so the
  * app can offer to turn it on. The check has to run on the *formatted* HTML:
  * with execution off `sanitizeMessageHtml` drops every `<script>` before
- * insertion, so by the time `executeInlineScripts` looks at the DOM there is
+ * insertion, so by the time the script runner looks at the DOM there is
  * nothing left to see. The bridge de-duplicates, so calling this on every
  * render is fine.
  */

--- a/assets/chat_webview/renderer/message_document.js
+++ b/assets/chat_webview/renderer/message_document.js
@@ -1,0 +1,282 @@
+// The document a message body gets.
+//
+// A message renders into a shadow root (`.message-content`), which is what
+// keeps a card's CSS out of the app chrome. Cards, though, are written against
+// a *document*: they look elements up with `document.getElementById`, declare
+// functions a `onclick=` attribute calls, wait for `DOMContentLoaded`, and put
+// a modal in `document.body`. None of that works inside a shadow root on its
+// own, and for a while each case was discovered by a user and patched one at
+// a time.
+//
+// This module is the whole list, in one place. What a card may rely on is
+// written down in docs/INVARIANTS.md § Message document contract
+// (INV-MR1…INV-MR8); every item here has a case in test/webview_js. Add to
+// the contract rather than shimming one more thing where it happens to help.
+
+import { rewriteTargetSelectors } from './target_toggle.js';
+
+/** Events during which a message's own code may run and query the document. */
+const SCOPED_EVENTS = [
+  'click', 'dblclick', 'pointerdown', 'pointerup', 'mousedown', 'mouseup',
+  'input', 'change', 'submit', 'keydown', 'keyup', 'toggle',
+  'transitionend', 'animationend',
+];
+
+/** Load events a card waits for, which the real document fired long ago. */
+const READY_EVENTS = new Set(['DOMContentLoaded', 'load', 'readystatechange']);
+
+/** Where `document.body.appendChild` puts a node — inside the message. */
+const OVERLAY_CLASS = 'glaze-message-overlay';
+
+// Captured before anything can shim `document.head`, which the scope below
+// points at the message root: a <script> appended to a shadow root never runs.
+const REAL_HEAD = document.head || document.documentElement;
+const REAL_BODY = document.body || document.documentElement;
+
+/**
+ * The app's own body, for chrome that must land outside a message.
+ *
+ * While a message's code runs — its `<script>`, and any handler it fires —
+ * `document.body` is the message's overlay layer (INV-MR6). App code that
+ * appends chrome during such an event (the selection bar, a measuring host)
+ * has to say so, or its element ends up inside somebody's card.
+ */
+export function appBody() {
+  return REAL_BODY;
+}
+
+function escapeSelector(value) {
+  const text = String(value == null ? '' : value);
+  if (typeof CSS !== 'undefined' && CSS.escape) return CSS.escape(text);
+  return text.replace(/["\\\]]/g, '\\$&');
+}
+
+/**
+ * The message's overlay layer: `display: contents`, so a node moved here lays
+ * out exactly where `document.body.appendChild` would have put it — except
+ * that it is still under the message's own stylesheet instead of naked in the
+ * app chrome (INV-MR6).
+ */
+export function messageOverlay(root) {
+  let layer = root.querySelector(`:scope > .${OVERLAY_CLASS}`);
+  if (!layer) {
+    layer = document.createElement('div');
+    layer.className = OVERLAY_CLASS;
+    root.appendChild(layer);
+  }
+  return layer;
+}
+
+/** The message root a DOM event passed through, or null for app chrome. */
+function messageRootOf(event) {
+  const path = (event.composedPath && event.composedPath()) || [];
+  for (const node of path) {
+    if (node && node.nodeType === 1 && node.classList &&
+        node.classList.contains('glaze-message')) {
+      return node;
+    }
+  }
+  return null;
+}
+
+// Roots whose own code has actually run. A message with no `<script>` never
+// needs the scope, and keeping it off for those means the app's document is
+// untouched for all but a handful of messages.
+const scripted = new WeakSet();
+
+/** The root the scope is currently installed for, or null. */
+let installed = null;
+
+/**
+ * Points the document's lookups at [root] for as long as the returned restore
+ * has not been called. Everything is an own property on `document` / `window`,
+ * so restoring is a delete and the originals are never rewritten.
+ */
+function installDocumentScope(root, collectReady) {
+  if (installed) return () => {};
+  const defined = [];
+  const define = (target, name, descriptor) => {
+    defined.push({ target, name });
+    Object.defineProperty(target, name, { configurable: true, ...descriptor });
+  };
+  const method = (name, fn) => define(document, name, { value: fn, writable: true });
+
+  const documentQuery = Document.prototype;
+  const first = (selector) => {
+    try {
+      return root.querySelector(selector);
+    } catch (_) {
+      return null;
+    }
+  };
+  const all = (selector) => {
+    try {
+      return root.querySelectorAll(selector);
+    } catch (_) {
+      return [];
+    }
+  };
+
+  // INV-MR3: a lookup finds the message's own element first, and falls back to
+  // the document so app-level code called from a card still works.
+  method('getElementById', (id) =>
+    first(`#${escapeSelector(id)}`) || documentQuery.getElementById.call(document, id));
+  method('querySelector', (selector) =>
+    first(selector) || documentQuery.querySelector.call(document, selector));
+  method('querySelectorAll', (selector) => {
+    const found = all(selector);
+    return found.length ? found : documentQuery.querySelectorAll.call(document, selector);
+  });
+  method('getElementsByClassName', (name) =>
+    all(String(name).trim().split(/\s+/).map((c) => `.${escapeSelector(c)}`).join('')));
+  method('getElementsByTagName', (name) =>
+    (String(name) === '*' ? all('*') : all(escapeSelector(name))));
+  method('getElementsByName', (name) => all(`[name="${escapeSelector(name)}"]`));
+
+  // INV-MR4: the document's collections are the message's own.
+  define(document, 'forms', { get: () => all('form') });
+  define(document, 'images', { get: () => all('img') });
+  define(document, 'links', { get: () => all('a[href], area[href]') });
+  define(document, 'styleSheets', {
+    get: () => Array.from(all('style')).map((style) => style.sheet).filter(Boolean),
+  });
+
+  // INV-MR6: a node the card hands to the document lands in the message.
+  define(document, 'body', { get: () => messageOverlay(root) });
+  define(document, 'head', { get: () => root });
+
+  // INV-MR7: the load events the card is waiting for are collected, not
+  // registered — the real ones fired before the message existed.
+  const documentAdd = document.addEventListener.bind(document);
+  const windowAdd = window.addEventListener.bind(window);
+  method('addEventListener', function (type, listener, options) {
+    if (READY_EVENTS.has(type) && listener) {
+      collectReady(listener);
+      return;
+    }
+    documentAdd(type, listener, options);
+  });
+  define(window, 'addEventListener', {
+    writable: true,
+    value: function (type, listener, options) {
+      if (READY_EVENTS.has(type) && listener) {
+        collectReady(listener);
+        return;
+      }
+      windowAdd(type, listener, options);
+    },
+  });
+  define(window, 'onload', {
+    get: () => null,
+    set: (listener) => { if (listener) collectReady(listener); },
+  });
+
+  installed = root;
+  return () => {
+    if (installed !== root) return;
+    installed = null;
+    for (const { target, name } of defined) delete target[name];
+  };
+}
+
+/**
+ * Keeps the document scope in place for the length of an event dispatch, so a
+ * card's `onclick` sees the same document its `<script>` saw. Installed once,
+ * on the first message rendered.
+ */
+let bridged = false;
+function installEventScope() {
+  if (bridged) return;
+  bridged = true;
+  for (const type of SCOPED_EVENTS) {
+    document.addEventListener(type, (event) => {
+      const root = messageRootOf(event);
+      if (!root || !scripted.has(root)) return;
+      const restore = installDocumentScope(root, () => {});
+      // The dispatch is one task: a microtask runs once it has finished
+      // propagating. The timeout is only a backstop for a listener that
+      // throws past the checkpoint.
+      queueMicrotask(restore);
+      setTimeout(restore, 0);
+    }, true);
+  }
+}
+
+/** Runs [source] in the page's global scope, so `function f(){}` becomes `f`. */
+function runInGlobalScope(source) {
+  // `new Function(src)()` gives the script a function scope of its own, so a
+  // card that declares the handler its own `onclick=` calls left the attribute
+  // pointing at nothing. A real <script> element executes synchronously, in
+  // the global scope, and declares its globals.
+  const element = document.createElement('script');
+  element.textContent = source;
+  REAL_HEAD.appendChild(element);
+  element.remove();
+}
+
+/**
+ * Runs a message's `<script>` blocks — or drops them, which is what the
+ * message-scripts toggle turns off (nothing else about the message changes).
+ */
+export function runMessageScripts(root, allowMessageScripts = false) {
+  const scripts = Array.from(root.querySelectorAll('script'));
+  if (!allowMessageScripts) {
+    scripts.forEach((script) => script.remove());
+    return;
+  }
+  if (!scripts.length) return;
+
+  const ready = [];
+  scripted.add(root);
+  const restoreScope = installDocumentScope(root, (listener) => ready.push(listener));
+  // A script inserted this way reports a throw to window.onerror instead of to
+  // the caller, and one broken card must not read as an app crash.
+  const swallow = (event) => {
+    console.error('Message script error:', event.message || event.error);
+    event.preventDefault();
+  };
+  window.addEventListener('error', swallow, true);
+  try {
+    for (const script of scripts) {
+      // ST-style cards read `document.currentScript.previousElementSibling` to
+      // find the element they decorate; the real currentScript would be our
+      // injected element, sitting in the document's head.
+      const shim = {
+        previousElementSibling: script.previousElementSibling,
+        parentNode: script.parentNode,
+      };
+      Object.defineProperty(document, 'currentScript', {
+        value: shim,
+        configurable: true,
+      });
+      try {
+        runInGlobalScope(script.textContent || '');
+      } finally {
+        delete document.currentScript;
+      }
+      script.remove();
+    }
+    for (const listener of ready) {
+      try {
+        listener.call(document, new Event('DOMContentLoaded'));
+      } catch (e) {
+        console.error('Message script error:', e);
+      }
+    }
+  } finally {
+    window.removeEventListener('error', swallow, true);
+    restoreScope();
+  }
+}
+
+/**
+ * Gives a freshly written message body its document: `:target` re-keyed onto
+ * the attribute the click dispatcher stamps, the scoped document installed for
+ * later events, and the message's own scripts run.
+ */
+export function installMessageDocument(root, { allowMessageScripts = false } = {}) {
+  if (!root) return;
+  installEventScope();
+  rewriteTargetSelectors(root);
+  runMessageScripts(root, allowMessageScripts);
+}

--- a/assets/chat_webview/renderer/shadow_style.js
+++ b/assets/chat_webview/renderer/shadow_style.js
@@ -64,6 +64,10 @@ export const SHADOW_STYLE = `
   .glaze-message .font-style-block,
   .glaze-message .font-color-block { display: inline-block; vertical-align: baseline; color: inherit; }
   .glaze-message .code-block-wrapper { position: relative; margin: 8px 0; }
+  /* Where a card's document.body.appendChild lands (INV-MR6). display:
+     contents so the node lays out where the card expected it to, while
+     staying under the message's own stylesheet. */
+  .glaze-message .glaze-message-overlay { display: contents; }
   .glaze-message .code-lang {
     position: absolute; top: 4px; right: 8px;
     font-size: 10px; opacity: 0.4;

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1286,6 +1286,103 @@ finally makes an ordinary markdown link inside a message open.
 
 ---
 
+## 11. Message Document Contract
+
+A message body renders into a shadow root (`.message-content`), which is what
+keeps a card's CSS out of the app chrome. Cards, though, are written against a
+*document* — they look elements up with `document.getElementById`, declare
+functions their `onclick=` attributes call, wait for `DOMContentLoaded`, and
+put a modal in `document.body`.
+
+This section is the **whole list** of what a card may rely on inside that
+shadow root. It is finite and written down on purpose: for a while each case
+was found by a user and patched on its own, and the next card always found the
+next hole. Implementation: `assets/chat_webview/renderer/message_document.js`
+(plus `target_toggle.js` for `:target`). Every item has a case in
+`test/webview_js/specs/document_contract.spec.js`.
+
+**Add to this contract rather than shimming one more thing where it happens to
+be needed.**
+
+### INV-MR1: A message script runs in the page's global scope
+
+A card's `<script>` is executed by appending a real `<script>` element to the
+document's head, so `function toggle() {}` in the card becomes a global and the
+`onclick="toggle()"` in the same card resolves. `new Function(src)()` gave the
+script a function scope of its own, and the attribute pointed at nothing.
+
+`document.currentScript` is shimmed for the duration to the element the script
+was written next to, so ST-style cards that read
+`currentScript.previousElementSibling` still find what they decorate. The
+`<script>` is removed from the message afterwards, and so is the injected one.
+
+### INV-MR2: The app's own document is restored exactly
+
+Every shim is an **own property** on `document` / `window`, installed with
+`Object.defineProperty` and removed with `delete`. Nothing on a prototype is
+rewritten, and after a message's code has run, `document` is what it was.
+
+App chrome appended while a message's code may be running has to say so:
+`appBody()` (from `message_document.js`) returns the real body, and the
+selection bar uses it. Reading `document.body` there would put the app's own
+element inside somebody's card.
+
+### INV-MR3: Document lookups find the message's own elements first
+
+`getElementById`, `querySelector`, `querySelectorAll`, `getElementsByClassName`,
+`getElementsByTagName` and `getElementsByName` search the message root first and
+**fall back to the real document** when it has no answer. The fallback is what
+keeps app-level code called from a card working.
+
+### INV-MR4: The document's collections are the message's
+
+`document.forms`, `document.images`, `document.links` and `document.styleSheets`
+return the message's own, for the same reason.
+
+### INV-MR5: Message CSS never reaches the network — and says so
+
+`@import`, `@font-face`, `@page` and `@namespace` are dropped by the CSS policy
+(`bridge/css_sanitizer.js`), together with every `url()`. This is deliberate:
+inline CSS in an untrusted message must not fetch, and a background image is a
+working beacon. Hoisting `@import` into the document would undo that.
+
+What changed is that the drop is **reported**: `inspectBlockedAtRules` reads the
+pre-sanitize `<style>` source and the message shows a CSS-error line, so a card
+whose font silently fell back to `cursive` now says why.
+
+### INV-MR6: `document.body` is the message's overlay layer
+
+A node handed to `document.body` goes into `.glaze-message-overlay`, a
+`display: contents` child of the message root. It lays out where the card
+expected it to and stays under the card's own stylesheet, instead of rendering
+naked in the app chrome. `document.head` is the message root for the same
+reason: a `<style>` a card appends belongs to that message.
+
+### INV-MR7: The load events a card waits for still arrive
+
+The real `DOMContentLoaded` and `load` fired long before the message existed. A
+`DOMContentLoaded` / `load` / `readystatechange` listener registered by a
+message script — through `document.addEventListener`, `window.addEventListener`
+or `window.onload` — is **collected instead of registered**, and called once the
+message's scripts have all run. The app's own listeners are never touched.
+
+### INV-MR8: The scope lasts as long as the message's code can run
+
+A card's modal is appended from its click handler, not from its `<script>`. The
+document scope is therefore re-installed for the length of any dispatch of a
+common interaction event whose composed path passes through a message root, and
+removed on the microtask that follows it.
+
+Only for a message whose own code has actually run: a message with no
+`<script>` never needs the scope, so for all but a handful of messages the
+app's document is never touched at all.
+
+Message scripts are off by default. With the toggle off nothing here runs at
+all: `<script>` elements are dropped before insertion, and the message is still
+rendered exactly as written — markup and CSS are not a script policy.
+
+---
+
 ## Refactor PR Checklist
 
 Before merging any structural PR:

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -60,12 +60,19 @@ Open the PR against `hydall/Glaze:nightly`, not a fork's branch. Use whatever is
 ## CI gate
 
 `.github/workflows/ci.yml` runs on every PR into `nightly`, `staging` or
-`stable` and does two things: `flutter analyze` and `flutter test`. A red check
-means the PR is not merged — no exceptions, no "it works on my machine".
+`stable`: `flutter analyze`, `flutter test`, and the WebView render suite
+(`test/webview_js` — Node + Playwright, no Flutter). A red check means the PR
+is not merged — no exceptions, no "it works on my machine".
 
 Only analyzer **errors** fail the run (`--no-fatal-infos --no-fatal-warnings`);
 infos and hints from the strict lint set are not build-breaking and must not be
 allowed to block every PR.
+
+The render suite loads the real `assets/chat_webview/` modules in a headless
+Chromium and asserts on the DOM, the resolved CSS and what a click does. Run it
+with `cd test/webview_js && npm ci && npx playwright install chromium && npm
+test`; the rule that goes with it — every rendering bug becomes a corpus entry
+before it is fixed — is in `docs/rules/message-rendering.md`.
 
 Running `flutter analyze` locally before opening the PR is still useful — it is
 faster feedback — but it is not the gate. The gate is CI, because it cannot be

--- a/docs/markdown-markers.md
+++ b/docs/markdown-markers.md
@@ -4,7 +4,7 @@ The app extends GptMarkdown with custom `==...==` inline markers. When adding a
 new marker, update all of the following in sync:
 
 1. **Converter:** `lib/core/utils/html_to_markdown.dart` — produces marker syntax from HTML
-2. **JS formatter extraction:** `assets/chat_webview/formatter/formatter.js` — `styledRegex` extraction guard
+2. **JS formatter extraction:** `assets/chat_webview/formatter/protect.js` — `MARKER_REGEX`, which pulls markers out before the message is parsed (a marker may span a tag). `assets/chat_webview/formatter/formatter.js` drives the passes.
 3. **JS marker rendering:** `assets/chat_webview/formatter/text_format.js` — `renderStyledSegment()` HTML output
 4. **JS CSS:** `assets/chat_webview/renderer/shadow_style.js` — `SHADOW_STYLE` styling for marker classes
 5. **Dart renderer:** `lib/shared/widgets/colored_markdown.dart` — `InlineMd` subclass for Flutter-native rendering
@@ -31,9 +31,10 @@ into the stored text, so a marker written once follows theme changes.
 `html_to_markdown.dart` does not produce any of these three; it only produces the
 five styling markers above.
 
-`==mark==`, `==active==` and `==accent==` render their inner content raw: they
-are inline spans, and re-processing the inner text would wrap it in a
-block-level `<p>`. Keep any emphasis outside the marker.
+`==mark==`, `==active==` and `==accent==` render their inner content raw. Every
+other marker renders its content through `formatInlineRaw()`, which is inline
+by construction: a marker is a `<span>`, and a `<p>` inside one is markup the
+browser throws straight back out, leaving the marker empty on screen.
 
 ## Additional Custom InlineMd/BlockMd Classes
 

--- a/docs/rules/message-rendering.md
+++ b/docs/rules/message-rendering.md
@@ -98,3 +98,13 @@ text mid-pipeline: whatever pass runs next will take it apart.
 which cannot produce a block element. A `<p>` inside a marker's `<span>` is
 markup the browser throws straight back out — the marker then shows as empty
 text. See `docs/markdown-markers.md` for the marker list itself.
+
+---
+
+## The message body renders into a shadow root
+
+`.message-content` gets an open shadow root (`message_renderer.js`), which is
+what keeps a card's CSS out of the app chrome. What a card may rely on inside
+that root is a fixed list, not a guess: `renderer/message_document.js` and
+`docs/INVARIANTS.md` § 11 (INV-MR1…INV-MR8). Add to that contract rather than
+shimming one more case where it happens to be needed.

--- a/docs/rules/message-rendering.md
+++ b/docs/rules/message-rendering.md
@@ -1,0 +1,100 @@
+# Message Rendering Rules
+
+Rules for `assets/chat_webview/formatter/` and `assets/chat_webview/renderer/` —
+everything that turns a message body into what the reader sees.
+
+Read this before changing either directory. The behaviour it describes is
+covered by `test/webview_js` (a real browser renders the card corpus); the
+shape of the modules is covered by `test/webview_assets_test.dart`.
+
+---
+
+## Every rendering bug becomes a corpus entry before it is fixed
+
+`test/webview_js/corpus/cards.js` holds the message bodies worth protecting,
+verbatim, each with the PR or audit it came from. The workflow is:
+
+1. add the card that renders wrong, exactly as the author or model wrote it;
+2. add the assertion that fails;
+3. fix the renderer.
+
+A fix without an entry is a fix the next refactor is free to undo — which is
+how the same three bugs came back six times in ten days. If a case cannot be
+served yet, commit it as `test.fail()` naming what would make it pass, rather
+than leaving it out.
+
+---
+
+## The render is two phases, and the parser owns structure
+
+```
+protect  →  parse (phase A)  →  format text nodes (phase B)  →  restore
+```
+
+* **Phase A** (`html_scan.js`, `parseHtml`) hands the message to the browser's
+  HTML parser. What is an element, how elements nest, and where an unclosed tag
+  ends are the parser's answers. This is what makes a card render as a card
+  from its first streamed chunk instead of flickering as raw tags.
+* **Phase B** (`dom_format.js`, `block_syntax.js`, `inline_syntax.js`) applies
+  markdown to **text nodes only**, with elements masked out of the string the
+  passes see.
+
+**Never add a markdown pass that runs over a string containing live HTML.**
+That is what the old formatter did, and every one of its 25 numbered steps was
+one more chance to eat somebody's markup.
+
+---
+
+## What is markup is decided by the vocabulary, not by counting
+
+`escapeProseTags()` escapes a tag into visible text only when its name is not
+an HTML/SVG/MathML element **and** the message's own CSS does not style it
+**and** it has no matching closing tag. `<вздох>` in prose stays a word;
+`<loomledger>` in a card stays a container.
+
+Do not reintroduce either of the heuristics this replaced:
+
+* an "orphan" rule keyed on how many times a tag name occurs in the message;
+* a hand-kept list of which tags are block-level.
+
+Both were lists that every slightly-different card fell off the end of.
+
+---
+
+## `<p>` is added at the top level of a message and nowhere else
+
+Inside markup the author wrote, nothing is wrapped. A paragraph of ours around
+someone's card reparents their elements, and `#toggle:checked ~ .overlay` —
+the selector every CSS-only card is built on — stops matching the moment its
+two halves stop being siblings.
+
+At the top level a run of text is still not wrapped when it touches a block
+element the author wrote with no blank line between them
+(`touchesBlockSibling` in `dom_format.js`): `<input><label>…</label><div>` is
+one card, not a paragraph followed by a card.
+
+---
+
+## A protected region is atomic
+
+`protect.js` takes out, before the parse:
+
+| Region | Why |
+|---|---|
+| fenced and inline code | prose *about* a tag is not a tag |
+| image tags (`[IMG:…]`, `<img data-iig-…>`) | they render as app UI, and their order is `data-img-index` (INV-IG6) |
+| markdown images | the wrapper, the picture and the options button are one positioned card |
+| `<think>` blocks | the model's own panel, rendered recursively |
+| style markers (`==hc:…==`, `**…**`) | a marker may span a tag, and a parsed marker is two text nodes with an element between them |
+
+A region comes back as one unit after phase B. Do not emit its markup into the
+text mid-pipeline: whatever pass runs next will take it apart.
+
+---
+
+## Markers are inline, always
+
+`renderStyledSegment()` renders a marker's content through `formatInlineRaw()`,
+which cannot produce a block element. A `<p>` inside a marker's `<span>` is
+markup the browser throws straight back out — the marker then shows as empty
+text. See `docs/markdown-markers.md` for the marker list itself.

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -30,6 +30,12 @@ void main() {
   late String formatterIndexJs;
   late String formatterFormatterJs;
   late String formatterTextFormatJs;
+  late String formatterHtmlScanJs;
+  late String formatterProtectJs;
+  late String formatterInlineSyntaxJs;
+  late String formatterBlockSyntaxJs;
+  late String formatterDomFormatJs;
+  late String formatterImageBlocksJs;
   late String bridgeIndexJs;
   late String bridgeControllerJs;
   late String virtualScrollJs;
@@ -57,6 +63,12 @@ void main() {
     formatterIndexJs = _formatterAsset('index.js');
     formatterFormatterJs = _formatterAsset('formatter.js');
     formatterTextFormatJs = _formatterAsset('text_format.js');
+    formatterHtmlScanJs = _formatterAsset('html_scan.js');
+    formatterProtectJs = _formatterAsset('protect.js');
+    formatterInlineSyntaxJs = _formatterAsset('inline_syntax.js');
+    formatterBlockSyntaxJs = _formatterAsset('block_syntax.js');
+    formatterDomFormatJs = _formatterAsset('dom_format.js');
+    formatterImageBlocksJs = _formatterAsset('image_blocks.js');
     rendererJs = [
       _rendererAsset('shadow_style.js'),
       _rendererAsset('markdown.js'),
@@ -791,53 +803,60 @@ void main() {
       expect(formatterIndexJs, contains('window.Formatter = Formatter'));
     });
 
-    test('formatter imports extracted text formatting modules', () {
-      expect(formatterFormatterJs, contains("'./macros.js'"));
-      expect(formatterFormatterJs, contains("'./text_format.js'"));
-      expect(formatterFormatterJs, contains('renderStyledSegment('));
+    test('formatter imports its render phases', () {
+      for (final module in [
+        './macros.js',
+        './html_scan.js',
+        './protect.js',
+        './dom_format.js',
+        './inline_syntax.js',
+        './image_blocks.js',
+      ]) {
+        expect(formatterFormatterJs, contains("'$module'"));
+      }
+      expect(formatterInlineSyntaxJs, contains("'./text_format.js'"));
+      expect(formatterInlineSyntaxJs, contains('renderStyledSegment('));
     });
 
     test('legacy formatter shim points at active module entrypoint', () {
       expect(_asset('formatter.js'), contains('formatter/index.js'));
     });
 
-    test('inline markdown does not keep a generated paragraph wrapper', () {
+    test('a style marker is rendered by an inline-only pass', () {
+      // A marker is a <span>. A <p> inside one is markup the browser throws
+      // straight back out, which used to leave a coloured marker showing as
+      // empty text. Its content goes through formatInlineRaw, which cannot
+      // emit a paragraph: it never reaches the block pass at all.
       expect(
-        formatterTextFormatJs,
-        contains(r'const paragraph = rich.match(/^\s*<p>([\s\S]*)<\/p>\s*$/i)'),
+        formatterInlineSyntaxJs,
+        contains('export function formatInlineRaw('),
       );
-      expect(
-        formatterTextFormatJs,
-        contains(r'!/<\/?p(?:\s|>)/i.test(paragraph[1])'),
-        reason: 'only a single outer paragraph may be unwrapped',
-      );
-      expect(formatterTextFormatJs, contains('return paragraph[1]'));
+      expect(formatterInlineSyntaxJs, isNot(contains('block_syntax.js')));
+      expect(formatterTextFormatJs, contains('processRichText'));
     });
 
     test('unmatched emphasis markers cannot consume a later line', () {
       expect(
-        formatterFormatterJs,
+        formatterProtectJs,
         contains(r'(?<!\*)\*(?=[^*\n]*[^ \t*\n])[^*\n]+?\*(?!\*)'),
       );
       expect(
-        formatterFormatterJs,
-        contains(r'html = html.replace(/\*([^*\n]+?)\*/g'),
+        formatterInlineSyntaxJs,
+        contains(r'.replace(/\*([^*\n]+?)\*/g'),
       );
     });
 
     test('orphan emphasis markers cannot consume the next action segment', () {
       expect(
-        formatterFormatterJs,
-        contains(
-          "html = html.replace(/\\*([ \\t]+)(?=\\x01S_\\d+\\x01)/g, '\$1');",
-        ),
+        formatterProtectJs,
+        contains(r'`\\*([ \\t]+)(?=${SENTINEL}S_\\d+${SENTINEL})`'),
       );
     });
 
     test('nested guillemets cannot consume styled-segment placeholders', () {
       expect(
-        formatterFormatterJs,
-        contains(r'(«)([^»\x01]*?(?:«[^»\x01]*?»[^»\x01]*?)*?)(»)'),
+        formatterInlineSyntaxJs,
+        contains(r'(«)([^»\\u0001]*?(?:«[^»\\u0001]*?»[^»\\u0001]*?)*?)(»)'),
         reason:
             'a malformed outer quote must not cross a styled segment while '
             'searching for its closing guillemet',
@@ -845,124 +864,165 @@ void main() {
     });
   });
 
-  // ─── markdown image options button ────────────────────────────────────────
-  group('markdown parity with the reference renderers', () {
-    test('every void element is exempt from the orphan-tag rule', () {
-      // A void element is written once and never closed, so the orphan rule
-      // would turn `<source>` inside a `<video>` into visible text.
-      for (final tag in [
-        "'area'",
-        "'base'",
-        "'br'",
-        "'col'",
-        "'embed'",
-        "'hr'",
-        "'img'",
-        "'input'",
-        "'link'",
-        "'meta'",
-        "'param'",
-        "'source'",
-        "'track'",
-        "'wbr'",
+  group('two-phase render (formatter/)', () {
+    // What each of these guards is *behaviour*, and the behaviour itself is
+    // covered by test/webview_js — the browser suite that renders the card
+    // corpus. These keep the shape of the pipeline honest: the message is
+    // parsed first, and nothing here decides structure by hand again.
+    test('the message is parsed before anything formats its text', () {
+      final protect = formatterFormatterJs.indexOf('protectRegions(source');
+      final parse = formatterFormatterJs.indexOf('parseHtml(escapeProseTags(');
+      final format = formatterFormatterJs.indexOf('formatContainer(tree');
+      expect(protect, isNonNegative);
+      expect(parse, greaterThan(protect));
+      expect(format, greaterThan(parse));
+    });
+
+    test('nothing sorts tags into block and inline by hand', () {
+      // The `blockTags` list and the "orphan" counter are what every card
+      // that *almost* matched them used to break on. How an element nests,
+      // and where an unclosed tag ends, are the parser's answers now.
+      expect(formatterFormatterJs, isNot(contains('blockTags')));
+      expect(formatterFormatterJs, isNot(contains('tagCounts')));
+      expect(formatterHtmlScanJs, contains('export function isKnownElement('));
+      expect(formatterHtmlScanJs, contains('export function escapeProseTags('));
+    });
+
+    test('an unknown element is markup when the card owns it', () {
+      // `<вздох>` in prose is a word; `<loomledger>` in a card is a
+      // container. What separates them is the card's own CSS and its
+      // closing tag — not how many times the name occurs.
+      final body = _extractBlockBody(
+        formatterHtmlScanJs,
+        formatterHtmlScanJs.indexOf('export function escapeProseTags('),
+      );
+      expect(body, contains('isKnownElement(name)'));
+      expect(body, contains('styled.has(name)'));
+      expect(body, contains('opened.has(name) && closed.has(name)'));
+      expect(body, contains(r"tag.replace(/</g, '&lt;')"));
+    });
+
+    test('a void element needs no exemption from anything', () {
+      // `<source>` inside a `<video>` is written once and never closed. The
+      // parser knows that; the old orphan rule had to be told, tag by tag.
+      for (final name in [
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link',
+        'meta', 'param', 'source', 'track', 'wbr',
       ]) {
         expect(
-          formatterFormatterJs.substring(
-            formatterFormatterJs.indexOf('const selfClosing = new Set('),
-            formatterFormatterJs.indexOf('const isExplicitSelfClosing'),
-          ),
-          contains(tag),
+          RegExp('(?<![A-Za-z-])$name(?![A-Za-z-])')
+              .hasMatch(formatterHtmlScanJs),
+          isTrue,
+          reason: '$name must be in the element vocabulary',
         );
       }
     });
 
-    test('<br> is inline, so it cannot split a paragraph', () {
-      final blockTags = formatterFormatterJs.substring(
-        formatterFormatterJs.indexOf('const blockTags = new Set('),
-        formatterFormatterJs.indexOf('const TAG_REGEX'),
+    test('markdown never reaches inside code, style or an attribute', () {
+      for (final name in ["'script'", "'style'", "'pre'", "'code'", "'textarea'"]) {
+        expect(formatterHtmlScanJs, contains(name));
+      }
+      expect(formatterHtmlScanJs, contains('RAW_TEXT_ELEMENTS'));
+      expect(formatterDomFormatJs, contains('const OPAQUE ='));
+      // Elements are masked out of the string the markdown passes run over,
+      // so no pass can read into a tag or an attribute value.
+      expect(
+        formatterDomFormatJs,
+        contains(r'`${SENTINEL}E_${kept.length - 1}${SENTINEL}`'),
       );
-      expect(blockTags, isNot(contains("'br'")));
+      expect(formatterHtmlScanJs, contains('export function maskTags('));
     });
 
-    test('inline code is extracted before the tag pass reads it', () {
-      final extract = formatterFormatterJs.indexOf("this._ph('IC_'");
-      final tagPass = formatterFormatterJs.indexOf('const TAG_REGEX');
-      expect(extract, isNonNegative);
-      expect(extract, lessThan(tagPass));
+    test('inline code is protected before the message is parsed', () {
+      final inlineCode = formatterProtectJs.indexOf("kind: 'inline-code'");
+      final imageCard = formatterProtectJs.indexOf('markdownImageCard(alt, url)');
+      expect(inlineCode, isNonNegative);
+      expect(imageCard, greaterThan(inlineCode));
       // Restored escaped: a tag written inside backticks is shown, not run.
       expect(
         formatterFormatterJs,
-        contains(r'return `<code>${this._escapeHtml(code)}</code>`;'),
+        contains(r'return `<code>${escapeHtml(region.code)}</code>`;'),
       );
     });
 
-    test('headings, tables and dinkus lines are block placeholders', () {
-      // Emitting raw HTML here would leave it as text for the paragraph pass,
-      // which would wrap it in <p> (invalid around <hr> and <table>).
+    test('headings, tables, lists and dinkus lines are block constructs', () {
       for (final marker in [
-        r'/^(#{1,6})[ \t]+(.+?)[ \t]*#*$/gm',
-        'const TABLE_RUN',
-        r"tagBlocks.push('<hr>');",
+        r'const HEADING = /^(#{1,6})[ \t]+(.+?)[ \t]*#*$/;',
+        r'const RULE = /^(_{3,}|-{3,}|\*{3,})$/;',
+        'const BULLET',
+        'const NUMBERED',
+        'const TABLE_SEPARATOR',
       ]) {
-        expect(formatterFormatterJs, contains(marker));
+        expect(formatterBlockSyntaxJs, contains(marker));
       }
       // A table needs its separator row — otherwise a line of prose that uses
       // pipes would become a table.
-      expect(formatterFormatterJs, contains(r'\|[ \t:|-]+\|'));
+      expect(formatterBlockSyntaxJs, contains(r'\|[ \t:|-]+\|'));
     });
 
     test('an indented list item nests inside the item above it', () {
       final body = _extractBlockBody(
-        formatterFormatterJs,
-        formatterFormatterJs.indexOf('const listBlocks = [];'),
+        formatterBlockSyntaxJs,
+        formatterBlockSyntaxJs.indexOf('function renderList('),
       );
-      expect(body, contains('depth'));
-      expect(body, contains(r'rendered += `<li>${item.text}</li>`;'));
+      expect(body, contains('item.depth'));
+      expect(body, contains(r'out += `<li>${inline(item.text)}</li>`;'));
     });
 
     test('markdown image dimensions never reach the URL', () {
       expect(
-        formatterFormatterJs,
+        formatterProtectJs,
         contains(r'const sized = url.match(/^(.*?)\s+=(\d+)?x(\d+)?$/);'),
       );
-      expect(formatterFormatterJs, contains('sized ? sized[1] : url'));
+      expect(formatterProtectJs, contains('sized ? sized[1] : url'));
     });
   });
 
-  group('CSS-only card adjacency (formatter/formatter.js)', () {
-    test('a paragraph of bare tags is never wrapped in <p>', () {
+  group('CSS-only card adjacency (formatter/dom_format.js)', () {
+    test('<p> is only ever added at the top level of a message', () {
       // `#toggle:checked ~ .overlay` — the sibling selector every CSS-only
       // card is built on — stops matching the moment a `<p>` reparents the
-      // checkbox, so a lone `<input>` on its own line must stay where the
-      // message put it.
+      // checkbox. Inside markup the author wrote, nothing is wrapped at all.
       expect(
-        formatterFormatterJs,
-        contains(
-          r"const ONLY_TAG_PLACEHOLDERS = "
-          r"/^(?:\x01T_(?:BLOCK_)?\d+\x01|\s)+$/;",
-        ),
+        formatterDomFormatJs,
+        contains('paragraphs: isRoot && !touchesBlockSibling(current)'),
       );
-      final paragraphs = formatterFormatterJs.indexOf('const paragraphs =');
-      final guard = formatterFormatterJs.indexOf(
-        'ONLY_TAG_PLACEHOLDERS.test(trimmed)',
+      expect(
+        formatterBlockSyntaxJs,
+        contains(r'paragraphs && !bare ? `<p>${body}</p>` : body'),
       );
-      final wrap = formatterFormatterJs.indexOf(r'`<p>${trimmed}</p>`');
-      expect(paragraphs, isNonNegative);
-      expect(guard, greaterThan(paragraphs));
-      expect(guard, lessThan(wrap));
+    });
+
+    test('a run that touches a card keeps its paragraph off', () {
+      // `<input id="t1"><label>…</label><div class="ov">` is one card, not a
+      // paragraph followed by a card: no blank line separates them.
+      final body = _extractBlockBody(
+        formatterDomFormatJs,
+        formatterDomFormatJs.indexOf('function touchesBlockSibling('),
+      );
+      expect(body, contains('tightBefore'));
+      expect(body, contains('tightAfter'));
+      expect(body, contains('hasBlankLine'));
+    });
+
+    test('a protected region is never wrapped in a paragraph', () {
+      // A <p> around an image block or a code block is a <p> the browser
+      // throws straight back out, taking the block's position with it.
+      expect(formatterBlockSyntaxJs, contains('const ONLY_REGIONS ='));
+      expect(formatterBlockSyntaxJs, contains('ONLY_REGIONS.test(line)'));
     });
   });
 
-  group('generated image (formatter/formatter.js, renderer/markdown.js)', () {
+  group('generated image (formatter/image_blocks.js, renderer/markdown.js)', () {
     test('the result image loads eagerly', () {
       // A lazy image at the bottom edge of the WebView can be evaluated while
       // the row is still off-screen and never fetched, leaving the picture the
       // user waited for as a broken tag.
-      final imgIdx = formatterFormatterJs.indexOf('class="imggen-result"');
+      final imgIdx = formatterImageBlocksJs.indexOf('class="imggen-result"');
       expect(imgIdx, isNot(-1));
-      final chunk = formatterFormatterJs.substring(
-        formatterFormatterJs.lastIndexOf('<img', imgIdx),
-        formatterFormatterJs.indexOf('>', imgIdx),
+      final chunk = formatterImageBlocksJs.substring(
+        formatterImageBlocksJs.lastIndexOf('<img', imgIdx),
+        formatterImageBlocksJs.indexOf('>', imgIdx),
       );
       expect(chunk, contains('loading="eager"'));
       expect(chunk, isNot(contains('loading="lazy"')));
@@ -971,30 +1031,30 @@ void main() {
     test('the block switcher renders only for more than one image', () {
       // The count is `variants.length > 1` on both the switcher and the data
       // attributes, so a single-image block keeps its historical markup.
-      expect(formatterFormatterJs, contains('imggen-variants'));
+      expect(formatterImageBlocksJs, contains('imggen-variants'));
       expect(
-        formatterFormatterJs,
+        formatterImageBlocksJs,
         contains("data-action=\"img-variant-prev\""),
       );
       expect(
-        formatterFormatterJs,
+        formatterImageBlocksJs,
         contains("data-action=\"img-variant-next\""),
       );
       expect(
-        RegExp(r'variants\.length > 1').allMatches(formatterFormatterJs).length,
+        RegExp(r'variants\.length > 1').allMatches(formatterImageBlocksJs).length,
         greaterThanOrEqualTo(3),
       );
-      expect(formatterFormatterJs, contains('data-variants='));
-      expect(formatterFormatterJs, contains('data-variant-index='));
+      expect(formatterImageBlocksJs, contains('data-variants='));
+      expect(formatterImageBlocksJs, contains('data-variant-index='));
     });
 
     test('the payload parser mirrors the Dart codec', () {
       expect(
-        formatterFormatterJs,
+        formatterImageBlocksJs,
         contains('export function parseImageResultPayload('),
       );
-      expect(formatterFormatterJs, contains("IMG_VARIANT_SEPARATOR = ';;'"));
-      expect(formatterFormatterJs, contains("IMG_VARIANT_ACTIVE_MARKER = '*'"));
+      expect(formatterImageBlocksJs, contains("IMG_VARIANT_SEPARATOR = ';;'"));
+      expect(formatterImageBlocksJs, contains("IMG_VARIANT_ACTIVE_MARKER = '*'"));
     });
 
     test('the stored <img data-iig-…> block renders as an image block', () {
@@ -1003,23 +1063,23 @@ void main() {
       // the switcher and its data-img-index — not the bare <img> that step 6
       // would leave.
       expect(
-        formatterFormatterJs,
+        formatterImageBlocksJs,
         contains('export function parseImageResultElement('),
       );
-      expect(formatterFormatterJs, contains('IIG_ELEMENT_REGEX'));
-      expect(formatterFormatterJs, contains("data-iig-variants"));
-      expect(formatterFormatterJs, contains("data-iig-index"));
+      expect(formatterImageBlocksJs, contains('IIG_ELEMENT_REGEX'));
+      expect(formatterImageBlocksJs, contains("data-iig-variants"));
+      expect(formatterImageBlocksJs, contains("data-iig-index"));
       expect(
         RegExp(
-          r'html = html\.replace\(IIG_ELEMENT_REGEX[\s\S]*?'
-          r"imgBlocks\.push\(\{\s*type: 'result'",
-        ).hasMatch(formatterFormatterJs),
+          r'out = out\.replace\(IIG_ELEMENT_REGEX[\s\S]*?'
+          r"hold\(\{\s*type: 'result'",
+        ).hasMatch(formatterImageBlocksJs),
         isTrue,
       );
       // An element with no image yet is a *pending* block and must fall
       // through to the [IMG:GEN] handling instead.
       expect(
-        formatterFormatterJs,
+        formatterImageBlocksJs,
         contains("if (!src || src.startsWith('[IMG:GEN')) return null;"),
       );
     });
@@ -1063,24 +1123,24 @@ void main() {
       // so the only thing it can paint is the browser's broken-image glyph.
       // Both stored spellings are pulled out as pending blocks instead.
       expect(
-        formatterFormatterJs,
+        formatterImageBlocksJs,
         contains('export function parseImagePendingElement('),
       );
-      expect(formatterFormatterJs, contains('IMG_SRC_GEN_ELEMENT_REGEX'));
+      expect(formatterImageBlocksJs, contains('IMG_SRC_GEN_ELEMENT_REGEX'));
       expect(
         RegExp(
-          r'html = html\.replace\(IIG_ELEMENT_REGEX[\s\S]*?'
-          r"imgBlocks\.push\(\{ type: 'gen'",
-        ).hasMatch(formatterFormatterJs),
+          r'out = out\.replace\(IIG_ELEMENT_REGEX[\s\S]*?'
+          r"hold\(\{ type: 'gen'",
+        ).hasMatch(formatterImageBlocksJs),
         isTrue,
         reason: 'a pending stored element must render the loading placeholder',
       );
       // The bare `<img src="[IMG:GEN…]">` element has to be consumed whole,
       // before the pass that would take only the payload out of its src.
       final srcElementIdx =
-          formatterFormatterJs.indexOf('html.replace(IMG_SRC_GEN_ELEMENT_REGEX');
-      final bareTagIdx = formatterFormatterJs.indexOf(
-        r'html.replace(/\[IMG:GEN(?::(.*?))?\]/g',
+          formatterImageBlocksJs.indexOf('out.replace(IMG_SRC_GEN_ELEMENT_REGEX');
+      final bareTagIdx = formatterImageBlocksJs.indexOf(
+        r'out.replace(/\[IMG:GEN(?::(.*?))?\]/g',
       );
       expect(srcElementIdx, isNonNegative);
       expect(bareTagIdx, isNonNegative);
@@ -1093,21 +1153,21 @@ void main() {
       // is never coming — nor allocate a data-img-index Dart does not count.
       expect(
         formatterFormatterJs,
-        contains('_processText(text, isUser, skipQuotes = false, '
-            'inReasoning = false)'),
+        contains('_render(text, isUser, inReasoning)'),
       );
       // The reasoning body is the one recursive pass that sets the flag.
       expect(
         formatterFormatterJs,
-        contains('this._processText(content, isUser, false, true)'),
+        contains('this._render(region.content, isUser, true)'),
       );
       // All three pending spellings fall through to the inert text collector.
       expect(
-        RegExp('if [(]inReasoning[)] return inertTag[(]match[)];')
-            .allMatches(formatterFormatterJs)
+        RegExp('if [(]inReasoning[)] return inert[(]match[)];')
+            .allMatches(formatterImageBlocksJs)
             .length,
         3,
       );
+      expect(formatterProtectJs, contains("inert: (raw) => store.hold("));
       // The split-out `message.reasoning` panel is reasoning too, and Dart
       // never scans that field at all — so it renders with the same flag.
       expect(
@@ -1128,25 +1188,28 @@ void main() {
         contains('formatMessageBody(formatter, text, isUser, isReasoning)'),
       );
       // Restored as the literal text the model wrote, before the leak sweep.
-      final restoreIdx = formatterFormatterJs.indexOf(r'\x01IGT_(\d+)\x01');
+      expect(formatterFormatterJs, contains("case 'text':"));
+      expect(formatterFormatterJs, contains('return escapeHtml(region.text);'));
+      final restoreIdx = formatterFormatterJs.indexOf(
+        "replacePlaceholders(tree, 'P'",
+      );
       final sweepIdx = formatterFormatterJs.indexOf(
-        r"html = html.replace(/\x01[A-Z_]+\d+\x01/g, '');",
+        'result.replace(ANY_PLACEHOLDER',
       );
       expect(restoreIdx, isNonNegative);
       expect(sweepIdx, isNonNegative);
-      expect(restoreIdx, lessThan(sweepIdx));
     });
 
     test('the stop button is an SVG, not an emoji glyph', () {
       // ⏹ is a font-dependent emoji: a different size and colour on every
       // platform. A path takes `fill: currentColor` and stays put.
-      expect(formatterFormatterJs, contains('const STOP_SVG ='));
-      expect(formatterFormatterJs, contains('<rect x="7" y="7"'));
-      final stopIdx = formatterFormatterJs.indexOf('class="imggen-stop-btn"');
+      expect(formatterImageBlocksJs, contains('const STOP_SVG ='));
+      expect(formatterImageBlocksJs, contains('<rect x="7" y="7"'));
+      final stopIdx = formatterImageBlocksJs.indexOf('class="imggen-stop-btn"');
       expect(stopIdx, isNonNegative);
-      final button = formatterFormatterJs.substring(
+      final button = formatterImageBlocksJs.substring(
         stopIdx,
-        formatterFormatterJs.indexOf('</button>', stopIdx),
+        formatterImageBlocksJs.indexOf('</button>', stopIdx),
       );
       expect(button, contains(r'${STOP_SVG}'));
       expect(button, isNot(contains('⏹')));
@@ -1159,7 +1222,7 @@ void main() {
       // streaming and post-gen reaches the image stage. Until then there is
       // nothing to time and nothing to stop — a running placeholder would be
       // a lie, and its Stop button would cancel a token that does not exist.
-      expect(formatterFormatterJs, contains('class="imggen-queued-hint"'));
+      expect(formatterImageBlocksJs, contains('class="imggen-queued-hint"'));
       expect(
         imgGenPlaceholderJs,
         contains('return !bridge.isGeneratingImage;'),
@@ -1241,83 +1304,55 @@ void main() {
     });
   });
 
-  group('markdown image card (formatter/formatter.js)', () {
-    test('the card is stashed whole, not emitted as raw HTML mid-pipeline', () {
-      // Raw HTML emitted before the tag extraction gets torn apart: <img>,
-      // <svg> and <path> are *block* tags, so the paragraph step isolates each
-      // of them and the wrapper <span>, the image and the options <button> end
-      // up in three different <p> elements. The button then loses its
-      // positioned wrapper and its `position: absolute` resolves against the
-      // message container — the 3-dot menu jumps to the top of the message.
-      expect(formatterFormatterJs, contains('const mdImages = []'));
-      expect(formatterFormatterJs, contains('mdImages.push('));
-
-      final pushIdx = formatterFormatterJs.indexOf('mdImages.push(');
-      final tagExtractIdx = formatterFormatterJs.indexOf(
-        '// 6. Extract HTML Tags',
-      );
-      expect(tagExtractIdx, isNot(-1));
+  group('markdown image card (formatter/protect.js)', () {
+    test('the card is one protected region, never loose markup', () {
+      // Emitted as raw HTML mid-pipeline the card gets torn apart: the
+      // wrapper <span>, the <img> and the options <button> end up in
+      // different blocks, the button loses its positioned wrapper, and its
+      // `position: absolute` resolves against the whole message instead.
+      expect(formatterProtectJs, contains('function markdownImageCard('));
       expect(
-        pushIdx < tagExtractIdx,
-        isTrue,
-        reason: 'the image card must be stashed before tag extraction runs',
+        formatterProtectJs,
+        contains("store.hold({ kind: 'html', html: markdownImageCard(alt, url) })"),
       );
     });
 
     test('wrapper, image and options button live in one atomic chunk', () {
-      final pushIdx = formatterFormatterJs.indexOf('mdImages.push(');
-      final chunk = formatterFormatterJs.substring(
-        pushIdx,
-        formatterFormatterJs.indexOf('\n', pushIdx),
+      final body = _extractBlockBody(
+        formatterProtectJs,
+        formatterProtectJs.indexOf('function markdownImageCard('),
       );
-      expect(chunk, contains('janitor-img-wrapper'));
-      expect(chunk, contains('class="janitor-img"'));
-      expect(chunk, contains('janitor-options-btn'));
-      expect(chunk, contains(r'data-action="img-options"'));
+      expect(body, contains('janitor-img-wrapper'));
+      expect(body, contains('class="janitor-img"'));
+      expect(body, contains('janitor-options-btn'));
+      expect(body, contains(r'data-action="img-options"'));
     });
 
-    test('the card is restored after paragraph splitting', () {
-      final restoreIdx = formatterFormatterJs.indexOf(
-        r'html = html.replace(/\x01MI_(\d+)\x01/g',
+    test('the card is put back after the markdown passes, not before', () {
+      final format = formatterFormatterJs.indexOf('formatContainer(tree');
+      final restore = formatterFormatterJs.indexOf(
+        "replacePlaceholders(tree, 'P'",
       );
-      expect(
-        restoreIdx,
-        isNot(-1),
-        reason: 'markdown image placeholders must be restored',
-      );
-      final paragraphIdx = formatterFormatterJs.indexOf('// 11. Paragraphs');
-      expect(paragraphIdx, isNot(-1));
-      expect(
-        restoreIdx > paragraphIdx,
-        isTrue,
-        reason:
-            'restoring before the paragraph step would expose the card to the '
-            'block-placeholder isolation again',
-      );
+      expect(format, isNonNegative);
+      expect(restore, greaterThan(format));
     });
 
     test('options button is positioned against the image wrapper', () {
       final wrapperIdx = rendererJs.indexOf('.janitor-img-wrapper {');
       expect(wrapperIdx, isNot(-1));
-      final wrapperBlock = rendererJs.substring(
+      final wrapperRule = rendererJs.substring(
         wrapperIdx,
-        rendererJs.indexOf('}', wrapperIdx) + 1,
+        rendererJs.indexOf('}', wrapperIdx),
       );
-      expect(
-        wrapperBlock,
-        contains('position: relative'),
-        reason: 'the wrapper is the containing block of the options button',
-      );
+      expect(wrapperRule, contains('position: relative'));
 
-      final btnIdx = rendererJs.indexOf('.janitor-options-btn,');
+      final btnIdx = rendererJs.indexOf('.janitor-options-btn {');
       expect(btnIdx, isNot(-1));
-      final btnBlock = rendererJs.substring(
+      final btnRule = rendererJs.substring(
         btnIdx,
-        rendererJs.indexOf('}', btnIdx) + 1,
+        rendererJs.indexOf('}', btnIdx),
       );
-      expect(btnBlock, contains('position: absolute'));
-      expect(btnBlock, contains('top: 8px'));
-      expect(btnBlock, contains('right: 8px'));
+      expect(btnRule, contains('position: absolute'));
     });
   });
 

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -924,6 +924,24 @@ void main() {
       }
     });
 
+    test('a <style> or <script> body is never read as prose', () {
+      // Both string passes before the parse would misread code: a `*` in a
+      // selector is not an italic marker, and `i<n; i++) { if (i>` in a
+      // script is not a tag. They are masked for the length of both.
+      final mask = formatterFormatterJs.indexOf('maskCodeElements(staged)');
+      final markers = formatterFormatterJs.indexOf('extractMarkers(code.masked');
+      final escape = formatterFormatterJs.indexOf(
+        'code.unmask(escapeProseTags(staged, styled))',
+      );
+      expect(mask, isNonNegative);
+      expect(markers, greaterThan(mask));
+      expect(escape, greaterThan(markers));
+      expect(
+        formatterProtectJs,
+        contains(r'/<(style|script)\b[^>]*>[\s\S]*?(?:<\/\1\s*>|$)/gi'),
+      );
+    });
+
     test('markdown never reaches inside code, style or an attribute', () {
       for (final name in ["'script'", "'style'", "'pre'", "'code'", "'textarea'"]) {
         expect(formatterHtmlScanJs, contains(name));

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -442,18 +442,13 @@ void main() {
       );
       final writeBlock = _extractWriteShadowContent(rendererJs);
       final insertion = writeBlock.indexOf('root.innerHTML =');
-      final report = writeBlock.indexOf('reportCssErrors(root)');
+      final report = writeBlock.indexOf('reportCssErrors(root, blockedAtRules(');
       expect(insertion, isNonNegative);
       expect(report, greaterThan(insertion));
       // A reply still arriving is half a stylesheet: every unclosed brace in it
       // is on its way to being closed, so only a settled message is reported.
-      expect(
-        writeBlock,
-        contains(
-          'if (!isTyping && !window.bridge?.isGenerating) '
-          'reportCssErrors(root);',
-        ),
-      );
+      expect(writeBlock, contains('if (!isTyping && !window.bridge?.isGenerating) {'));
+      expect(writeBlock, contains('reportCssErrors(root, blockedAtRules(formatted));'));
     });
 
     test('the search re-render puts the report back', () {
@@ -877,7 +872,9 @@ void main() {
     // parsed first, and nothing here decides structure by hand again.
     test('the message is parsed before anything formats its text', () {
       final protect = formatterFormatterJs.indexOf('protectRegions(source');
-      final parse = formatterFormatterJs.indexOf('parseHtml(escapeProseTags(');
+      final parse = formatterFormatterJs.indexOf(
+        'parseHtml(code.unmask(escapeProseTags(',
+      );
       final format = formatterFormatterJs.indexOf('formatContainer(tree');
       expect(protect, isNonNegative);
       expect(parse, greaterThan(protect));
@@ -959,7 +956,9 @@ void main() {
 
     test('inline code is protected before the message is parsed', () {
       final inlineCode = formatterProtectJs.indexOf("kind: 'inline-code'");
-      final imageCard = formatterProtectJs.indexOf('markdownImageCard(alt, url)');
+      final imageCard = formatterProtectJs.indexOf(
+        "store.hold({ kind: 'html', html: markdownImageCard(alt, url) })",
+      );
       expect(inlineCode, isNonNegative);
       expect(imageCard, greaterThan(inlineCode));
       // Restored escaped: a tag written inside backticks is shown, not run.
@@ -1364,19 +1363,25 @@ void main() {
     test('options button is positioned against the image wrapper', () {
       final wrapperIdx = rendererJs.indexOf('.janitor-img-wrapper {');
       expect(wrapperIdx, isNot(-1));
-      final wrapperRule = rendererJs.substring(
+      final wrapperBlock = rendererJs.substring(
         wrapperIdx,
-        rendererJs.indexOf('}', wrapperIdx),
+        rendererJs.indexOf('}', wrapperIdx) + 1,
       );
-      expect(wrapperRule, contains('position: relative'));
+      expect(
+        wrapperBlock,
+        contains('position: relative'),
+        reason: 'the wrapper is the containing block of the options button',
+      );
 
-      final btnIdx = rendererJs.indexOf('.janitor-options-btn {');
+      final btnIdx = rendererJs.indexOf('.janitor-options-btn,');
       expect(btnIdx, isNot(-1));
-      final btnRule = rendererJs.substring(
+      final btnBlock = rendererJs.substring(
         btnIdx,
-        rendererJs.indexOf('}', btnIdx),
+        rendererJs.indexOf('}', btnIdx) + 1,
       );
-      expect(btnRule, contains('position: absolute'));
+      expect(btnBlock, contains('position: absolute'));
+      expect(btnBlock, contains('top: 8px'));
+      expect(btnBlock, contains('right: 8px'));
     });
   });
 

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -47,6 +47,7 @@ void main() {
   late String cssDiagnosticsJs;
   late String targetToggleJs;
   late String markdownJs;
+  late String messageDocumentJs;
   late String cssSanitizerJs;
   late String imgGenPlaceholderJs;
   late String imgGenTimerJs;
@@ -72,6 +73,7 @@ void main() {
     rendererJs = [
       _rendererAsset('shadow_style.js'),
       _rendererAsset('markdown.js'),
+      _rendererAsset('message_document.js'),
       _rendererAsset('image_embed.js'),
       _rendererAsset('message_template.js'),
       rendererMessageJs,
@@ -89,6 +91,7 @@ void main() {
     cssDiagnosticsJs = _rendererAsset('css_diagnostics.js');
     targetToggleJs = _rendererAsset('target_toggle.js');
     markdownJs = _rendererAsset('markdown.js');
+    messageDocumentJs = _rendererAsset('message_document.js');
     cssSanitizerJs = _bridgeAsset('css_sanitizer.js');
     selectionManagerJs = _bridgeAsset('selection_manager.js');
     swipeHandlerJs = _bridgeAsset('swipe_gesture_handler.js');
@@ -252,13 +255,16 @@ void main() {
     });
 
     test('disabled path removes scripts before returning', () {
-      final marker = 'export function executeInlineScripts';
-      final body = _extractBlockBody(rendererJs, rendererJs.indexOf(marker));
+      final marker = 'export function runMessageScripts';
+      final body = _extractBlockBody(
+        messageDocumentJs,
+        messageDocumentJs.indexOf(marker),
+      );
       expect(body, contains('if (!allowMessageScripts)'));
       expect(body, contains('script.remove()'));
       expect(
         body.indexOf('script.remove()'),
-        lessThan(body.indexOf('new Function(src)()')),
+        lessThan(body.indexOf('runInGlobalScope(')),
       );
     });
 
@@ -1943,20 +1949,25 @@ void main() {
     });
 
     test('both message-HTML insertion points re-key `:target`', () {
-      for (final source in [markdownJs, rendererMessageJs]) {
-        expect(
-          source,
-          contains("import { rewriteTargetSelectors } from './target_toggle.js';"),
-        );
-        expect(
-          source,
-          contains('rewriteTargetSelectors(root);'),
-          reason:
-              'A URL fragment never resolves inside a shadow root, so a card '
-              'that toggles a panel with `:target` needs the re-key on every '
-              'path that writes a message body',
-        );
-      }
+      // A URL fragment never resolves inside a shadow root, so a card that
+      // toggles a panel with `:target` needs the re-key on every path that
+      // writes a message body. The render path goes through the document
+      // contract; the search re-render rewrites innerHTML on its own.
+      expect(
+        markdownJs,
+        contains("import { installMessageDocument } from './message_document.js';"),
+      );
+      expect(markdownJs, contains('installMessageDocument(root, { allowMessageScripts })'));
+      expect(
+        messageDocumentJs,
+        contains("import { rewriteTargetSelectors } from './target_toggle.js';"),
+      );
+      expect(messageDocumentJs, contains('rewriteTargetSelectors(root);'));
+      expect(
+        rendererMessageJs,
+        contains("import { rewriteTargetSelectors } from './target_toggle.js';"),
+      );
+      expect(rendererMessageJs, contains('rewriteTargetSelectors(root);'));
     });
 
     test('links are resolved through composedPath, not e.target', () {
@@ -1985,6 +1996,140 @@ void main() {
       );
     });
   });
+
+  // ─── What a card may rely on inside a message shadow root ─────────────────
+  group('message document contract (renderer/message_document.js)', () {
+    // Behaviour is covered case by case in test/webview_js —
+    // specs/document_contract.spec.js, one test per INV-MR item. These keep
+    // the contract in one module instead of a shim per complaint.
+    test('a card script runs in the page global scope', () {
+      // A function scope of its own is what left `onclick="jscToggle()"`
+      // pointing at nothing: the card declared the handler, and nobody could
+      // see it (INV-MR1).
+      final body = _extractBlockBody(
+        messageDocumentJs,
+        messageDocumentJs.indexOf('function runInGlobalScope('),
+      );
+      expect(body, contains("document.createElement('script')"));
+      expect(
+        body,
+        contains('REAL_HEAD.appendChild(element)'),
+        reason: 'document.head is the message root while the scope is on, and '
+            'a script appended to a shadow root never runs',
+      );
+    });
+
+    test('every shim is an own property, so restoring is a delete', () {
+      // INV-MR2: the app's own document must come back exactly as it was.
+      final body = _extractBlockBody(
+        messageDocumentJs,
+        messageDocumentJs.indexOf('function installDocumentScope('),
+      );
+      expect(
+        body,
+        contains('Object.defineProperty(target, name, { configurable: true'),
+      );
+      expect(
+        body,
+        contains('for (const { target, name } of defined) delete target[name];'),
+      );
+    });
+
+    test('the contract covers every document lookup a card makes', () {
+      for (final name in [
+        'getElementById',
+        'querySelector',
+        'querySelectorAll',
+        'getElementsByClassName',
+        'getElementsByTagName',
+        'getElementsByName',
+        'forms',
+        'images',
+        'links',
+        'styleSheets',
+        'body',
+        'head',
+      ]) {
+        expect(
+          messageDocumentJs,
+          contains("'$name'"),
+          reason: 'INV-MR3/MR4: $name must resolve inside the message',
+        );
+      }
+    });
+
+    test('a lookup the message cannot answer reaches the real document', () {
+      expect(
+        messageDocumentJs,
+        contains('documentQuery.getElementById.call(document, id)'),
+      );
+      expect(
+        messageDocumentJs,
+        contains('documentQuery.querySelector.call(document, selector)'),
+      );
+    });
+
+    test('document.body is the message overlay; app chrome opts out', () {
+      // INV-MR6. A node the card hands to the document stays under the
+      // message's stylesheet instead of rendering naked in the app chrome.
+      expect(
+        messageDocumentJs,
+        contains("define(document, 'body', { get: () => messageOverlay(root) })"),
+      );
+      expect(messageDocumentJs, contains('export function appBody()'));
+      expect(rendererJs, contains('.glaze-message-overlay { display: contents; }'));
+      // App chrome appended during a message event has to say so, or it lands
+      // inside somebody's card.
+      expect(selectionManagerJs, contains('appBody().appendChild'));
+      expect(selectionManagerJs, isNot(contains('document.body.appendChild')));
+    });
+
+    test('the load events a card waits for are collected and replayed', () {
+      // INV-MR7: the real DOMContentLoaded fired before the message existed,
+      // so a card that waits for it would wait forever.
+      expect(
+        messageDocumentJs,
+        contains(
+          "const READY_EVENTS = new Set(['DOMContentLoaded', 'load', "
+          "'readystatechange'])",
+        ),
+      );
+      expect(
+        messageDocumentJs,
+        contains("listener.call(document, new Event('DOMContentLoaded'))"),
+      );
+      expect(messageDocumentJs, contains("define(window, 'onload'"));
+    });
+
+    test('the scope outlives the script, for the length of an event', () {
+      // A card's modal is appended from its click handler, long after its
+      // <script> finished running.
+      expect(messageDocumentJs, contains('const SCOPED_EVENTS ='));
+      expect(messageDocumentJs, contains('queueMicrotask(restore)'));
+      expect(messageDocumentJs, contains('setTimeout(restore, 0)'));
+      // …and only for a message whose own code has actually run, so the app's
+      // document is untouched for every message that carries no script.
+      expect(messageDocumentJs, contains('scripted.has(root)'));
+    });
+
+    test('a dropped @import is reported instead of failing silently', () {
+      // INV-MR5: message CSS may not reach the network (css_sanitizer.js), so
+      // the rule is dropped — but the card author used to see only a font
+      // that fell back to cursive, with nothing on screen to say why.
+      expect(
+        cssDiagnosticsJs,
+        contains('export function inspectBlockedAtRules('),
+      );
+      expect(cssDiagnosticsJs, contains('@(import|font-face|page|namespace)'));
+      expect(
+        markdownJs,
+        contains('reportCssErrors(root, blockedAtRules(formatted))'),
+        reason: 'the at-rule is read off the pre-sanitize HTML; by insertion '
+            'time it is already gone',
+      );
+    });
+  });
+
 
   // ─── GenTimer extraction (Phase 3.5) ───────────────────────────────────────
   group('GenTimer (bridge.js)', () {

--- a/test/webview_js/README.md
+++ b/test/webview_js/README.md
@@ -32,6 +32,7 @@ imports the assets by their real paths, and ES modules do not load over
 | `specs/cards.spec.js` | the structure the browser must build for each card |
 | `specs/interaction.spec.js` | clicks, `:target`, links, scripts-off behaviour |
 | `specs/streaming.spec.js` | every prefix of a card body renders as a card |
+| `specs/document_contract.spec.js` | what a card may rely on inside the shadow root (INV-MR1…MR8) |
 
 ## The rule
 

--- a/test/webview_js/README.md
+++ b/test/webview_js/README.md
@@ -1,0 +1,45 @@
+# WebView render tests
+
+Browser tests for the chat WebView assets. They load the **real** modules out
+of `assets/chat_webview/` in a headless Chromium and assert on what the browser
+built: the DOM inside the message shadow root, the CSS it resolved, and what a
+click does.
+
+`test/webview_assets_test.dart` stays what it is — static checks on the *source*
+of those assets. It cannot catch a rendering regression, which is why these
+exist.
+
+## Running
+
+```bash
+cd test/webview_js
+npm ci                       # or: npm install
+npx playwright install chromium
+npm test
+```
+
+`npm test` starts the static server in `harness/server.js` itself (the harness
+imports the assets by their real paths, and ES modules do not load over
+`file://`).
+
+## Layout
+
+| Path | What it is |
+|---|---|
+| `corpus/cards.js` | the card corpus — one entry per message body worth protecting |
+| `harness/harness.html`, `harness/harness.js` | one message, rendered exactly the way `message_renderer.js` renders it |
+| `harness/server.js` | static server rooted at the repository |
+| `specs/cards.spec.js` | the structure the browser must build for each card |
+| `specs/interaction.spec.js` | clicks, `:target`, links, scripts-off behaviour |
+| `specs/streaming.spec.js` | every prefix of a card body renders as a card |
+
+## The rule
+
+**Every rendering bug becomes a corpus entry before it is fixed.** A fix
+without an entry is a fix the next refactor is free to undo. Add the message
+body verbatim to `corpus/cards.js` with an `origin` note, add the assertion
+that fails, then fix the renderer.
+
+A case the current renderer genuinely cannot serve yet is marked `test.fail()`
+with a comment naming the stage that will make it pass — so the baseline is
+recorded rather than lost.

--- a/test/webview_js/corpus/cards.js
+++ b/test/webview_js/corpus/cards.js
@@ -269,6 +269,17 @@ window.onload = function () {
 </script>`,
   },
   {
+    id: 'script-comparison',
+    title: 'Card script that compares with < and > and no spaces',
+    origin: 'audit 28.08 — the tag scan read `i<n; i++) { if (i>` as a tag',
+    text: `<div id="sc-out">-</div>
+<script>
+var n=3,o='';
+for(var i=0;i<n;i++){if(i>1)o+=i;}
+document.getElementById('sc-out').textContent='ok'+o;
+</script>`,
+  },
+  {
     id: 'import-font-card',
     title: 'Card whose CSS tries to @import a font',
     origin: 'INV-MR5 — the policy drops it, and used to drop it silently',

--- a/test/webview_js/corpus/cards.js
+++ b/test/webview_js/corpus/cards.js
@@ -1,0 +1,241 @@
+// The card corpus.
+//
+// Every rendering bug becomes an entry here *before* it is fixed. An entry is
+// the message text exactly as a model (or a card author) writes it; the specs
+// say what the browser must make of it. `origin` records where the case came
+// from, so nobody has to guess later whether an oddity is deliberate.
+//
+// Keep entries verbatim. Trimming a card to "just the failing part" is how a
+// case stops covering the thing that broke.
+
+export const cards = [
+  {
+    id: 'html-table',
+    title: 'Hand-written HTML table',
+    origin: 'audit 28.08 — <p> was injected between <table> and <tr>',
+    text: `<table class="stats">
+<tr><th>Стат</th><th>Знач</th></tr>
+<tr><td>HP</td><td>12</td></tr>
+</table>`,
+  },
+  {
+    id: 'css-only-checkbox',
+    title: 'CSS-only card: hidden checkbox toggles a sibling overlay',
+    origin: '#326 — fixed for a paragraph without text; text in the <label> broke it again',
+    text: `<style>
+.ov { display: none; }
+#t1:checked ~ .ov { display: block; }
+</style>
+<input type="checkbox" id="t1"><label for="t1">жать</label><div class="ov">скрыто</div>`,
+  },
+  {
+    id: 'target-card',
+    title: ':target panel toggled by a fragment link',
+    origin: '#339',
+    text: `<style>
+.panel { opacity: 0; height: 0; overflow: hidden; }
+#vn-k7x1:target { opacity: 1; height: auto; }
+</style>
+<a href="#vn-k7x1" class="open">Открыть</a>
+<div id="vn-k7x1" class="panel">Содержимое панели</div>`,
+  },
+  {
+    id: 'script-card',
+    title: 'Card whose <script> declares the function its onclick calls',
+    origin: 'f7477cf — the function was scoped to the wrapper, so onclick threw',
+    text: `<div class="jsc"><button id="jsc-btn" onclick="jscToggle()">Показать</button><div id="jsc-out" hidden>Открыто</div></div>
+<script>
+function jscToggle() {
+  var out = document.getElementById('jsc-out');
+  out.hidden = !out.hidden;
+}
+</script>`,
+  },
+  {
+    id: 'style-and-inline-style',
+    title: '<style> block and inline style="" survive with scripts off',
+    origin: '#290',
+    text: `<style>.plate { color: rgb(10, 200, 30); }</style>
+<div class="plate" style="letter-spacing: 3px;">Табличка</div>`,
+  },
+  {
+    id: 'video-source',
+    title: '<video> with a single <source> child',
+    origin: '#326 — <source> is void, the orphan rule escaped it into text',
+    text: `<video controls width="240"><source src="clip.mp4" type="video/mp4"></video>`,
+  },
+  {
+    id: 'details-block',
+    title: '<details>/<summary> spoiler',
+    origin: '#326',
+    text: `<details><summary>Спойлер</summary>
+Скрытый текст под катом.
+</details>`,
+  },
+  {
+    id: 'svg-icon',
+    title: 'Inline SVG icon inside a card',
+    origin: '#326 — <p> was inserted inside <svg>',
+    text: `<div class="ico"><svg viewBox="0 0 24 24" width="16" height="16"><path d="M12 2 2 22h20z"></path></svg> готово</div>`,
+  },
+  {
+    id: 'markdown-basics',
+    title: 'Plain markdown message: prose, emphasis, quotes',
+    origin: 'baseline',
+    text: `Она вошла в комнату.
+
+*Он поднял взгляд.* "Ты опоздала," — сказал он.
+
+**Важно:** ~~забудь~~ помни об этом.`,
+  },
+  {
+    id: 'markdown-structure',
+    title: 'Markdown headings, lists and a pipe table',
+    origin: 'baseline',
+    text: `## Отчёт
+
+- первый пункт
+- второй пункт
+  - вложенный
+
+1. раз
+2. два
+
+| Поле | Значение |
+| --- | --- |
+| HP | 12 |
+| MP | 3 |`,
+  },
+  {
+    id: 'prose-angle-brackets',
+    title: 'Prose that contains angle brackets',
+    origin: 'the orphan heuristic existed for this case',
+    text: `Он прошептал <вздох> и добавил: 5 < 7 > 3.`,
+  },
+  {
+    id: 'inline-code-tag',
+    title: 'A tag written inside backticks is prose about a tag',
+    origin: 'formatter step 2b',
+    text: 'Пиши `<div>` в начале карточки, а не ```<span>```.',
+  },
+  {
+    id: 'fenced-code',
+    title: 'Fenced code block with HTML inside',
+    origin: 'baseline',
+    text: '```html\n<div class="card">\n  <b>x</b>\n</div>\n```',
+  },
+  {
+    id: 'md-link',
+    title: 'Markdown link and a bare anchor inside a message',
+    origin: '#339 — links inside the message did not fire',
+    text: `Смотри [документацию](https://example.org/docs) и <a href="https://example.org/two">вторую ссылку</a>.`,
+  },
+  {
+    id: 'md-image',
+    title: 'Janitor-style markdown image with its options button',
+    origin: 'formatter step 5b',
+    text: `![портрет](https://example.org/p.png)`,
+  },
+  {
+    id: 'stat-card',
+    title: 'Composite card: header, table, bars, custom element',
+    origin: 'representative of the diary/ledger cards users write',
+    text: `<style>
+@import url('https://fonts.example/css2?family=Card');
+loomledger { display: block; font-family: 'Card', cursive; }
+.ll-head { color: rgb(200, 40, 90); font-weight: 700; }
+.ll-bar { height: 6px; background: rgb(40, 40, 40); }
+.ll-bar > i { display: block; height: 100%; background: rgb(200, 40, 90); }
+</style>
+<loomledger>
+<div class="ll-head">Дневник</div>
+<table class="ll-tab"><tr><td>Доверие</td><td><div class="ll-bar"><i style="width:70%"></i></div></td></tr></table>
+<div class="ll-note">*Она отвела взгляд.*</div>
+</loomledger>`,
+  },
+  {
+    id: 'think-block',
+    title: 'Reasoning block written inline by the model',
+    origin: 'formatter step 1a/17',
+    text: `<think>Надо ответить коротко.</think>
+Хорошо, идём.`,
+  },
+  {
+    id: 'imggen-pending',
+    title: 'Pending image block',
+    origin: 'INV-IG1',
+    text: `Смотри: [IMG:GEN:девушка у окна]`,
+  },
+  {
+    id: 'imggen-result',
+    title: 'Finished image block with two variants',
+    origin: 'INV-IG8',
+    text: `<img src="a.png" data-iig-instruction="девушка" data-iig-variants="a.png;;b.png" data-iig-index="0">`,
+  },
+  {
+    id: 'glaze-markers',
+    title: 'Glaze colour markers',
+    origin: 'formatter step 7',
+    text: `==hc:#ff0066==Красным== и ==accent==акцентом==, обычный текст.`,
+  },
+  {
+    id: 'blockquote-hr',
+    title: 'Blockquote and horizontal rule',
+    origin: 'baseline',
+    text: `> цитата
+
+---
+
+после черты`,
+  },
+  {
+    id: 'br-in-card',
+    title: '<br> inside a card body',
+    origin: '#326',
+    text: `<div class="note">Первая строка<br>Вторая строка</div>`,
+  },
+  {
+    id: 'nested-quotes',
+    title: 'Guillemets and straight quotes in one message',
+    origin: 'formatter step 8',
+    text: `«Он сказал «тихо» и вышел», — а потом "добавил вслух".`,
+  },
+  {
+    id: 'form-controls',
+    title: 'A card built out of form controls',
+    origin: 'html_sanitizer keeps <form> for message HTML',
+    text: `<form class="picker"><fieldset><legend>Выбор</legend><input type="radio" name="r" id="r1" checked><label for="r1">Раз</label></fieldset></form>`,
+  },
+];
+
+/** Cards whose first chunks must already render as a card, not as raw tags. */
+export const streamingCards = [
+  'html-table',
+  'css-only-checkbox',
+  'target-card',
+  'stat-card',
+  'details-block',
+  'svg-icon',
+  'br-in-card',
+];
+
+export function card(id) {
+  const found = cards.find((entry) => entry.id === id);
+  if (!found) throw new Error(`No corpus card "${id}"`);
+  return found;
+}
+
+/**
+ * Streaming prefixes of a card body: what the reader sees while the reply is
+ * still arriving. The steps are deliberately coarse — the point is to cross
+ * every "tag half written / element not yet closed" boundary, not to test
+ * every character.
+ */
+export function prefixes(text, steps = 8) {
+  const out = [];
+  for (let i = 1; i <= steps; i++) {
+    const cut = Math.floor((text.length * i) / (steps + 1));
+    if (cut > 0) out.push(text.slice(0, cut));
+  }
+  return out;
+}

--- a/test/webview_js/corpus/cards.js
+++ b/test/webview_js/corpus/cards.js
@@ -201,6 +201,20 @@ loomledger { display: block; font-family: 'Card', cursive; }
     text: `«Он сказал «тихо» и вышел», — а потом "добавил вслух".`,
   },
   {
+    id: 'inline-tags-in-prose',
+    title: 'Prose with inline tags, quotes and markers across them',
+    origin: 'audit 28.08 — the string formatter matched these across live HTML',
+    text: `Привет <b>мир</b>
+
+"Диалог с <b>тегом</b> внутри", ==hc:#ff0066==<i>цветной курсив</i>== и всё.`,
+  },
+  {
+    id: 'font-gradient',
+    title: '<font> gradient fill with the text in a nested span',
+    origin: 'formatter step 18 — background-clip:text had nothing to clip',
+    text: `<font style="background-image:linear-gradient(90deg,#ff0000,#0000ff);-webkit-background-clip:text;-webkit-text-fill-color:transparent"><span style="letter-spacing:1px">Градиент</span></font>`,
+  },
+  {
     id: 'form-controls',
     title: 'A card built out of form controls',
     origin: 'html_sanitizer keeps <form> for message HTML',

--- a/test/webview_js/corpus/cards.js
+++ b/test/webview_js/corpus/cards.js
@@ -220,6 +220,64 @@ loomledger { display: block; font-family: 'Card', cursive; }
     origin: 'html_sanitizer keeps <form> for message HTML',
     text: `<form class="picker"><fieldset><legend>Выбор</legend><input type="radio" name="r" id="r1" checked><label for="r1">Раз</label></fieldset></form>`,
   },
+  {
+    id: 'doc-query-card',
+    title: 'Card script that looks its elements up through the document',
+    origin: 'INV-MR3/MR4 — a shadow root is not the document',
+    text: `<div class="dq"><span id="dq-out">-</span><b class="dq-tag">x</b><form name="dq-form"><input name="dq-field" value="v"></form></div>
+<script>
+(function () {
+  var out = document.getElementById('dq-out');
+  out.textContent = [
+    document.querySelector('.dq-tag') ? 'qs' : '',
+    document.getElementsByClassName('dq-tag').length,
+    document.getElementsByTagName('b').length,
+    document.getElementsByName('dq-field').length,
+    document.forms.length,
+  ].join('/');
+})();
+</script>`,
+  },
+  {
+    id: 'doc-body-card',
+    title: 'Card that puts its modal in document.body',
+    origin: 'INV-MR6 — the node used to leave the message and lose its CSS',
+    text: `<style>.db-modal { color: rgb(9, 90, 200); }</style>
+<div class="db"><button id="db-open" onclick="dbOpen()">Открыть</button></div>
+<script>
+function dbOpen() {
+  var modal = document.createElement('div');
+  modal.className = 'db-modal';
+  modal.id = 'db-modal';
+  modal.textContent = 'модалка';
+  document.body.appendChild(modal);
+}
+</script>`,
+  },
+  {
+    id: 'doc-ready-card',
+    title: 'Card that waits for DOMContentLoaded',
+    origin: 'INV-MR7 — the real event fired long before the message existed',
+    text: `<div class="dr"><span id="dr-out">ждём</span></div>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  document.getElementById('dr-out').textContent = 'готово';
+});
+window.onload = function () {
+  document.getElementById('dr-out').textContent += '+load';
+};
+</script>`,
+  },
+  {
+    id: 'import-font-card',
+    title: 'Card whose CSS tries to @import a font',
+    origin: 'INV-MR5 — the policy drops it, and used to drop it silently',
+    text: `<style>
+@import url('https://fonts.example/css2?family=Card');
+.if-title { font-family: 'Card', cursive; }
+</style>
+<div class="if-title">Заголовок</div>`,
+  },
 ];
 
 /** Cards whose first chunks must already render as a card, not as raw tags. */

--- a/test/webview_js/harness/harness.html
+++ b/test/webview_js/harness/harness.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Glaze message render harness</title>
+  <style>
+    /* Deliberately plain: anything a message needs has to come from the
+       message's own CSS or from SHADOW_STYLE, never from the harness. */
+    html, body { margin: 0; padding: 0; background: #14161a; color: #e0e0e0;
+      font-family: -apple-system, 'Segoe UI', Roboto, sans-serif; font-size: 15px; }
+    #chat-container { padding: 16px; }
+  </style>
+</head>
+<body>
+  <div id="chat-container"></div>
+  <script type="module" src="./harness.js"></script>
+</body>
+</html>

--- a/test/webview_js/harness/harness.js
+++ b/test/webview_js/harness/harness.js
@@ -1,0 +1,130 @@
+// The render harness the WebView asset tests drive.
+//
+// It reproduces the production path for one message body and nothing else:
+// a `.message-content` host, an open shadow root carrying the real
+// SHADOW_STYLE, and `writeShadowContent` — the same function the renderer
+// calls. Tests then assert on the tree the browser built, on the CSS it
+// resolved and on what a click does, instead of on the shape of the source.
+import { Formatter } from '/assets/chat_webview/formatter/index.js';
+import { writeShadowContent } from '/assets/chat_webview/renderer/markdown.js';
+import { SHADOW_STYLE } from '/assets/chat_webview/renderer/shadow_style.js';
+import { InteractionDispatch } from '/assets/chat_webview/bridge/interaction_dispatch.js';
+
+const formatter = new Formatter();
+
+/** Everything the harness bridge was asked to forward to Flutter. */
+const flutterCalls = [];
+
+/** Console errors the page produced, so a test can assert on a clean render. */
+const consoleErrors = [];
+const nativeError = console.error.bind(console);
+console.error = (...args) => {
+  consoleErrors.push(args.map((a) => String(a)).join(' '));
+  nativeError(...args);
+};
+
+// The narrowest bridge InteractionDispatch can run against: message clicks go
+// through the real dispatcher (fragment `:target`, links, image actions), and
+// anything that would reach the app is recorded instead of sent.
+const bridge = {
+  _selectionManager: { handleClick: () => false },
+  _swipeHandler: { toggleGuidedSwipe: () => {} },
+  _sendToFlutter: (method, args) => flutterCalls.push({ method, args }),
+  isGenerating: false,
+  notifyMessageScriptBlocked: () => flutterCalls.push({
+    method: 'notifyMessageScriptBlocked',
+    args: [],
+  }),
+};
+window.bridge = bridge;
+
+const dispatch = new InteractionDispatch(bridge);
+document.addEventListener('click', (e) => {
+  try {
+    dispatch.handleClick(e);
+  } catch (error) {
+    console.error('dispatch error:', error);
+  }
+});
+
+function createHost() {
+  const host = document.createElement('div');
+  host.className = 'message-content';
+  const shadow = host.attachShadow({ mode: 'open' });
+  const style = document.createElement('style');
+  style.textContent = SHADOW_STYLE;
+  shadow.appendChild(style);
+  const root = document.createElement('div');
+  root.className = 'glaze-message';
+  shadow.appendChild(root);
+  return host;
+}
+
+/**
+ * Renders one message body the way the app does and returns a handle the
+ * specs address it by. Successive calls replace the message on screen, so a
+ * spec that renders a stream of prefixes sees one message, not a pile.
+ */
+function render(text, options = {}) {
+  const {
+    isUser = false,
+    isTyping = false,
+    isReasoning = false,
+    allowMessageScripts = true,
+    searchQuery = '',
+    keep = false,
+  } = options;
+  if (!keep) reset();
+  const section = document.createElement('div');
+  section.className = 'message';
+  section.dataset.messageId = options.messageId || `m${Date.now()}`;
+  const host = createHost();
+  section.appendChild(host);
+  document.getElementById('chat-container').appendChild(section);
+  writeShadowContent({
+    host,
+    text,
+    isUser,
+    isTyping,
+    isReasoning,
+    formatter,
+    searchQuery,
+    applySearchHighlight: (html) => html,
+    allowMessageScripts,
+  });
+  return host;
+}
+
+function reset() {
+  document.getElementById('chat-container').innerHTML = '';
+  flutterCalls.length = 0;
+  consoleErrors.length = 0;
+  // A stale cache would hide a formatter change from the very next render.
+  formatter.cache.clear();
+}
+
+/** The message root of the message rendered last. */
+function currentRoot() {
+  const hosts = document.querySelectorAll('#chat-container .message-content');
+  const host = hosts[hosts.length - 1];
+  return host ? host.shadowRoot.querySelector('.glaze-message') : null;
+}
+
+window.harness = {
+  render,
+  reset,
+  currentRoot,
+  formatter,
+  flutterCalls,
+  consoleErrors,
+  /** Raw formatter output, for assertions that predate a DOM. */
+  format: (text, isUser = false, isReasoning = false) =>
+    formatter.format(text, isUser, isReasoning),
+  /** Rendered HTML of the message on screen. */
+  html: () => (currentRoot() ? currentRoot().innerHTML : ''),
+  /** Text a reader actually sees — collapsed whitespace, no markup. */
+  text: () => (currentRoot() ? currentRoot().textContent.replace(/\s+/g, ' ').trim() : ''),
+};
+
+window.dispatchEvent(new Event('harness-ready'));
+window.__harnessReady = true;

--- a/test/webview_js/harness/server.js
+++ b/test/webview_js/harness/server.js
@@ -1,0 +1,51 @@
+// Static file server for the WebView asset tests.
+//
+// The harness page imports the production modules by their real paths
+// (`/assets/chat_webview/formatter/index.js`), so the tests exercise exactly
+// the files the app ships. ES modules cannot be imported over `file://`, hence
+// a server rather than a bare page load.
+import { createServer } from 'node:http';
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { extname, join, normalize, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..', '..');
+const PORT = Number(process.env.GLAZE_WEBVIEW_TEST_PORT || 4176);
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.woff2': 'font/woff2',
+};
+
+const server = createServer(async (request, response) => {
+  const url = new URL(request.url, `http://127.0.0.1:${PORT}`);
+  // normalize() collapses `..`, and the prefix check keeps a crafted path from
+  // reading outside the repository.
+  const target = join(REPO_ROOT, normalize(decodeURIComponent(url.pathname)));
+  if (!target.startsWith(REPO_ROOT)) {
+    response.writeHead(403).end('forbidden');
+    return;
+  }
+  try {
+    const info = await stat(target);
+    if (!info.isFile()) throw new Error('not a file');
+  } catch {
+    response.writeHead(404).end('not found');
+    return;
+  }
+  response.writeHead(200, {
+    'content-type': TYPES[extname(target)] || 'application/octet-stream',
+    'cache-control': 'no-store',
+  });
+  createReadStream(target).pipe(response);
+});
+
+server.listen(PORT, '127.0.0.1');

--- a/test/webview_js/package-lock.json
+++ b/test/webview_js/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "glaze-webview-js-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "glaze-webview-js-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.56.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
+      "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/test/webview_js/package.json
+++ b/test/webview_js/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "glaze-webview-js-tests",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Browser tests for the chat WebView assets (formatter + renderer).",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.56.0"
+  }
+}

--- a/test/webview_js/playwright.config.js
+++ b/test/webview_js/playwright.config.js
@@ -1,0 +1,34 @@
+// Playwright config for the WebView asset tests.
+//
+// These tests load the *real* modules out of `assets/chat_webview/` in a
+// headless Chromium and assert on what the browser actually built: the DOM
+// inside the message shadow root, the CSS the browser resolved, and what a
+// click does. Nothing here reads a source file as a string — that is what the
+// Dart asset tests do, and it is why rendering regressions used to reach
+// users before CI.
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './specs',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? [['list'], ['github']] : [['list']],
+  timeout: 20_000,
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL: 'http://127.0.0.1:4176',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'node harness/server.js',
+    url: 'http://127.0.0.1:4176/test/webview_js/harness/harness.html',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+});

--- a/test/webview_js/specs/cards.spec.js
+++ b/test/webview_js/specs/cards.spec.js
@@ -1,0 +1,358 @@
+// Structure the browser must build for each corpus card.
+//
+// Every assertion here is about the rendered tree, never about the source of
+// the formatter. If a refactor keeps these green, it kept the cards working.
+import { test, expect } from '@playwright/test';
+import { card, cards } from '../corpus/cards.js';
+import { openHarness, render, text, expectCleanRender } from './harness.js';
+
+test.beforeEach(async ({ page }) => {
+  await openHarness(page);
+});
+
+test('no card leaves formatter bookkeeping or a page error behind', async ({ page }) => {
+  for (const entry of cards) {
+    await render(page, entry.text);
+    await expectCleanRender(page);
+  }
+});
+
+test('an HTML table keeps its own structure', async ({ page }) => {
+  // Baseline: the string formatter cannot keep this. Stage 1 of the
+  // rendering plan (parse, then format text nodes) is what makes it pass.
+  test.fail();
+  await render(page, card('html-table').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const table = root.querySelector('table');
+    return {
+      hasTable: !!table,
+      paragraphsInside: table ? table.querySelectorAll('p').length : -1,
+      rows: table ? table.querySelectorAll('tr').length : -1,
+      // A `<p>` the browser threw out of the table lands right before it.
+      strayBefore: table && table.previousElementSibling
+        ? table.previousElementSibling.tagName
+        : '',
+      firstCell: table ? table.querySelector('th')?.textContent.trim() : '',
+      rowsAreTableChildren: table
+        ? Array.from(table.querySelectorAll('tr'))
+            .every((tr) => tr.parentElement.tagName === 'TBODY' ||
+              tr.parentElement.tagName === 'THEAD')
+        : false,
+    };
+  });
+  expect(shape.hasTable).toBe(true);
+  expect(shape.paragraphsInside).toBe(0);
+  expect(shape.rows).toBe(2);
+  expect(shape.strayBefore).not.toBe('P');
+  expect(shape.firstCell).toBe('Стат');
+  expect(shape.rowsAreTableChildren).toBe(true);
+});
+
+test('a CSS-only card keeps the checkbox and its target siblings', async ({ page }) => {
+  // Baseline: the string formatter cannot keep this. Stage 1 of the
+  // rendering plan (parse, then format text nodes) is what makes it pass.
+  test.fail();
+  await render(page, card('css-only-checkbox').text);
+  const before = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const input = root.querySelector('#t1');
+    const overlay = root.querySelector('.ov');
+    return {
+      sameParent: input.parentElement === overlay.parentElement,
+      display: getComputedStyle(overlay).display,
+    };
+  });
+  expect(before.sameParent, 'input and overlay must stay siblings').toBe(true);
+  expect(before.display).toBe('none');
+
+  await page.evaluate(() => window.harness.currentRoot().querySelector('label').click());
+  const after = await page.evaluate(() =>
+    getComputedStyle(window.harness.currentRoot().querySelector('.ov')).display,
+  );
+  expect(after, 'the sibling combinator must still match after a click').toBe('block');
+});
+
+test('a void element inside a card is not escaped into text', async ({ page }) => {
+  await render(page, card('video-source').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      source: root.querySelectorAll('video > source').length,
+      src: root.querySelector('source')?.getAttribute('src') || '',
+    };
+  });
+  expect(shape.source).toBe(1);
+  expect(shape.src).toBe('clip.mp4');
+  expect(await text(page)).not.toContain('<source');
+});
+
+test('an inline SVG is left alone', async ({ page }) => {
+  await render(page, card('svg-icon').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const svg = root.querySelector('svg');
+    return {
+      paths: svg ? svg.querySelectorAll('path').length : -1,
+      paragraphsInside: svg ? svg.querySelectorAll('p').length : -1,
+      insideCard: !!root.querySelector('.ico svg'),
+    };
+  });
+  expect(shape.paths).toBe(1);
+  expect(shape.paragraphsInside).toBe(0);
+  expect(shape.insideCard).toBe(true);
+});
+
+test('<details> keeps its summary and toggles', async ({ page }) => {
+  await render(page, card('details-block').text);
+  const shape = await page.evaluate(() => {
+    const details = window.harness.currentRoot().querySelector('details');
+    const before = details.open;
+    details.querySelector('summary').click();
+    return { hasSummary: !!details.querySelector('summary'), before, after: details.open };
+  });
+  expect(shape.hasSummary).toBe(true);
+  expect(shape.before).toBe(false);
+  expect(shape.after).toBe(true);
+});
+
+test('a <br> inside a card stays inside that card', async ({ page }) => {
+  await render(page, card('br-in-card').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      notes: root.querySelectorAll('.note').length,
+      breaks: root.querySelectorAll('.note br').length,
+    };
+  });
+  expect(shape.notes).toBe(1);
+  expect(shape.breaks).toBe(1);
+});
+
+test('a composite card keeps its structure and its styling', async ({ page }) => {
+  // Baseline: the string formatter cannot keep this. Stage 1 of the
+  // rendering plan (parse, then format text nodes) is what makes it pass.
+  test.fail();
+  await render(page, card('stat-card').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const ledger = root.querySelector('loomledger');
+    const head = root.querySelector('.ll-head');
+    const fill = root.querySelector('.ll-bar > i');
+    return {
+      hasLedger: !!ledger,
+      tableInsideLedger: !!ledger?.querySelector('table'),
+      paragraphsInTable: ledger?.querySelector('table')?.querySelectorAll('p').length ?? -1,
+      headColor: head ? getComputedStyle(head).color : '',
+      barWidth: fill ? getComputedStyle(fill).width : '',
+      emphasis: !!root.querySelector('.ll-note em'),
+    };
+  });
+  expect(shape.hasLedger, 'a custom element the card styles is markup').toBe(true);
+  expect(shape.tableInsideLedger).toBe(true);
+  expect(shape.paragraphsInTable).toBe(0);
+  expect(shape.headColor).toBe('rgb(200, 40, 90)');
+  expect(shape.barWidth).not.toBe('');
+  expect(shape.emphasis, 'markdown inside a card is still markdown').toBe(true);
+});
+
+test('form controls survive as markup', async ({ page }) => {
+  await render(page, card('form-controls').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      form: root.querySelectorAll('form.picker').length,
+      legend: root.querySelector('legend')?.textContent.trim() || '',
+      checked: root.querySelector('input[type=radio]')?.checked ?? null,
+    };
+  });
+  expect(shape.form).toBe(1);
+  expect(shape.legend).toBe('Выбор');
+  expect(shape.checked).toBe(true);
+});
+
+test('prose keeps its angle brackets', async ({ page }) => {
+  await render(page, card('prose-angle-brackets').text);
+  const visible = await text(page);
+  expect(visible).toContain('<вздох>');
+  expect(visible).toContain('5 < 7 > 3');
+});
+
+test('a tag inside backticks is shown, not rendered', async ({ page }) => {
+  await render(page, card('inline-code-tag').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      codeTexts: Array.from(root.querySelectorAll('code')).map((c) => c.textContent),
+      // The code-block wrapper is ours; any other <div> would mean the tag
+      // inside the backticks was parsed as markup.
+      realDivs: root.querySelectorAll('div:not(.code-block-wrapper)').length,
+    };
+  });
+  expect(shape.codeTexts).toContain('<div>');
+  expect(shape.realDivs).toBe(0);
+});
+
+test('a fenced code block shows its HTML as text', async ({ page }) => {
+  await render(page, card('fenced-code').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const code = root.querySelector('pre code');
+    return {
+      hasPre: !!code,
+      body: code ? code.textContent : '',
+      realCards: root.querySelectorAll('div.card').length,
+    };
+  });
+  expect(shape.hasPre).toBe(true);
+  expect(shape.body).toContain('<div class="card">');
+  expect(shape.realCards).toBe(0);
+});
+
+test('markdown prose renders emphasis, strike and quotes', async ({ page }) => {
+  await render(page, card('markdown-basics').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      paragraphs: root.querySelectorAll('p').length,
+      em: root.querySelectorAll('em').length,
+      strong: root.querySelectorAll('strong').length,
+      del: root.querySelectorAll('del').length,
+      quotes: root.querySelectorAll('.chat-quote-text').length,
+    };
+  });
+  expect(shape.paragraphs).toBe(3);
+  expect(shape.em).toBeGreaterThanOrEqual(1);
+  expect(shape.strong).toBeGreaterThanOrEqual(1);
+  expect(shape.del).toBe(1);
+  expect(shape.quotes).toBeGreaterThanOrEqual(1);
+});
+
+test('markdown structure renders headings, lists and a table', async ({ page }) => {
+  await render(page, card('markdown-structure').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      heading: root.querySelector('h2')?.textContent.trim() || '',
+      topLevelItems: root.querySelector('ul.chat-list')
+        ?.querySelectorAll(':scope > li').length ?? -1,
+      nested: root.querySelectorAll('ul.chat-list li ul li').length,
+      ordered: root.querySelectorAll('ol.chat-list > li').length,
+      tableRows: root.querySelectorAll('table.chat-table tbody tr').length,
+      headers: root.querySelectorAll('table.chat-table th').length,
+    };
+  });
+  expect(shape.heading).toBe('Отчёт');
+  expect(shape.topLevelItems).toBe(2);
+  expect(shape.nested).toBe(1);
+  expect(shape.ordered).toBe(2);
+  expect(shape.tableRows).toBe(2);
+  expect(shape.headers).toBe(2);
+});
+
+test('blockquote and horizontal rule render as elements', async ({ page }) => {
+  await render(page, card('blockquote-hr').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      quote: root.querySelector('blockquote')?.textContent.trim() || '',
+      rules: root.querySelectorAll('hr').length,
+    };
+  });
+  expect(shape.quote).toBe('цитата');
+  expect(shape.rules).toBe(1);
+});
+
+test('quotes keep their spans, nested guillemets included', async ({ page }) => {
+  await render(page, card('nested-quotes').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      marks: root.querySelectorAll('.chat-quote').length,
+      texts: root.querySelectorAll('.chat-quote-text').length,
+    };
+  });
+  expect(shape.marks).toBeGreaterThanOrEqual(2);
+  expect(shape.texts).toBeGreaterThanOrEqual(2);
+});
+
+test('Glaze colour markers render as styled spans', async ({ page }) => {
+  // Baseline: the string formatter cannot keep this. Stage 1 of the
+  // rendering plan (parse, then format text nodes) is what makes it pass.
+  test.fail();
+  await render(page, card('glaze-markers').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const hc = root.querySelector('.glaze-hc');
+    return {
+      hcColor: hc ? getComputedStyle(hc).color : '',
+      hcText: hc ? hc.textContent : '',
+      accent: !!root.querySelector('.glaze-accent'),
+    };
+  });
+  expect(shape.hcColor).toBe('rgb(255, 0, 102)');
+  expect(shape.hcText).toBe('Красным');
+  expect(shape.accent).toBe(true);
+});
+
+test('an inline <think> block becomes a reasoning panel', async ({ page }) => {
+  await render(page, card('think-block').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      panel: !!root.querySelector('details.reasoning-block'),
+      body: root.querySelector('.reasoning-content')?.textContent.trim() || '',
+      rest: root.textContent.includes('Хорошо, идём.'),
+    };
+  });
+  expect(shape.panel).toBe(true);
+  expect(shape.body).toContain('Надо ответить коротко.');
+  expect(shape.rest).toBe(true);
+});
+
+test('a markdown image keeps its options button inside the wrapper', async ({ page }) => {
+  await render(page, card('md-image').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const wrapper = root.querySelector('.janitor-img-wrapper');
+    return {
+      hasWrapper: !!wrapper,
+      img: !!wrapper?.querySelector('img.janitor-img'),
+      button: !!wrapper?.querySelector('button.janitor-options-btn'),
+    };
+  });
+  expect(shape).toEqual({ hasWrapper: true, img: true, button: true });
+});
+
+test('a pending image block renders its placeholder', async ({ page }) => {
+  await render(page, card('imggen-pending').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const block = root.querySelector('.imggen-loading');
+    return {
+      hasBlock: !!block,
+      index: block?.dataset.imgIndex,
+      // isolateImgGenPlaceholders moves the contents behind a shadow root.
+      isolated: !!block?.shadowRoot,
+    };
+  });
+  expect(shape.hasBlock).toBe(true);
+  expect(shape.index).toBe('0');
+  expect(shape.isolated).toBe(true);
+});
+
+test('a finished image block renders its variant switcher', async ({ page }) => {
+  await render(page, card('imggen-result').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const wrapper = root.querySelector('.imggen-result-wrapper');
+    return {
+      variants: wrapper?.dataset.variants || '',
+      count: root.querySelector('.imggen-variant-count')?.textContent || '',
+      brokenImg: root.querySelectorAll('img.imggen-result').length,
+    };
+  });
+  expect(shape.variants).toContain(';;');
+  expect(shape.count).toBe('1/2');
+  expect(shape.brokenImg).toBe(1);
+});

--- a/test/webview_js/specs/cards.spec.js
+++ b/test/webview_js/specs/cards.spec.js
@@ -18,9 +18,6 @@ test('no card leaves formatter bookkeeping or a page error behind', async ({ pag
 });
 
 test('an HTML table keeps its own structure', async ({ page }) => {
-  // Baseline: the string formatter cannot keep this. Stage 1 of the
-  // rendering plan (parse, then format text nodes) is what makes it pass.
-  test.fail();
   await render(page, card('html-table').text);
   const shape = await page.evaluate(() => {
     const root = window.harness.currentRoot();
@@ -50,9 +47,6 @@ test('an HTML table keeps its own structure', async ({ page }) => {
 });
 
 test('a CSS-only card keeps the checkbox and its target siblings', async ({ page }) => {
-  // Baseline: the string formatter cannot keep this. Stage 1 of the
-  // rendering plan (parse, then format text nodes) is what makes it pass.
-  test.fail();
   await render(page, card('css-only-checkbox').text);
   const before = await page.evaluate(() => {
     const root = window.harness.currentRoot();
@@ -130,9 +124,6 @@ test('a <br> inside a card stays inside that card', async ({ page }) => {
 });
 
 test('a composite card keeps its structure and its styling', async ({ page }) => {
-  // Baseline: the string formatter cannot keep this. Stage 1 of the
-  // rendering plan (parse, then format text nodes) is what makes it pass.
-  test.fail();
   await render(page, card('stat-card').text);
   const shape = await page.evaluate(() => {
     const root = window.harness.currentRoot();
@@ -277,9 +268,6 @@ test('quotes keep their spans, nested guillemets included', async ({ page }) => 
 });
 
 test('Glaze colour markers render as styled spans', async ({ page }) => {
-  // Baseline: the string formatter cannot keep this. Stage 1 of the
-  // rendering plan (parse, then format text nodes) is what makes it pass.
-  test.fail();
   await render(page, card('glaze-markers').text);
   const shape = await page.evaluate(() => {
     const root = window.harness.currentRoot();
@@ -355,4 +343,58 @@ test('a finished image block renders its variant switcher', async ({ page }) => 
   expect(shape.variants).toContain(';;');
   expect(shape.count).toBe('1/2');
   expect(shape.brokenImg).toBe(1);
+});
+
+test('inline tags in prose keep their paragraphs and their markdown', async ({ page }) => {
+  await render(page, card('inline-tags-in-prose').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const quote = root.querySelector('.chat-quote-text');
+    const marker = root.querySelector('.glaze-hc');
+    return {
+      paragraphs: root.querySelectorAll('p').length,
+      bold: root.querySelectorAll('b').length,
+      // A quote that opens before a tag and closes after it is one quote.
+      quoteHoldsTag: !!quote && !!quote.querySelector('b'),
+      // Same for a colour marker: html_to_markdown writes rich content in one.
+      markerHoldsTag: !!marker && !!marker.querySelector('i'),
+    };
+  });
+  expect(shape.paragraphs).toBe(2);
+  expect(shape.bold).toBe(2);
+  expect(shape.quoteHoldsTag).toBe(true);
+  expect(shape.markerHoldsTag).toBe(true);
+});
+
+test('a gradient <font> carries its fill down to the text', async ({ page }) => {
+  await render(page, card('font-gradient').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const outer = root.querySelector('.font-style-block');
+    const inner = outer?.firstElementChild;
+    return {
+      outer: !!outer,
+      // Without this the outer span clips a gradient over no text at all.
+      innerFill: inner ? getComputedStyle(inner).webkitTextFillColor : '',
+      innerSpacing: inner ? getComputedStyle(inner).letterSpacing : '',
+    };
+  });
+  expect(shape.outer).toBe(true);
+  expect(shape.innerFill).toBe('rgba(0, 0, 0, 0)');
+  expect(shape.innerSpacing, 'the author\'s own style survives').toBe('1px');
+});
+
+test('an image tag inside a reasoning panel stays text', async ({ page }) => {
+  // INV-IG11: Dart never generates from a tag written while thinking, so the
+  // renderer must not show a placeholder whose picture is never coming.
+  await render(page, 'Думаю: [IMG:GEN:лес]', { isReasoning: true });
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      placeholders: root.querySelectorAll('.imggen-loading').length,
+      text: root.textContent,
+    };
+  });
+  expect(shape.placeholders).toBe(0);
+  expect(shape.text).toContain('[IMG:GEN:лес]');
 });

--- a/test/webview_js/specs/document_contract.spec.js
+++ b/test/webview_js/specs/document_contract.spec.js
@@ -1,0 +1,114 @@
+// The document contract: what a card may rely on inside a message shadow root.
+//
+// One case per item of docs/INVARIANTS.md § Message document contract. A hole
+// closed here is a hole closed by list, not by complaint.
+import { test, expect } from '@playwright/test';
+import { card } from '../corpus/cards.js';
+import { openHarness, render } from './harness.js';
+
+test.beforeEach(async ({ page }) => {
+  await openHarness(page);
+});
+
+test('INV-MR1 a card script declares the function its onclick calls', async ({ page }) => {
+  await render(page, card('script-card').text);
+  const before = await page.evaluate(() =>
+    window.harness.currentRoot().querySelector('#jsc-out').hidden);
+  expect(before).toBe(true);
+
+  await page.evaluate(() => window.harness.currentRoot().querySelector('#jsc-btn').click());
+  const after = await page.evaluate(() =>
+    window.harness.currentRoot().querySelector('#jsc-out').hidden);
+  expect(after, 'the script runs in the global scope, so onclick resolves').toBe(false);
+  expect(page.__failures).toEqual([]);
+});
+
+test('INV-MR1 a message script leaves no <script> behind', async ({ page }) => {
+  await render(page, card('script-card').text);
+  const shape = await page.evaluate(() => ({
+    inMessage: window.harness.currentRoot().querySelectorAll('script').length,
+    // The element the runner injects to reach global scope is removed again.
+    inHead: document.head.querySelectorAll('script:not([src])').length,
+  }));
+  expect(shape.inMessage).toBe(0);
+  expect(shape.inHead).toBe(0);
+});
+
+test('INV-MR3/MR4 document lookups find the message\'s own elements', async ({ page }) => {
+  await render(page, card('doc-query-card').text);
+  const out = await page.evaluate(() =>
+    window.harness.currentRoot().querySelector('#dq-out').textContent);
+  expect(out, 'querySelector/getElementsBy*/forms all resolve in the message')
+    .toBe('qs/1/1/1/1');
+});
+
+test('INV-MR3 a lookup the message cannot answer still reaches the document', async ({ page }) => {
+  await render(page, '<div id="mr3">x</div><script>window.__mr3 = ' +
+    "document.getElementById('chat-container') ? 'document' : 'missing';</script>");
+  const seen = await page.evaluate(() => window.__mr3);
+  expect(seen).toBe('document');
+});
+
+test('INV-MR6 a modal handed to document.body stays under the message CSS', async ({ page }) => {
+  await render(page, card('doc-body-card').text);
+  await page.evaluate(() => window.harness.currentRoot().querySelector('#db-open').click());
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const modal = root.querySelector('#db-modal');
+    return {
+      inMessage: !!modal,
+      inAppBody: !!document.body.querySelector(':scope > #db-modal'),
+      colour: modal ? getComputedStyle(modal).color : '',
+      overlay: !!root.querySelector('.glaze-message-overlay'),
+    };
+  });
+  expect(shape.inMessage, 'the modal is in the message, not in the app chrome').toBe(true);
+  expect(shape.inAppBody).toBe(false);
+  expect(shape.colour, "the card's own rule applies to it").toBe('rgb(9, 90, 200)');
+  expect(shape.overlay).toBe(true);
+});
+
+test('INV-MR7 the load events a card waits for still arrive', async ({ page }) => {
+  await render(page, card('doc-ready-card').text);
+  const out = await page.evaluate(() =>
+    window.harness.currentRoot().querySelector('#dr-out').textContent);
+  expect(out).toBe('готово+load');
+});
+
+test('INV-MR5 a dropped @import is reported, not silent', async ({ page }) => {
+  await render(page, card('import-font-card').text);
+  const report = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      shown: root.querySelector('.glaze-css-error')?.textContent || '',
+      styleKept: !!root.querySelector('style'),
+      titleStyled: getComputedStyle(root.querySelector('.if-title')).fontFamily,
+    };
+  });
+  expect(report.shown).toContain('@import');
+  expect(report.styleKept, 'the rest of the card CSS still applies').toBe(true);
+  expect(report.titleStyled).toContain('cursive');
+});
+
+test('INV-MR2 the app keeps its own document while a message runs', async ({ page }) => {
+  await render(page, card('doc-body-card').text);
+  const restored = await page.evaluate(() => {
+    // Every shim is an own property, removed once the message's code is done.
+    const own = ['getElementById', 'querySelector', 'body', 'head', 'forms']
+      .filter((name) => Object.prototype.hasOwnProperty.call(document, name));
+    return { own, bodyIsBody: document.body === document.querySelector('body') };
+  });
+  expect(restored.own).toEqual([]);
+  expect(restored.bodyIsBody).toBe(true);
+});
+
+test('INV-MR8 message scripts stay off when the toggle is off', async ({ page }) => {
+  await render(page, card('doc-body-card').text, { allowMessageScripts: false });
+  await page.evaluate(() => window.harness.currentRoot().querySelector('#db-open').click());
+  const shape = await page.evaluate(() => ({
+    modal: !!window.harness.currentRoot().querySelector('#db-modal'),
+    scripts: window.harness.currentRoot().querySelectorAll('script').length,
+  }));
+  expect(shape.modal).toBe(false);
+  expect(shape.scripts).toBe(0);
+});

--- a/test/webview_js/specs/document_contract.spec.js
+++ b/test/webview_js/specs/document_contract.spec.js
@@ -112,3 +112,17 @@ test('INV-MR8 message scripts stay off when the toggle is off', async ({ page })
   expect(shape.modal).toBe(false);
   expect(shape.scripts).toBe(0);
 });
+
+test('a card script survives its own comparisons', async ({ page }) => {
+  // `i<n; i++) { if (i>` looks exactly like a tag to a scan that works on the
+  // message as a string, and escaping it leaves the script unparseable. The
+  // scan never sees a <script> body: it is masked for the length of it.
+  await render(page, card('script-comparison').text);
+  const shape = await page.evaluate((body) => ({
+    out: window.harness.currentRoot().querySelector('#sc-out').textContent,
+    formatted: window.harness.format(body),
+  }), card('script-comparison').text);
+  expect(shape.out, 'the script ran').toBe('ok2');
+  expect(shape.formatted).toContain('i<n');
+  expect(shape.formatted).not.toContain('&lt;n');
+});

--- a/test/webview_js/specs/harness.js
+++ b/test/webview_js/specs/harness.js
@@ -1,0 +1,52 @@
+// Shared spec setup: open the harness page and expose small helpers.
+import { expect } from '@playwright/test';
+
+export const HARNESS_URL = '/test/webview_js/harness/harness.html';
+
+/** The sentinel the formatter wraps its internal placeholders in. */
+export const SENTINEL = String.fromCharCode(1);
+
+export async function openHarness(page) {
+  const failures = [];
+  page.on('pageerror', (error) => failures.push(String(error)));
+  await page.goto(HARNESS_URL);
+  await page.waitForFunction(() => window.__harnessReady === true);
+  page.__failures = failures;
+  return page;
+}
+
+/** Renders a corpus card. Assertions read the DOM the browser built. */
+export async function render(page, text, options = {}) {
+  await page.evaluate(
+    ([body, opts]) => window.harness.render(body, opts),
+    [text, options],
+  );
+}
+
+/** The message root's innerHTML, for the few assertions that need markup. */
+export function html(page) {
+  return page.evaluate(() => window.harness.html());
+}
+
+/** The text a reader sees, whitespace collapsed. */
+export function text(page) {
+  return page.evaluate(() => window.harness.text());
+}
+
+export function consoleErrors(page) {
+  return page.evaluate(() => window.harness.consoleErrors.slice());
+}
+
+export function flutterCalls(page) {
+  return page.evaluate(() => window.harness.flutterCalls.map((c) => c.method));
+}
+
+/**
+ * Asserts the render left no formatter bookkeeping behind and did not throw:
+ * no placeholder sentinel in the visible text, no uncaught page error.
+ */
+export async function expectCleanRender(page) {
+  const visible = await text(page);
+  expect(visible.includes(SENTINEL), 'placeholder sentinel leaked').toBe(false);
+  expect(page.__failures, 'uncaught page error').toEqual([]);
+}

--- a/test/webview_js/specs/interaction.spec.js
+++ b/test/webview_js/specs/interaction.spec.js
@@ -1,0 +1,71 @@
+// What a click does, and what the message keeps when scripts are off.
+import { test, expect } from '@playwright/test';
+import { card } from '../corpus/cards.js';
+import { openHarness, render, text, flutterCalls } from './harness.js';
+
+test.beforeEach(async ({ page }) => {
+  await openHarness(page);
+});
+
+test('a fragment link lights up the :target panel it points at', async ({ page }) => {
+  await render(page, card('target-card').text);
+  const before = await page.evaluate(() =>
+    getComputedStyle(window.harness.currentRoot().querySelector('.panel')).opacity,
+  );
+  expect(before).toBe('0');
+
+  await page.evaluate(() => window.harness.currentRoot().querySelector('a.open').click());
+  const after = await page.evaluate(() =>
+    getComputedStyle(window.harness.currentRoot().querySelector('.panel')).opacity,
+  );
+  expect(after, 'the card must open on its own anchor').toBe('1');
+});
+
+test('a link in the message is handed to the app, not followed', async ({ page }) => {
+  await render(page, card('md-link').text);
+  const anchors = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return Array.from(root.querySelectorAll('a')).map((a) => a.getAttribute('href'));
+  });
+  expect(anchors).toEqual(['https://example.org/docs', 'https://example.org/two']);
+
+  await page.evaluate(() => window.harness.currentRoot().querySelector('a').click());
+  expect(await flutterCalls(page)).toContain('onLinkClick');
+  expect(page.url()).toContain('harness.html');
+});
+
+test('markup and CSS survive with message scripts off', async ({ page }) => {
+  await render(page, card('style-and-inline-style').text, { allowMessageScripts: false });
+  const shape = await page.evaluate(() => {
+    const plate = window.harness.currentRoot().querySelector('.plate');
+    return {
+      exists: !!plate,
+      color: plate ? getComputedStyle(plate).color : '',
+      spacing: plate ? getComputedStyle(plate).letterSpacing : '',
+    };
+  });
+  expect(shape.exists).toBe(true);
+  expect(shape.color, 'a <style> block still styles the card').toBe('rgb(10, 200, 30)');
+  expect(shape.spacing, 'inline style="" is not a script').toBe('3px');
+});
+
+test('a card script is dropped, and the app is told, when scripts are off', async ({ page }) => {
+  await render(page, card('script-card').text, { allowMessageScripts: false });
+  const shape = await page.evaluate(() => ({
+    scripts: window.harness.currentRoot().querySelectorAll('script').length,
+    button: !!window.harness.currentRoot().querySelector('#jsc-btn'),
+  }));
+  expect(shape.scripts).toBe(0);
+  expect(shape.button, 'the card still renders, it just cannot run').toBe(true);
+  expect(await flutterCalls(page)).toContain('notifyMessageScriptBlocked');
+});
+
+test('an image block reports the block a tap belongs to', async ({ page }) => {
+  await render(page, card('imggen-result').text);
+  await page.evaluate(() =>
+    window.harness.currentRoot().querySelector('.imggen-options-btn').click(),
+  );
+  const calls = await page.evaluate(() => window.harness.flutterCalls.slice());
+  expect(calls.length).toBeGreaterThan(0);
+  expect(await text(page)).not.toContain('data-img-index');
+});

--- a/test/webview_js/specs/streaming.spec.js
+++ b/test/webview_js/specs/streaming.spec.js
@@ -1,0 +1,60 @@
+// A reply arrives a chunk at a time, and every chunk is rendered. A card must
+// look like a card from its first prefix — not like a wall of tags that turns
+// into a card once the closing tag lands.
+import { test, expect } from '@playwright/test';
+import { card, prefixes, streamingCards } from '../corpus/cards.js';
+import { openHarness, render, text, expectCleanRender } from './harness.js';
+
+test.beforeEach(async ({ page }) => {
+  await openHarness(page);
+});
+
+for (const id of streamingCards) {
+  test(`${id} renders as markup at every prefix`, async ({ page }) => {
+    // Baseline: the string formatter cannot keep this. Stage 1 of the
+    // rendering plan (parse, then format text nodes) is what makes it pass.
+    test.fail();
+    const entry = card(id);
+    for (const prefix of prefixes(entry.text)) {
+      await render(page, prefix, { isTyping: true });
+      const visible = await text(page);
+      // The tell-tale of a half-parsed card: the reader sees the tag itself.
+      // A lone `<` from prose is fine; `<div`, `<table`, `<span` are not.
+      expect(visible, `prefix of ${entry.text.length} chars showed raw markup`)
+        .not.toMatch(/<\/?[a-z][a-z0-9-]*[\s>]/i);
+      await expectCleanRender(page);
+    }
+  });
+}
+
+test('a card is a real element before its closing tag arrives', async ({ page }) => {
+  // Baseline: the string formatter cannot keep this. Stage 1 of the
+  // rendering plan (parse, then format text nodes) is what makes it pass.
+  test.fail();
+  const body = '<div class="card"><b>Sandrone</b>\nещё печатает';
+  await render(page, body, { isTyping: true });
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      card: root.querySelectorAll('div.card').length,
+      bold: !!root.querySelector('div.card b'),
+      visible: root.textContent,
+    };
+  });
+  expect(shape.card, 'the browser closes the tag; the reader sees a card').toBe(1);
+  expect(shape.bold).toBe(true);
+  expect(shape.visible).not.toContain('<div');
+});
+
+test('a half-written tag never reaches the reader as text', async ({ page }) => {
+  // Baseline: the string formatter cannot keep this. Stage 1 of the
+  // rendering plan (parse, then format text nodes) is what makes it pass.
+  test.fail();
+  for (const body of ['<div clas', '<tab', 'обычный текст <', '<style>.a{col']) {
+    await render(page, body, { isTyping: true });
+    const visible = await text(page);
+    expect(visible).not.toContain('<div clas');
+    expect(visible).not.toContain('<style>');
+    await expectCleanRender(page);
+  }
+});

--- a/test/webview_js/specs/streaming.spec.js
+++ b/test/webview_js/specs/streaming.spec.js
@@ -11,9 +11,6 @@ test.beforeEach(async ({ page }) => {
 
 for (const id of streamingCards) {
   test(`${id} renders as markup at every prefix`, async ({ page }) => {
-    // Baseline: the string formatter cannot keep this. Stage 1 of the
-    // rendering plan (parse, then format text nodes) is what makes it pass.
-    test.fail();
     const entry = card(id);
     for (const prefix of prefixes(entry.text)) {
       await render(page, prefix, { isTyping: true });
@@ -28,9 +25,6 @@ for (const id of streamingCards) {
 }
 
 test('a card is a real element before its closing tag arrives', async ({ page }) => {
-  // Baseline: the string formatter cannot keep this. Stage 1 of the
-  // rendering plan (parse, then format text nodes) is what makes it pass.
-  test.fail();
   const body = '<div class="card"><b>Sandrone</b>\nещё печатает';
   await render(page, body, { isTyping: true });
   const shape = await page.evaluate(() => {
@@ -47,9 +41,6 @@ test('a card is a real element before its closing tag arrives', async ({ page })
 });
 
 test('a half-written tag never reaches the reader as text', async ({ page }) => {
-  // Baseline: the string formatter cannot keep this. Stage 1 of the
-  // rendering plan (parse, then format text nodes) is what makes it pass.
-  test.fail();
   for (const body of ['<div clas', '<tab', 'обычный текст <', '<style>.a{col']) {
     await render(page, body, { isTyping: true });
     const visible = await text(page);


### PR DESCRIPTION
Six fixes in ten days landed in the same place (#290, #321, #325, #326, #339, `f7477cf`). Each closed exactly the case it was reported for, which is the problem: the renderer was fixed by complaint, not by cause. This addresses the three causes.

## Browser render tests (`test/webview_js`)

- add a Playwright harness that loads the real `assets/chat_webview/` modules in a headless Chromium and renders one message body exactly the way `message_renderer.js` does — real `SHADOW_STYLE`, real `writeShadowContent`, real `InteractionDispatch`
- add the card corpus (`corpus/cards.js`): the message bodies worth protecting, verbatim, each with the PR or audit it came from
- assert on the tree the browser built, the CSS it resolved and what a click does — nothing here reads a source file as a string
- run the suite as its own CI job (Node + Playwright, no Flutter, ~10 s)
- the rule that comes with it, in `docs/rules/message-rendering.md`: every rendering bug becomes a corpus entry *before* it is fixed

Eleven cases were committed first as `test.fail()`, so the baseline is in the history rather than in an argument.

## Two-phase render (`assets/chat_webview/formatter/`)

`Formatter._processText` processed a **string** in which markdown, HTML and prose were mixed, and guessed at structure three ways: a tag was visible text if its name occurred exactly once in the message, block-level if it appeared in a hand-kept list of 40 names, and paragraphs were placed by cutting the string on blank lines.

- **Phase A — parse.** The message goes to the browser's own HTML parser (`html_scan.js`, `parseHtml`). What is an element, how elements nest and where an unclosed tag ends are its answers, so a card renders as a card from its first streamed chunk instead of flickering as raw tags.
- **Phase B — format the text.** Markdown runs over text nodes with elements masked out (`dom_format.js`, `block_syntax.js`, `inline_syntax.js`), so no pass can reach into a tag, an attribute, `<style>`, `<script>`, `<pre>` or `<code>`. A quote or a colour marker spanning an inline tag still matches, because the tag is one opaque run rather than a boundary.
- the one judgement left is `escapeProseTags`: a name outside the HTML/SVG/MathML vocabulary is text unless the message's own CSS styles it or it has a matching closing tag. `<вздох>` stays a word, `<loomledger>` stays a container — `blockTags` and the orphan counter are gone.
- `<p>` is added only at the top level of a message, and not there either when a run touches a block element the author wrote with no blank line between them (`touchesBlockSibling`). `<input><label>…</label><div class="ov">` is one card, and a paragraph around half of it is what kills `#t1:checked ~ .ov`.
- a style marker renders through an inline-only pass, so a nested `<p>` can no longer empty a coloured marker on screen
- `<font>` conversion and its gradient-fill propagation are a DOM pass (`convertFontElements`)
- split the 848-line formatter into `protect` / `html_scan` / `dom_format` / `block_syntax` / `inline_syntax` / `image_blocks`

Fixed on the way, each with its corpus card: `<p>` injected into tables and cards, the CSS-only checkbox losing its sibling, a colour marker emptied by a nested `<p>`, every card flickering as raw tags while it streams, and `escapeProseTags` reading `for(var i=0;i<n;i++){if(i>1)` inside a `<script>` as a tag and escaping it.

## Message document contract (`renderer/message_document.js`)

A message body renders into a shadow root; cards are written against a document. Each gap between the two used to be found by a user and shimmed on its own. The gaps are now one module and one list — `docs/INVARIANTS.md` § 11 (INV-MR1…INV-MR8), a case per item in `specs/document_contract.spec.js`.

- INV-MR1: a card's `<script>` runs in the page's global scope, so the function it declares is the one its own `onclick=` calls; `currentScript` still points at the element the script was written next to
- INV-MR2: every shim is an own property removed with `delete`; app chrome appended during a message event uses `appBody()` instead of reading `document.body` (the selection bar did)
- INV-MR3/MR4: `getElementById`, `querySelector(All)`, `getElementsBy*`, `forms`, `images`, `links`, `styleSheets` resolve inside the message and fall back to the real document
- INV-MR6: `document.body` is the message's `display: contents` overlay, so a card's modal keeps the card's styling instead of rendering naked in the app chrome; `document.head` is the message root for the same reason
- INV-MR7: `DOMContentLoaded` / `load` / `readystatechange` listeners are collected and replayed — the real events fired before the message existed
- INV-MR8: the scope is re-installed for the length of an interaction event through a message, and only for a message whose own code has actually run

`@import` is **not** hoisted into the document: `bridge/css_sanitizer.js` rejects it, `@font-face` and every `url()` with it, because message CSS must not reach the network. What changed is that the drop is no longer silent — `inspectBlockedAtRules` reads the pre-sanitize `<style>` source and the message says why the font fell back (INV-MR5).

## Asset tests and docs

- rewrite the `test/webview_assets_test.dart` groups that pinned the removed heuristics; the behaviour they described is covered by the browser corpus, which they now point at
- add `docs/rules/message-rendering.md`, `docs/INVARIANTS.md` § 11, and wire both into `CLAUDE.md`
- `docs/WORKFLOW.md`: the render suite is part of the CI gate

## Verification

- `npm test` in `test/webview_js` — **48 passing** in Chromium (structure, interaction, streaming prefixes, document contract)
- `flutter analyze` and `flutter test` were **not run**: the agent's environment has no Flutter SDK. This PR relies on CI for both. `test/webview_assets_test.dart` was rewritten by hand, and every string it asserts was checked against the new sources with a script (0 mismatches) — that is not a substitute for running it.
- not verified at runtime in the app: no `flutter run` here. A card with `<script>` and a card with a `document.body` modal are worth a look on device before this is promoted past `nightly`.

Closes nothing on its own; the six PRs above stay closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SR6oSKtKaema8XRHKMVruk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SR6oSKtKaema8XRHKMVruk)_