### PR TITLE
fix(ledger): recover reconciliation after network loss

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2415,6 +2415,8 @@
   "agent_ops_run_reconciliation": "Run reconciliation",
   "agent_ops_rerun_ledger": "Rerun latest Ledger",
   "agent_ops_run_missing_ledger": "Run missing Ledger",
+  "agent_ops_missing_ledger_blocks_reconciliation": "Run the missing Ledger before starting reconciliation.",
+  "agent_ops_missing_ledger_recovery_started": "A missing Ledger was found. Running it instead of the latest turn.",
   "agent_ops_commits": "Commits",
   "agent_ops_no_commits": "No reconciliation commits recorded for this session.",
   "agent_ops_parsing_attempts": "Parsing attempts",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -2414,6 +2414,7 @@
   "agent_ops_checkpoint": "Checkpoint: {count} messages, ending at message {messageNumber}",
   "agent_ops_run_reconciliation": "Run reconciliation",
   "agent_ops_rerun_ledger": "Rerun latest Ledger",
+  "agent_ops_run_missing_ledger": "Run missing Ledger",
   "agent_ops_commits": "Commits",
   "agent_ops_no_commits": "No reconciliation commits recorded for this session.",
   "agent_ops_parsing_attempts": "Parsing attempts",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -2444,6 +2444,8 @@
   "agent_ops_run_reconciliation": "Запустить сверку",
   "agent_ops_rerun_ledger": "Повторить последний Ledger",
   "agent_ops_run_missing_ledger": "Запустить пропущенный Ledger",
+  "agent_ops_missing_ledger_blocks_reconciliation": "Сначала запусти пропущенный Ledger, затем reconciliation.",
+  "agent_ops_missing_ledger_recovery_started": "Найден пропущенный Ledger. Запускаю его вместо последнего хода.",
   "agent_ops_commits": "Коммиты",
   "agent_ops_no_commits": "Для этой сессии нет коммитов сверки.",
   "agent_ops_parsing_attempts": "Попытки разбора",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -2443,6 +2443,7 @@
   "agent_ops_checkpoint": "Контрольная точка: сообщений — {count}, последнее — сообщение {messageNumber}",
   "agent_ops_run_reconciliation": "Запустить сверку",
   "agent_ops_rerun_ledger": "Повторить последний Ledger",
