### PR TITLE
fix: preserve edited swipes and refresh long-running apps

### DIFF
--- a/assets/chat_webview/formatter/block_syntax.js
+++ b/assets/chat_webview/formatter/block_syntax.js
@@ -18,7 +18,7 @@ const ONLY_REGIONS = new RegExp(`^(?:${SENTINEL}P_\\d+${SENTINEL}|\\s)+$`);
 const HEADING = /^(#{1,6})[ \t]+(.+?)[ \t]*#*$/;
 const RULE = /^(_{3,}|-{3,}|\*{3,})$/;
 const BULLET = /^([ \t]*)[-*] (.*)$/;
-const NUMBERED = /^\d+\. (.*)$/;
+const NUMBERED = /^(\d+)\. (.*)$/;
 const QUOTED = /^>[ \t]?(.*)$/;
 const TABLE_ROW = /^[ \t]*\|.*\|[ \t]*$/;
 const TABLE_SEPARATOR = /^[ \t]*\|[ \t:|-]+\|[ \t]*$/;
@@ -145,11 +145,14 @@ export function applyBlockSyntax(text, { inline, paragraphs }) {
       const items = [];
       let j = i;
       let match;
+      let start = 1;
       while (j < lines.length && (match = NUMBERED.exec(lines[j])) !== null) {
-        items.push(`<li>${inline(match[1])}</li>`);
+        if (!items.length) start = Number(match[1]);
+        items.push(`<li>${inline(match[2])}</li>`);
         j++;
       }
-      out.push(`<ol class="chat-list">${items.join('')}</ol>`);
+      const startAttr = start === 1 ? '' : ` start="${start}"`;
+      out.push(`<ol class="chat-list"${startAttr}>${items.join('')}</ol>`);
       i = j - 1;
       continue;
     }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -67,6 +67,7 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
   final List<ProviderSubscription> _warmSubs = [];
   late bool _startupReady;
   bool _startupHooksAttached = false;
+  AutomaticUpdateCheckController? _updateChecks;
 
   @override
   void initState() {
@@ -133,6 +134,7 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _navSub?.cancel();
+    _updateChecks?.dispose();
     for (final sub in _warmSubs) {
       sub.close();
     }
@@ -144,11 +146,14 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
     if (!_startupReady) return;
     GenerationNotificationService.instance.updateLifecycleState(state);
     if (state == AppLifecycleState.resumed) {
+      _updateChecks?.resume();
       unawaited(ref.read(sessionLorebookEmbeddingWorkerProvider).drain());
       final service = ref.read(syncServiceProvider).value;
       if (service != null && service.status != SyncStatus.syncing) {
         ref.read(syncStatusProvider.notifier).state = service.status;
       }
+    } else {
+      _updateChecks?.pause();
     }
   }
 
@@ -215,7 +220,10 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
     unawaited(
       ref.read(sessionLorebookEmbeddingWorkerProvider).recoverAndDrain(),
     );
-    unawaited(checkAndShowUpdateOnStartup());
+    _updateChecks = AutomaticUpdateCheckController(
+      check: (presentedUpdateIds) =>
+          checkAndShowUpdateOnStartup(presentedUpdateIds: presentedUpdateIds),
+    )..start();
   }
 
   void _listenNotificationNavigation() {

--- a/lib/core/services/update_check_coordinator.dart
+++ b/lib/core/services/update_check_coordinator.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -19,7 +21,10 @@ const _dismissedShaKey = 'update_dismissed_sha';
 /// exists on this build's channel and the user hasn't muted that exact update.
 /// Any failure (offline, rate-limited, dev build) is swallowed — never blocks
 /// or interrupts launch. Skipped while onboarding is still pending.
-Future<void> checkAndShowUpdateOnStartup({UpdateCheckService? service}) async {
+Future<void> checkAndShowUpdateOnStartup({
+  UpdateCheckService? service,
+  Set<String>? presentedUpdateIds,
+}) async {
   if (!await isOnboardingComplete()) return;
 
   final result = await (service ?? UpdateCheckService()).check();
@@ -36,13 +41,83 @@ Future<void> checkAndShowUpdateOnStartup({UpdateCheckService? service}) async {
   if (info == null) return;
 
   if (prefs.getString(_dismissedShaKey) == info.dismissId) return;
+  if (presentedUpdateIds?.contains(info.dismissId) == true) return;
 
   // Show on the root navigator: the startup hook fires above MaterialApp,
   // so its own context has no Navigator/Overlay (same reason onboarding uses
   // rootNavigatorKey).
   final navContext = rootNavigatorKey.currentContext;
   if (navContext == null || !navContext.mounted) return;
+  presentedUpdateIds?.add(info.dismissId);
   await _present(navContext, info);
+}
+
+/// Runs silent update checks while the app is in the foreground.
+///
+/// The same build is presented at most once per app lifetime. Persistent
+/// suppression remains owned by [checkAndShowUpdateOnStartup].
+class AutomaticUpdateCheckController {
+  AutomaticUpdateCheckController({
+    required this.check,
+    this.interval = const Duration(hours: 1),
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  final Future<void> Function(Set<String> presentedUpdateIds) check;
+  final Duration interval;
+  final DateTime Function() _now;
+  final Set<String> _presentedUpdateIds = {};
+
+  Timer? _timer;
+  DateTime? _lastAttemptAt;
+  bool _inFlight = false;
+
+  void start() {
+    _startTimer();
+    _schedule(force: true);
+  }
+
+  void pause() => _timer?.cancel();
+
+  void resume() {
+    _startTimer();
+    _schedule();
+  }
+
+  Future<void> runNow({bool force = false}) async {
+    if (_inFlight) return;
+    final now = _now();
+    final lastAttemptAt = _lastAttemptAt;
+    if (!force &&
+        lastAttemptAt != null &&
+        now.difference(lastAttemptAt) < interval) {
+      return;
+    }
+
+    _lastAttemptAt = now;
+    _inFlight = true;
+    try {
+      await check(_presentedUpdateIds);
+    } finally {
+      _inFlight = false;
+    }
+  }
+
+  void dispose() => _timer?.cancel();
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(interval, (_) => _schedule());
+  }
+
+  void _schedule({bool force = false}) {
+    unawaited(
+      runNow(force: force).catchError((Object _) {
+        // Automatic checks are deliberately silent. Manual checks still report
+        // failures through [runManualUpdateCheck].
+      }),
+    );
+  }
 }
 
 /// Manual "Check for updates" entry point. Always reports the outcome:

--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -67,10 +67,35 @@ class ChatMessageService {
         ? (List<String>.from(msg.swipes)..[swipeIdx] = text)
         : msg.swipes;
     final updatedSwipesMeta = List<Map<String, dynamic>>.from(msg.swipesMeta);
+    while (updatedSwipesMeta.length < msg.swipes.length) {
+      updatedSwipesMeta.add(<String, dynamic>{});
+    }
+    final updatedTokens = estimateTokens(text);
+    final updatedAgentSwipes = List<AgentSwipe>.from(msg.agentSwipes);
+    if (msg.agentSwipeId >= 0 && msg.agentSwipeId < updatedAgentSwipes.length) {
+      final active = updatedAgentSwipes[msg.agentSwipeId];
+      updatedAgentSwipes[msg.agentSwipeId] = AgentSwipe(
+        content: text,
+        kind: active.kind,
+        reasoning: newReasoning,
+        genTime: active.genTime,
+        tokens: updatedTokens,
+        time: active.time,
+        studioOutputs: active.studioOutputs,
+        parentSwipeId: active.parentSwipeId,
+      );
+    }
     if (swipeIdx >= 0 && swipeIdx < updatedSwipesMeta.length) {
       updatedSwipesMeta[swipeIdx] = {
         ...updatedSwipesMeta[swipeIdx],
         'reasoning': newReasoning,
+        'tokens': updatedTokens,
+        if (updatedAgentSwipes.isNotEmpty) ...{
+          'agentSwipes': updatedAgentSwipes
+              .map((swipe) => swipe.toJson())
+              .toList(),
+          'agentSwipeId': msg.agentSwipeId,
+        },
       };
     }
     newMessages[index] = msg.copyWith(
@@ -79,7 +104,8 @@ class ChatMessageService {
       isAllReasoning: isAllReasoning,
       swipes: updatedSwipes,
       swipesMeta: updatedSwipesMeta,
-      tokens: estimateTokens(text),
+      agentSwipes: updatedAgentSwipes,
+      tokens: updatedTokens,
     );
     return _persist(session, newMessages);
   }

--- a/test/automatic_update_check_controller_test.dart
+++ b/test/automatic_update_check_controller_test.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/services/update_check_coordinator.dart';
+
+void main() {
+  test('deduplicates concurrent checks and respects cooldown', () async {
+    var now = DateTime.utc(2026, 8, 31);
+    var calls = 0;
+    final pending = Completer<void>();
+    final controller = AutomaticUpdateCheckController(
+      interval: const Duration(hours: 1),
+      now: () => now,
+      check: (_) {
+        calls++;
+        return pending.future;
+      },
+    );
+    addTearDown(controller.dispose);
+
+    final first = controller.runNow(force: true);
+    await controller.runNow(force: true);
+    expect(calls, 1);
+    pending.complete();
+    await first;
+
+    await controller.runNow();
+    expect(calls, 1);
+    now = now.add(const Duration(hours: 1));
+    await controller.runNow();
+    expect(calls, 2);
+  });
+
+  test('keeps presented update identities for the app lifetime', () async {
+    Set<String>? firstSet;
+    Set<String>? secondSet;
+    final controller = AutomaticUpdateCheckController(
+      check: (presented) async {
+        if (firstSet == null) {
+          firstSet = presented;
+          presented.add('build-a');
+        } else {
+          secondSet = presented;
+        }
+      },
+    );
+    addTearDown(controller.dispose);
+
+    await controller.runNow(force: true);
+    await controller.runNow(force: true);
+    expect(identical(firstSet, secondSet), isTrue);
+    expect(secondSet, contains('build-a'));
+  });
+
+  test('releases the in-flight guard after an error', () async {
+    var calls = 0;
+    final controller = AutomaticUpdateCheckController(
+      check: (_) async {
+        calls++;
+        if (calls == 1) throw StateError('offline');
+      },
+    );
+    addTearDown(controller.dispose);
+
+    await expectLater(controller.runNow(force: true), throwsStateError);
+    await controller.runNow(force: true);
+    expect(calls, 2);
+  });
+}

--- a/test/nested_swipes_test.dart
+++ b/test/nested_swipes_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:glaze_flutter/core/models/chat_message.dart';
 import 'package:glaze_flutter/features/chat/chat_message_service.dart';
 import 'package:glaze_flutter/features/chat/services/saved_message_writer.dart';
+
+final _messageServiceProvider = Provider(ChatMessageService.new);
 
 void main() {
   group('AgentSwipe', () {
@@ -108,6 +111,116 @@ void main() {
       final msg = ChatMessage.fromJson(json);
       expect(msg.agentSwipes, isEmpty);
       expect(msg.agentSwipeId, 0);
+    });
+  });
+
+  group('ChatMessageService nested swipe edits', () {
+    test('edited variation survives switching away and back', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final service = container.read(_messageServiceProvider);
+      final message = ChatMessage(
+        id: 'a1',
+        role: 'assistant',
+        content: 'four',
+        swipes: const ['one', 'two', 'three', 'four'],
+        swipeId: 3,
+        swipesMeta: [
+          <String, dynamic>{},
+          <String, dynamic>{},
+          <String, dynamic>{},
+          <String, dynamic>{
+            'agentSwipes': [const AgentSwipe(content: 'four').toJson()],
+            'agentSwipeId': 0,
+          },
+        ],
+        agentSwipes: const [AgentSwipe(content: 'four')],
+      );
+      final session = ChatSession(
+        id: 's1',
+        characterId: 'c1',
+        sessionIndex: 0,
+        messages: [message],
+      );
+
+      final edited = service.editMessage(session, 0, 'four edited');
+      final editedMessage = edited.messages.single;
+      expect(editedMessage.agentSwipes.single.content, 'four edited');
+      final stored = editedMessage.swipesMeta[3]['agentSwipes'] as List;
+      expect(
+        AgentSwipe.fromJson(
+          Map<String, dynamic>.from(stored.single as Map<dynamic, dynamic>),
+        ).content,
+        'four edited',
+      );
+
+      final second = service.setSwipe(edited, 0, 1);
+      final fourth = service.setSwipe(second, 0, 3);
+      expect(fourth.messages.single.content, 'four edited');
+      expect(fourth.messages.single.swipes[3], 'four edited');
+    });
+
+    test('editing active nested swipe clears its reasoning only', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final service = container.read(_messageServiceProvider);
+      final message = ChatMessage(
+        id: 'a1',
+        role: 'assistant',
+        content: 'cleaned',
+        reasoning: 'old thought',
+        swipes: const ['cleaned'],
+        swipesMeta: [
+          <String, dynamic>{
+            'agentSwipes': [
+              const AgentSwipe(
+                content: 'final',
+                kind: 'final',
+                reasoning: 'final thought',
+              ).toJson(),
+              const AgentSwipe(
+                content: 'cleaned',
+                kind: 'cleaned',
+                reasoning: 'old thought',
+              ).toJson(),
+            ],
+            'agentSwipeId': 1,
+          },
+        ],
+        agentSwipes: const [
+          AgentSwipe(
+            content: 'final',
+            kind: 'final',
+            reasoning: 'final thought',
+          ),
+          AgentSwipe(
+            content: 'cleaned',
+            kind: 'cleaned',
+            reasoning: 'old thought',
+          ),
+        ],
+        agentSwipeId: 1,
+      );
+      final session = ChatSession(
+        id: 's1',
+        characterId: 'c1',
+        sessionIndex: 0,
+        messages: [message],
+      );
+
+      final edited = service.editMessage(
+        session,
+        0,
+        'cleaned edit',
+        tagStart: '<think>',
+        tagEnd: '</think>',
+      );
+      final result = edited.messages.single;
+      expect(result.reasoning, isNull);
+      expect(result.agentSwipes[0].reasoning, 'final thought');
+      expect(result.agentSwipes[0].content, 'final');
+      expect(result.agentSwipes[1].reasoning, isNull);
+      expect(result.agentSwipes[1].content, 'cleaned edit');
     });
   });
 

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -986,6 +986,7 @@ void main() {
       // A table needs its separator row — otherwise a line of prose that uses
       // pipes would become a table.
       expect(formatterBlockSyntaxJs, contains(r'\|[ \t:|-]+\|'));
+      expect(formatterBlockSyntaxJs, contains('const startAttr = start === 1'));
     });
 
     test('an indented list item nests inside the item above it', () {

--- a/test/webview_js/corpus/cards.js
+++ b/test/webview_js/corpus/cards.js
@@ -107,6 +107,12 @@ function jscToggle() {
 | MP | 3 |`,
   },
   {
+    id: 'ordered-list-zero',
+    title: 'Ordered Markdown list starting at zero',
+    origin: 'Discord #1543310048007295086 — `0. test` rendered as `1. test`',
+    text: `0. test`,
+  },
+  {
     id: 'prose-angle-brackets',
     title: 'Prose that contains angle brackets',
     origin: 'the orphan heuristic existed for this case',

--- a/test/webview_js/specs/cards.spec.js
+++ b/test/webview_js/specs/cards.spec.js
@@ -229,6 +229,7 @@ test('markdown structure renders headings, lists and a table', async ({ page }) 
         ?.querySelectorAll(':scope > li').length ?? -1,
       nested: root.querySelectorAll('ul.chat-list li ul li').length,
       ordered: root.querySelectorAll('ol.chat-list > li').length,
+      orderedStart: root.querySelector('ol.chat-list')?.start ?? -1,
       tableRows: root.querySelectorAll('table.chat-table tbody tr').length,
       headers: root.querySelectorAll('table.chat-table th').length,
     };
@@ -237,8 +238,25 @@ test('markdown structure renders headings, lists and a table', async ({ page }) 
   expect(shape.topLevelItems).toBe(2);
   expect(shape.nested).toBe(1);
   expect(shape.ordered).toBe(2);
+  expect(shape.orderedStart).toBe(1);
   expect(shape.tableRows).toBe(2);
   expect(shape.headers).toBe(2);
+});
+
+test('ordered markdown list preserves a zero start', async ({ page }) => {
+  await render(page, card('ordered-list-zero').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const list = root.querySelector('ol.chat-list');
+    return {
+      start: list?.start ?? -1,
+      items: list?.querySelectorAll(':scope > li').length ?? -1,
+      text: list?.querySelector('li')?.textContent.trim() || '',
+    };
+  });
+  expect(shape.start).toBe(0);
+  expect(shape.items).toBe(1);
+  expect(shape.text).toBe('test');
 });
 
 test('blockquote and horizontal rule render as elements', async ({ page }) => {


### PR DESCRIPTION
## Summary

- keep edited assistant variation content aligned with its active nested swipe
- periodically check for updates while the app remains open and recheck after resume
- preserve non-default ordered-list starts such as `0. test` in chat rendering

## Tests

- `flutter test` (3577 passed)
- `flutter analyze` (no new findings; 3 pre-existing findings)
- WebView Playwright suite (51 passed)
- `git diff --check`