### PR TITLE
feat(webview): hoist a card's @import into the document head

### DIFF
--- a/assets/chat_webview/renderer/css_diagnostics.js
+++ b/assets/chat_webview/renderer/css_diagnostics.js
@@ -148,13 +148,13 @@ function droppedRules(css, blocks) {
 /**
  * At-rules the CSS policy drops before the message is rendered.
  *
- * `@import` is rejected on purpose (css_sanitizer.js: message CSS never
- * reaches the network), and `@font-face` with it. The card author saw only a
- * font that silently fell back, so the drop is reported instead of hidden.
- * Read from the *pre-sanitize* source — by the time the style element exists,
- * the rule is already gone.
+ * Not `@import`: that one is lifted into the document head instead
+ * (renderer/message_document.js, INV-MR5). These three have nowhere to go —
+ * the card author saw only a rule that did nothing, so the drop is reported
+ * rather than hidden. Read from the *pre-sanitize* source: by the time the
+ * style element exists, the rule is already gone.
  */
-const BLOCKED_AT_RULE = /@(import|font-face|page|namespace)\b/gi;
+const BLOCKED_AT_RULE = /@(font-face|page|namespace)\b/gi;
 
 export function inspectBlockedAtRules(css) {
   const source = String(css == null ? '' : css);

--- a/assets/chat_webview/renderer/markdown.js
+++ b/assets/chat_webview/renderer/markdown.js
@@ -3,7 +3,7 @@ import { formatMessageBody } from './macros_in_message.js';
 import { inspectBlockedAtRules, reportCssErrors } from './css_diagnostics.js';
 import { isolateImgGenPlaceholders } from './imggen_placeholder.js';
 import { sanitizeMessageHtml } from '../bridge/html_sanitizer.js';
-import { installMessageDocument } from './message_document.js';
+import { hoistStyleImports, installMessageDocument } from './message_document.js';
 
 /** Cheap pre-sanitize probe for an embedded `<script>` in formatted HTML. */
 const SCRIPT_TAG = /<script\b/i;
@@ -34,20 +34,27 @@ function notifyMessageScriptBlocked() {
 const STYLE_BLOCK = /<style\b[^>]*>([\s\S]*?)(?:<\/style\s*>|$)/gi;
 
 /**
- * At-rules the CSS policy dropped, read off the formatted HTML.
+ * The message's own CSS, as written.
  *
- * The sanitizer removes them, so by the time the message is in the DOM there
- * is nothing left to notice — which is how a card's `@import`ed font came to
- * fall back to `cursive` with no explanation anywhere.
+ * Read off the formatted HTML rather than the DOM: the sanitizer rewrites
+ * every `<style>` before insertion, so by the time the message is on screen
+ * the at-rules it carried are already gone.
  */
-function blockedAtRules(formatted) {
-  const problems = [];
+function styleSources(formatted) {
+  const sources = [];
   STYLE_BLOCK.lastIndex = 0;
   let match;
-  while ((match = STYLE_BLOCK.exec(formatted)) !== null) {
-    problems.push(...inspectBlockedAtRules(match[1]));
-  }
-  return problems;
+  while ((match = STYLE_BLOCK.exec(formatted)) !== null) sources.push(match[1]);
+  return sources;
+}
+
+/** What the CSS policy did to the message's at-rules, as report lines. */
+function cssPolicyNotes(sources, refusedImports) {
+  const notes = refusedImports.map(
+    (url) => `@import ignored: ${url} (only https is loaded)`,
+  );
+  for (const css of sources) notes.push(...inspectBlockedAtRules(css));
+  return notes;
 }
 
 export function writeShadowContent({
@@ -88,8 +95,13 @@ export function writeShadowContent({
     // A reply still arriving is half a stylesheet, and every unclosed brace in
     // it is on its way to being closed — report only what the message settled
     // on. `isGenerating` covers the whole reply, `isTyping` its first chunks.
+    // `@import` cannot work inside a shadow root, so the sheets a card pulls
+    // are lifted to the document head (INV-MR5). Everything the CSS policy
+    // still refuses is reported instead of failing silently.
+    const styles = styleSources(formatted);
+    const refusedImports = hoistStyleImports(styles);
     if (!isTyping && !window.bridge?.isGenerating) {
-      reportCssErrors(root, blockedAtRules(formatted));
+      reportCssErrors(root, cssPolicyNotes(styles, refusedImports));
     }
     // The message's document: `:target` re-keyed, the scoped `document.*`
     // lookups installed for later events, and the card's own scripts run.

--- a/assets/chat_webview/renderer/message_document.js
+++ b/assets/chat_webview/renderer/message_document.js
@@ -45,6 +45,64 @@ export function appBody() {
   return REAL_BODY;
 }
 
+/**
+ * A stylesheet a message imported, hoisted into the document.
+ *
+ * `@import` inside a shadow root is ignored by the browser, so a card that
+ * pulls a web font this way used to fall back to `cursive` with nothing on
+ * screen to say why. The rule is lifted to a `<link>` in the document head,
+ * which is the only place a `@font-face` can be registered from.
+ *
+ * The cost is real and deliberate: the sheet is fetched from a third party
+ * (which learns the reader's IP), and its rules apply to the whole document,
+ * app chrome included. Only `https:` is loaded, each URL once, and no more
+ * than MAX_HOISTED per session — a message cannot turn the app into a
+ * request generator. See INV-MR5.
+ */
+const MAX_HOISTED = 32;
+const hoisted = new Set();
+
+// `@import url(x)`, `@import url("x")`, `@import "x"` — the three spellings.
+const IMPORT_RULE =
+  /@import\s+(?:url\(\s*(?:"([^"]*)"|'([^']*)'|([^)'"]*))\s*\)|"([^"]*)"|'([^']*)')/gi;
+
+/**
+ * Hoists every `@import` in [styleSources] and returns the URLs it refused.
+ *
+ * [styleSources] are the `<style>` bodies as the message wrote them: the CSS
+ * policy strips the rule before insertion, so by the time the message is in
+ * the DOM there is nothing left to read.
+ */
+export function hoistStyleImports(styleSources) {
+  const refused = [];
+  for (const css of styleSources) {
+    IMPORT_RULE.lastIndex = 0;
+    let match;
+    while ((match = IMPORT_RULE.exec(css)) !== null) {
+      const url = (match[1] ?? match[2] ?? match[3] ?? match[4] ?? match[5] ?? '').trim();
+      if (!url) continue;
+      // https only: `http:` is a downgrade, and `data:`/`javascript:` in a
+      // stylesheet href is a rule-injection vector rather than a font.
+      if (!/^https:\/\//i.test(url)) {
+        refused.push(url);
+        continue;
+      }
+      if (hoisted.has(url)) continue;
+      if (hoisted.size >= MAX_HOISTED) {
+        refused.push(url);
+        continue;
+      }
+      hoisted.add(url);
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = url;
+      link.dataset.glazeImport = '';
+      REAL_HEAD.appendChild(link);
+    }
+  }
+  return refused;
+}
+
 function escapeSelector(value) {
   const text = String(value == null ? '' : value);
   if (typeof CSS !== 'undefined' && CSS.escape) return CSS.escape(text);

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1339,16 +1339,28 @@ keeps app-level code called from a card working.
 `document.forms`, `document.images`, `document.links` and `document.styleSheets`
 return the message's own, for the same reason.
 
-### INV-MR5: Message CSS never reaches the network — and says so
+### INV-MR5: An `@import` is hoisted into the document head
 
-`@import`, `@font-face`, `@page` and `@namespace` are dropped by the CSS policy
-(`bridge/css_sanitizer.js`), together with every `url()`. This is deliberate:
-inline CSS in an untrusted message must not fetch, and a background image is a
-working beacon. Hoisting `@import` into the document would undo that.
+`@import` inside a shadow root is ignored by the browser, and a `@font-face`
+can only be registered from the document — so a card that pulls a web font
+this way rendered in `cursive` with nothing on screen to say why.
 
-What changed is that the drop is **reported**: `inspectBlockedAtRules` reads the
-pre-sanitize `<style>` source and the message shows a CSS-error line, so a card
-whose font silently fell back to `cursive` now says why.
+`hoistStyleImports` reads the `<style>` bodies as the message wrote them
+(before the CSS policy strips the rule) and lifts each sheet to a
+`<link rel="stylesheet" data-glaze-import>` in the document head.
+
+The cost is deliberate and bounded:
+
+- **only `https:`** — `http:` is a downgrade, and a `data:`/`javascript:`
+  stylesheet href is rule injection rather than a font. Anything else is
+  refused and reported in the message's CSS-error box.
+- **each URL once**, and at most 32 per session, so a message cannot turn the
+  app into a request generator.
+- what remains is accepted knowingly: the sheet is fetched from a third party,
+  which learns the reader's IP, and its rules apply to the whole document —
+  app chrome included. `bridge/css_sanitizer.js` still rejects every `url()`
+  *inside* message CSS, and `@font-face`, `@page` and `@namespace` are still
+  dropped and reported (`inspectBlockedAtRules`).
 
 ### INV-MR6: `document.body` is the message's overlay layer
 

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -442,13 +442,16 @@ void main() {
       );
       final writeBlock = _extractWriteShadowContent(rendererJs);
       final insertion = writeBlock.indexOf('root.innerHTML =');
-      final report = writeBlock.indexOf('reportCssErrors(root, blockedAtRules(');
+      final report = writeBlock.indexOf('reportCssErrors(root, cssPolicyNotes(');
       expect(insertion, isNonNegative);
       expect(report, greaterThan(insertion));
       // A reply still arriving is half a stylesheet: every unclosed brace in it
       // is on its way to being closed, so only a settled message is reported.
       expect(writeBlock, contains('if (!isTyping && !window.bridge?.isGenerating) {'));
-      expect(writeBlock, contains('reportCssErrors(root, blockedAtRules(formatted));'));
+      expect(
+        writeBlock,
+        contains('reportCssErrors(root, cssPolicyNotes(styles, refusedImports));'),
+      );
     });
 
     test('the search re-render puts the report back', () {
@@ -1978,7 +1981,10 @@ void main() {
       // contract; the search re-render rewrites innerHTML on its own.
       expect(
         markdownJs,
-        contains("import { installMessageDocument } from './message_document.js';"),
+        contains(
+          "import { hoistStyleImports, installMessageDocument } from "
+          "'./message_document.js';",
+        ),
       );
       expect(markdownJs, contains('installMessageDocument(root, { allowMessageScripts })'));
       expect(
@@ -2135,20 +2141,34 @@ void main() {
       expect(messageDocumentJs, contains('scripted.has(root)'));
     });
 
-    test('a dropped @import is reported instead of failing silently', () {
-      // INV-MR5: message CSS may not reach the network (css_sanitizer.js), so
-      // the rule is dropped — but the card author used to see only a font
-      // that fell back to cursive, with nothing on screen to say why.
+    test('an @import is hoisted, and only over https', () {
+      // INV-MR5: `@import` cannot work inside a shadow root, and a @font-face
+      // can only be registered from the document — so the sheet is lifted to
+      // a <link> in the head. `http:` and `data:` are refused there, and the
+      // rest of the CSS policy is unchanged.
+      expect(messageDocumentJs, contains('export function hoistStyleImports('));
+      final body = _extractBlockBody(
+        messageDocumentJs,
+        messageDocumentJs.indexOf('export function hoistStyleImports('),
+      );
+      expect(body, contains(r"if (!/^https:\/\//i.test(url))"));
+      expect(body, contains('hoisted.has(url)'));
+      expect(body, contains('hoisted.size >= MAX_HOISTED'));
+      expect(body, contains("link.dataset.glazeImport = ''"));
+      expect(body, contains('REAL_HEAD.appendChild(link)'));
+      expect(markdownJs, contains('hoistStyleImports(styles)'));
+
+      // The rules with nowhere to go are still dropped, and still reported.
       expect(
         cssDiagnosticsJs,
         contains('export function inspectBlockedAtRules('),
       );
-      expect(cssDiagnosticsJs, contains('@(import|font-face|page|namespace)'));
+      expect(cssDiagnosticsJs, contains('@(font-face|page|namespace)'));
       expect(
-        markdownJs,
-        contains('reportCssErrors(root, blockedAtRules(formatted))'),
-        reason: 'the at-rule is read off the pre-sanitize HTML; by insertion '
-            'time it is already gone',
+        cssSanitizerJs,
+        contains('// @import, @font-face, @page, @namespace, @charset and anything unknown.'),
+        reason: 'the sanitizer still strips the rule from message CSS itself; '
+            'the hoist reads the source before it runs',
       );
     });
   });

--- a/test/webview_js/corpus/cards.js
+++ b/test/webview_js/corpus/cards.js
@@ -281,13 +281,24 @@ document.getElementById('sc-out').textContent='ok'+o;
   },
   {
     id: 'import-font-card',
-    title: 'Card whose CSS tries to @import a font',
-    origin: 'INV-MR5 — the policy drops it, and used to drop it silently',
+    title: 'Card whose CSS imports a web font',
+    origin: 'INV-MR5 — @import is ignored inside a shadow root',
     text: `<style>
 @import url('https://fonts.example/css2?family=Card');
 .if-title { font-family: 'Card', cursive; }
 </style>
 <div class="if-title">Заголовок</div>`,
+  },
+  {
+    id: 'import-insecure-card',
+    title: 'Card that imports over http, and one that imports a data: sheet',
+    origin: 'INV-MR5 — only https is hoisted',
+    text: `<style>
+@import url('http://fonts.example/plain.css');
+@import "data:text/css,body{display:none}";
+.ii-title { color: rgb(3, 4, 5); }
+</style>
+<div class="ii-title">Заголовок</div>`,
   },
 ];
 

--- a/test/webview_js/specs/document_contract.spec.js
+++ b/test/webview_js/specs/document_contract.spec.js
@@ -75,19 +75,55 @@ test('INV-MR7 the load events a card waits for still arrive', async ({ page }) =
   expect(out).toBe('готово+load');
 });
 
-test('INV-MR5 a dropped @import is reported, not silent', async ({ page }) => {
+test('INV-MR5 an @import is hoisted into the document head', async ({ page }) => {
+  // `@import` inside a shadow root is ignored by the browser, and a
+  // `@font-face` can only be registered from the document — so the sheet is
+  // lifted to a <link> in the head, where the card's font can reach it.
   await render(page, card('import-font-card').text);
-  const report = await page.evaluate(() => {
+  const shape = await page.evaluate(() => {
     const root = window.harness.currentRoot();
+    const links = Array.from(document.head.querySelectorAll('link[data-glaze-import]'));
     return {
-      shown: root.querySelector('.glaze-css-error')?.textContent || '',
+      hrefs: links.map((l) => l.getAttribute('href')),
+      rel: links[0]?.getAttribute('rel'),
+      report: root.querySelector('.glaze-css-error')?.textContent || '',
       styleKept: !!root.querySelector('style'),
       titleStyled: getComputedStyle(root.querySelector('.if-title')).fontFamily,
     };
   });
-  expect(report.shown).toContain('@import');
-  expect(report.styleKept, 'the rest of the card CSS still applies').toBe(true);
-  expect(report.titleStyled).toContain('cursive');
+  expect(shape.hrefs).toEqual(['https://fonts.example/css2?family=Card']);
+  expect(shape.rel).toBe('stylesheet');
+  expect(shape.report, 'a hoisted import is not a problem to report').toBe('');
+  expect(shape.styleKept, 'the rest of the card CSS still applies').toBe(true);
+  expect(shape.titleStyled).toContain('Card');
+});
+
+test('INV-MR5 the same sheet is hoisted once, however many renders', async ({ page }) => {
+  const body = card('import-font-card').text;
+  await render(page, body);
+  await render(page, body);
+  await render(page, body, { keep: true });
+  const count = await page.evaluate(
+    () => document.head.querySelectorAll('link[data-glaze-import]').length,
+  );
+  expect(count).toBe(1);
+});
+
+test('INV-MR5 only https is hoisted; the rest is reported', async ({ page }) => {
+  await render(page, card('import-insecure-card').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    return {
+      links: document.head.querySelectorAll('link[data-glaze-import]').length,
+      report: root.querySelector('.glaze-css-error')?.textContent || '',
+      colour: getComputedStyle(root.querySelector('.ii-title')).color,
+    };
+  });
+  expect(shape.links, 'http: and data: are refused').toBe(0);
+  expect(shape.report).toContain('@import ignored');
+  expect(shape.report).toContain('http://fonts.example/plain.css');
+  expect(shape.report).toContain('data:text/css');
+  expect(shape.colour, 'the rest of the card CSS still applies').toBe('rgb(3, 4, 5)');
 });
 
 test('INV-MR2 the app keeps its own document while a message runs', async ({ page }) => {


### PR DESCRIPTION
Follow-up to #340, which reported a dropped `@import` instead of making it work.

`@import` inside a shadow root is ignored by the browser, and a `@font-face` can only be registered from the document — so a card that pulls a web font that way rendered in `cursive`.

## What changed

- `hoistStyleImports` (`renderer/message_document.js`) reads the `<style>` bodies as the message wrote them — before `bridge/css_sanitizer.js` strips the rule — and lifts each sheet to a `<link rel="stylesheet" data-glaze-import>` in the document head
- `renderer/markdown.js` collects those sources once and passes them to both the hoist and the CSS report
- `inspectBlockedAtRules` no longer lists `@import`; `@font-face`, `@page` and `@namespace` are still dropped and still reported
- INV-MR5 rewritten to describe the hoist and its bounds

## Bounds

- **only `https:`** — `http:` is a downgrade, and a `data:` / `javascript:` stylesheet href is rule injection rather than a font. Anything else is refused and named in the message's CSS-error box, so the card author still learns why
- **each URL once**, at most 32 per session, so a message cannot turn the app into a request generator

## What this accepts, knowingly

This is the reason the sanitizer refused `@import` in the first place, and it is now a deliberate trade rather than an oversight:

- the sheet is fetched from a third party, which learns the reader's IP
- its rules apply to the whole document, app chrome included — a hoisted sheet can restyle the app, not just the card

Everything else in the CSS policy is unchanged: every `url()` *inside* message CSS is still rejected.

## Verification

- `npm test` in `test/webview_js` — **50 passing** in Chromium, including three new corpus cases: the font card is hoisted once across re-renders, and the `http:` / `data:` imports are refused and reported
- `flutter analyze` / `flutter test` were **not run** here (no Flutter SDK in this environment); this PR relies on CI. Every string the asset test looks for — `contains` literals and `indexOf` anchors alike — was checked against the sources with a script (0 mismatches)
- not verified at runtime in the app: a real font host was not exercised, only the element the hoist creates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SR6oSKtKaema8XRHKMVruk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SR6oSKtKaema8XRHKMVruk)_