+  "agent_ops_run_missing_ledger": "Запустить пропущенный Ledger",
   "agent_ops_commits": "Коммиты",
   "agent_ops_no_commits": "Для этой сессии нет коммитов сверки.",
   "agent_ops_parsing_attempts": "Попытки разбора",

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -154,6 +154,10 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
 
   Future<void> _initializeStartup() async {
     try {
+      await _runStartupStep(
+        'orphaned reconciliation leases',
+        ref.read(ledgerReconciliationLeaseRepoProvider).clearProcessOrphans,
+      );
       await _runStartupStep('dotenv', () => dotenv.load(fileName: '.env'));
       await _runStartupStep('tokenizer', preloadO200kBase);
       await _runStartupStep('prompt worker', PromptWorker.ensureInitialized);

--- a/lib/core/db/repositories/ledger_raw_tracker_state_reader.dart
+++ b/lib/core/db/repositories/ledger_raw_tracker_state_reader.dart
@@ -17,13 +17,21 @@ final class LedgerRawTrackerStateReader {
   final TrackerRepo _trackers;
   final TrackerSnapshotRepo _snapshots;
 
-  Future<LedgerRawTrackerState> read(String sessionId) async {
-    final snapshot = await _snapshots.getLatestCommitted(sessionId);
+  Future<LedgerRawTrackerState> read(
+    String sessionId, {
+    String? excludeSnapshotMessageId,
+  }) async {
+    final snapshot = excludeSnapshotMessageId == null
+        ? await _snapshots.getLatestCommitted(sessionId)
+        : await _snapshots.getLatestCommittedExcludingMessage(
+            sessionId,
+            excludeSnapshotMessageId,
+          );
     final controls = await _trackers.getLiveCanonControls(sessionId);
     final committed = snapshot?.trackers
         .where((tracker) => tracker.scope == 'ledger')
         .toList(growable: true);
-    if (committed != null) {
+    if (committed != null && excludeSnapshotMessageId == null) {
       final names = committed.map((tracker) => tracker.name).toSet();
       final liveClock = await _trackers.getCompleteGameTime(sessionId);
       committed.addAll(

--- a/lib/core/db/repositories/ledger_reconciliation_lease_repo.dart
+++ b/lib/core/db/repositories/ledger_reconciliation_lease_repo.dart
@@ -8,6 +8,12 @@ final class LedgerReconciliationLeaseRepo {
 
   final AppDatabase db;
 
+  /// Reconciliation leases coordinate work inside one running app process.
+  /// A new app scope has no surviving owner, so persisted rows are orphans.
+  Future<void> clearProcessOrphans() async {
+    await db.delete(db.ledgerReconciliationLeases).go();
+  }
+
   Future<bool> acquire({
     required String sessionId,
     required String ownerId,

--- a/lib/core/llm/aux_retry_runner.dart
+++ b/lib/core/llm/aux_retry_runner.dart
@@ -80,6 +80,16 @@ class AuxRetryPolicy {
     if (error is HttpException) return true; // connection closed mid-stream
     if (error is SocketException) return true; // TCP reset / refused
     if (error is DioException) {
+      if (error.type == DioExceptionType.connectionError ||
+          error.type == DioExceptionType.connectionTimeout ||
+          error.type == DioExceptionType.sendTimeout ||
+          error.type == DioExceptionType.receiveTimeout) {
+        return true;
+      }
+      if (error.type == DioExceptionType.unknown &&
+          error.error is SocketException) {
+        return true;
+      }
       final code = error.response?.statusCode ?? 0;
       if (code >= 500 && code < 600) return true;
     }

--- a/lib/core/llm/ledger/ledger_prompt_factory.dart
+++ b/lib/core/llm/ledger/ledger_prompt_factory.dart
@@ -131,7 +131,7 @@ Game clock (world:time, world:date, world:day):
 - When the final response or chat implies elapsed time, advance world:time to the
   new in-game time based on how much time the narrated events would take.
 - For an ordinary continuous turn with no explicit duration, advance the clock
-  by 3–10 minutes. Use an explicitly narrated duration instead when available.
+  by 1–5 minutes. Use an explicitly narrated duration instead when available.
 - The game clock only moves FORWARD. Never rewind time; flashbacks and memories
   stay in prose without touching world:time. When time passes midnight, advance
   world:day (day 0 is the first day of the story) and world:date.

--- a/lib/core/llm/ledger/ledger_reconciliation_runner.dart
+++ b/lib/core/llm/ledger/ledger_reconciliation_runner.dart
@@ -306,7 +306,7 @@ final class LedgerReconciliationRunner {
         return LedgerRunResult.aborted;
       }
       final timeoutMs = _llm.resolveLedgerTimeout(request.settings);
-      final outcome = await _llm.callOnceWithLog(
+      final outcome = await _llm.callStreamWithLog(
         config: request.config,
         prompt: prompt,
         maxTokens: request.settings.ledger.studioLedgerMaxTokens > 0
@@ -411,7 +411,7 @@ final class LedgerReconciliationRunner {
         if (!await _renewLease(request.sessionId, leaseOwnerId)) {
           return LedgerRunResult.aborted;
         }
-        final repair = await _llm.callOnceWithLog(
+        final repair = await _llm.callStreamWithLog(
           config: request.config,
           prompt: repairPrompt,
           maxTokens: request.settings.ledger.studioLedgerMaxTokens > 0

--- a/lib/core/llm/prompt_payload_builder.dart
+++ b/lib/core/llm/prompt_payload_builder.dart
@@ -153,6 +153,7 @@ class PromptPayloadBuilder {
     bool skipVectorSearch = false,
     bool includeEffectiveCanon = false,
     bool readOnlyEffectiveCanon = false,
+    String? excludeSnapshotMessageId,
     bool allowRemoteRetrieval = true,
     bool Function()? shouldAbort,
     CancelToken? cancelToken,
@@ -184,10 +185,15 @@ class PromptPayloadBuilder {
               .loadReadOnly(
                 sessionId: session.id,
                 sourceCharacter: sourceCharacter,
+                excludeSnapshotMessageId: excludeSnapshotMessageId,
               )
         : await _ref
               .read(effectiveCanonContextLoaderProvider)
-              .load(sessionId: session.id, sourceCharacter: sourceCharacter);
+              .load(
+                sessionId: session.id,
+                sourceCharacter: sourceCharacter,
+                excludeSnapshotMessageId: excludeSnapshotMessageId,
+              );
     final character = effectiveContext?.character ?? sourceCharacter;
     final effectiveProjection = effectiveContext == null
         ? null
@@ -502,6 +508,7 @@ class PromptPayloadBuilder {
       charId: effectiveCharId,
       session: session,
       context: effectiveContext,
+      excludeSnapshotMessageId: excludeSnapshotMessageId,
     );
     final gameTimeState = GameTimeState.fromTrackers(
       ledgerTrackers ?? const <Tracker>[],
@@ -757,6 +764,7 @@ class PromptPayloadBuilder {
     required String charId,
     required ChatSession? session,
     required EffectiveCanonContext? context,
+    String? excludeSnapshotMessageId,
   }) async {
     if (session == null || context == null) return;
     final current = await _ref.read(characterRepoProvider).getById(charId);
@@ -768,6 +776,7 @@ class PromptPayloadBuilder {
               sessionId: session.id,
               sourceCharacter: current,
               stamp: context.stamp,
+              excludeSnapshotMessageId: excludeSnapshotMessageId,
             );
     if (!isCurrent) {
       throw const PromptBuildStaleException(

--- a/lib/core/llm/studio_ledger_prompt.dart
+++ b/lib/core/llm/studio_ledger_prompt.dart
@@ -394,7 +394,7 @@ Rules:
   FORWARD — never rewind it; flashbacks stay in prose. Past midnight, advance
   world:day (day 0 = first story day) and world:date.
   For an ordinary continuous turn with no explicit duration, advance the clock
-  by 3–10 minutes. Use an explicitly narrated duration instead when available.
+  by 1–5 minutes. Use an explicitly narrated duration instead when available.
   Do not invent time skips the narrative does not support.''';
 
   static const String _legacyTurnOnlySystemPrompt =

--- a/lib/core/llm/studio_ledger_reconciliation.dart
+++ b/lib/core/llm/studio_ledger_reconciliation.dart
@@ -267,13 +267,11 @@ Never create facts, rewrite fact content, or retract a fact merely because it is
 old or absent from the review range.
 
 Game clock (world:time, world:date, world:day): advance world:time (24h HH:MM)
-through the review range according to how much in-game time the narrated events
-take, crossing midnight into the next world:day (day 0 = first story day) and
-world:date. Keep the complete DD.MM.YYYY / RP day / HH:MM tuple and never guess
-a missing date or day. The clock only moves FORWARD — never rewind it; treat
-flashbacks and memories as prose, not clock changes. For each ordinary continuous
-turn with no explicit duration, advance time by 3–10 minutes and accumulate those
-steps across the review range. Use explicitly narrated durations when available.''';
+only to correct a demonstrable clock error in the committed endpoint state.
+The ordinary turns in the review range were already applied; never add their
+elapsed time again. Keep the complete DD.MM.YYYY / RP day / HH:MM tuple and never
+guess a missing date or day. The clock only moves FORWARD — never rewind it;
+treat flashbacks and memories as prose, not clock changes.''';
   }
 
   List<CharacterKnowledgeFact> relevantKnowledgeFacts(

--- a/lib/core/services/card_rewriter/effective_canon_context_loader.dart
+++ b/lib/core/services/card_rewriter/effective_canon_context_loader.dart
@@ -92,10 +92,12 @@ class EffectiveCanonContextLoader {
   Future<EffectiveCanonContext> load({
     required String sessionId,
     required Character sourceCharacter,
+    String? excludeSnapshotMessageId,
   }) async => _load(
     sourceCharacter: sourceCharacter,
     sessionId: sessionId,
     reconcile: true,
+    excludeSnapshotMessageId: excludeSnapshotMessageId,
   );
 
   /// Builds the current effective canon without reconciling or persisting a
@@ -103,10 +105,12 @@ class EffectiveCanonContextLoader {
   Future<EffectiveCanonContext> loadReadOnly({
     required String sessionId,
     required Character sourceCharacter,
+    String? excludeSnapshotMessageId,
   }) async => _load(
     sourceCharacter: sourceCharacter,
     sessionId: sessionId,
     reconcile: false,
+    excludeSnapshotMessageId: excludeSnapshotMessageId,
   );
 
   /// Builds effective canon from an exact reconciliation state without
@@ -170,11 +174,13 @@ class EffectiveCanonContextLoader {
     required String sessionId,
     required Character sourceCharacter,
     required EffectiveCanonContextStamp stamp,
+    String? excludeSnapshotMessageId,
   }) async =>
       (await _load(
         sourceCharacter: sourceCharacter,
         sessionId: sessionId,
         reconcile: false,
+        excludeSnapshotMessageId: excludeSnapshotMessageId,
       )).stamp.identity ==
       stamp.identity;
 
@@ -182,6 +188,7 @@ class EffectiveCanonContextLoader {
     required String sessionId,
     required Character sourceCharacter,
     required bool reconcile,
+    String? excludeSnapshotMessageId,
   }) async {
     final source = reconcile
         ? await _reconcileSource(sourceCharacter)
@@ -189,6 +196,7 @@ class EffectiveCanonContextLoader {
     final input = await _readRepository.readFromSource(
       sessionId: sessionId,
       sourceCharacter: sourceCharacter,
+      excludeSnapshotMessageId: excludeSnapshotMessageId,
     );
     final assembly = _assemble(
       EffectiveCanonAssemblyInput(

--- a/lib/core/services/card_rewriter/effective_canon_read_repository.dart
+++ b/lib/core/services/card_rewriter/effective_canon_read_repository.dart
@@ -77,9 +77,13 @@ class EffectiveCanonReadRepository {
   Future<EffectiveCanonAssemblyInput> readFromSource({
     required String sessionId,
     required Character sourceCharacter,
+    String? excludeSnapshotMessageId,
   }) => db.transaction(
-    () =>
-        _readFromSource(sessionId: sessionId, sourceCharacter: sourceCharacter),
+    () => _readFromSource(
+      sessionId: sessionId,
+      sourceCharacter: sourceCharacter,
+      excludeSnapshotMessageId: excludeSnapshotMessageId,
+    ),
   );
 
   Future<EffectiveCanonAssemblyInput> _read({
@@ -101,13 +105,20 @@ class EffectiveCanonReadRepository {
   Future<EffectiveCanonAssemblyInput> _readFromSource({
     required String sessionId,
     required Character sourceCharacter,
+    String? excludeSnapshotMessageId,
   }) async {
     final lineage = await revisionRepo.getForCharacter(sourceCharacter.id);
     final baseline = await baselineRepo.getBySessionId(sessionId);
-    final facts = await factRepo.getReviewableForSession(sessionId);
-    final raw =
-        await (_runtimeRawTrackerStateLoader?.call(sessionId) ??
-            _rawTrackerStateReader.read(sessionId));
+    final facts = (await factRepo.getReviewableForSession(sessionId))
+        .where((fact) => fact.sourceMessageId != excludeSnapshotMessageId)
+        .toList(growable: false);
+    final raw = excludeSnapshotMessageId == null
+        ? await (_runtimeRawTrackerStateLoader?.call(sessionId) ??
+              _rawTrackerStateReader.read(sessionId))
+        : await _rawTrackerStateReader.read(
+            sessionId,
+            excludeSnapshotMessageId: excludeSnapshotMessageId,
+          );
     final transitions = await transitionRepo.getForContext(
       characterId: sourceCharacter.id,
       sessionId: sessionId,

--- a/lib/core/state/db_provider.dart
+++ b/lib/core/state/db_provider.dart
@@ -32,6 +32,7 @@ import '../db/repositories/tracker_snapshot_repo.dart';
 import '../db/repositories/ledger_raw_tracker_state_reader.dart';
 import '../db/repositories/ledger_reconciliation_checkpoint_repo.dart';
 import '../db/repositories/ledger_reconciliation_run_repo.dart';
+import '../db/repositories/ledger_reconciliation_lease_repo.dart';
 import '../db/repositories/ledger_debug_run_repo.dart';
 import '../db/repositories/llm_request_capture_repo.dart';
 import '../db/repositories/card_evolution_repo.dart';
@@ -136,6 +137,11 @@ final characterRepoProvider = Provider<CharacterRepo>((ref) {
 final chatRepoProvider = Provider<ChatRepo>((ref) {
   return ChatRepo(ref.watch(appDbProvider));
 });
+
+final ledgerReconciliationLeaseRepoProvider =
+    Provider<LedgerReconciliationLeaseRepo>((ref) {
+      return LedgerReconciliationLeaseRepo(ref.watch(appDbProvider));
+    });
 
 final chatSessionBranchRepoProvider = Provider<ChatSessionBranchRepo>((ref) {
   return ChatSessionBranchRepo(ref.watch(appDbProvider));

--- a/lib/features/chat/services/manual_studio_ledger_service.dart
+++ b/lib/features/chat/services/manual_studio_ledger_service.dart
@@ -252,6 +252,7 @@ class ManualStudioLedgerService {
           session.messages,
           maxMessages: 10,
           upToMessageId: target.id,
+          excludeMessageId: target.id,
         ),
         target: target,
         macroCtx: macroCtx,
@@ -548,18 +549,25 @@ String _recentHistoryText(
   List<ChatMessage> messages, {
   int maxMessages = 10,
   String? upToMessageId,
+  String? excludeMessageId,
 }) {
   var source = messages;
   if (upToMessageId != null) {
     final idx = messages.indexWhere((m) => m.id == upToMessageId);
     if (idx >= 0) source = messages.sublist(0, idx + 1);
   }
-  final start = source.length > maxMessages ? source.length - maxMessages : 0;
+  final eligible = source.where((message) {
+    if (message.id == excludeMessageId) return false;
+    if (message.role != 'user' && message.role != 'assistant') return false;
+    if (message.isHidden || message.isError || message.isTyping) return false;
+    return message.content.trim().isNotEmpty;
+  }).toList();
+  final start = eligible.length > maxMessages
+      ? eligible.length - maxMessages
+      : 0;
   final lines = <String>[];
-  for (final msg in source.sublist(start)) {
-    if (msg.isError || msg.isTyping) continue;
+  for (final msg in eligible.sublist(start)) {
     final content = msg.content.trim();
-    if (content.isEmpty) continue;
     final role = msg.role == 'assistant' ? 'Assistant' : 'User';
     lines.add('$role: $content');
   }

--- a/lib/features/chat/services/manual_studio_ledger_service.dart
+++ b/lib/features/chat/services/manual_studio_ledger_service.dart
@@ -281,30 +281,35 @@ class ManualStudioLedgerService {
     );
   }
 
+  Future<ManualStudioLedgerResult> rerunMissingForReconciliation(
+    String sessionId,
+  ) async {
+    final session = await chatRepo.getById(sessionId);
+    if (session == null) throw StateError('Session not found');
+    final plan = await _reconciliationPlan(session);
+    if (plan == null) {
+      throw StateError('No batch of five committed Ledger ranges is due');
+    }
+    final endpoint = plan.endMessage;
+    final snapshot = await snapshotRepo.getByAnchor(
+      sessionId: sessionId,
+      messageId: endpoint.id,
+      swipeId: endpoint.swipeId,
+      agentSwipeId: endpoint.agentSwipeId,
+    );
+    if (snapshot?.committed == true) {
+      throw StateError('The reconciliation endpoint is already committed');
+    }
+    return rerun(sessionId: sessionId, target: endpoint);
+  }
+
   Future<ManualStudioLedgerResult> reconcile(String sessionId) async {
     final turnConfigFuture = _resolveTurnConfig(sessionId);
     final session = await chatRepo.getById(sessionId);
     if (session == null) throw StateError('Session not found');
     final turnConfig = await turnConfigFuture;
     _requireLedgerEnabled(turnConfig);
-    final trigger = session.messages.reversed.where((message) {
-      return message.role == 'assistant' &&
-          !message.isError &&
-          !message.isTyping &&
-          !message.isHidden &&
-          message.content.trim().isNotEmpty;
-    }).firstOrNull;
-    if (trigger == null) {
-      throw StateError('No assistant turn can trigger reconciliation');
-    }
-    final checkpoint = await reconciliationCheckpointRepo.get(sessionId);
-    final previousHead = await reconciliationRunRepo.getHead(sessionId);
-    final plan = const LedgerReconciliationPlanner().plan(
-      messages: session.messages,
-      currentAssistantMessageId: trigger.id,
-      checkpoint: checkpoint,
-      previousEndMessageId: previousHead?.endMessageId,
-    );
+    final plan = await _reconciliationPlan(session);
     if (plan == null) {
       throw StateError('No batch of five committed Ledger ranges is due');
     }
@@ -355,6 +360,29 @@ class ManualStudioLedgerService {
       target: endpoint,
       result: result,
       startedAtMs: startedAt,
+    );
+  }
+
+  Future<LedgerReconciliationPlan?> _reconciliationPlan(
+    ChatSession session,
+  ) async {
+    final trigger = session.messages.reversed.where((message) {
+      return message.role == 'assistant' &&
+          !message.isError &&
+          !message.isTyping &&
+          !message.isHidden &&
+          message.content.trim().isNotEmpty;
+    }).firstOrNull;
+    if (trigger == null) {
+      throw StateError('No assistant turn can trigger reconciliation');
+    }
+    final checkpoint = await reconciliationCheckpointRepo.get(session.id);
+    final previousHead = await reconciliationRunRepo.getHead(session.id);
+    return const LedgerReconciliationPlanner().plan(
+      messages: session.messages,
+      currentAssistantMessageId: trigger.id,
+      checkpoint: checkpoint,
+      previousEndMessageId: previousHead?.endMessageId,
     );
   }
 

--- a/lib/features/chat/services/pipeline_utils.dart
+++ b/lib/features/chat/services/pipeline_utils.dart
@@ -14,6 +14,9 @@ String extractRecentHistoryText(
   /// If non-null, only messages up to AND INCLUDING the one with this id
   /// are considered. Messages after it are dropped.
   String? upToMessageId,
+
+  /// Excludes a message already supplied separately to the auxiliary prompt.
+  String? excludeMessageId,
 }) {
   // Truncate to the historical slice first if requested.
   List<ChatMessage> source = messages;
@@ -23,14 +26,19 @@ String extractRecentHistoryText(
       source = messages.sublist(0, idx + 1);
     }
   }
-  final start = source.length > maxMessages ? source.length - maxMessages : 0;
-  final recent = source.sublist(start);
+  final eligible = source.where((msg) {
+    if (msg.id == excludeMessageId) return false;
+    if (msg.role != 'user' && msg.role != 'assistant') return false;
+    if (msg.isHidden || msg.isError || msg.isTyping) return false;
+    return msg.content.trim().isNotEmpty;
+  }).toList();
+  final start = eligible.length > maxMessages
+      ? eligible.length - maxMessages
+      : 0;
   final lines = <String>[];
-  for (final msg in recent) {
-    if (msg.isError || msg.isTyping) continue;
+  for (final msg in eligible.sublist(start)) {
     final role = msg.role == 'assistant' ? 'Assistant' : 'User';
     final content = msg.content.trim();
-    if (content.isEmpty) continue;
     lines.add('$role: $content');
   }
   return lines.join('\n\n');

--- a/lib/features/chat/services/reconciler_view_service.dart
+++ b/lib/features/chat/services/reconciler_view_service.dart
@@ -7,6 +7,8 @@ import '../../../core/db/repositories/chat_repo.dart';
 import '../../../core/db/repositories/ledger_debug_run_repo.dart';
 import '../../../core/db/repositories/ledger_reconciliation_checkpoint_repo.dart';
 import '../../../core/db/repositories/ledger_reconciliation_run_repo.dart';
+import '../../../core/db/repositories/tracker_snapshot_repo.dart';
+import '../../../core/llm/studio_ledger_reconciliation.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/state/db_provider.dart';
 
@@ -52,6 +54,7 @@ final class ReconcilerViewSnapshot {
     required this.debugRuns,
     required this.checkpoint,
     required this.checkpointEndMessageOrdinal,
+    required this.missingLedgerTarget,
   });
 
   final ReconciliationRunIntegrity integrity;
@@ -59,6 +62,7 @@ final class ReconcilerViewSnapshot {
   final List<LedgerDebugRunRow> debugRuns;
   final LedgerReconciliationCheckpoint? checkpoint;
   final int? checkpointEndMessageOrdinal;
+  final ChatMessage? missingLedgerTarget;
 
   bool get chainIsValid => integrity is ReconciliationRunValid;
 }
@@ -69,19 +73,22 @@ class ReconcilerViewService {
     required LedgerDebugRunRepo debugRepo,
     required LedgerReconciliationCheckpointRepo checkpointRepo,
     required ChatRepo chatRepo,
-  }) : this._(runRepo, debugRepo, checkpointRepo, chatRepo);
+    required TrackerSnapshotRepo snapshotRepo,
+  }) : this._(runRepo, debugRepo, checkpointRepo, chatRepo, snapshotRepo);
 
   const ReconcilerViewService._(
     this._runRepo,
     this._debugRepo,
     this._checkpointRepo,
     this._chatRepo,
+    this._snapshotRepo,
   );
 
   final LedgerReconciliationRunRepo _runRepo;
   final LedgerDebugRunRepo _debugRepo;
   final LedgerReconciliationCheckpointRepo _checkpointRepo;
   final ChatRepo _chatRepo;
+  final TrackerSnapshotRepo _snapshotRepo;
 
   Future<ReconcilerViewSnapshot> load(String sessionId) async {
     final values = await Future.wait<Object?>([
@@ -114,6 +121,13 @@ class ReconcilerViewService {
     };
     final logicalIds = logical.map((row) => row.id).toSet();
     final invalidationByRun = {for (final row in invalidations) row.runId: row};
+    final missingLedgerTarget = session == null
+        ? null
+        : await _missingLedgerTarget(
+            session,
+            checkpoint: checkpoint,
+            previousEndMessageId: logical.lastOrNull?.endMessageId,
+          );
 
     return ReconcilerViewSnapshot(
       integrity: integrity,
@@ -121,6 +135,7 @@ class ReconcilerViewService {
       checkpointEndMessageOrdinal: checkpoint == null
           ? null
           : messageOrdinals[checkpoint.endMessageId],
+      missingLedgerTarget: missingLedgerTarget,
       debugRuns: debugRows,
       runs: [
         for (final row in physical)
@@ -134,6 +149,36 @@ class ReconcilerViewService {
           ),
       ],
     );
+  }
+
+  Future<ChatMessage?> _missingLedgerTarget(
+    ChatSession session, {
+    required LedgerReconciliationCheckpoint? checkpoint,
+    required String? previousEndMessageId,
+  }) async {
+    final trigger = session.messages.reversed.where((message) {
+      return message.role == 'assistant' &&
+          !message.isError &&
+          !message.isTyping &&
+          !message.isHidden &&
+          message.content.trim().isNotEmpty;
+    }).firstOrNull;
+    if (trigger == null) return null;
+    final plan = const LedgerReconciliationPlanner().plan(
+      messages: session.messages,
+      currentAssistantMessageId: trigger.id,
+      checkpoint: checkpoint,
+      previousEndMessageId: previousEndMessageId,
+    );
+    if (plan == null) return null;
+    final endpoint = plan.endMessage;
+    final snapshot = await _snapshotRepo.getByAnchor(
+      sessionId: session.id,
+      messageId: endpoint.id,
+      swipeId: endpoint.swipeId,
+      agentSwipeId: endpoint.agentSwipeId,
+    );
+    return snapshot?.committed == true ? null : endpoint;
   }
 
   ReconciliationRunView _toRunView(
@@ -190,6 +235,7 @@ final reconcilerViewServiceProvider = Provider<ReconcilerViewService>((ref) {
     debugRepo: ref.watch(ledgerDebugRunRepoProvider),
     checkpointRepo: ref.watch(ledgerReconciliationCheckpointRepoProvider),
     chatRepo: ref.watch(chatRepoProvider),
+    snapshotRepo: ref.watch(trackerSnapshotRepoProvider),
   );
 });
 

--- a/lib/features/chat/services/stages/ledger_stage.dart
+++ b/lib/features/chat/services/stages/ledger_stage.dart
@@ -211,7 +211,11 @@ class LedgerStage {
         return;
       }
 
-      final recentHistory = extractRecentHistoryText(messages, maxMessages: 10);
+      final recentHistory = extractRecentHistoryText(
+        messages,
+        maxMessages: 10,
+        excludeMessageId: targetMessage.id,
+      );
 
       final service = ctx.ref.read(studioLedgerServiceProvider);
 

--- a/lib/features/chat/services/stream_generation_service.dart
+++ b/lib/features/chat/services/stream_generation_service.dart
@@ -36,7 +36,6 @@ import '../../../core/models/pipeline_settings.dart';
 import '../../../core/services/model_usage_service.dart';
 import '../../../core/services/preset_defaults.dart';
 import '../../../core/state/active_selection_provider.dart';
-import '../../../core/state/db_provider.dart';
 import '../../../core/state/memory_agent_providers.dart';
 import '../chat_provider.dart';
 import '../chat_state.dart';
@@ -130,6 +129,7 @@ class StreamGenerationService {
             ? null
             : kContinueInstruction,
         includeEffectiveCanon: turnConfig.enabled,
+        excludeSnapshotMessageId: regenTargetId,
         shouldAbort: _isAborted,
         cancelToken: cancelToken,
         onPhase: _phase,
@@ -328,6 +328,7 @@ class StreamGenerationService {
           studioReportedPhase = next;
           _phase(next);
         }
+
         void scheduleStudioStreamingUpdate() {
           if (studioFrameScheduled) return;
           studioFrameScheduled = true;
@@ -468,15 +469,12 @@ class StreamGenerationService {
             studioFinalMessages,
           ),
         );
-        // Opening game clock: read the current ledger trackers before the
-        // message is written so the badge travels with the initial append
-        // (the post-turn Ledger stamp refines it afterwards). Null when no
-        // complete date/day/time tuple exists — never a partial clock.
-        final openingTrackers = await _ref
-            .read(trackerRepoProvider)
-            .getBySessionAndScope(session.id, 'ledger');
-        final openingClock = GameTimeState.fromTrackers(
-          openingTrackers,
+        // Use the same clock projection that built the prompt. During regen it
+        // excludes the target message's own snapshot.
+        final openingClock = GameTimeState(
+          time: inputs.gameTime,
+          date: inputs.gameDate,
+          day: int.tryParse(inputs.gameDay ?? ''),
         ).format();
         final finalState = _writer
             .writeAssistant(

--- a/lib/features/chat/widgets/agentic_reconciler_tab.dart
+++ b/lib/features/chat/widgets/agentic_reconciler_tab.dart
@@ -63,8 +63,17 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
     return null;
   }
 
-  Future<void> _runReconciliation() async {
+  Future<void> _runReconciliation({required bool hasMissingLedger}) async {
     if (_runningReconciliation) return;
+    if (hasMissingLedger) {
+      GlazeToast.show(
+        context,
+        'agent_ops_missing_ledger_blocks_reconciliation'.tr(),
+        isError: true,
+        position: ToastPosition.top,
+      );
+      return;
+    }
     setState(() => _runningReconciliation = true);
     try {
       final outcome = await ref
@@ -101,6 +110,14 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
 
   Future<void> _rerunLedger({required bool missingEndpoint}) async {
     if (_runningLedger) return;
+    if (missingEndpoint) {
+      GlazeToast.show(
+        context,
+        'agent_ops_missing_ledger_recovery_started'.tr(),
+        isError: true,
+        position: ToastPosition.top,
+      );
+    }
     setState(() => _runningLedger = true);
     try {
       final service = ref.read(manualStudioLedgerServiceProvider);
@@ -288,11 +305,13 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
                         FilledButton.tonalIcon(
                           onPressed:
                               ledgerEnabled &&
-                                  data.missingLedgerTarget == null &&
                                   !_runningLedger &&
                                   !_runningReconciliation &&
                                   _regeneratingRunId == null
-                              ? _runReconciliation
+                              ? () => _runReconciliation(
+                                  hasMissingLedger:
+                                      data.missingLedgerTarget != null,
+                                )
                               : null,
                           icon: _runningReconciliation
                               ? const SizedBox.square(

--- a/lib/features/chat/widgets/agentic_reconciler_tab.dart
+++ b/lib/features/chat/widgets/agentic_reconciler_tab.dart
@@ -288,6 +288,7 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
                         FilledButton.tonalIcon(
                           onPressed:
                               ledgerEnabled &&
+                                  data.missingLedgerTarget == null &&
                                   !_runningLedger &&
                                   !_runningReconciliation &&
                                   _regeneratingRunId == null
@@ -302,6 +303,12 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
                           label: Text('agent_ops_run_reconciliation'.tr()),
                         ),
                         FilledButton.tonalIcon(
+                          style: data.missingLedgerTarget == null
+                              ? null
+                              : FilledButton.styleFrom(
+                                  backgroundColor: context.cs.errorContainer,
+                                  foregroundColor: context.cs.onErrorContainer,
+                                ),
                           onPressed:
                               ledgerEnabled &&
                                   !_runningLedger &&
@@ -317,7 +324,11 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
                                   dimension: 16,
                                   child: GlazeSpinner(),
                                 )
-                              : const Icon(Icons.replay_outlined),
+                              : Icon(
+                                  data.missingLedgerTarget == null
+                                      ? Icons.replay_outlined
+                                      : Icons.warning_amber_rounded,
+                                ),
                           label: Text(
                             (data.missingLedgerTarget == null
                                     ? 'agent_ops_rerun_ledger'

--- a/lib/features/chat/widgets/agentic_reconciler_tab.dart
+++ b/lib/features/chat/widgets/agentic_reconciler_tab.dart
@@ -99,16 +99,19 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
     }
   }
 
-  Future<void> _rerunLedger() async {
+  Future<void> _rerunLedger({required bool missingEndpoint}) async {
     if (_runningLedger) return;
-    final target = await _latestAssistant();
-    if (target == null || !mounted) return;
     setState(() => _runningLedger = true);
     try {
-      final outcome = await ref
-          .read(manualStudioLedgerServiceProvider)
-          .rerun(sessionId: widget.sessionId, target: target);
-      if (!mounted) return;
+      final service = ref.read(manualStudioLedgerServiceProvider);
+      final outcome = missingEndpoint
+          ? await service.rerunMissingForReconciliation(widget.sessionId)
+          : await (() async {
+              final target = await _latestAssistant();
+              if (target == null) return null;
+              return service.rerun(sessionId: widget.sessionId, target: target);
+            })();
+      if (outcome == null || !mounted) return;
       final result = outcome.result;
       GlazeToast.show(
         context,
@@ -304,7 +307,10 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
                                   !_runningLedger &&
                                   !_runningReconciliation &&
                                   _regeneratingRunId == null
-                              ? _rerunLedger
+                              ? () => _rerunLedger(
+                                  missingEndpoint:
+                                      data.missingLedgerTarget != null,
+                                )
                               : null,
                           icon: _runningLedger
                               ? const SizedBox.square(
@@ -312,7 +318,12 @@ class _AgenticReconcilerTabState extends ConsumerState<AgenticReconcilerTab> {
                                   child: GlazeSpinner(),
                                 )
                               : const Icon(Icons.replay_outlined),
-                          label: Text('agent_ops_rerun_ledger'.tr()),
+                          label: Text(
+                            (data.missingLedgerTarget == null
+                                    ? 'agent_ops_rerun_ledger'
+                                    : 'agent_ops_run_missing_ledger')
+                                .tr(),
+                          ),
                         ),
                       ],
                     ),

--- a/test/aux_retry_test.dart
+++ b/test/aux_retry_test.dart
@@ -130,6 +130,38 @@ void main() {
       expect(outcome.attempts.last.status, 'ok');
     });
 
+    for (final type in const [
+      DioExceptionType.connectionError,
+      DioExceptionType.connectionTimeout,
+      DioExceptionType.sendTimeout,
+      DioExceptionType.receiveTimeout,
+    ]) {
+      test('retries transient Dio $type', () async {
+        var calls = 0;
+        final outcome =
+            await const AuxRetryRunner(
+              policy: AuxRetryPolicy(
+                maxAttempts: 2,
+                backoffDelays: [Duration.zero],
+              ),
+            ).run(
+              attempt: (_) async {
+                calls++;
+                if (calls == 1) {
+                  throw DioException(
+                    requestOptions: RequestOptions(path: ''),
+                    type: type,
+                  );
+                }
+                return 'recovered';
+              },
+            );
+
+        expect(outcome.text, 'recovered');
+        expect(calls, 2);
+      });
+    }
+
     test(
       'does NOT retry on TimeoutException when retryOnTimeout=false',
       () async {

--- a/test/effective_canon_context_loader_test.dart
+++ b/test/effective_canon_context_loader_test.dart
@@ -9,11 +9,13 @@ import 'package:glaze_flutter/core/db/repositories/character_knowledge_fact_repo
 import 'package:glaze_flutter/core/db/repositories/character_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/character_revision_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/character_session_baseline_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/tracker_snapshot_repo.dart';
 import 'package:glaze_flutter/core/llm/prompt/ledger_tracker_loader.dart';
 import 'package:glaze_flutter/core/models/character.dart';
 import 'package:glaze_flutter/core/models/character_knowledge_fact.dart';
 import 'package:glaze_flutter/core/models/character_session_baseline.dart';
 import 'package:glaze_flutter/core/models/tracker.dart';
+import 'package:glaze_flutter/core/models/tracker_snapshot.dart';
 import 'package:glaze_flutter/core/services/card_rewriter/card_rewriter_contracts.dart';
 import 'package:glaze_flutter/core/services/card_rewriter/effective_canon_context_loader.dart';
 import 'package:glaze_flutter/core/services/card_rewriter/effective_canon_assembler.dart';
@@ -118,6 +120,65 @@ void main() {
 
     expect(context.effectiveRevision.number, 1);
     expect(await revisions.getForCharacter('c'), isEmpty);
+  });
+
+  test('regen exclusion removes target snapshot and target facts', () async {
+    await TrackerSnapshotRepo(db).upsert(
+      const TrackerSnapshot(
+        sessionId: 's',
+        messageId: 'previous',
+        swipeId: 0,
+        agentSwipeId: 0,
+        trackers: [
+          Tracker(
+            sessionId: 's',
+            name: 'scene.location',
+            value: 'before',
+            scope: 'ledger',
+          ),
+        ],
+        committed: true,
+        createdAt: 1,
+      ),
+    );
+    await TrackerSnapshotRepo(db).upsert(
+      const TrackerSnapshot(
+        sessionId: 's',
+        messageId: 'target',
+        swipeId: 0,
+        agentSwipeId: 0,
+        trackers: [
+          Tracker(
+            sessionId: 's',
+            name: 'scene.location',
+            value: 'after',
+            scope: 'ledger',
+          ),
+        ],
+        committed: true,
+        createdAt: 2,
+      ),
+    );
+    await facts.insertTentative(_fact('kept', sourceMessageId: 'previous'));
+    await facts.insertTentative(_fact('excluded', sourceMessageId: 'target'));
+
+    final context = await loader.loadReadOnly(
+      sessionId: 's',
+      sourceCharacter: _character('one'),
+      excludeSnapshotMessageId: 'target',
+    );
+
+    expect(context.committedTrackers.single.value, 'before');
+    expect(context.resolution.activeFacts.map((fact) => fact.id), ['kept']);
+    expect(
+      await loader.isStillCurrentReadOnly(
+        sessionId: 's',
+        sourceCharacter: _character('one'),
+        stamp: context.stamp,
+        excludeSnapshotMessageId: 'target',
+      ),
+      isTrue,
+    );
   });
 
   test('read-only exact state overrides current Ledger and facts', () async {
@@ -504,16 +565,17 @@ void main() {
 Character _character(String description) =>
     Character(id: 'c', name: 'Character', description: description);
 
-CharacterKnowledgeFact _fact(String id) => CharacterKnowledgeFact(
-  id: id,
-  chatSessionId: 's',
-  knowerKey: 'alice',
-  subjectKey: 'bob',
-  factClass: CharacterKnowledgeFactClass.knowledge,
-  predicate: 'knows',
-  object: 'original',
-  epistemicState: CharacterKnowledgeEpistemicState.observed,
-  sourceMessageId: 'm',
-  sourceSwipeId: 0,
-  sourceAgentSwipeId: 0,
-);
+CharacterKnowledgeFact _fact(String id, {String sourceMessageId = 'm'}) =>
+    CharacterKnowledgeFact(
+      id: id,
+      chatSessionId: 's',
+      knowerKey: 'alice',
+      subjectKey: 'bob',
+      factClass: CharacterKnowledgeFactClass.knowledge,
+      predicate: 'knows',
+      object: 'original',
+      epistemicState: CharacterKnowledgeEpistemicState.observed,
+      sourceMessageId: sourceMessageId,
+      sourceSwipeId: 0,
+      sourceAgentSwipeId: 0,
+    );

--- a/test/ledger_raw_tracker_state_reader_test.dart
+++ b/test/ledger_raw_tracker_state_reader_test.dart
@@ -180,4 +180,77 @@ void main() {
       {'world:time': '14:15', 'world:date': '26.08.2026', 'world:day': '0'},
     );
   });
+
+  test(
+    'regen exclusion reads the previous snapshot without live leakage',
+    () async {
+      await snapshots.upsertTrackers(
+        sessionId: 'session',
+        messageId: 'previous',
+        swipeId: 0,
+        agentSwipeId: 0,
+        committed: true,
+        trackers: const [
+          Tracker(
+            sessionId: 'session',
+            name: 'world:time',
+            value: '12:00',
+            scope: 'ledger',
+          ),
+          Tracker(
+            sessionId: 'session',
+            name: 'scene.location',
+            value: 'before',
+            scope: 'ledger',
+          ),
+        ],
+      );
+      await snapshots.upsertTrackers(
+        sessionId: 'session',
+        messageId: 'target',
+        swipeId: 0,
+        agentSwipeId: 0,
+        committed: true,
+        trackers: const [
+          Tracker(
+            sessionId: 'session',
+            name: 'world:time',
+            value: '12:30',
+            scope: 'ledger',
+          ),
+          Tracker(
+            sessionId: 'session',
+            name: 'scene.location',
+            value: 'after',
+            scope: 'ledger',
+          ),
+        ],
+      );
+      await trackers.upsertValue(
+        'session',
+        'world:time',
+        '12:30',
+        scope: 'ledger',
+      );
+      await trackers.upsertValue(
+        'session',
+        'world:date',
+        '01.01.2027',
+        scope: 'ledger',
+      );
+      await trackers.upsertValue('session', 'world:day', '1', scope: 'ledger');
+
+      final state = await db.transaction(
+        () => reader.read('session', excludeSnapshotMessageId: 'target'),
+      );
+
+      expect(
+        {
+          for (final tracker in state.committedTrackers)
+            tracker.name: tracker.value,
+        },
+        {'world:time': '12:00', 'scene.location': 'before'},
+      );
+    },
+  );
 }

--- a/test/ledger_reconciliation_lease_repo_test.dart
+++ b/test/ledger_reconciliation_lease_repo_test.dart
@@ -118,4 +118,18 @@ void main() {
 
     expect(await db.select(db.ledgerReconciliationLeases).get(), isEmpty);
   });
+
+  test('new app scope clears process-orphaned leases', () async {
+    await repo.acquire(
+      sessionId: 'session',
+      ownerId: 'dead-process',
+      purpose: 'manual',
+      ttlSeconds: 3600,
+      now: 100,
+    );
+
+    await repo.clearProcessOrphans();
+
+    expect(await db.select(db.ledgerReconciliationLeases).get(), isEmpty);
+  });
 }

--- a/test/manual_studio_ledger_service_test.dart
+++ b/test/manual_studio_ledger_service_test.dart
@@ -164,7 +164,8 @@ void main() {
     expect(ledger.lastTurnConfig?.pipelineSettings, isNot(same(pipeline)));
     expect(ledger.lastConfig?.endpoint, 'https://snapshot.example');
     expect(ledger.lastConfig?.model, 'snapshot-model');
-    expect(ledger.lastRecentHistory, contains('Assistant: Two'));
+    expect(ledger.lastRecentHistory, contains('User: Second'));
+    expect(ledger.lastRecentHistory, isNot(contains('Assistant: Two')));
     expect(ledger.lastMacroContext?.charName, 'Character');
     final diagnostic = await trackerRepo.get(
       'session',
@@ -251,6 +252,19 @@ void main() {
       ),
     );
     expect(ledger.reconcileCalls, 0);
+  });
+
+  test('missing Ledger recovery reruns the exact due endpoint', () async {
+    final messages = reconciliationMessages();
+    await putSession('session', messages: messages);
+
+    final outcome = await createService().rerunMissingForReconciliation(
+      'session',
+    );
+
+    expect(outcome.target.id, 'a6');
+    expect(ledger.runCalls, 1);
+    expect(ledger.lastTarget?.id, 'a6');
   });
 
   test('disabled Ledger preset blocks manual reconciliation', () async {
@@ -404,6 +418,7 @@ class _FakeLedgerExecutor implements StudioLedgerExecutor {
   MacroContext? lastMacroContext;
   LedgerReconciliationPlan? lastPlan;
   StudioLedgerEngine? lastEngine;
+  ChatMessage? lastTarget;
   String? lastExpectedRunId;
   Future<void> Function()? beforeRunComplete;
   Future<void> Function()? beforeReconcileComplete;
@@ -428,6 +443,7 @@ class _FakeLedgerExecutor implements StudioLedgerExecutor {
     lastRecentHistory = recentHistoryText;
     lastMacroContext = macroCtx;
     lastEngine = engine;
+    lastTarget = target;
     if (!runStarted.isCompleted) runStarted.complete();
     await beforeRunComplete?.call();
     if (!await isStillCurrent()) return LedgerRunResult.aborted;

--- a/test/pipeline_utils_test.dart
+++ b/test/pipeline_utils_test.dart
@@ -9,6 +9,7 @@ ChatMessage _msg({
   required String content,
   bool isError = false,
   bool isTyping = false,
+  bool isHidden = false,
 }) {
   return ChatMessage(
     id: id,
@@ -16,6 +17,7 @@ ChatMessage _msg({
     content: content,
     isError: isError,
     isTyping: isTyping,
+    isHidden: isHidden,
   );
 }
 
@@ -41,7 +43,7 @@ void main() {
       expect(result, 'User: Hello\n\nAssistant: Hi there');
     });
 
-    test('uses "Assistant" for assistant role, "User" for everything else', () {
+    test('keeps only user and assistant roles', () {
       final result = extractRecentHistoryText([
         _msg(id: 'm1', role: 'user', content: 'Q'),
         _msg(id: 'm2', role: 'assistant', content: 'A'),
@@ -49,7 +51,7 @@ void main() {
       ]);
       expect(result.contains('User: Q'), isTrue);
       expect(result.contains('Assistant: A'), isTrue);
-      expect(result.contains('User: S'), isTrue);
+      expect(result.contains('S'), isFalse);
     });
 
     test('skips error messages', () {
@@ -77,6 +79,25 @@ void main() {
         _msg(id: 'm3', role: 'assistant', content: 'Real reply'),
       ]);
       expect(result, 'User: Hello\n\nAssistant: Real reply');
+    });
+
+    test('skips hidden messages before applying the limit', () {
+      final result = extractRecentHistoryText([
+        _msg(id: 'm1', role: 'user', content: 'Kept'),
+        _msg(id: 'm2', role: 'assistant', content: 'Hidden', isHidden: true),
+        _msg(id: 'm3', role: 'assistant', content: 'Visible'),
+      ], maxMessages: 2);
+
+      expect(result, 'User: Kept\n\nAssistant: Visible');
+    });
+
+    test('excludes a response supplied separately to Ledger', () {
+      final result = extractRecentHistoryText([
+        _msg(id: 'u1', role: 'user', content: 'Question'),
+        _msg(id: 'a1', role: 'assistant', content: 'Answer'),
+      ], excludeMessageId: 'a1');
+
+      expect(result, 'User: Question');
     });
 
     test('limits to last N messages', () {

--- a/test/reconciler_view_service_test.dart
+++ b/test/reconciler_view_service_test.dart
@@ -7,6 +7,8 @@ import 'package:glaze_flutter/core/db/repositories/chat_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_debug_run_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_checkpoint_repo.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_run_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/tracker_snapshot_repo.dart';
+import 'package:glaze_flutter/core/models/tracker_snapshot.dart';
 import 'package:glaze_flutter/core/utils/cast_helpers.dart';
 import 'package:glaze_flutter/features/chat/services/reconciler_view_service.dart';
 
@@ -23,6 +25,7 @@ void main() {
       debugRepo: LedgerDebugRunRepo(db),
       checkpointRepo: LedgerReconciliationCheckpointRepo(db),
       chatRepo: ChatRepo(db),
+      snapshotRepo: TrackerSnapshotRepo(db),
     );
   });
 
@@ -65,6 +68,39 @@ void main() {
       expect(snapshot.runs.single.invalidation?.reason, 'manual replacement');
     },
   );
+
+  test('reports the exact missing Ledger endpoint for a due range', () async {
+    final messages = [
+      const {'id': 'a1', 'role': 'assistant', 'content': 'Opening'},
+      for (var i = 2; i <= 7; i++) ...[
+        {'id': 'u$i', 'role': 'user', 'content': 'User $i'},
+        {'id': 'a$i', 'role': 'assistant', 'content': 'Assistant $i'},
+      ],
+    ];
+    await db.customStatement(
+      'INSERT INTO chat_sessions '
+      '(session_id, character_id, session_index, messages_json) '
+      'VALUES (?, ?, ?, ?)',
+      ['due', 'character', 0, jsonEncode(messages)],
+    );
+
+    var snapshot = await service.load('due');
+    expect(snapshot.missingLedgerTarget?.id, 'a6');
+
+    await TrackerSnapshotRepo(db).upsert(
+      const TrackerSnapshot(
+        sessionId: 'due',
+        messageId: 'a6',
+        swipeId: 0,
+        agentSwipeId: 0,
+        trackers: [],
+        committed: true,
+        createdAt: 1,
+      ),
+    );
+    snapshot = await service.load('due');
+    expect(snapshot.missingLedgerTarget, isNull);
+  });
 
   test(
     'returns reconciliation debug rows without normal Ledger rows',

--- a/test/studio_ledger_test.dart
+++ b/test/studio_ledger_test.dart
@@ -192,7 +192,7 @@ void main() {
       expect(prompt, contains('delete npc:Name.location'));
       expect(prompt, contains('never use it as a backlog'));
       expect(prompt, contains('accepted assistant prose as evidence'));
-      expect(prompt, contains('3–10 minutes'));
+      expect(prompt, contains('1–5 minutes'));
     });
 
     test('rejects append histories and legacy knowledge tracker keys', () {
@@ -435,7 +435,8 @@ void main() {
         expect(prompt, contains('DB PROMPT'));
         expect(prompt, contains('npc:Unidentified Netrunner.location'));
         expect(prompt, contains('npc:Rebecca.location'));
-        expect(prompt, contains('advance time by 3–10 minutes'));
+        expect(prompt, contains('never add their'));
+        expect(prompt, contains('elapsed time again'));
         final state = RegExp(
           r'<committed_state>([\s\S]*?)</committed_state>',
         ).firstMatch(prompt)!.group(1)!;

--- a/test/studio_ledger_transaction_test.dart
+++ b/test/studio_ledger_transaction_test.dart
@@ -1518,18 +1518,8 @@ Future<({String url, Future<void> Function() close})> _serve(
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   unawaited(
     server.first.then((request) async {
-      await utf8.decoder.bind(request).join();
-      request.response.headers.contentType = ContentType.json;
-      request.response.write(
-        jsonEncode({
-          'choices': [
-            {
-              'message': {'content': content},
-            },
-          ],
-        }),
-      );
-      await request.response.close();
+      final body = await utf8.decoder.bind(request).join();
+      await _respondChat(request, body, content);
     }),
   );
   return (
@@ -1545,18 +1535,8 @@ Future<({String url, Future<void> Function() close})> _serveTwice(
 ) async {
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   server.listen((request) async {
-    await utf8.decoder.bind(request).join();
-    request.response.headers.contentType = ContentType.json;
-    request.response.write(
-      jsonEncode({
-        'choices': [
-          {
-            'message': {'content': content},
-          },
-        ],
-      }),
-    );
-    await request.response.close();
+    final body = await utf8.decoder.bind(request).join();
+    await _respondChat(request, body, content);
   });
   return (
     url: 'http://${server.address.host}:${server.port}',
@@ -1577,20 +1557,10 @@ _serveDelayed(String content) async {
   final requestReceived = Completer<void>();
   final release = Completer<void>();
   server.listen((request) async {
-    await utf8.decoder.bind(request).join();
+    final body = await utf8.decoder.bind(request).join();
     if (!requestReceived.isCompleted) requestReceived.complete();
     await release.future;
-    request.response.headers.contentType = ContentType.json;
-    request.response.write(
-      jsonEncode({
-        'choices': [
-          {
-            'message': {'content': content},
-          },
-        ],
-      }),
-    );
-    await request.response.close();
+    await _respondChat(request, body, content);
   });
   return (
     url: 'http://${server.address.host}:${server.port}',
@@ -1608,19 +1578,8 @@ _serveCounting(String content, {int statusCode = 200}) async {
   var count = 0;
   server.listen((request) async {
     count++;
-    await utf8.decoder.bind(request).join();
-    request.response.statusCode = statusCode;
-    request.response.headers.contentType = ContentType.json;
-    request.response.write(
-      jsonEncode({
-        'choices': [
-          {
-            'message': {'content': content},
-          },
-        ],
-      }),
-    );
-    await request.response.close();
+    final body = await utf8.decoder.bind(request).join();
+    await _respondChat(request, body, content, statusCode: statusCode);
   });
   return (
     url: 'http://${server.address.host}:${server.port}',
@@ -1711,9 +1670,54 @@ _serveSequence(List<String> contents) async {
   var requests = 0;
   final bodies = <String>[];
   server.listen((request) async {
-    bodies.add(await utf8.decoder.bind(request).join());
+    final body = await utf8.decoder.bind(request).join();
+    bodies.add(body);
     final index = requests++;
     final content = contents[index.clamp(0, contents.length - 1)];
+    await _respondChat(request, body, content);
+  });
+  return (
+    url: 'http://${server.address.host}:${server.port}',
+    close: () async {
+      await server.close(force: true);
+    },
+    requests: () => requests,
+    bodies: () => List<String>.unmodifiable(bodies),
+  );
+}
+
+Future<void> _respondChat(
+  HttpRequest request,
+  String requestBody,
+  String content, {
+  int statusCode = 200,
+}) async {
+  request.response.statusCode = statusCode;
+  if (statusCode != 200) {
+    request.response.headers.contentType = ContentType.json;
+    request.response.write('{}');
+    await request.response.close();
+    return;
+  }
+
+  final payload = jsonDecode(requestBody) as Map<String, dynamic>;
+  if (payload['stream'] == true) {
+    request.response.headers.contentType = ContentType(
+      'text',
+      'event-stream',
+      charset: 'utf-8',
+    );
+    request.response.write(
+      'data: ${jsonEncode({
+        'choices': [
+          {
+            'delta': {'content': content},
+          },
+        ],
+      })}\n\n',
+    );
+    request.response.write('data: [DONE]\n\n');
+  } else {
     request.response.headers.contentType = ContentType.json;
     request.response.write(
       jsonEncode({
@@ -1724,14 +1728,6 @@ _serveSequence(List<String> contents) async {
         ],
       }),
     );
-    await request.response.close();
-  });
-  return (
-    url: 'http://${server.address.host}:${server.port}',
-    close: () async {
-      await server.close(force: true);
-    },
-    requests: () => requests,
-    bodies: () => List<String>.unmodifiable(bodies),
-  );
+  }
+  await request.response.close();
 }


### PR DESCRIPTION
## Summary
- stream reconciliation and repair responses so long-running calls survive response delivery failures
- retry transient Dio connection and timeout failures, and clear process-orphaned reconciliation leases during startup
- tighten ordinary Ledger clock advancement to 1-5 minutes while preventing reconciliation from charging elapsed time twice
- exclude the separately supplied assistant response and hidden/non-chat messages from recent Ledger history
- update reconciliation HTTP fixtures to cover streaming responses

## Verification
- `flutter test test/aux_retry_test.dart test/ledger_reconciliation_lease_repo_test.dart test/pipeline_utils_test.dart`
- `flutter test test/studio_ledger_test.dart test/studio_ledger_transaction_test.dart`
- targeted `flutter analyze` for all changed Dart files
- `git diff --check`