### PR TITLE
fix: sync app settings and restore generation lifecycle

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -950,16 +950,13 @@ compatibility backfill into `messageRange`.
 
 `MemoryDraftPlanner` scans stable user/assistant messages, leaves a configurable
 recent-message lag, and creates only complete fixed-size ranges. The post-turn
-`MemoryDraftStage` and manual **Scan Chat** action create empty drafts without an
-LLM call. Draft text is generated later through
-`MemoryDraftGenerationController` + `memory_draft_generator.dart`, then remains
-`pending_approval` until the user accepts it. Approval copies content, keys,
-message provenance, and range into an active `MemoryEntry`; vector indexing is
-best-effort when enabled.
-
-The `autoGenerateEnabled` setting exists in model/UI, but the current automatic
-post-turn stage does not invoke LLM draft generation. Automatic draft creation
-is not automatic memory population or approval.
+`MemoryDraftStage` and manual **Scan Chat** create drafts from complete ranges.
+When `autoGenerateEnabled` is enabled, the post-turn stage immediately fills
+newly created drafts through the configured Memory Book LLM. Generated drafts
+remain `pending_approval` until the user accepts them. Approval copies content,
+keys, message provenance, and range into an active `MemoryEntry`; vector indexing
+is best-effort when enabled. Manual **Scan Chat** keeps its explicit review and
+generation workflow.
 
 ### Retrieval and injection rule
 

--- a/lib/core/db/repositories/memory_book_repo.dart
+++ b/lib/core/db/repositories/memory_book_repo.dart
@@ -198,6 +198,27 @@ class MemoryBookRepo extends DatabaseAccessor<AppDatabase>
     });
   }
 
+  /// Applies a narrow mutation to one draft using the latest durable book.
+  /// Returns false when the book or draft was removed while work was in flight.
+  Future<bool> mutateDraft({
+    required String sessionId,
+    required String draftId,
+    required MemoryDraft Function(MemoryDraft current) mutate,
+  }) async {
+    var updated = false;
+    await transaction(() async {
+      final existing = await getBySessionId(sessionId);
+      if (existing == null) return;
+      final index = existing.pendingDrafts.indexWhere((d) => d.id == draftId);
+      if (index < 0) return;
+      final drafts = [...existing.pendingDrafts];
+      drafts[index] = mutate(drafts[index]);
+      await put(existing.copyWith(pendingDrafts: drafts));
+      updated = true;
+    });
+    return updated;
+  }
+
   /// Atomically appends [entries] to the approved entries of the memory book
   /// for [sessionId]. Wraps the read-modify-write in a transaction so
   /// concurrent writes cannot interleave (database.md Rule 3).

--- a/lib/features/chat/memory_draft_generator.dart
+++ b/lib/features/chat/memory_draft_generator.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 
 import '../../core/llm/transport/chat_transport_request.dart';
 import '../../core/llm/memory_book_api_config_resolver.dart';
