### PR TITLE
fix(ledger): constrain ordinary turn time

### DIFF
--- a/lib/core/llm/ledger/ledger_prompt_factory.dart
+++ b/lib/core/llm/ledger/ledger_prompt_factory.dart
@@ -130,12 +130,12 @@ Game clock (world:time, world:date, world:day):
   world:time. Never guess a missing date or day.
 - When the final response or chat implies elapsed time, advance world:time to the
   new in-game time based on how much time the narrated events would take.
+- For an ordinary continuous turn with no explicit duration, advance the clock
+  by 3–10 minutes. Use an explicitly narrated duration instead when available.
 - The game clock only moves FORWARD. Never rewind time; flashbacks and memories
   stay in prose without touching world:time. When time passes midnight, advance
   world:day (day 0 is the first day of the story) and world:date.
-- Do not invent time skips that the narrative does not support. When the scene
-  clearly continues immediately, keep world:time unchanged or move it by only a
-  few minutes.''';
+- Do not invent time skips that the narrative does not support.''';
 
     return const StudioAuxPromptAssembler().assemble(
       blocks: ledgerBlocks,

--- a/lib/core/llm/studio_ledger_prompt.dart
+++ b/lib/core/llm/studio_ledger_prompt.dart
@@ -393,6 +393,8 @@ Rules:
   advance it when narrated events imply elapsed time. The clock only moves
   FORWARD — never rewind it; flashbacks stay in prose. Past midnight, advance
   world:day (day 0 = first story day) and world:date.
+  For an ordinary continuous turn with no explicit duration, advance the clock
+  by 3–10 minutes. Use an explicitly narrated duration instead when available.
   Do not invent time skips the narrative does not support.''';
 
   static const String _legacyTurnOnlySystemPrompt =

--- a/lib/core/llm/studio_ledger_reconciliation.dart
+++ b/lib/core/llm/studio_ledger_reconciliation.dart
@@ -271,8 +271,9 @@ through the review range according to how much in-game time the narrated events
 take, crossing midnight into the next world:day (day 0 = first story day) and
 world:date. Keep the complete DD.MM.YYYY / RP day / HH:MM tuple and never guess
 a missing date or day. The clock only moves FORWARD — never rewind it; treat
-flashbacks and memories as prose, not clock changes. When the range continues a
-scene immediately, advance time by only a few minutes.''';
+flashbacks and memories as prose, not clock changes. For each ordinary continuous
+turn with no explicit duration, advance time by 3–10 minutes and accumulate those
+steps across the review range. Use explicitly narrated durations when available.''';
   }
 
   List<CharacterKnowledgeFact> relevantKnowledgeFacts(

--- a/test/studio_ledger_test.dart
+++ b/test/studio_ledger_test.dart
@@ -192,6 +192,7 @@ void main() {
       expect(prompt, contains('delete npc:Name.location'));
       expect(prompt, contains('never use it as a backlog'));
       expect(prompt, contains('accepted assistant prose as evidence'));
+      expect(prompt, contains('3–10 minutes'));
     });
 
     test('rejects append histories and legacy knowledge tracker keys', () {
@@ -434,6 +435,7 @@ void main() {
         expect(prompt, contains('DB PROMPT'));
         expect(prompt, contains('npc:Unidentified Netrunner.location'));
         expect(prompt, contains('npc:Rebecca.location'));
+        expect(prompt, contains('advance time by 3–10 minutes'));
         final state = RegExp(
           r'<committed_state>([\s\S]*?)</committed_state>',
         ).firstMatch(prompt)!.group(1)!;


### PR DESCRIPTION
## Changes
- require ordinary continuous Ledger turns to advance the game clock by 3-10 minutes when no duration is stated
- keep explicitly narrated durations authoritative
- apply the same cadence while reconciling multi-turn ranges
- cover both prompt paths with regression assertions

## Verification
- `flutter test test/studio_ledger_test.dart`
- `flutter analyze lib/core/llm/ledger/ledger_prompt_factory.dart lib/core/llm/studio_ledger_prompt.dart lib/core/llm/studio_ledger_reconciliation.dart test/studio_ledger_test.dart`
- `git diff --check`