### PR TITLE
fix(studio): preserve configured inline reasoning tags

### DIFF
--- a/lib/core/llm/agent_stream_runner.dart
+++ b/lib/core/llm/agent_stream_runner.dart
@@ -230,9 +230,13 @@ class AgentStreamRunner {
     String? charName,
     String? userName,
   }) {
+    final hasInlineReasoningTags =
+        resolved.reasoningTagStart?.isNotEmpty == true &&
+        resolved.reasoningTagEnd?.isNotEmpty == true;
     final requestMessages =
         isFinalResponse &&
-            (!resolved.requestReasoning || resolved.omitReasoning)
+            (!resolved.requestReasoning || resolved.omitReasoning) &&
+            !hasInlineReasoningTags
         ? ReasoningStripper.stripMessageReasoning(messages)
         : messages;
     final spec = StudioControllerOntology.specForAgent(agent);

--- a/test/agent_stream_runner_test.dart
+++ b/test/agent_stream_runner_test.dart
@@ -126,6 +126,54 @@ void main() {
     },
   );
 
+  test('final request preserves configured inline reasoning tags', () {
+    const messages = [
+      {
+        'role': 'system',
+        'content': 'Use <think>reasoning</think> before the response.',
+      },
+    ];
+
+    final request = AgentStreamRunner.buildRequest(
+      agent: _agent,
+      messages: messages,
+      resolved: const ResolvedAgentConfig(
+        endpoint: 'https://example.com',
+        apiKey: 'key',
+        model: 'model',
+        protocol: 'custom_chat_completion',
+        requestReasoning: false,
+        omitReasoning: true,
+        reasoningTagStart: '<think>',
+        reasoningTagEnd: '</think>',
+      ),
+      sessionId: 'session',
+      isFinalResponse: true,
+    );
+
+    expect(request.messages, messages);
+    expect(request.messages.single['content'], contains('<think>'));
+    expect(request.messages.single['content'], isNot(contains('hidden reasoning')));
+  });
+
+  test('final request still neutralizes think tags without a configured pair', () {
+    final request = AgentStreamRunner.buildRequest(
+      agent: _agent,
+      messages: const [
+        {
+          'role': 'system',
+          'content': 'Use <think>reasoning</think> before the response.',
+        },
+      ],
+      resolved: _resolved,
+      sessionId: 'session',
+      isFinalResponse: true,
+    );
+
+    expect(request.messages.single['content'], contains('hidden reasoning'));
+    expect(request.messages.single['content'], isNot(contains('<think>')));
+  });
+
   test('timeout cancels the in-flight transport request', () async {
     final transport = _FakeTransport(waitForCancellation: true);
     final runner = AgentStreamRunner((_) => transport);


### PR DESCRIPTION
## Changes
- Preserve an explicitly configured inline reasoning tag pair when building the Studio final request, even when native reasoning is disabled or omitted.
- Keep the legacy `<think>` neutralization behavior when no complete inline tag pair is configured.
- Add regression coverage for both configured and fallback behavior.

## Verification
- `flutter test test/agent_stream_runner_test.dart`
- `flutter analyze lib/core/llm/agent_stream_runner.dart test/agent_stream_runner_test.dart`