@@ -14,9 +15,11 @@ import '../../core/state/memory_settings_provider.dart';
 import '../settings/api_list_provider.dart';
 
 class MemoryDraftGenerator {
-  final WidgetRef _ref;
+  final T Function<T>(ProviderListenable<T> provider) _read;
 
-  MemoryDraftGenerator(this._ref);
+  MemoryDraftGenerator(Ref ref) : _read = ref.read;
+
+  MemoryDraftGenerator.widget(WidgetRef ref) : _read = ref.read;
 
   Future<MemoryDraft> generate({
     required MemoryDraft draft,
@@ -26,7 +29,7 @@ class MemoryDraftGenerator {
     CancelToken? cancelToken,
   }) async {
     final customPrompts = MemoryPromptPreset.fromJsonList(
-      _ref.read(memoryGlobalSettingsProvider).customPrompts,
+      _read(memoryGlobalSettingsProvider).customPrompts,
     );
     final template = MemoryPromptPresets.resolve(
       settings.promptPreset,
@@ -50,10 +53,10 @@ class MemoryDraftGenerator {
       model = pipeline.memoryBookApi.generationModel;
       protocol = LlmProtocol.customChatCompletion;
     } else {
-      await _ref.read(apiListProvider.future);
+      await _read(apiListProvider.future);
       final chatConfig = MemoryBookApiConfigResolver(
-        apiConfigs: _ref.read(apiListProvider).value ?? const [],
-        activeConfig: _ref.read(activeApiConfigProvider),
+        apiConfigs: _read(apiListProvider).value ?? const [],
+        activeConfig: _read(activeApiConfigProvider),
       ).resolve(pipeline.memoryBookApi);
       if (chatConfig == null) {
         throw Exception('No chat API config available');

--- a/lib/features/chat/services/stages/memory_draft_stage.dart
+++ b/lib/features/chat/services/stages/memory_draft_stage.dart
@@ -1,25 +1,66 @@
 import 'package:flutter/foundation.dart';
 
 import '../../../../core/llm/memory_draft_planner.dart';
+import '../../../../core/llm/auxiliary_timed_history.dart';
 import '../../../../core/models/chat_message.dart';
+import '../../../../core/models/memory_book.dart';
+import '../../../../core/models/pipeline_settings.dart';
 import '../../../../core/state/db_provider.dart';
 import '../../../../core/state/memory_settings_provider.dart';
+import '../../../memory/state/memory_active_drafts_provider.dart';
+import '../../memory_draft_generator.dart';
 import 'stage_context.dart';
 
-/// Stage 9 / 6: Auto-create memory drafts (parallel fire-and-forget,
-/// no LLM — just a planner over the MemoryBook).
+typedef GenerateMemoryDraft =
+    Future<MemoryDraft> Function({
+      required MemoryDraft draft,
+      required MemoryBookSettings settings,
+      required PipelineSettings pipeline,
+      required String historyText,
+    });
+
+/// Stage 9 / 6: Auto-create memory drafts and optionally fill them with the
+/// configured Memory Book LLM.
 class MemoryDraftStage {
   final StageContext ctx;
+  final GenerateMemoryDraft _generate;
 
-  MemoryDraftStage(this.ctx);
+  MemoryDraftStage(this.ctx, {GenerateMemoryDraft? generate})
+    : _generate =
+          generate ??
+          (({
+            required draft,
+            required settings,
+            required pipeline,
+            required historyText,
+          }) => MemoryDraftGenerator(ctx.ref).generate(
+            draft: draft,
+            settings: settings,
+            pipeline: pipeline,
+            historyText: historyText,
+          ));
 
-  Future<void> run(ChatSession? session) async {
-    if (!ctx.ref.mounted) return;
-    if (session == null) return;
+  MemoryDraftLease? reserveAutoGeneration(ChatSession? session) {
+    if (session == null || !ctx.ref.mounted) return null;
     final settings = ctx.ref.read(memoryGlobalSettingsProvider);
-    if (!settings.enabled || !settings.autoCreateEnabled) return;
+    if (!settings.enabled ||
+        !settings.autoCreateEnabled ||
+        !settings.autoGenerateEnabled) {
+      return null;
+    }
+    return ctx.ref
+        .read(memoryActiveDraftsProvider.notifier)
+        .tryAcquireExclusive(session.id);
+  }
 
+  Future<void> run(
+    ChatSession? session, {
+    MemoryDraftLease? generationLease,
+  }) async {
     try {
+      if (!ctx.ref.mounted || session == null) return;
+      final settings = ctx.ref.read(memoryGlobalSettingsProvider);
+      if (!settings.enabled || !settings.autoCreateEnabled) return;
       final repo = ctx.ref.read(memoryBookRepoProvider);
       final book = await repo.ensureForSession(session.id);
       if (!ctx.ref.mounted) return;
@@ -33,11 +74,58 @@ class MemoryDraftStage {
       );
       if (plan.drafts.isEmpty) return;
 
-      await repo.put(
-        book.copyWith(pendingDrafts: [...book.pendingDrafts, ...plan.drafts]),
-      );
+      await repo.appendDrafts(session.id, plan.drafts);
+      if (!settings.autoGenerateEnabled || generationLease == null) return;
+
+      final pipeline = ctx.ref.read(pipelineSettingsProvider);
+      for (final draft in plan.drafts.take(settings.batchSize)) {
+        if (!ctx.ref.mounted) return;
+        final draftMessages = session.messages
+            .where((message) => draft.messageIds.contains(message.id))
+            .toList();
+        if (draftMessages.isEmpty) continue;
+        final historyText = draftMessages
+            .map(
+              (message) => '${message.role}: ${auxiliaryTimedContent(message)}',
+            )
+            .join('\n\n');
+        try {
+          final generated = await _generate(
+            draft: draft,
+            settings: book.settings,
+            pipeline: pipeline,
+            historyText: historyText,
+          );
+          if (!ctx.ref.mounted) return;
+          await repo.mutateDraft(
+            sessionId: session.id,
+            draftId: draft.id,
+            mutate: (current) => current.copyWith(
+              content: generated.content,
+              keys: generated.keys,
+              status: 'pending_approval',
+              generatedAt: generated.generatedAt,
+              updatedAt: generated.updatedAt,
+              error: null,
+            ),
+          );
+        } catch (e) {
+          if (!ctx.ref.mounted) return;
+          await repo.mutateDraft(
+            sessionId: session.id,
+            draftId: draft.id,
+            mutate: (current) => current.copyWith(
+              status: 'needs_regeneration',
+              error: e.toString(),
+              updatedAt: DateTime.now().millisecondsSinceEpoch,
+            ),
+          );
+        }
+      }
     } catch (e) {
       debugPrint('[MemoryDraftStage] auto-create failed: $e');
+    } finally {
+      generationLease?.release();
     }
   }
 }

--- a/lib/features/chat/services/stages/post_gen_coordinator.dart
+++ b/lib/features/chat/services/stages/post_gen_coordinator.dart
@@ -70,11 +70,15 @@ class PostGenCoordinator {
   void _runInBackground(
     Future<void> Function() task,
     String label,
-    GenerationNotificationService notifService,
-  ) {
+    GenerationNotificationService notifService, {
+    void Function()? onTaskNotStarted,
+  }) {
     unawaited(() async {
-      final lease = await notifService.acquirePostGenerationLease();
+      var taskStarted = false;
+      PostGenerationForegroundLease? lease;
       try {
+        lease = await notifService.acquirePostGenerationLease();
+        taskStarted = true;
         await task();
       } catch (error, stackTrace) {
         debugPrint(
@@ -82,7 +86,8 @@ class PostGenCoordinator {
           '$error\n$stackTrace',
         );
       } finally {
-        await lease.release();
+        if (!taskStarted) onTaskNotStarted?.call();
+        await lease?.release();
       }
     }());
   }
@@ -147,17 +152,30 @@ class PostGenCoordinator {
     if (result.session == null) return;
 
     final sessionId = result.session!.id;
+    final studioEnabled = studioTurnConfig?.enabled == true;
+    // Normal chat has no foreground post-gen hold. Claim the memory session
+    // before the first await so a new send cannot enter while auto-generation
+    // is waiting to be scheduled.
+    final ordinaryMemoryLease = studioEnabled
+        ? null
+        : draftStage.reserveAutoGeneration(result.session);
 
     // Stage 3 / 2: Sync + notification (immediate, awaited).
-    await syncStage.run(
-      result: result,
-      genId: genId,
-      character: character,
-      notifService: notifService,
-    );
-    if (!ctx.ref.mounted || !ctx.abortHandler.isCurrentGen(genId)) return;
-
-    final studioEnabled = studioTurnConfig?.enabled == true;
+    try {
+      await syncStage.run(
+        result: result,
+        genId: genId,
+        character: character,
+        notifService: notifService,
+      );
+    } catch (_) {
+      ordinaryMemoryLease?.release();
+      rethrow;
+    }
+    if (!ctx.ref.mounted || !ctx.abortHandler.isCurrentGen(genId)) {
+      ordinaryMemoryLease?.release();
+      return;
+    }
 
     // Embedding is independent of the Studio Ledger clock and can start from
     // the committed response immediately.
@@ -172,9 +190,13 @@ class PostGenCoordinator {
     );
     if (!studioEnabled) {
       _runInBackground(
-        () => draftStage.run(result.session),
+        () => draftStage.run(
+          result.session,
+          generationLease: ordinaryMemoryLease,
+        ),
         'memory auto-draft',
         notifService,
+        onTaskNotStarted: ordinaryMemoryLease?.release,
       );
       _runInBackground(
         () => autoSummaryStage.run(result.session),
@@ -237,10 +259,12 @@ class PostGenCoordinator {
             refreshed == null) {
           return;
         }
+        final memoryLease = draftStage.reserveAutoGeneration(refreshed);
         _runInBackground(
-          () => draftStage.run(refreshed),
+          () => draftStage.run(refreshed, generationLease: memoryLease),
           'memory auto-draft',
           notifService,
+          onTaskNotStarted: memoryLease?.release,
         );
         _runInBackground(
           () => autoSummaryStage.run(refreshed),

--- a/lib/features/chat/widgets/chat_message_sync.dart
+++ b/lib/features/chat/widgets/chat_message_sync.dart
@@ -46,6 +46,7 @@ class ChatMessageSync {
     required int visibleStartIndex,
     required bool busy,
     required bool sessionSwitching,
+    void Function()? onDomReset,
   }) async {
     if (sessionSwitching) return;
     if (bridge == null) return;
@@ -55,6 +56,7 @@ class ChatMessageSync {
     final newLen = newIds.length;
 
     if (oldIds.isEmpty) {
+      onDomReset?.call();
       await bridge.setMessages(newMsgs, visibleStartIndex: visibleStartIndex);
       if (!busy) {
         await bridge.setLastMessage(
@@ -65,6 +67,7 @@ class ChatMessageSync {
     }
 
     if (newIds.isEmpty) {
+      onDomReset?.call();
       await bridge.clearAll();
       return;
     }
@@ -114,6 +117,7 @@ class ChatMessageSync {
         }
         return;
       }
+      onDomReset?.call();
       await bridge.clearAll();
       await bridge.setMessages(newMsgs, visibleStartIndex: visibleStartIndex);
       if (!busy) {
@@ -129,6 +133,7 @@ class ChatMessageSync {
     for (int i = 0; i < minLen; i++) {
       if (i >= newIds.length) break;
       if (newIds[i] != oldIds[i]) {
+        onDomReset?.call();
         await bridge.clearAll();
         await bridge.setMessages(newMsgs, visibleStartIndex: visibleStartIndex);
         if (!busy) {

--- a/lib/features/chat/widgets/chat_streaming_bridge_sync.dart
+++ b/lib/features/chat/widgets/chat_streaming_bridge_sync.dart
@@ -1,6 +1,74 @@
 import '../../../core/models/chat_message.dart';
 import '../bridge/chat_bridge_controller.dart';
+import '../chat_state.dart';
+import '../services/continuation_message_merger.dart';
 import 'chat_webview_sync_dispatcher.dart';
+
+/// Restores the transient generation presentation after [setMessages] replaces
+/// the WebView DOM. Unlike the regular dispatcher this is level-triggered: a
+/// generation may already be active when a fresh widget attaches.
+Future<void> reconcileActiveGenerationBridge({
+  required ChatBridgeController bridge,
+  required ChatWebViewSyncState syncState,
+  required bool isGenerating,
+  required bool isImpersonating,
+  required String? regenTargetId,
+  required String? continuationTargetId,
+  required StreamingState streaming,
+  required List<ChatMessage> messages,
+  required String streamingId,
+  required bool Function() isCurrent,
+}) async {
+  syncState.wasGenerating = isGenerating;
+  bridge.continuationTargetId = continuationTargetId;
+
+  if (!isGenerating || isImpersonating || !isCurrent()) {
+    syncState.streamingSent = false;
+    syncState.regenStreamingSent = false;
+    return;
+  }
+
+  final targetId = regenTargetId ?? continuationTargetId;
+  if (targetId != null) {
+    final index = messages.indexWhere((message) => message.id == targetId);
+    if (index < 0) return;
+    final original = messages[index];
+    final updated = continuationTargetId != null
+        ? original.copyWith(
+            content: joinContinuation(original.content, streaming.text),
+            reasoning:
+                joinContinuationReasoning(
+                  original.reasoning,
+                  streaming.reasoning,
+                ) ??
+                original.reasoning,
+            isTyping: true,
+          )
+        : original.copyWith(
+            content: streaming.text,
+            reasoning: streaming.reasoning ?? original.reasoning,
+            isTyping: true,
+          );
+    await bridge.updateMessage(updated);
+    if (isCurrent()) syncState.regenStreamingSent = true;
+    return;
+  }
+
+  final placeholder = ChatMessage(
+    id: streamingId,
+    role: 'assistant',
+    content: streaming.text,
+    reasoning: streaming.reasoning,
+    timestamp: DateTime.now().millisecondsSinceEpoch,
+    isTyping: true,
+  );
+  if (syncState.streamingSent) {
+    await bridge.updateMessage(placeholder);
+  } else {
+    await bridge.appendMessage(placeholder);
+  }
+  if (isCurrent()) syncState.streamingSent = true;
+}
 
 /// Serializes streaming bridge calls and drops completions that no longer own
 /// the current generation/session epoch.

--- a/lib/features/chat/widgets/chat_webview_build_listeners.dart
+++ b/lib/features/chat/widgets/chat_webview_build_listeners.dart
@@ -45,6 +45,8 @@ class ChatWebViewBuildListeners {
     required this.visibleStartIndex,
     required this.onRefreshExtBlocksPanel,
     required this.onSyncExtBlockPanels,
+    required this.onReconcileActiveGeneration,
+    required this.onDomReset,
     this.isCurrentBridge,
   });
 
@@ -65,6 +67,9 @@ class ChatWebViewBuildListeners {
   final Future<void> Function(String sessionId, String messageId)
   onRefreshExtBlocksPanel;
   final Future<void> Function() onSyncExtBlockPanels;
+  final Future<void> Function(ChatBridgeController bridge)
+  onReconcileActiveGeneration;
+  final void Function() onDomReset;
   final bool Function(ChatBridgeController bridge)? isCurrentBridge;
 
   /// Attach all `ref.listen` callbacks for the current build. Call
@@ -76,7 +81,8 @@ class ChatWebViewBuildListeners {
     _listenStreaming();
     _listenInfoBlocks();
     _listenExtSettingsAndPresets();
-}
+  }
+
   void _listenDisplayRegexes() {
     ref.listen<AsyncValue<List<PresetRegex>>>(displayRegexesProvider, (
       prev,
@@ -99,11 +105,16 @@ class ChatWebViewBuildListeners {
         // full re-render of every message. Preserve the current scroll position
         // so the chat stays put instead of jumping (see restoreAnchor in the
         // webview virtual list).
-        b.setMessages(
-          messages,
-          visibleStartIndex: visibleStartIndex,
-          preserveScroll: true,
-        );
+        unawaited(() async {
+          onDomReset();
+          await b.setMessages(
+            messages,
+            visibleStartIndex: visibleStartIndex,
+            preserveScroll: true,
+          );
+          if (isCurrentBridge?.call(b) == false || !ready()) return;
+          await onReconcileActiveGeneration(b);
+        }());
       }
     });
   }

--- a/lib/features/chat/widgets/chat_webview_initializer.dart
+++ b/lib/features/chat/widgets/chat_webview_initializer.dart
@@ -201,6 +201,11 @@ class ChatWebViewInitializer {
           .toList(),
       patchMessages: false,
     );
+    // Seed the phase before rendering an active typing node. The renderer uses
+    // this value while constructing the node, not only on later transitions.
+    await bridge.setGenerationPhase(
+      generationPhaseLabel(ref.read(generationPhaseProvider(input.charId))),
+    );
     await bridge.setMessages(
       input.messages,
       visibleStartIndex: input.visibleStartIndex,
@@ -232,14 +237,6 @@ class ChatWebViewInitializer {
         'window.bridge.setPostGenRunning(${input.isPostGenRunning}); '
         'window.bridge.setImageGenerating(${input.isGeneratingImage}); '
         '}',
-      ),
-    );
-    // A fresh page starts with the default typing label, so re-push the phase
-    // of a run that is already in flight (session switch, WebView reload).
-    // `ref.listen` only fires on transitions and would leave it stale here.
-    unawaited(
-      bridge.setGenerationPhase(
-        generationPhaseLabel(ref.read(generationPhaseProvider(input.charId))),
       ),
     );
     onReady();

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -19,7 +19,9 @@ import '../../../shared/widgets/glaze_error_dialog.dart';
 import '../../extensions/services/panel_host_service.dart';
 import '../bridge/chat_bridge_registry.dart';
 import '../chat_provider.dart';
+import '../state/generation_phase_provider.dart';
 import 'chat_message_sync.dart';
+import 'chat_streaming_bridge_sync.dart';
 import 'chat_webview_build_listeners.dart';
 import 'chat_webview_callbacks.dart';
 import 'chat_webview_ext_block_callbacks.dart';
@@ -413,6 +415,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     final initSessionId = widget.sessionId;
     final initMessages = List<ChatMessage>.of(widget.messages);
     final initVisibleStartIndex = widget.visibleStartIndex;
+    _resetStreamingPresentationState();
     PerfDebug.chatWebViewInitAttempted();
     try {
       await _waitForJsBridgeReady();
@@ -487,6 +490,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     }
 
     if (!mounted) return;
+    await _reconcileActiveGenerationPresentation(bridge);
     // Init can take longer than the rebaseline window opened above, and the
     // list settles for a few more frames after it. Re-arm once everything is in
     // place so the chat is guaranteed to open with the header showing.
@@ -566,6 +570,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       // header tracker would otherwise read as the user scrolling down.
       await _showChatHeader(bridge);
       await _bridgeOp(bridge.clearAll(), label: 'clearAll');
+      _resetStreamingPresentationState();
       await _bridgeOp(
         bridge.setMessages(
           widget.messages,
@@ -573,6 +578,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
         ),
         label: 'setMessages',
       );
+      await _reconcileActiveGenerationPresentation(bridge);
       unawaited(_syncExtBlockPanels());
       await _bridgeOp(bridge.scrollToBottom(), label: 'scrollToBottom');
     } finally {
@@ -602,9 +608,11 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
         visibleStartIndex: widget.visibleStartIndex,
         busy: widget.isGenerating || widget.isSendPending,
         sessionSwitching: false,
+        onDomReset: _resetStreamingPresentationState,
       ),
       label: 'resyncMessagesAfterInit',
     );
+    await _reconcileActiveGenerationPresentation(bridge);
   }
 
   void _bindBridgeCallbacks() {
@@ -814,6 +822,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
 
       await _bridgeOp(bridge.clearAll(), label: 'clearAll');
       if (!ownsSwitch()) return;
+      _resetStreamingPresentationState();
       await _bridgeOp(
         bridge.setMessages(
           widget.messages,
@@ -822,12 +831,69 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
         label: 'setMessages',
       );
       if (!ownsSwitch()) return;
+      await _reconcileActiveGenerationPresentation(bridge);
+      if (!ownsSwitch()) return;
       unawaited(_syncExtBlockPanels());
       await _bridgeOp(bridge.scrollToBottom(), label: 'scrollToBottom');
     } finally {
       if (ownsSwitch()) _setSessionSwitching(false);
     }
-    _syncState.wasGenerating = widget.isGenerating;
+  }
+
+  Future<void> _reconcileActiveGenerationPresentation(
+    ChatBridgeController bridge, {
+    bool enqueue = true,
+  }) async {
+    if (!mounted || !identical(_bridge, bridge) || !_ready) return;
+    final charId = widget.charId;
+    final sessionId = widget.sessionId;
+    final epoch = _syncState.streamEpoch;
+    final isGenerating = widget.isGenerating;
+    final regenTargetId = widget.regenTargetId;
+    final continuationTargetId = widget.continuationTargetId;
+    final messages = List<ChatMessage>.of(widget.messages);
+    final streaming = ref.read(streamingStateProvider(charId));
+    final isImpersonating = ref.read(impersonationStateProvider(charId)).active;
+
+    bool isCurrent() =>
+        mounted &&
+        identical(_bridge, bridge) &&
+        _ready &&
+        widget.charId == charId &&
+        widget.sessionId == sessionId &&
+        _syncState.streamEpoch == epoch &&
+        widget.isGenerating == isGenerating &&
+        widget.regenTargetId == regenTargetId &&
+        widget.continuationTargetId == continuationTargetId;
+
+    Future<void> reconcile() async {
+      if (!isCurrent()) return;
+      await bridge.setGenerationPhase(
+        generationPhaseLabel(ref.read(generationPhaseProvider(charId))),
+      );
+      if (!isCurrent()) return;
+      await reconcileActiveGenerationBridge(
+        bridge: bridge,
+        syncState: _syncState,
+        isGenerating: isGenerating,
+        isImpersonating: isImpersonating,
+        regenTargetId: regenTargetId,
+        continuationTargetId: continuationTargetId,
+        streaming: streaming,
+        messages: messages,
+        streamingId: _kStreamingId,
+        isCurrent: isCurrent,
+      );
+    }
+
+    if (enqueue) {
+      await _syncState.enqueueMessageMutation(reconcile);
+    } else {
+      await reconcile();
+    }
+  }
+
+  void _resetStreamingPresentationState() {
     _syncState.streamingSent = false;
     _syncState.regenStreamingSent = false;
   }
@@ -1027,6 +1093,10 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
                 sessionSwitching: sessionSwitching,
                 bridge: bridge,
               );
+              await _reconcileActiveGenerationPresentation(
+                bridge,
+                enqueue: false,
+              );
             }
             if (result.rehighlightSearch &&
                 mounted &&
@@ -1085,6 +1155,7 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       visibleStartIndex: visibleStartIndex,
       busy: busy,
       sessionSwitching: sessionSwitching,
+      onDomReset: _resetStreamingPresentationState,
     );
   }
 
@@ -1134,6 +1205,8 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       visibleStartIndex: widget.visibleStartIndex,
       onRefreshExtBlocksPanel: _refreshExtBlocksPanel,
       onSyncExtBlockPanels: _syncExtBlockPanels,
+      onReconcileActiveGeneration: _reconcileActiveGenerationPresentation,
+      onDomReset: _resetStreamingPresentationState,
       isCurrentBridge: (bridge) => identical(_bridge, bridge),
     ).attach();
 

--- a/lib/features/cloud_sync/services/sync_controller.dart
+++ b/lib/features/cloud_sync/services/sync_controller.dart
@@ -11,11 +11,13 @@ import '../../../core/state/chat_session_ops_provider.dart';
 import '../../../core/state/lorebook_provider.dart';
 import '../../../core/state/lorebook_embedding_provider.dart';
 import '../../../core/state/global_regex_provider.dart';
+import '../../../core/state/pipeline_settings_provider.dart';
 import '../../../core/state/shared_prefs_provider.dart';
 import '../../../core/state/studio_regex_provider.dart';
 import '../../../shared/theme/theme_provider.dart';
 import '../../personas/persona_list_provider.dart';
 import '../../settings/api_list_provider.dart';
+import '../../settings/app_settings_provider.dart';
 import '../../card_rewrite/card_rewriter_recovery_view_service.dart';
 import '../../chat/chat_provider.dart';
 import '../../chat/chat_session_service.dart';
@@ -218,7 +220,7 @@ class SyncController {
             'pulled': itemsCount,
             'conflictsCount': service.conflicts.length,
           };
-          invalidateDataProviders();
+          await refreshDataProvidersAfterPull();
           statusNotifier.state = service.status;
           conflictsNotifier.state = service.conflicts;
           if (service.conflicts.isNotEmpty) {
@@ -235,7 +237,7 @@ class SyncController {
             },
           );
           _syncResult = {'type': 'full'};
-          invalidateDataProviders();
+          await refreshDataProvidersAfterPull();
           statusNotifier.state = service.status;
           conflictsNotifier.state = service.conflicts;
           return 'sync_full_done'.tr();
@@ -334,7 +336,7 @@ class SyncController {
           setProgress(p);
         },
       );
-      if (isMounted()) invalidateDataProviders();
+      if (isMounted()) await refreshDataProvidersAfterPull();
       return 'Sync complete';
     } catch (e) {
       setError(e.toString());
@@ -345,7 +347,13 @@ class SyncController {
     }
   }
 
-  void invalidateDataProviders() {
+  Future<void> refreshDataProvidersAfterPull() async {
+    final prefs = await _ref.read(sharedPreferencesProvider.future);
+    await prefs.reload();
+    _ref.invalidate(appSettingsProvider);
+    await _ref.read(appSettingsProvider.future);
+    await _ref.read(pipelineSettingsProvider.notifier).load();
+
     // Evict all cached avatar images so that Image.file widgets re-read the
     // updated files from disk immediately (without a full app restart).
     _evictAvatarImageCache();
@@ -370,7 +378,7 @@ class SyncController {
     _ref.invalidate(globalRegexProvider);
     _ref.invalidate(studioRegexProvider);
     unawaited(_ref.read(sessionLorebookEmbeddingWorkerProvider).drain());
-    _ref.read(themeProvider.notifier).reload();
+    await _ref.read(themeProvider.notifier).reload();
 
     // Bump the version counter so widgets that watch avatarVersionProvider
     // (chat_header, character_list) rebuild and pick up the new paths.

--- a/lib/features/cloud_sync/services/sync_engine.dart
+++ b/lib/features/cloud_sync/services/sync_engine.dart
@@ -26,6 +26,7 @@ import '../sync_repo_interfaces.dart';
 import '../../../features/extensions/models/extension_preset.dart';
 import '../../../features/extensions/models/extensions_settings.dart';
 import '../../../features/extensions/models/info_block.dart';
+import '../../settings/app_settings_provider.dart';
 
 class SyncProgress {
   final int current;
@@ -1455,17 +1456,15 @@ class SyncEngine {
     final studioRegexScripts = prefs.getString(
       SyncSerialization.studioRegexScriptsKey,
     );
-    if (pipelineSettings == null &&
-        activeStudioPresetId == null &&
-        globalRegexScripts == null &&
-        studioRegexScripts == null) {
-      return null;
-    }
+    final appSettings = AppSettingsPreferences.encode(
+      AppSettingsPreferences.read(prefs),
+    );
     return SyncSerialization.localStoragePayload(
       pipelineSettings: pipelineSettings,
       activeStudioPresetId: activeStudioPresetId,
       globalRegexScripts: globalRegexScripts,
       studioRegexScripts: studioRegexScripts,
+      appSettings: appSettings,
     );
   }
 
@@ -1503,6 +1502,13 @@ class SyncEngine {
       data,
       SyncSerialization.studioRegexScriptsKey,
     );
+    final rawAppSettings = data[SyncSerialization.appSettingsKey];
+    if (rawAppSettings is Map) {
+      await AppSettingsPreferences.applyPartial(
+        prefs,
+        Map<String, dynamic>.from(rawAppSettings),
+      );
+    }
   }
 
   Future<void> _applyLocalStorageString(
@@ -1525,5 +1531,6 @@ class SyncEngine {
     await prefs.remove(SyncSerialization.activeStudioPresetKey);
     await prefs.remove(SyncSerialization.globalRegexScriptsKey);
     await prefs.remove(SyncSerialization.studioRegexScriptsKey);
+    await AppSettingsPreferences.removeAll(prefs);
   }
 }

--- a/lib/features/cloud_sync/services/sync_manifest.dart
+++ b/lib/features/cloud_sync/services/sync_manifest.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../settings/app_settings_provider.dart';
 import 'sync_serialization.dart';
 import '../sync_models.dart';
 import '../sync_repo_interfaces.dart';
@@ -687,16 +688,17 @@ class SyncManifestBuilder implements SyncManifestProvider {
     final studioRegexScripts = prefs.getString(
       SyncSerialization.studioRegexScriptsKey,
     );
-    if (pipelineSettings != null ||
-        activeStudioPresetId != null ||
-        globalRegexScripts != null ||
-        studioRegexScripts != null) {
+    final appSettings = AppSettingsPreferences.encode(
+      AppSettingsPreferences.read(prefs),
+    );
+    {
       const type = 'local_storage';
       final payload = SyncSerialization.localStoragePayload(
         pipelineSettings: pipelineSettings,
         activeStudioPresetId: activeStudioPresetId,
         globalRegexScripts: globalRegexScripts,
         studioRegexScripts: studioRegexScripts,
+        appSettings: appSettings,
       );
       final hash = SyncSerialization.computeSyncHash(payload);
       final key = entryKey(type, type);

--- a/lib/features/cloud_sync/services/sync_serialization.dart
+++ b/lib/features/cloud_sync/services/sync_serialization.dart
@@ -15,6 +15,7 @@ class SyncSerialization {
   static const activeStudioPresetKey = 'activeStudioPresetId';
   static const globalRegexScriptsKey = 'gz_global_regex_scripts';
   static const studioRegexScriptsKey = 'gz_studio_regex_scripts';
+  static const appSettingsKey = 'appSettings';
 
   /// Content fingerprint for manifest conflict detection (not full session JSON).
   static String computeChatMetadataHash(SessionMetadata metadata) {
@@ -173,6 +174,7 @@ class SyncSerialization {
     String? activeStudioPresetId,
     String? globalRegexScripts,
     String? studioRegexScripts,
+    Map<String, dynamic>? appSettings,
   }) {
     return {
       '__localStorage': true,
@@ -180,6 +182,7 @@ class SyncSerialization {
       activeStudioPresetKey: ?activeStudioPresetId,
       globalRegexScriptsKey: ?globalRegexScripts,
       studioRegexScriptsKey: ?studioRegexScripts,
+      appSettingsKey: ?appSettings,
     };
   }
 

--- a/lib/features/memory/controllers/memory_draft_generation_controller.dart
+++ b/lib/features/memory/controllers/memory_draft_generation_controller.dart
@@ -50,6 +50,7 @@ class MemoryDraftGenerationController {
   final Set<String> _activeDraftIds = {};
   final Map<String, DateTime> _genStartTimes = {};
   final Map<String, CancelToken> _cancelTokens = {};
+  final Map<String, MemoryDraftLease> _leases = {};
   Timer? _genElapsedTimer;
 
   MemoryDraftGenerationController({
@@ -138,11 +139,13 @@ class MemoryDraftGenerationController {
     _generatingDrafts[draftId] = true;
     _genStartTimes[draftId] = DateTime.now();
     _startGenElapsedTimer();
-    _ref.read(memoryActiveDraftsProvider.notifier).markActive(_sessionId);
+    _leases[draftId] = _ref
+        .read(memoryActiveDraftsProvider.notifier)
+        .acquire(_sessionId);
     onStart();
 
     try {
-      final generator = MemoryDraftGenerator(_ref);
+      final generator = MemoryDraftGenerator.widget(_ref);
       final result = await generator.generate(
         draft: draft,
         settings: _bookSettings,
@@ -186,11 +189,7 @@ class MemoryDraftGenerationController {
         _generatingDrafts.remove(draftId);
         _genStartTimes.remove(draftId);
         _stopGenElapsedTimer();
-        if (_generatingDrafts.isEmpty) {
-          _ref
-              .read(memoryActiveDraftsProvider.notifier)
-              .markInactive(_sessionId);
-        }
+        _leases.remove(draftId)?.release();
       }
     }
   }
@@ -207,10 +206,8 @@ class MemoryDraftGenerationController {
     _activeDraftIds.remove(draftId);
     _generatingDrafts.remove(draftId);
     _genStartTimes.remove(draftId);
+    _leases.remove(draftId)?.release();
     _stopGenElapsedTimer();
-    if (_generatingDrafts.isEmpty) {
-      _ref.read(memoryActiveDraftsProvider.notifier).markInactive(_sessionId);
-    }
   }
 
   Future<void> batchGenerate({

--- a/lib/features/memory/state/memory_active_drafts_provider.dart
+++ b/lib/features/memory/state/memory_active_drafts_provider.dart
@@ -3,16 +3,43 @@ import 'package:flutter_riverpod/legacy.dart';
 class MemoryActiveDraftsNotifier extends StateNotifier<Set<String>> {
   MemoryActiveDraftsNotifier() : super(const <String>{});
 
+  final Map<String, Set<Object>> _owners = {};
+
   bool isActive(String sessionId) => state.contains(sessionId);
 
-  void markActive(String sessionId) {
-    if (state.contains(sessionId)) return;
+  MemoryDraftLease acquire(String sessionId) {
+    final owner = Object();
+    (_owners[sessionId] ??= <Object>{}).add(owner);
     state = {...state, sessionId};
+    return MemoryDraftLease._(this, sessionId, owner);
   }
 
-  void markInactive(String sessionId) {
-    if (!state.contains(sessionId)) return;
+  MemoryDraftLease? tryAcquireExclusive(String sessionId) {
+    if (isActive(sessionId)) return null;
+    return acquire(sessionId);
+  }
+
+  void _release(String sessionId, Object owner) {
+    final owners = _owners[sessionId];
+    if (owners == null || !owners.remove(owner)) return;
+    if (owners.isNotEmpty) return;
+    _owners.remove(sessionId);
     state = {...state}..remove(sessionId);
+  }
+}
+
+class MemoryDraftLease {
+  MemoryDraftLease._(this._notifier, this.sessionId, this._owner);
+
+  final MemoryActiveDraftsNotifier _notifier;
+  final String sessionId;
+  final Object _owner;
+  bool _released = false;
+
+  void release() {
+    if (_released) return;
+    _released = true;
+    _notifier._release(sessionId, _owner);
   }
 }
 

--- a/lib/features/settings/app_settings_provider.dart
+++ b/lib/features/settings/app_settings_provider.dart
@@ -9,31 +9,22 @@ part 'app_settings_provider.freezed.dart';
 
 const supportedAppLanguages = {'en', 'ru'};
 
-bool _readBoolPref(
-  SharedPreferences prefs,
-  String key, {
-  required bool defaultValue,
-}) {
-  final value = prefs.get(key);
+bool? _coerceBool(Object? value) {
   if (value is bool) return value;
   if (value is int) return value != 0;
   if (value is String) {
     final normalized = value.toLowerCase();
-    return normalized == '1' || normalized == 'true';
+    if (normalized == '1' || normalized == 'true') return true;
+    if (normalized == '0' || normalized == 'false') return false;
   }
-  return defaultValue;
+  return null;
 }
 
-double _readDoublePref(
-  SharedPreferences prefs,
-  String key, {
-  required double defaultValue,
-}) {
-  final value = prefs.get(key);
+double? _coerceDouble(Object? value) {
   if (value is int) return value.toDouble();
   if (value is double) return value;
-  if (value is String) return double.tryParse(value) ?? defaultValue;
-  return defaultValue;
+  if (value is String) return double.tryParse(value);
+  return null;
 }
 
 final appSettingsProvider =
@@ -83,96 +74,225 @@ abstract class AppSettings with _$AppSettings {
   }) = _AppSettings;
 }
 
+/// Canonical SharedPreferences schema for [AppSettings]. Cloud sync uses the
+/// same codec as the settings provider so newly added fields cannot silently
+/// be omitted from one of the two paths.
+abstract final class AppSettingsPreferences {
+  static const keys = <String>{
+    'enterToSend',
+    'hideMessageId',
+    'hideGenerationTime',
+    'hideTokenCount',
+    'dialogGrouping',
+    'batterySaver',
+    'hideTooltips',
+    'disableSwipeRegeneration',
+    'allowMessageScripts',
+    'language',
+    'virtualKeyboardSend',
+    'tokenizerHidePercent',
+    'tokenizerHistoryFillThreshold',
+    'showOurPicks',
+    'gz_force_mobile_layout',
+    'addBlockAtTop',
+    'openCardAfterImport',
+    'hapticFeedback',
+    'messageVibration',
+    'extractJanitorLocally',
+    'lorebookBuildPrompt',
+    'lorebookBuildPromptJs',
+    'useStandardRandomizer',
+  };
+
+  static AppSettings read(SharedPreferences prefs) {
+    const defaults = AppSettings();
+    final savedLanguage = prefs.getString('language');
+    return AppSettings(
+      enterToSend:
+          _coerceBool(prefs.get('enterToSend')) ?? defaults.enterToSend,
+      hideMessageId:
+          _coerceBool(prefs.get('hideMessageId')) ?? defaults.hideMessageId,
+      hideGenerationTime:
+          _coerceBool(prefs.get('hideGenerationTime')) ??
+          defaults.hideGenerationTime,
+      hideTokenCount:
+          _coerceBool(prefs.get('hideTokenCount')) ?? defaults.hideTokenCount,
+      groupDialogs:
+          _coerceBool(prefs.get('dialogGrouping')) ?? defaults.groupDialogs,
+      batterySaver:
+          _coerceBool(prefs.get('batterySaver')) ?? defaults.batterySaver,
+      hideTooltips:
+          _coerceBool(prefs.get('hideTooltips')) ?? defaults.hideTooltips,
+      disableSwipeRegeneration:
+          _coerceBool(prefs.get('disableSwipeRegeneration')) ??
+          defaults.disableSwipeRegeneration,
+      allowMessageScripts:
+          _coerceBool(prefs.get('allowMessageScripts')) ??
+          defaults.allowMessageScripts,
+      language: supportedAppLanguages.contains(savedLanguage)
+          ? savedLanguage!
+          : defaults.language,
+      virtualKeyboardSend:
+          _coerceBool(prefs.get('virtualKeyboardSend')) ??
+          defaults.virtualKeyboardSend,
+      tokenizerHidePercent:
+          _coerceDouble(prefs.get('tokenizerHidePercent')) ??
+          defaults.tokenizerHidePercent,
+      tokenizerHistoryFillThreshold:
+          _coerceDouble(prefs.get('tokenizerHistoryFillThreshold')) ??
+          defaults.tokenizerHistoryFillThreshold,
+      showOurPicks:
+          _coerceBool(prefs.get('showOurPicks')) ?? defaults.showOurPicks,
+      forceMobileLayout:
+          _coerceBool(prefs.get('gz_force_mobile_layout')) ??
+          defaults.forceMobileLayout,
+      addBlockAtTop:
+          _coerceBool(prefs.get('addBlockAtTop')) ?? defaults.addBlockAtTop,
+      openCardAfterImport:
+          _coerceBool(prefs.get('openCardAfterImport')) ??
+          defaults.openCardAfterImport,
+      hapticFeedback:
+          _coerceBool(prefs.get('hapticFeedback')) ?? defaults.hapticFeedback,
+      messageVibration:
+          _coerceBool(prefs.get('messageVibration')) ??
+          defaults.messageVibration,
+      extractJanitorLocally:
+          _coerceBool(prefs.get('extractJanitorLocally')) ??
+          defaults.extractJanitorLocally,
+      lorebookBuildPrompt:
+          prefs.getString('lorebookBuildPrompt') ??
+          defaults.lorebookBuildPrompt,
+      lorebookBuildPromptJs:
+          prefs.getString('lorebookBuildPromptJs') ??
+          defaults.lorebookBuildPromptJs,
+      useStandardRandomizer:
+          _coerceBool(prefs.get('useStandardRandomizer')) ??
+          defaults.useStandardRandomizer,
+    );
+  }
+
+  static Map<String, dynamic> encode(AppSettings settings) {
+    final normalized = _normalize(settings);
+    return {
+      'enterToSend': normalized.enterToSend,
+      'hideMessageId': normalized.hideMessageId,
+      'hideGenerationTime': normalized.hideGenerationTime,
+      'hideTokenCount': normalized.hideTokenCount,
+      'dialogGrouping': normalized.groupDialogs,
+      'batterySaver': normalized.batterySaver,
+      'hideTooltips': normalized.hideTooltips,
+      'disableSwipeRegeneration': normalized.disableSwipeRegeneration,
+      'allowMessageScripts': normalized.allowMessageScripts,
+      'language': normalized.language,
+      'virtualKeyboardSend': normalized.virtualKeyboardSend,
+      'tokenizerHidePercent': normalized.tokenizerHidePercent,
+      'tokenizerHistoryFillThreshold': normalized.tokenizerHistoryFillThreshold,
+      'showOurPicks': normalized.showOurPicks,
+      'gz_force_mobile_layout': normalized.forceMobileLayout,
+      'addBlockAtTop': normalized.addBlockAtTop,
+      'openCardAfterImport': normalized.openCardAfterImport,
+      'hapticFeedback': normalized.hapticFeedback,
+      'messageVibration': normalized.messageVibration,
+      'extractJanitorLocally': normalized.extractJanitorLocally,
+      'lorebookBuildPrompt': normalized.lorebookBuildPrompt,
+      'lorebookBuildPromptJs': normalized.lorebookBuildPromptJs,
+      'useStandardRandomizer': normalized.useStandardRandomizer,
+    };
+  }
+
+  static Future<void> write(
+    SharedPreferences prefs,
+    AppSettings settings,
+  ) async {
+    final values = encode(settings);
+    for (final entry in values.entries) {
+      final value = entry.value;
+      if (value is bool) {
+        await prefs.setBool(entry.key, value);
+      } else if (value is double) {
+        await prefs.setDouble(entry.key, value);
+      } else if (value is String) {
+        await prefs.setString(entry.key, value);
+      }
+    }
+  }
+
+  /// Applies only recognized, valid fields. Missing fields from older clients
+  /// preserve their local values instead of resetting newly introduced prefs.
+  static Future<void> applyPartial(
+    SharedPreferences prefs,
+    Map<String, dynamic> values,
+  ) async {
+    final merged = encode(read(prefs));
+    for (final key in keys) {
+      if (!values.containsKey(key)) continue;
+      final incoming = values[key];
+      final current = merged[key];
+      if (current is bool) {
+        final parsed = _coerceBool(incoming);
+        if (parsed != null) merged[key] = parsed;
+      } else if (current is double) {
+        final parsed = _coerceDouble(incoming);
+        if (parsed != null) merged[key] = parsed;
+      } else if (current is String && incoming is String) {
+        merged[key] =
+            key == 'language' && !supportedAppLanguages.contains(incoming)
+            ? 'en'
+            : incoming;
+      }
+    }
+    await write(prefs, _fromMap(merged));
+  }
+
+  static Future<void> removeAll(SharedPreferences prefs) async {
+    for (final key in keys) {
+      await prefs.remove(key);
+    }
+  }
+
+  static AppSettings _normalize(AppSettings settings) =>
+      supportedAppLanguages.contains(settings.language)
+      ? settings
+      : settings.copyWith(language: 'en');
+
+  static AppSettings _fromMap(Map<String, dynamic> values) => AppSettings(
+    enterToSend: values['enterToSend'] as bool,
+    hideMessageId: values['hideMessageId'] as bool,
+    hideGenerationTime: values['hideGenerationTime'] as bool,
+    hideTokenCount: values['hideTokenCount'] as bool,
+    groupDialogs: values['dialogGrouping'] as bool,
+    batterySaver: values['batterySaver'] as bool,
+    hideTooltips: values['hideTooltips'] as bool,
+    disableSwipeRegeneration: values['disableSwipeRegeneration'] as bool,
+    allowMessageScripts: values['allowMessageScripts'] as bool,
+    language: values['language'] as String,
+    virtualKeyboardSend: values['virtualKeyboardSend'] as bool,
+    tokenizerHidePercent: values['tokenizerHidePercent'] as double,
+    tokenizerHistoryFillThreshold:
+        values['tokenizerHistoryFillThreshold'] as double,
+    showOurPicks: values['showOurPicks'] as bool,
+    forceMobileLayout: values['gz_force_mobile_layout'] as bool,
+    addBlockAtTop: values['addBlockAtTop'] as bool,
+    openCardAfterImport: values['openCardAfterImport'] as bool,
+    hapticFeedback: values['hapticFeedback'] as bool,
+    messageVibration: values['messageVibration'] as bool,
+    extractJanitorLocally: values['extractJanitorLocally'] as bool,
+    lorebookBuildPrompt: values['lorebookBuildPrompt'] as String,
+    lorebookBuildPromptJs: values['lorebookBuildPromptJs'] as String,
+    useStandardRandomizer: values['useStandardRandomizer'] as bool,
+  );
+}
+
 class AppSettingsNotifier extends AsyncNotifier<AppSettings> {
   @override
   Future<AppSettings> build() async {
     final prefs = await ref.read(sharedPreferencesProvider.future);
-    final savedLanguage = prefs.getString('language');
-    final hapticFeedback = _readBoolPref(
-      prefs,
-      'hapticFeedback',
-      defaultValue: true,
-    );
-    final messageVibration = _readBoolPref(
-      prefs,
-      'messageVibration',
-      defaultValue: true,
-    );
+    final settings = AppSettingsPreferences.read(prefs);
     // Cache the toggles so the central [Haptics] gate can decide synchronously
     // in tap handlers and on message completion.
-    Haptics.configure(enabled: hapticFeedback);
-    Haptics.configureMessageVibration(enabled: messageVibration);
-    return AppSettings(
-      enterToSend: _readBoolPref(prefs, 'enterToSend', defaultValue: true),
-      hideMessageId: _readBoolPref(prefs, 'hideMessageId', defaultValue: false),
-      hideGenerationTime: _readBoolPref(
-        prefs,
-        'hideGenerationTime',
-        defaultValue: false,
-      ),
-      hideTokenCount: _readBoolPref(
-        prefs,
-        'hideTokenCount',
-        defaultValue: false,
-      ),
-      groupDialogs: _readBoolPref(prefs, 'dialogGrouping', defaultValue: false),
-      batterySaver: _readBoolPref(prefs, 'batterySaver', defaultValue: true),
-      hideTooltips: _readBoolPref(prefs, 'hideTooltips', defaultValue: false),
-      disableSwipeRegeneration: _readBoolPref(
-        prefs,
-        'disableSwipeRegeneration',
-        defaultValue: false,
-      ),
-      allowMessageScripts: _readBoolPref(
-        prefs,
-        'allowMessageScripts',
-        defaultValue: false,
-      ),
-      language: supportedAppLanguages.contains(savedLanguage)
-          ? savedLanguage!
-          : 'en',
-      virtualKeyboardSend: _readBoolPref(
-        prefs,
-        'virtualKeyboardSend',
-        defaultValue: false,
-      ),
-      tokenizerHidePercent: _readDoublePref(
-        prefs,
-        'tokenizerHidePercent',
-        defaultValue: 30,
-      ),
-      tokenizerHistoryFillThreshold: _readDoublePref(
-        prefs,
-        'tokenizerHistoryFillThreshold',
-        defaultValue: 85,
-      ),
-      showOurPicks: _readBoolPref(prefs, 'showOurPicks', defaultValue: true),
-      forceMobileLayout: _readBoolPref(
-        prefs,
-        'gz_force_mobile_layout',
-        defaultValue: true,
-      ),
-      addBlockAtTop: _readBoolPref(prefs, 'addBlockAtTop', defaultValue: false),
-      openCardAfterImport: _readBoolPref(
-        prefs,
-        'openCardAfterImport',
-        defaultValue: true,
-      ),
-      hapticFeedback: hapticFeedback,
-      messageVibration: messageVibration,
-      extractJanitorLocally: _readBoolPref(
-        prefs,
-        'extractJanitorLocally',
-        defaultValue: false,
-      ),
-      lorebookBuildPrompt: prefs.getString('lorebookBuildPrompt') ?? '',
-      lorebookBuildPromptJs: prefs.getString('lorebookBuildPromptJs') ?? '',
-      useStandardRandomizer: _readBoolPref(
-        prefs,
-        'useStandardRandomizer',
-        defaultValue: false,
-      ),
-    );
+    Haptics.configure(enabled: settings.hapticFeedback);
+    Haptics.configureMessageVibration(enabled: settings.messageVibration);
+    return settings;
   }
 
   Future<void> save(AppSettings settings) async {
@@ -180,50 +300,7 @@ class AppSettingsNotifier extends AsyncNotifier<AppSettings> {
     final normalized = supportedAppLanguages.contains(settings.language)
         ? settings
         : settings.copyWith(language: 'en');
-    await prefs.setBool('enterToSend', settings.enterToSend);
-    await prefs.setBool('hideMessageId', settings.hideMessageId);
-    await prefs.setBool('hideGenerationTime', settings.hideGenerationTime);
-    await prefs.setBool('hideTokenCount', settings.hideTokenCount);
-    await prefs.setBool('dialogGrouping', settings.groupDialogs);
-    await prefs.setBool('batterySaver', settings.batterySaver);
-    await prefs.setBool('hideTooltips', settings.hideTooltips);
-    await prefs.setBool(
-      'disableSwipeRegeneration',
-      settings.disableSwipeRegeneration,
-    );
-    await prefs.setBool('allowMessageScripts', settings.allowMessageScripts);
-    await prefs.setString('language', normalized.language);
-    await prefs.setBool('virtualKeyboardSend', normalized.virtualKeyboardSend);
-    await prefs.setDouble(
-      'tokenizerHidePercent',
-      normalized.tokenizerHidePercent,
-    );
-    await prefs.setDouble(
-      'tokenizerHistoryFillThreshold',
-      normalized.tokenizerHistoryFillThreshold,
-    );
-    await prefs.setBool('showOurPicks', normalized.showOurPicks);
-    await prefs.setBool('gz_force_mobile_layout', normalized.forceMobileLayout);
-    await prefs.setBool('addBlockAtTop', normalized.addBlockAtTop);
-    await prefs.setBool('openCardAfterImport', normalized.openCardAfterImport);
-    await prefs.setBool('hapticFeedback', normalized.hapticFeedback);
-    await prefs.setBool('messageVibration', normalized.messageVibration);
-    await prefs.setBool(
-      'extractJanitorLocally',
-      normalized.extractJanitorLocally,
-    );
-    await prefs.setString(
-      'lorebookBuildPrompt',
-      normalized.lorebookBuildPrompt,
-    );
-    await prefs.setString(
-      'lorebookBuildPromptJs',
-      normalized.lorebookBuildPromptJs,
-    );
-    await prefs.setBool(
-      'useStandardRandomizer',
-      normalized.useStandardRandomizer,
-    );
+    await AppSettingsPreferences.write(prefs, normalized);
     Haptics.configure(enabled: normalized.hapticFeedback);
     Haptics.configureMessageVibration(enabled: normalized.messageVibration);
     state = AsyncData(normalized);

--- a/test/app_settings_preferences_test.dart
+++ b/test/app_settings_preferences_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/features/settings/app_settings_provider.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('round-trips every app setting through the canonical codec', () async {
+    const expected = AppSettings(
+      enterToSend: false,
+      hideMessageId: true,
+      hideGenerationTime: true,
+      hideTokenCount: true,
+      groupDialogs: true,
+      batterySaver: false,
+      hideTooltips: true,
+      disableSwipeRegeneration: true,
+      allowMessageScripts: true,
+      language: 'ru',
+      virtualKeyboardSend: true,
+      tokenizerHidePercent: 42.5,
+      tokenizerHistoryFillThreshold: 91.5,
+      showOurPicks: false,
+      forceMobileLayout: false,
+      addBlockAtTop: true,
+      openCardAfterImport: false,
+      hapticFeedback: false,
+      messageVibration: false,
+      extractJanitorLocally: true,
+      lorebookBuildPrompt: 'closed prompt',
+      lorebookBuildPromptJs: 'script prompt',
+      useStandardRandomizer: true,
+    );
+    final prefs = await SharedPreferences.getInstance();
+
+    await AppSettingsPreferences.write(prefs, expected);
+
+    expect(AppSettingsPreferences.read(prefs), expected);
+    expect(
+      AppSettingsPreferences.encode(expected).keys.toSet(),
+      AppSettingsPreferences.keys,
+    );
+  });
+
+  test(
+    'partial cloud settings preserve omitted and invalid local values',
+    () async {
+      final prefs = await SharedPreferences.getInstance();
+      await AppSettingsPreferences.write(
+        prefs,
+        const AppSettings(hideMessageId: true, language: 'ru'),
+      );
+
+      await AppSettingsPreferences.applyPartial(prefs, {
+        'enterToSend': false,
+        'hideMessageId': <String>[],
+      });
+
+      final result = AppSettingsPreferences.read(prefs);
+      expect(result.enterToSend, isFalse);
+      expect(result.hideMessageId, isTrue);
+      expect(result.language, 'ru');
+    },
+  );
+
+  test('removeAll restores defaults', () async {
+    final prefs = await SharedPreferences.getInstance();
+    await AppSettingsPreferences.write(
+      prefs,
+      const AppSettings(hideMessageId: true, language: 'ru'),
+    );
+
+    await AppSettingsPreferences.removeAll(prefs);
+
+    expect(AppSettingsPreferences.read(prefs), const AppSettings());
+  });
+}

--- a/test/characterization/memory_draft_mutex_test.dart
+++ b/test/characterization/memory_draft_mutex_test.dart
@@ -28,11 +28,11 @@ void main() {
       expect(container.read(memoryActiveDraftsProvider), isEmpty);
     });
 
-    test('markActive adds a sessionId; isActive reports true', () {
+    test('acquire adds a sessionId; isActive reports true', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
 
-      container.read(memoryActiveDraftsProvider.notifier).markActive('s1');
+      container.read(memoryActiveDraftsProvider.notifier).acquire('s1');
 
       expect(container.read(memoryActiveDraftsProvider), {'s1'});
       expect(
@@ -41,13 +41,13 @@ void main() {
       );
     });
 
-    test('markInactive removes a sessionId; isActive reports false', () {
+    test('release removes a sessionId; isActive reports false', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final notifier = container.read(memoryActiveDraftsProvider.notifier);
 
-      notifier.markActive('s1');
-      notifier.markInactive('s1');
+      final lease = notifier.acquire('s1');
+      lease.release();
 
       expect(container.read(memoryActiveDraftsProvider), isEmpty);
       expect(notifier.isActive('s1'), isFalse);
@@ -58,40 +58,44 @@ void main() {
       addTearDown(container.dispose);
       final notifier = container.read(memoryActiveDraftsProvider.notifier);
 
-      notifier.markActive('s1');
-      notifier.markActive('s2');
-      notifier.markActive('s3');
+      final first = notifier.acquire('s1');
+      final second = notifier.acquire('s2');
+      final third = notifier.acquire('s3');
 
       expect(container.read(memoryActiveDraftsProvider), {'s1', 's2', 's3'});
       expect(notifier.isActive('s2'), isTrue);
 
-      notifier.markInactive('s2');
+      second.release();
 
       expect(container.read(memoryActiveDraftsProvider), {'s1', 's3'});
       expect(notifier.isActive('s2'), isFalse);
+      first.release();
+      third.release();
     });
 
-    test('markActive is idempotent — no duplicate entries', () {
+    test('multiple owners keep a session active until all release', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final notifier = container.read(memoryActiveDraftsProvider.notifier);
 
-      notifier.markActive('s1');
-      notifier.markActive('s1');
-      notifier.markActive('s1');
+      final first = notifier.acquire('s1');
+      final second = notifier.acquire('s1');
 
       expect(container.read(memoryActiveDraftsProvider), {'s1'});
+      first.release();
+      expect(container.read(memoryActiveDraftsProvider), {'s1'});
+      second.release();
+      expect(container.read(memoryActiveDraftsProvider), isEmpty);
     });
 
-    test('markInactive on unknown sessionId is a no-op (no exception)', () {
+    test('lease release is idempotent', () {
       final container = ProviderContainer();
       addTearDown(container.dispose);
       final notifier = container.read(memoryActiveDraftsProvider.notifier);
 
-      notifier.markActive('s1');
-      notifier.markInactive('unknown');
-      notifier.markInactive('s1');
-      notifier.markInactive('s1');
+      final lease = notifier.acquire('s1');
+      lease.release();
+      lease.release();
 
       expect(container.read(memoryActiveDraftsProvider), isEmpty);
     });
@@ -102,11 +106,26 @@ void main() {
       final notifier = container.read(memoryActiveDraftsProvider.notifier);
 
       final before = container.read(memoryActiveDraftsProvider);
-      notifier.markActive('s1');
+      notifier.acquire('s1');
       final after = container.read(memoryActiveDraftsProvider);
 
-      expect(identical(before, after), isFalse,
-          reason: 'set must be reassigned so listeners rebuild');
+      expect(
+        identical(before, after),
+        isFalse,
+        reason: 'set must be reassigned so listeners rebuild',
+      );
+    });
+
+    test('exclusive acquisition fails while another owner is active', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(memoryActiveDraftsProvider.notifier);
+
+      final first = notifier.tryAcquireExclusive('s1');
+      expect(first, isNotNull);
+      expect(notifier.tryAcquireExclusive('s1'), isNull);
+      first!.release();
+      expect(notifier.tryAcquireExclusive('s1'), isNotNull);
     });
   });
 }

--- a/test/characterization/shared_prefs_keys_test.dart
+++ b/test/characterization/shared_prefs_keys_test.dart
@@ -24,6 +24,13 @@ void main() {
       'showOurPicks': bool,
       'gz_force_mobile_layout': bool,
       'addBlockAtTop': bool,
+      'openCardAfterImport': bool,
+      'hapticFeedback': bool,
+      'messageVibration': bool,
+      'extractJanitorLocally': bool,
+      'lorebookBuildPrompt': String,
+      'lorebookBuildPromptJs': String,
+      'useStandardRandomizer': bool,
     };
 
     test('AppSettings defaults match SharedPrefs fallbacks', () {
@@ -38,7 +45,10 @@ void main() {
             if (entry.key == 'enterToSend' ||
                 entry.key == 'showOurPicks' ||
                 entry.key == 'gz_force_mobile_layout' ||
-                entry.key == 'batterySaver') {
+                entry.key == 'batterySaver' ||
+                entry.key == 'openCardAfterImport' ||
+                entry.key == 'hapticFeedback' ||
+                entry.key == 'messageVibration') {
               expect(
                 _getBoolDefault(defaults, entry.key),
                 isTrue,
@@ -82,7 +92,7 @@ void main() {
     });
 
     test('all expected SharedPrefs keys are covered', () {
-      expect(expectedKeys.length, 16);
+      expect(expectedKeys.keys.toSet(), AppSettingsPreferences.keys);
     });
 
     test('legacy string values are accepted', () async {
@@ -294,6 +304,16 @@ bool _getBoolDefault(AppSettings s, String key) {
       return s.forceMobileLayout;
     case 'addBlockAtTop':
       return s.addBlockAtTop;
+    case 'openCardAfterImport':
+      return s.openCardAfterImport;
+    case 'hapticFeedback':
+      return s.hapticFeedback;
+    case 'messageVibration':
+      return s.messageVibration;
+    case 'extractJanitorLocally':
+      return s.extractJanitorLocally;
+    case 'useStandardRandomizer':
+      return s.useStandardRandomizer;
     default:
       return false;
   }

--- a/test/chat_webview_sync_dispatcher_test.dart
+++ b/test/chat_webview_sync_dispatcher_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:glaze_flutter/core/models/chat_message.dart';
 import 'package:glaze_flutter/features/chat/bridge/chat_bridge_controller.dart';
 import 'package:glaze_flutter/features/chat/bridge/chat_overlay_blur_region.dart';
+import 'package:glaze_flutter/features/chat/chat_state.dart';
 import 'package:glaze_flutter/features/chat/widgets/chat_message_sync.dart';
 import 'package:glaze_flutter/features/chat/widgets/chat_streaming_bridge_sync.dart';
 import 'package:glaze_flutter/features/chat/widgets/chat_webview_sync_dispatcher.dart';
@@ -59,27 +60,30 @@ void main() {
       expect(completed, isTrue);
     });
 
-    test('withholds Regenerate while the send is still being persisted', () async {
-      // The optimistic user bubble is a tail append and the durable append can
-      // take a while on a long chat. Stamping the Regenerate button there put
-      // it under the message for that whole window, then took it away again
-      // the moment `isGenerating` went up — a visible flash on every send.
-      final bridge = _FakeBridge();
-      final greeting = _assistant('a1');
-      final user = _user('u1');
+    test(
+      'withholds Regenerate while the send is still being persisted',
+      () async {
+        // The optimistic user bubble is a tail append and the durable append can
+        // take a while on a long chat. Stamping the Regenerate button there put
+        // it under the message for that whole window, then took it away again
+        // the moment `isGenerating` went up — a visible flash on every send.
+        final bridge = _FakeBridge();
+        final greeting = _assistant('a1');
+        final user = _user('u1');
 
-      await const ChatMessageSync().sync(
-        bridge: bridge,
-        oldMsgs: [greeting],
-        newMsgs: [greeting, user],
-        visibleStartIndex: 0,
-        busy: true,
-        sessionSwitching: false,
-      );
+        await const ChatMessageSync().sync(
+          bridge: bridge,
+          oldMsgs: [greeting],
+          newMsgs: [greeting, user],
+          visibleStartIndex: 0,
+          busy: true,
+          sessionSwitching: false,
+        );
 
-      expect(bridge.appendedMessages, [user]);
-      expect(bridge.lastMessageIds, isEmpty);
-    });
+        expect(bridge.appendedMessages, [user]);
+        expect(bridge.lastMessageIds, isEmpty);
+      },
+    );
 
     test('stamps Regenerate on a trailing user message once idle', () async {
       final bridge = _FakeBridge();
@@ -182,6 +186,80 @@ void main() {
   });
 
   group('ChatWebViewSyncDispatcher', () {
+    test(
+      'restores an already-active normal generation after DOM reset',
+      () async {
+        final bridge = _FakeBridge();
+        final state = ChatWebViewSyncState()..wasGenerating = true;
+
+        await reconcileActiveGenerationBridge(
+          bridge: bridge,
+          syncState: state,
+          isGenerating: true,
+          isImpersonating: false,
+          regenTargetId: null,
+          continuationTargetId: null,
+          streaming: const StreamingState(text: 'partial reply'),
+          messages: [_user('u1')],
+          streamingId: '__streaming__',
+          isCurrent: () => true,
+        );
+
+        expect(bridge.appendedMessages, hasLength(1));
+        expect(bridge.appendedMessages.single.id, '__streaming__');
+        expect(bridge.appendedMessages.single.content, 'partial reply');
+        expect(bridge.appendedMessages.single.isTyping, isTrue);
+        expect(state.streamingSent, isTrue);
+      },
+    );
+
+    test('restores continuation in place without a virtual message', () async {
+      final bridge = _FakeBridge();
+      final state = ChatWebViewSyncState();
+      final original = _assistant('a1').copyWith(content: 'First');
+
+      await reconcileActiveGenerationBridge(
+        bridge: bridge,
+        syncState: state,
+        isGenerating: true,
+        isImpersonating: false,
+        regenTargetId: null,
+        continuationTargetId: 'a1',
+        streaming: const StreamingState(text: 'second'),
+        messages: [original],
+        streamingId: '__streaming__',
+        isCurrent: () => true,
+      );
+
+      expect(bridge.appendedMessages, isEmpty);
+      expect(bridge.updatedMessages, hasLength(1));
+      expect(bridge.updatedMessages.single.content, contains('second'));
+      expect(bridge.continuationTargetId, 'a1');
+      expect(state.regenStreamingSent, isTrue);
+    });
+
+    test('does not restore a chat bubble for impersonation', () async {
+      final bridge = _FakeBridge();
+      final state = ChatWebViewSyncState();
+
+      await reconcileActiveGenerationBridge(
+        bridge: bridge,
+        syncState: state,
+        isGenerating: true,
+        isImpersonating: true,
+        regenTargetId: null,
+        continuationTargetId: null,
+        streaming: const StreamingState(text: 'composer text'),
+        messages: const [],
+        streamingId: '__streaming__',
+        isCurrent: () => true,
+      );
+
+      expect(bridge.appendedMessages, isEmpty);
+      expect(bridge.updatedMessages, isEmpty);
+      expect(state.streamingSent, isFalse);
+    });
+
     test('serializes persisted and streaming message mutations', () async {
       final state = ChatWebViewSyncState();
       final firstMutation = Completer<void>();
@@ -414,10 +492,7 @@ void main() {
         // The image stage flag goes through a setter, not a bare assignment:
         // it is what tells a pending block apart from a running one, and the
         // WebView has to restamp its placeholders when it flips (INV-IG1).
-        expect(
-          bridge.evalCalls.single,
-          contains('setImageGenerating(false)'),
-        );
+        expect(bridge.evalCalls.single, contains('setImageGenerating(false)'));
       },
     );
 
@@ -746,6 +821,9 @@ class _FakeBridge implements ChatBridgeController {
 
   @override
   bool isPostGenRunning = false;
+
+  @override
+  String? continuationTargetId;
 
   final List<List<ChatOverlayBlurRegion>> overlayBlurCalls = [];
   final List<String> evalCalls = [];

--- a/test/memory_draft_stage_test.dart
+++ b/test/memory_draft_stage_test.dart
@@ -1,0 +1,178 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:glaze_flutter/core/state/memory_settings_provider.dart';
+import 'package:glaze_flutter/features/chat/abort_handler.dart';
+import 'package:glaze_flutter/features/chat/chat_state.dart';
+import 'package:glaze_flutter/features/chat/services/stages/memory_draft_stage.dart';
+import 'package:glaze_flutter/features/chat/services/stages/stage_context.dart';
+import 'package:glaze_flutter/features/memory/state/memory_active_drafts_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'auto-generation fills newly planned drafts and releases its lease',
+    () async {
+      final harness = await _createHarness(autoGenerate: true);
+      addTearDown(harness.dispose);
+      final lease = harness.stage.reserveAutoGeneration(harness.session);
+      expect(lease, isNotNull);
+      expect(harness.container.read(memoryActiveDraftsProvider), {'s1'});
+
+      await harness.stage.run(harness.session, generationLease: lease);
+
+      final book = await harness.container
+          .read(memoryBookRepoProvider)
+          .getBySessionId('s1');
+      expect(harness.calls(), 1);
+      expect(book!.pendingDrafts, hasLength(1));
+      expect(book.pendingDrafts.single.content, 'Generated memory');
+      expect(book.pendingDrafts.single.status, 'pending_approval');
+      expect(book.pendingDrafts.single.messageIds, ['u1', 'a1']);
+      expect(harness.container.read(memoryActiveDraftsProvider), isEmpty);
+    },
+  );
+
+  test(
+    'disabled auto-generation creates an empty draft without an LLM call',
+    () async {
+      final harness = await _createHarness(autoGenerate: false);
+      addTearDown(harness.dispose);
+
+      expect(harness.stage.reserveAutoGeneration(harness.session), isNull);
+      await harness.stage.run(harness.session);
+
+      final book = await harness.container
+          .read(memoryBookRepoProvider)
+          .getBySessionId('s1');
+      expect(harness.calls(), 0);
+      expect(book!.pendingDrafts.single.status, 'pending_generation');
+      expect(book.pendingDrafts.single.content, isEmpty);
+    },
+  );
+
+  test(
+    'generation failure leaves the draft retryable and releases lease',
+    () async {
+      final harness = await _createHarness(
+        autoGenerate: true,
+        generationError: StateError('provider failed'),
+      );
+      addTearDown(harness.dispose);
+      final lease = harness.stage.reserveAutoGeneration(harness.session);
+
+      await harness.stage.run(harness.session, generationLease: lease);
+
+      final book = await harness.container
+          .read(memoryBookRepoProvider)
+          .getBySessionId('s1');
+      expect(book!.pendingDrafts.single.status, 'needs_regeneration');
+      expect(book.pendingDrafts.single.error, contains('provider failed'));
+      expect(harness.container.read(memoryActiveDraftsProvider), isEmpty);
+    },
+  );
+}
+
+Future<_Harness> _createHarness({
+  required bool autoGenerate,
+  Object? generationError,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  final db = AppDatabase.forTesting(NativeDatabase.memory());
+  final container = ProviderContainer(
+    overrides: [appDbProvider.overrideWithValue(db)],
+  );
+  await container
+      .read(memoryGlobalSettingsProvider.notifier)
+      .save(
+        MemoryGlobalSettings(
+          autoGenerateEnabled: autoGenerate,
+          autoCreateInterval: 2,
+          autoCreateLagMessages: 0,
+          batchSize: 1,
+        ),
+      );
+
+  var calls = 0;
+  final stageProvider = Provider<MemoryDraftStage>((ref) {
+    late AsyncValue<ChatState> state = const AsyncData(ChatState());
+    final abortHandler = AbortHandler(
+      ref: ref,
+      charId: 'c1',
+      setState: (next) => state = next,
+      getState: () => state,
+      mutateSession: (_, _) async => null,
+      loadSession: (_) async => null,
+    );
+    return MemoryDraftStage(
+      StageContext(
+        ref: ref,
+        charId: 'c1',
+        abortHandler: abortHandler,
+        setState: (next) => state = next,
+        getState: () => state,
+      ),
+      generate:
+          ({
+            required draft,
+            required settings,
+            required pipeline,
+            required historyText,
+          }) async {
+            calls++;
+            if (generationError != null) throw generationError;
+            expect(historyText, contains('User turn'));
+            return draft.copyWith(
+              content: 'Generated memory',
+              keys: ['memory'],
+              status: 'pending_approval',
+              generatedAt: 100,
+              updatedAt: 100,
+            );
+          },
+    );
+  });
+  return _Harness(
+    container: container,
+    db: db,
+    stage: container.read(stageProvider),
+    session: const ChatSession(
+      id: 's1',
+      characterId: 'c1',
+      sessionIndex: 0,
+      sessionVars: {},
+      messages: [
+        ChatMessage(id: 'u1', role: 'user', content: 'User turn'),
+        ChatMessage(id: 'a1', role: 'assistant', content: 'Assistant turn'),
+      ],
+    ),
+    calls: () => calls,
+  );
+}
+
+class _Harness {
+  const _Harness({
+    required this.container,
+    required this.db,
+    required this.stage,
+    required this.session,
+    required this.calls,
+  });
+
+  final ProviderContainer container;
+  final AppDatabase db;
+  final MemoryDraftStage stage;
+  final ChatSession session;
+  final int Function() calls;
+
+  Future<void> dispose() async {
+    container.dispose();
+    await db.close();
+  }
+}

--- a/test/sync_lifecycle_test.dart
+++ b/test/sync_lifecycle_test.dart
@@ -1730,6 +1730,70 @@ void main() {
     );
   });
 
+  test('Cloud round-trip restores app settings', () async {
+    final source = SyncWorld();
+    final sourcePrefs = await SharedPreferences.getInstance();
+    await sourcePrefs.setBool('enterToSend', false);
+    await sourcePrefs.setBool('hideMessageId', true);
+    await sourcePrefs.setString('language', 'ru');
+
+    await source.engine.pushEntities(onProgress: (_) {});
+
+    final cloudPayload =
+        jsonDecode(
+              source.cloud.files[cloudPath('local_storage', 'local_storage')]!,
+            )
+            as Map<String, dynamic>;
+    expect(
+      (cloudPayload[SyncSerialization.appSettingsKey] as Map)['hideMessageId'],
+      isTrue,
+    );
+
+    SharedPreferences.setMockInitialValues({
+      'enterToSend': true,
+      'hideMessageId': false,
+      'language': 'en',
+    });
+    final target = SyncWorld();
+    target.cloud.files.addAll(source.cloud.files);
+    await target.engine.pullEntities(onProgress: (_) {}, onConflict: (_) {});
+
+    final targetPrefs = await SharedPreferences.getInstance();
+    expect(targetPrefs.getBool('enterToSend'), isFalse);
+    expect(targetPrefs.getBool('hideMessageId'), isTrue);
+    expect(targetPrefs.getString('language'), 'ru');
+  });
+
+  test('Legacy local_storage payload preserves local app settings', () async {
+    final world = SyncWorld();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('hideMessageId', true);
+    const payload = {
+      '__localStorage': true,
+      'pipelineSettings': '{"legacy":true}',
+    };
+    final entry = SyncManifestEntry(
+      type: 'local_storage',
+      id: 'local_storage',
+      path: cloudPath('local_storage', 'local_storage'),
+      updatedAt: 1000,
+      hash: SyncSerialization.computeSyncHash(payload),
+    );
+    world.cloud.files[entry.path] = jsonEncode(payload);
+    world.cloud.files[cloudPath('manifest', 'manifest')] = jsonEncode(
+      SyncManifest(
+        deviceId: 'cloud',
+        createdAt: 1,
+        lastSync: 1000,
+        entries: {entry.key: entry},
+      ).toJson(),
+    );
+
+    await world.engine.pullEntities(onProgress: (_) {}, onConflict: (_) {});
+
+    expect(prefs.getBool('hideMessageId'), isTrue);
+  });
+
   test(
     'Legacy local_storage payload preserves local regex collections',
     () async {

--- a/test/sync_serialization_test.dart
+++ b/test/sync_serialization_test.dart
@@ -13,6 +13,7 @@ void main() {
         activeStudioPresetId: 'studio_loom_causal_direct_v1',
         globalRegexScripts: '[{"id":"global"}]',
         studioRegexScripts: '[{"script":{"id":"studio"}}]',
+        appSettings: const {'enterToSend': false},
       ),
       {
         '__localStorage': true,
@@ -20,6 +21,7 @@ void main() {
         'activeStudioPresetId': 'studio_loom_causal_direct_v1',
         'gz_global_regex_scripts': '[{"id":"global"}]',
         'gz_studio_regex_scripts': '[{"script":{"id":"studio"}}]',
+        'appSettings': {'enterToSend': false},
       },
     );
   });

--- a/test/trigger_generation_test.dart
+++ b/test/trigger_generation_test.dart
@@ -164,7 +164,7 @@ void main() {
       );
       final container = _container(charId: 'c1', initial: state);
       addTearDown(container.dispose);
-      container.read(memoryActiveDraftsProvider.notifier).markActive('s1');
+      container.read(memoryActiveDraftsProvider.notifier).acquire('s1');
 
       final dispatcher = container.read(generationDispatcherProvider);
       final result = await dispatcher.dispatch(charId: 'c1');


### PR DESCRIPTION
## Summary
- sync the complete AppSettings snapshot and refresh preference-backed providers after cloud pulls
- rehydrate active normal, regeneration, and continuation UI after WebView DOM resets
- execute Memory Book auto-generation with owner-aware leases and atomic draft updates

## Discord reports
- fixes app settings not syncing between Android and Windows through cloud storage
- fixes the generating bubble disappearing after leaving and reopening a chat
- fixes Memory Book auto-generate creating empty drafts without invoking the configured LLM
- retains the existing chat-cache refresh fix for cloud-pulled chats
- does not alter lorebook matching because the reported reverse-substring activation could not be reproduced in the matcher

## Verification
- flutter test: 3572 passed
- flutter analyze: no new findings; 3 pre-existing findings remain
- git diff --check