### PR TITLE
feat(memory): scope draft keys to paragraphs

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -91,6 +91,7 @@
   "regex_max_depth": "Max Depth",
   "regex_other_options": "Other Options",
   "regex_run_on_edit": "Run On Edit",
+  "regex_memory_book_retrieval": "Apply when generating Memory Book drafts",
   "regex_macros_find": "Macros in Find Regex",
   "regex_ephemerality": "Ephemerality",
   "regex_user_input": "User Input",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -91,6 +91,7 @@
   "regex_max_depth": "Макс. глубина",
   "regex_other_options": "Другие опции",
   "regex_run_on_edit": "Срабатывать при редактировании",
+  "regex_memory_book_retrieval": "Применять при генерации черновиков Memory Book",
   "regex_macros_find": "Макросы в поиске",
   "regex_ephemerality": "Эфемерность",
   "regex_user_input": "Ввод пользователя",

--- a/lib/core/llm/memory/memory_chunker.dart
+++ b/lib/core/llm/memory/memory_chunker.dart
@@ -3,10 +3,16 @@ import '../tokenizer.dart';
 /// A text chunk with its index and token cost.
 class ExcerptChunk {
   final int index;
+  final int paragraphIndex;
   final String text;
   final int tokenCost;
 
-  const ExcerptChunk(this.index, this.text, this.tokenCost);
+  const ExcerptChunk(
+    this.index,
+    this.paragraphIndex,
+    this.text,
+    this.tokenCost,
+  );
 }
 
 /// Text chunking logic for memory excerpt selection.
@@ -29,17 +35,18 @@ class MemoryChunker {
     int maxTokens,
     int Function(String text) tokenCounter,
   ) {
-    final blocks = content
-        .split(RegExp(r'\n\s*\n+'))
-        .map((part) => part.trim())
-        .where((part) => part.isNotEmpty)
-        .toList(growable: false);
+    final blocks = paragraphs(content);
     final chunks = <ExcerptChunk>[];
     var index = 0;
-    for (final block in blocks) {
+    for (
+      var paragraphIndex = 0;
+      paragraphIndex < blocks.length;
+      paragraphIndex++
+    ) {
+      final block = blocks[paragraphIndex];
       final tokenCost = tokenCounter(block);
       if (tokenCost <= maxTokens) {
-        chunks.add(ExcerptChunk(index++, block, tokenCost));
+        chunks.add(ExcerptChunk(index++, paragraphIndex, block, tokenCost));
         continue;
       }
       final sentences = MemoryChunker.sentences(block);
@@ -47,30 +54,64 @@ class MemoryChunker {
       for (final sentence in sentences) {
         final candidate = [...window, sentence].join(' ').trim();
         if (candidate.isEmpty) continue;
-        if (tokenCounter(candidate) > maxTokens && window.isNotEmpty) {
+        if (tokenCounter(candidate) <= maxTokens) {
+          window.add(sentence);
+          continue;
+        }
+        if (window.isNotEmpty) {
           final text = window.join(' ').trim();
-          chunks.add(ExcerptChunk(index++, text, tokenCounter(text)));
-          window = [sentence];
-        } else if (tokenCounter(candidate) > maxTokens) {
+          chunks.add(
+            ExcerptChunk(index++, paragraphIndex, text, tokenCounter(text)),
+          );
+          window = [];
+        }
+        if (tokenCounter(sentence) > maxTokens) {
           final words = sentence.split(RegExp(r'\s+'));
-          final shortText = words.take(maxTokens * 3).join(' ').trim();
-          if (shortText.isNotEmpty) {
-            chunks.add(
-              ExcerptChunk(index++, shortText, tokenCounter(shortText)),
-            );
+          var wordStart = 0;
+          while (wordStart < words.length) {
+            var wordEnd = wordStart + 1;
+            while (wordEnd <= words.length &&
+                tokenCounter(words.sublist(wordStart, wordEnd).join(' ')) <=
+                    maxTokens) {
+              wordEnd++;
+            }
+            final safeEnd = (wordEnd - 1).clamp(wordStart + 1, words.length);
+            final shortText = words
+                .sublist(wordStart, safeEnd)
+                .join(' ')
+                .trim();
+            if (shortText.isNotEmpty) {
+              chunks.add(
+                ExcerptChunk(
+                  index++,
+                  paragraphIndex,
+                  shortText,
+                  tokenCounter(shortText),
+                ),
+              );
+            }
+            wordStart = safeEnd;
           }
           window = [];
-        } else {
-          window.add(sentence);
+          continue;
         }
+        window.add(sentence);
       }
       if (window.isNotEmpty) {
         final text = window.join(' ').trim();
-        chunks.add(ExcerptChunk(index++, text, tokenCounter(text)));
+        chunks.add(
+          ExcerptChunk(index++, paragraphIndex, text, tokenCounter(text)),
+        );
       }
     }
     return chunks;
   }
+
+  static List<String> paragraphs(String content) => content
+      .split(RegExp(r'\n\s*\n+'))
+      .map((part) => part.trim())
+      .where((part) => part.isNotEmpty)
+      .toList(growable: false);
 
   /// Split text into sentences using punctuation boundaries.
   static List<String> sentences(String text) {

--- a/lib/core/llm/memory_catalog_builder.dart
+++ b/lib/core/llm/memory_catalog_builder.dart
@@ -30,6 +30,7 @@ class MemoryCatalogBuilder {
     final revision = _hash({
       'content': entry.content,
       'keys': entry.keys,
+      'keyParagraphs': entry.keyParagraphs,
       'status': entry.status,
       'sourceHash': sourceHash,
       'messageRange': entry.messageRange?.toJson(),

--- a/lib/core/llm/memory_draft_response_parser.dart
+++ b/lib/core/llm/memory_draft_response_parser.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+
+import '../models/memory_book.dart';
+import 'memory/memory_chunker.dart';
+
+class MemoryDraftResponseParser {
+  const MemoryDraftResponseParser._();
+
+  static MemoryDraft parse(MemoryDraft draft, String raw, {int? nowMillis}) {
+    final parsed = _parseStructured(raw) ?? _parseLegacy(raw);
+    final now = nowMillis ?? DateTime.now().millisecondsSinceEpoch;
+    return draft.copyWith(
+      content: parsed.content,
+      keys: parsed.keys,
+      keyParagraphs: parsed.keyParagraphs,
+      status: 'pending_approval',
+      generatedAt: now,
+      updatedAt: now,
+      error: null,
+    );
+  }
+
+  static _ParsedDraft? _parseStructured(String raw) {
+    var text = raw.trim();
+    final fence = RegExp(
+      r'^```(?:json)?\s*([\s\S]*?)\s*```$',
+      caseSensitive: false,
+    ).firstMatch(text);
+    if (fence != null) text = fence.group(1)!.trim();
+    try {
+      final decoded = jsonDecode(text);
+      if (decoded is! Map || decoded['paragraphs'] is! List) return null;
+      final paragraphs = <String>[];
+      final keys = <String>[];
+      final scopes = <String, List<int>>{};
+      for (final item in decoded['paragraphs'] as List) {
+        if (item is! Map) continue;
+        final itemParagraphs = MemoryChunker.paragraphs(
+          item['text']?.toString() ?? '',
+        );
+        if (itemParagraphs.isEmpty) continue;
+        final paragraphIndexes = List<int>.generate(
+          itemParagraphs.length,
+          (index) => paragraphs.length + index,
+          growable: false,
+        );
+        paragraphs.addAll(itemParagraphs);
+        final rawKeys = item['keys'];
+        if (rawKeys is! List) continue;
+        for (final value in rawKeys) {
+          if (value is! String) continue;
+          final key = value.trim();
+          if (key.isEmpty) continue;
+          final canonical = _existingKey(keys, key) ?? key;
+          if (!keys.contains(canonical)) keys.add(canonical);
+          scopes.putIfAbsent(canonical, () => <int>[]).addAll(paragraphIndexes);
+        }
+      }
+      if (paragraphs.isEmpty) return null;
+      return _ParsedDraft(paragraphs.join('\n\n'), keys, scopes);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static _ParsedDraft _parseLegacy(String raw) {
+    var content = raw.trim();
+    var keys = <String>[];
+    final memoryMatch = RegExp(
+      r'^Memory:\s*(.*?)(?=^Keys:|\z)',
+      dotAll: true,
+      multiLine: true,
+      caseSensitive: false,
+    ).firstMatch(raw);
+    final keysMatch = RegExp(
+      r'^Keys:\s*(.*?)$',
+      dotAll: true,
+      multiLine: true,
+      caseSensitive: false,
+    ).firstMatch(raw);
+    if (memoryMatch != null) content = memoryMatch.group(1)!.trim();
+    if (keysMatch != null) {
+      keys = _dedupe(keysMatch.group(1)!.split(',').map((key) => key.trim()));
+    }
+    return _ParsedDraft(content, keys, const {});
+  }
+
+  static String? _existingKey(List<String> keys, String candidate) {
+    final lower = candidate.toLowerCase();
+    return keys.where((key) => key.toLowerCase() == lower).firstOrNull;
+  }
+
+  static List<String> _dedupe(Iterable<String> values) {
+    final seen = <String>{};
+    return [
+      for (final value in values)
+        if (value.isNotEmpty && seen.add(value.toLowerCase())) value,
+    ];
+  }
+}
+
+class _ParsedDraft {
+  final String content;
+  final List<String> keys;
+  final Map<String, List<int>> keyParagraphs;
+
+  const _ParsedDraft(this.content, this.keys, this.keyParagraphs);
+}

--- a/lib/core/llm/memory_draft_transcript_builder.dart
+++ b/lib/core/llm/memory_draft_transcript_builder.dart
@@ -1,0 +1,67 @@
+import '../models/chat_message.dart';
+import '../models/preset.dart';
+import 'auxiliary_timed_history.dart';
+import 'regex_service.dart';
+
+class MemoryDraftTranscriptBuilder {
+  const MemoryDraftTranscriptBuilder._();
+
+  static String build({
+    required List<ChatMessage> messages,
+    required List<PresetRegex> scripts,
+    required RegexApplyContext context,
+  }) {
+    final enabled = scripts
+        .where((script) => !script.disabled && script.memoryBookRetrieval)
+        .toList(growable: false);
+    final eligible = messages
+        .where(
+          (message) =>
+              !message.isHidden &&
+              !message.isTyping &&
+              message.content.trim().isNotEmpty &&
+              (message.role == 'user' || message.role == 'assistant'),
+        )
+        .toList(growable: false);
+
+    return [
+      for (var index = 0; index < eligible.length; index++)
+        _formatMessage(
+          eligible[index],
+          enabled,
+          context,
+          depth: eligible.length - 1 - index,
+          totalMessages: eligible.length,
+        ),
+    ].join('\n\n');
+  }
+
+  static String _formatMessage(
+    ChatMessage message,
+    List<PresetRegex> scripts,
+    RegexApplyContext context, {
+    required int depth,
+    required int totalMessages,
+  }) {
+    final transformed = scripts.isEmpty
+        ? message.content
+        : applyRegexes(
+            message.content,
+            message.role == 'user' ? 1 : 2,
+            2,
+            scripts,
+            RegexApplyContext(
+              char: context.char,
+              persona: context.persona,
+              sessionVars: context.sessionVars,
+              globalVars: context.globalVars,
+              depth: depth,
+              totalMessages: totalMessages,
+              macroContext: context.macroContext,
+            ),
+            isPrompt: true,
+            ignoreEphemerality: true,
+          );
+    return '${message.role}: ${auxiliaryTimedContent(message.copyWith(content: transformed))}';
+  }
+}

--- a/lib/core/llm/memory_excerpt_selector.dart
+++ b/lib/core/llm/memory_excerpt_selector.dart
@@ -98,11 +98,16 @@ class MemoryExcerptSelector {
       );
     }
 
+    final hasScopedEntries = selection.allScores.any(
+      (score) => _scopedParagraphs(score) != null,
+    );
     if (normalizedPackingMode == 'full' ||
-        budget == null ||
+        (budget == null && !hasScopedEntries) ||
         (normalizedPackingMode == 'hybrid' &&
+            budget != null &&
             selectedFullTokens <= budget &&
-            !selection.budgetTrimmed)) {
+            !selection.budgetTrimmed &&
+            !hasScopedEntries)) {
       return fullEntries(selection);
     }
 
@@ -110,6 +115,7 @@ class MemoryExcerptSelector {
         ? selection.entryCap
         : selection.entries.length;
     final items = <MemoryInjectionItem>[];
+    final packingBudget = budget ?? selectedFullTokens;
     var usedTokens = 0;
     var trimmed = selection.budgetTrimmed;
 
@@ -120,9 +126,11 @@ class MemoryExcerptSelector {
       final fullText = entry.content.trim();
       if (fullText.isEmpty) continue;
       final fullTokens = tokenFn(fullText);
+      final scopedParagraphs = _scopedParagraphs(score);
 
       if (normalizedPackingMode == 'hybrid' &&
-          usedTokens + fullTokens <= budget) {
+          scopedParagraphs == null &&
+          usedTokens + fullTokens <= packingBudget) {
         items.add(
           MemoryInjectionItem(
             entry: entry,
@@ -136,16 +144,16 @@ class MemoryExcerptSelector {
         continue;
       }
 
-      final remaining = budget - usedTokens;
+      final remaining = packingBudget - usedTokens;
       if (remaining <= 0 && items.isNotEmpty) {
         trimmed = true;
         continue;
       }
 
-      final perEntryBudget = budget <= 0
+      final perEntryBudget = packingBudget <= 0
           ? 0
           : items.isEmpty
-          ? maxExcerptTokensPerEntry.clamp(1, budget)
+          ? maxExcerptTokensPerEntry.clamp(1, packingBudget)
           : maxExcerptTokensPerEntry.clamp(1, remaining);
       final excerpt = _buildExcerpt(
         score,
@@ -173,7 +181,7 @@ class MemoryExcerptSelector {
         continue;
       }
 
-      if (usedTokens + excerpt.tokenCost <= budget || items.isEmpty) {
+      if (usedTokens + excerpt.tokenCost <= packingBudget || items.isEmpty) {
         items.add(excerpt);
         usedTokens += excerpt.tokenCost;
       } else {
@@ -208,9 +216,18 @@ class MemoryExcerptSelector {
       final fullText = score.entry.content.trim();
       if (fullText.isEmpty) continue;
 
-      final chunks = MemoryChunker.chunk(fullText, maxExcerptTokensPerChunk, tokenFn);
+      final chunks = MemoryChunker.chunk(
+        fullText,
+        maxExcerptTokensPerChunk,
+        tokenFn,
+      );
+      final scopedParagraphs = _scopedParagraphs(score);
       final terms = ExcerptScorer.termsFor(score);
       for (final chunk in chunks) {
+        if (scopedParagraphs != null &&
+            !scopedParagraphs.contains(chunk.paragraphIndex)) {
+          continue;
+        }
         ranked.add(
           GlobalChunkCandidate(
             entry: score.entry,
@@ -248,7 +265,10 @@ class MemoryExcerptSelector {
           .add(candidate);
     }
     final entryFloorCap = topEntries.clamp(0, 64);
-    final chunksPerGuaranteedEntry = topChunks.clamp(1, maxExcerptChunksPerEntry);
+    final chunksPerGuaranteedEntry = topChunks.clamp(
+      1,
+      maxExcerptChunksPerEntry,
+    );
     if (entryFloorCap > 0) {
       var floorEntriesProcessed = 0;
       for (final score in selection.allScores) {
@@ -370,7 +390,17 @@ class MemoryExcerptSelector {
     required int Function(String text) tokenCounter,
   }) {
     if (maxTokens <= 0 || maxChunks <= 0) return null;
-    final chunks = MemoryChunker.chunk(score.entry.content, maxTokens, tokenCounter);
+    var chunks = MemoryChunker.chunk(
+      score.entry.content,
+      maxTokens,
+      tokenCounter,
+    );
+    final scopedParagraphs = _scopedParagraphs(score);
+    if (scopedParagraphs != null) {
+      chunks = chunks
+          .where((chunk) => scopedParagraphs.contains(chunk.paragraphIndex))
+          .toList(growable: false);
+    }
     if (chunks.isEmpty) return null;
     final terms = ExcerptScorer.termsFor(score);
     final ranked =
@@ -438,5 +468,24 @@ class MemoryExcerptSelector {
     }
     chunksForEntry.add(candidate);
     return true;
+  }
+
+  static Set<int>? _scopedParagraphs(MemoryCandidateScore score) {
+    if (score.matchedKeys.isEmpty || score.entry.keyParagraphs.isEmpty) {
+      return null;
+    }
+    final normalized = {
+      for (final entry in score.entry.keyParagraphs.entries)
+        entry.key.trim().toLowerCase(): entry.value,
+    };
+    final resolved = <int>{};
+    for (final key in score.matchedKeys) {
+      final indexes = normalized[key.trim().toLowerCase()];
+      if (indexes == null || indexes.isEmpty) return null;
+      resolved.addAll(indexes);
+    }
+    final paragraphCount = MemoryChunker.paragraphs(score.entry.content).length;
+    resolved.removeWhere((index) => index < 0 || index >= paragraphCount);
+    return resolved.isEmpty ? null : resolved;
   }
 }

--- a/lib/core/llm/regex_service.dart
+++ b/lib/core/llm/regex_service.dart
@@ -35,6 +35,7 @@ String applyRegexes(
   RegexApplyContext ctx, {
   bool isMarkdown = false,
   bool isPrompt = false,
+  bool ignoreEphemerality = false,
   List<TriggeredEntry>? triggered,
 }) {
   var result = text;
@@ -52,7 +53,8 @@ String applyRegexes(
     if (script.markdownOnly && !isMarkdown) continue;
 
     final sEphemerality = script.ephemerality;
-    if (sEphemerality.isNotEmpty &&
+    if (!ignoreEphemerality &&
+        sEphemerality.isNotEmpty &&
         !sEphemerality.contains(ephemeralityFilter)) {
       continue;
     }

--- a/lib/core/models/memory_book.dart
+++ b/lib/core/models/memory_book.dart
@@ -10,6 +10,7 @@ abstract class MemoryDraft with _$MemoryDraft {
     @Default('') String title,
     @Default('') String content,
     @Default([]) List<String> keys,
+    @Default({}) Map<String, List<int>> keyParagraphs,
     @Default([]) List<String> glazeKeys,
     @Default(false) bool vectorSearch,
     @Default([]) List<String> messageIds,
@@ -25,7 +26,7 @@ abstract class MemoryDraft with _$MemoryDraft {
   }) = _MemoryDraft;
 
   factory MemoryDraft.fromJson(Map<String, dynamic> json) =>
-      _$MemoryDraftFromJson(json);
+      _$MemoryDraftFromJson(_migrateKeyParagraphsInPlace(json));
 }
 
 @freezed
@@ -43,6 +44,7 @@ abstract class MemoryEntry with _$MemoryEntry {
     required String id,
     @Default('') String title,
     @Default([]) List<String> keys,
+    @Default({}) Map<String, List<int>> keyParagraphs,
     @Default('') String content,
     @Default('active') String status,
     @Default(false) bool vectorSearch,
@@ -161,7 +163,7 @@ Map<String, dynamic> _migrateInjectionTargetInPlace(Map<String, dynamic> json) {
 /// Coerces new optional fields into safe defaults when reading older JSON
 /// payloads written before the v2 selector schema.
 Map<String, dynamic> _migrateEntryInPlace(Map<String, dynamic> json) {
-  var out = json;
+  var out = _migrateKeyParagraphsInPlace(json);
   if (out['messageRange'] != null && out['messageRange'] is! Map) {
     out = {...out, 'messageRange': null};
   }
@@ -190,6 +192,28 @@ Map<String, dynamic> _migrateEntryInPlace(Map<String, dynamic> json) {
     out = {...out, 'source': ''};
   }
   return out;
+}
+
+Map<String, dynamic> _migrateKeyParagraphsInPlace(Map<String, dynamic> json) {
+  final raw = json['keyParagraphs'];
+  if (raw is! Map) return {...json, 'keyParagraphs': <String, List<int>>{}};
+  final normalized = <String, List<int>>{};
+  for (final entry in raw.entries) {
+    final key = entry.key.toString().trim();
+    if (key.isEmpty || entry.value is! List) continue;
+    final indexes =
+        (entry.value as List)
+            .map(
+              (value) => value is int ? value : int.tryParse(value.toString()),
+            )
+            .whereType<int>()
+            .where((value) => value >= 0)
+            .toSet()
+            .toList()
+          ..sort();
+    if (indexes.isNotEmpty) normalized[key] = indexes;
+  }
+  return {...json, 'keyParagraphs': normalized};
 }
 
 Map<String, int>? _parseLegacyTitleRange(Object? title) {

--- a/lib/core/models/preset.dart
+++ b/lib/core/models/preset.dart
@@ -50,6 +50,7 @@ abstract class PresetRegex with _$PresetRegex {
     @Default(false) bool markdownOnly,
     @Default(false) bool promptOnly,
     @Default(false) bool runOnEdit,
+    @Default(false) bool memoryBookRetrieval,
     @Default(0) int substituteRegex,
   }) = _PresetRegex;
 
@@ -156,6 +157,10 @@ Map<String, dynamic> _normalizeRegex(Map<String, dynamic> json) {
   n['markdownOnly'] = _coerceBool(n['markdownOnly'], false);
   n['promptOnly'] = _coerceBool(n['promptOnly'], false);
   n['runOnEdit'] = _coerceBool(n['runOnEdit'], false);
+  n['memoryBookRetrieval'] = _coerceBool(
+    n['memoryBookRetrieval'] ?? n['memory_book_retrieval'],
+    false,
+  );
   n['substituteRegex'] = _coerceInt(n['substituteRegex']) ?? 0;
   if (n['placement'] is List) {
     n['placement'] = _migrateGlazePlacementIds(

--- a/lib/core/services/backup/js_memory_importer.dart
+++ b/lib/core/services/backup/js_memory_importer.dart
@@ -16,11 +16,20 @@ class JsMemoryImporter with TypeConverters {
       await _importMemoryBooksFromMap(charId, memoryBooksRaw);
     } else if (memoryBooksRaw is List) {
       final sessionId = '${charId}_1';
-      await _importMemoryBookEntries(charId, sessionId, memoryBooksRaw, {}, null);
+      await _importMemoryBookEntries(
+        charId,
+        sessionId,
+        memoryBooksRaw,
+        {},
+        null,
+      );
     }
   }
 
-  Future<void> importMemoryDrafts(String charId, dynamic pendingDraftsRaw) async {
+  Future<void> importMemoryDrafts(
+    String charId,
+    dynamic pendingDraftsRaw,
+  ) async {
     if (pendingDraftsRaw is! Map) return;
     for (final entry in pendingDraftsRaw.entries) {
       final sessionIdx = entry.key;
@@ -32,7 +41,9 @@ class JsMemoryImporter with TypeConverters {
   }
 
   Future<void> _importMemoryBooksFromMap(
-      String charId, Map<dynamic, dynamic> memoryBooksRaw) async {
+    String charId,
+    Map<dynamic, dynamic> memoryBooksRaw,
+  ) async {
     for (final mbEntry in memoryBooksRaw.entries) {
       final mbSessionIdx = mbEntry.key;
       final mbData = mbEntry.value;
@@ -40,28 +51,34 @@ class JsMemoryImporter with TypeConverters {
 
       final mbFullSessionId = '${charId}_$mbSessionIdx';
       final rawEntries = mbData['entries'];
-      final rawSettings =
-          mbData['settings'] is Map ? mbData['settings'] as Map : <String, dynamic>{};
+      final rawSettings = mbData['settings'] is Map
+          ? mbData['settings'] as Map
+          : <String, dynamic>{};
 
       if (rawEntries is List) {
         await _importMemoryBookEntries(
-            charId, mbFullSessionId, rawEntries, rawSettings, mbData);
+          charId,
+          mbFullSessionId,
+          rawEntries,
+          rawSettings,
+          mbData,
+        );
       }
 
       final rawDrafts = mbData['pendingDrafts'];
       if (rawDrafts is List) {
-        await _importMemoryDraftsForSession(
-            mbFullSessionId, rawDrafts);
+        await _importMemoryDraftsForSession(mbFullSessionId, rawDrafts);
       }
     }
   }
 
   Future<void> _importMemoryBookEntries(
-      String charId,
-      String sessionId,
-      List<dynamic> rawEntries,
-      Map<dynamic, dynamic> rawSettings,
-      Map<dynamic, dynamic>? mbData) async {
+    String charId,
+    String sessionId,
+    List<dynamic> rawEntries,
+    Map<dynamic, dynamic> rawSettings,
+    Map<dynamic, dynamic>? mbData,
+  ) async {
     final entries = <Map<String, dynamic>>[];
     for (final e in rawEntries) {
       if (e is! Map) continue;
@@ -73,28 +90,25 @@ class JsMemoryImporter with TypeConverters {
         'keys': e['keys'] is List
             ? List<String>.from((e['keys'] as List).whereType<String>())
             : <String>[],
+        'keyParagraphs': e['keyParagraphs'] is Map
+            ? Map<String, dynamic>.from(e['keyParagraphs'] as Map)
+            : <String, List<int>>{},
         'glazeKeys': e['glazeKeys'] is List
             ? List<String>.from((e['glazeKeys'] as List).whereType<String>())
             : <String>[],
-        'content':
-            e['content'] is String ? e['content'] as String : '',
+        'content': e['content'] is String ? e['content'] as String : '',
         'rawContent': e['rawContent'] is String
             ? e['rawContent'] as String
             : null,
-        'status': e['status'] is String
-            ? e['status'] as String
-            : 'active',
+        'status': e['status'] is String ? e['status'] as String : 'active',
         'vectorSearch': e['vectorSearch'] == true,
         'messageIds': e['messageIds'] is List
-            ? List<String>.from(
-                (e['messageIds'] as List).whereType<String>())
+            ? List<String>.from((e['messageIds'] as List).whereType<String>())
             : <String>[],
         'messageRange': e['messageRange'] is Map
             ? _convertMessageRange(e['messageRange'] as Map)
             : null,
-        'source': e['source'] is String
-            ? e['source'] as String
-            : 'manual',
+        'source': e['source'] is String ? e['source'] as String : 'manual',
         'createdAt': toInt(e['createdAt']),
         'updatedAt': toInt(e['updatedAt']) ?? 0,
         'generatedAt': toInt(e['generatedAt']),
@@ -103,19 +117,25 @@ class JsMemoryImporter with TypeConverters {
 
     final settings = _parseMemorySettings(rawSettings);
 
-    await db.into(db.memoryBookRows).insertOnConflictUpdate(
+    await db
+        .into(db.memoryBookRows)
+        .insertOnConflictUpdate(
           MemoryBookRowsCompanion.insert(
             sessionId: sessionId,
             entriesJson: Value(jsonEncode(entries)),
             settingsJson: Value(jsonEncode(settings)),
-            lastProcessedMessageCount: Value(toInt(mbData?['automation']
-                        is Map
-                    ? (mbData!['automation'] as Map)[
-                        'lastProcessedMessageCount']
-                    : null) ??
-                0),
-            updatedAt: Value(toInt(mbData?['updatedAt']) ??
-                currentTimestampSeconds()),
+            lastProcessedMessageCount: Value(
+              toInt(
+                    mbData?['automation'] is Map
+                        ? (mbData!['automation']
+                              as Map)['lastProcessedMessageCount']
+                        : null,
+                  ) ??
+                  0,
+            ),
+            updatedAt: Value(
+              toInt(mbData?['updatedAt']) ?? currentTimestampSeconds(),
+            ),
           ),
         );
   }
@@ -124,26 +144,20 @@ class JsMemoryImporter with TypeConverters {
     return <String, dynamic>{
       'enabled': rawSettings['enabled'] == true,
       'autoCreateEnabled': rawSettings['autoCreateEnabled'] == true,
-      'autoGenerateEnabled':
-          rawSettings['autoGenerateEnabled'] == true,
-      'maxInjectedEntries':
-          toInt(rawSettings['maxInjectedEntries']) ?? 7,
+      'autoGenerateEnabled': rawSettings['autoGenerateEnabled'] == true,
+      'maxInjectedEntries': toInt(rawSettings['maxInjectedEntries']) ?? 7,
       'memoryExcerptingEnabled':
           rawSettings['memoryExcerptingEnabled'] != false,
-      'autoCreateInterval':
-          toInt(rawSettings['autoCreateInterval']) ?? 15,
-      'autoCreateLagMessages':
-          toInt(rawSettings['autoCreateLagMessages']) ?? 4,
-      'useDelayedAutomation':
-          rawSettings['useDelayedAutomation'] == true,
+      'autoCreateInterval': toInt(rawSettings['autoCreateInterval']) ?? 15,
+      'autoCreateLagMessages': toInt(rawSettings['autoCreateLagMessages']) ?? 4,
+      'useDelayedAutomation': rawSettings['useDelayedAutomation'] == true,
       'injectionTarget': _migrateInjectionTarget(
         rawSettings['injectionTarget'] is String
             ? rawSettings['injectionTarget'] as String
             : null,
       ),
       'batchSize': toInt(rawSettings['batchSize']) ?? 3,
-      'vectorSearchEnabled':
-          rawSettings['vectorSearchEnabled'] == true,
+      'vectorSearchEnabled': rawSettings['vectorSearchEnabled'] == true,
       'keyMatchMode': rawSettings['keyMatchMode'] is String
           ? rawSettings['keyMatchMode'] as String
           : 'glaze',
@@ -153,10 +167,9 @@ class JsMemoryImporter with TypeConverters {
       'generationModel': rawSettings['generationModel'] is String
           ? rawSettings['generationModel'] as String
           : '',
-      'generationEndpoint':
-          rawSettings['generationEndpoint'] is String
-              ? rawSettings['generationEndpoint'] as String
-              : '',
+      'generationEndpoint': rawSettings['generationEndpoint'] is String
+          ? rawSettings['generationEndpoint'] as String
+          : '',
       'generationApiKey': rawSettings['generationApiKey'] is String
           ? rawSettings['generationApiKey'] as String
           : '',
@@ -164,7 +177,9 @@ class JsMemoryImporter with TypeConverters {
   }
 
   Future<void> _importMemoryDraftsForSession(
-      String sessionId, List<dynamic> rawDrafts) async {
+    String sessionId,
+    List<dynamic> rawDrafts,
+  ) async {
     final drafts = <Map<String, dynamic>>[];
     for (final d in rawDrafts) {
       if (d is! Map) continue;
@@ -175,6 +190,9 @@ class JsMemoryImporter with TypeConverters {
         'keys': d['keys'] is List
             ? List<String>.from((d['keys'] as List).whereType<String>())
             : <String>[],
+        'keyParagraphs': d['keyParagraphs'] is Map
+            ? Map<String, dynamic>.from(d['keyParagraphs'] as Map)
+            : <String, List<int>>{},
         'glazeKeys': d['glazeKeys'] is List
             ? List<String>.from((d['glazeKeys'] as List).whereType<String>())
             : <String>[],
@@ -185,7 +203,9 @@ class JsMemoryImporter with TypeConverters {
         'messageRange': d['messageRange'] is Map
             ? _convertMessageRange(d['messageRange'] as Map)
             : null,
-        'status': d['status'] is String ? d['status'] as String : 'pending_generation',
+        'status': d['status'] is String
+            ? d['status'] as String
+            : 'pending_generation',
         'source': d['source'] is String ? d['source'] as String : '',
         'createdAt': toInt(d['createdAt']) ?? 0,
         'updatedAt': toInt(d['updatedAt']) ?? 0,
@@ -194,17 +214,19 @@ class JsMemoryImporter with TypeConverters {
       });
     }
 
-    final existing = await (db.select(db.memoryBookRows)
-          ..where((t) => t.sessionId.equals(sessionId)))
-        .getSingleOrNull();
+    final existing = await (db.select(
+      db.memoryBookRows,
+    )..where((t) => t.sessionId.equals(sessionId))).getSingleOrNull();
     if (existing != null) {
-      await (db.update(db.memoryBookRows)
-            ..where((t) => t.sessionId.equals(sessionId)))
-          .write(MemoryBookRowsCompanion(
-        pendingDraftsJson: Value(jsonEncode(drafts)),
-      ));
+      await (db.update(
+        db.memoryBookRows,
+      )..where((t) => t.sessionId.equals(sessionId))).write(
+        MemoryBookRowsCompanion(pendingDraftsJson: Value(jsonEncode(drafts))),
+      );
     } else {
-      await db.into(db.memoryBookRows).insertOnConflictUpdate(
+      await db
+          .into(db.memoryBookRows)
+          .insertOnConflictUpdate(
             MemoryBookRowsCompanion.insert(
               sessionId: sessionId,
               pendingDraftsJson: Value(jsonEncode(drafts)),
@@ -215,10 +237,7 @@ class JsMemoryImporter with TypeConverters {
 
   Map<String, dynamic>? _convertMessageRange(Map<dynamic, dynamic> raw) {
     if (raw.containsKey('start') && raw.containsKey('end')) {
-      return {
-        'start': toInt(raw['start']) ?? 0,
-        'end': toInt(raw['end']) ?? 0,
-      };
+      return {'start': toInt(raw['start']) ?? 0, 'end': toInt(raw['end']) ?? 0};
     }
     return null;
   }

--- a/lib/core/services/memory_prompt_presets.dart
+++ b/lib/core/services/memory_prompt_presets.dart
@@ -74,15 +74,15 @@ class MemoryPromptPresets {
 
   static const _detailedBeats = '''
 Analyze the following roleplay segment and create a structured memory entry.
-Preserve the original language. Exclude casual [OOC] conversation, BUT if OOC messages contain story rules, formatting instructions, backstory clarifications, or scene-setting directives, reflect those instructions in the memory entry under the relevant sections.
+Write every memory paragraph and every keyword in the language used for the roleplay. Do not translate or transliterate names or keywords. Exclude casual [OOC] conversation, BUT if OOC messages contain story rules, formatting instructions, backstory clarifications, or scene-setting directives, reflect those instructions in the memory entry under the relevant sections.
 
-Use this markdown structure (skip sections if not applicable):
-Timeline: Always label as "Day N" (Day 1, Day 2, Day 3, etc.) — increment the day counter each time a new in-story day begins. Write clock times HH:MM;  If the scene spans multiple days, write "Day N–M HH:MM-HH:MM".
-Story Beats: Important plot events and developments
-Key Interactions: Significant character exchanges and relationship shifts
-Notable Details: Important objects, settings, revelations, quotes
-OOC Rules & Directives: Any player-established rules, formatting requirements, backstory additions, or scene-setting instructions given through OOC
-Outcome: Results, emotional states, consequences
+Cover the following information when applicable, using natural labels in the roleplay language rather than these English names:
+- Timeline: increment the in-story day counter when a new day begins and include clock times as HH:MM when known.
+- Story beats: important plot events and developments.
+- Key interactions: significant character exchanges and relationship shifts.
+- Notable details: important objects, settings, revelations, and quotes.
+- OOC rules and directives: player-established rules, formatting requirements, backstory additions, or scene-setting instructions given through OOC.
+- Outcome: results, emotional states, and consequences.
 
 Write in past tense, third person. Be comprehensive but avoid verbatim repetition.
 
@@ -90,9 +90,10 @@ For keywords: generate 15-25 concrete scene-specific tags:
 - Proper nouns, locations, specific objects, unique actions
 - NOT abstract concepts, emotions, or character names
 
-Return plain text in this exact format:
-Memory: <structured markdown summary following the template above>
-Keys: <15-25 comma-separated concrete keywords>
+Return JSON only, without a markdown fence, in this exact shape:
+{"paragraphs":[{"text":"one self-contained memory paragraph","keys":["keywords specific to this paragraph"]}]}
+
+Create a separate paragraph object for each meaningful beat or section. Give each paragraph only the keywords that should retrieve that paragraph. Across all paragraphs, generate 15-25 concrete scene-specific keywords. Keep the JSON property names exactly as shown; only the text and keyword values use the roleplay language.
 
 {{history}}''';
 

--- a/lib/features/chat/memory_draft_generator.dart
+++ b/lib/features/chat/memory_draft_generator.dart
@@ -5,13 +5,22 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 
 import '../../core/llm/transport/chat_transport_request.dart';
+import '../../core/llm/macro_engine.dart';
 import '../../core/llm/memory_book_api_config_resolver.dart';
+import '../../core/llm/memory_draft_response_parser.dart';
+import '../../core/llm/memory_draft_transcript_builder.dart';
+import '../../core/llm/regex_service.dart';
 import '../../core/llm/transport/llm_protocol.dart';
 import '../../core/llm/transport/transport_factory.dart';
 import '../../core/models/memory_book.dart';
+import '../../core/models/chat_message.dart';
 import '../../core/models/pipeline_settings.dart';
 import '../../core/services/memory_prompt_presets.dart';
 import '../../core/state/memory_settings_provider.dart';
+import '../../core/state/active_selection_provider.dart';
+import '../../core/state/db_provider.dart';
+import '../../core/state/global_regex_provider.dart';
+import '../../core/state/studio_regex_provider.dart';
 import '../settings/api_list_provider.dart';
 
 class MemoryDraftGenerator {
@@ -25,9 +34,61 @@ class MemoryDraftGenerator {
     required MemoryDraft draft,
     required MemoryBookSettings settings,
     required PipelineSettings pipeline,
-    required String historyText,
+    required List<ChatMessage> messages,
+    required String charId,
+    required String sessionId,
+    required Map<String, String> sessionVars,
     CancelToken? cancelToken,
   }) async {
+    final character = await _read(characterRepoProvider).getById(charId);
+    if (character == null) throw StateError('Character not found: $charId');
+    final presets = await _read(presetRepoProvider).getAll();
+    final preset = getEffectivePreset(
+      presets,
+      charId,
+      sessionId,
+      _read(activePresetIdProvider),
+      _read(presetConnectionsProvider),
+    );
+    final personas = await _read(personaRepoProvider).getAll();
+    final persona = getEffectivePersona(
+      personas,
+      charId,
+      sessionId,
+      _read(activePersonaIdProvider),
+      _read(personaConnectionsProvider),
+    );
+    final globalRegexes = await _read(globalRegexProvider.future);
+    final studioRegexes = await _read(studioRegexProvider.future);
+    final globalVars = _read(globalVarsProvider);
+    final historyText = MemoryDraftTranscriptBuilder.build(
+      messages: messages,
+      scripts: [
+        ...?preset?.regexes,
+        ...globalRegexes,
+        ...studioRegexes.map((entry) => entry.script),
+      ],
+      context: RegexApplyContext(
+        char: character,
+        persona: persona,
+        sessionVars: sessionVars,
+        globalVars: globalVars,
+        macroContext: MacroContext(
+          charName: character.name,
+          charDescription: character.description,
+          charScenario: character.scenario,
+          charPersonality: character.personality,
+          charMesExample: character.mesExample,
+          userName: persona?.name ?? 'User',
+          personaPrompt: persona?.prompt,
+          sessionVars: sessionVars,
+          globalVars: globalVars,
+          charId: charId,
+          sessionId: sessionId,
+          macroName: character.macroName,
+        ),
+      ),
+    );
     final customPrompts = MemoryPromptPreset.fromJsonList(
       _read(memoryGlobalSettingsProvider).customPrompts,
     );
@@ -111,38 +172,6 @@ class MemoryDraftGenerator {
     );
 
     final result = await completer.future;
-    return _parseDraftResult(draft, result);
-  }
-
-  MemoryDraft _parseDraftResult(MemoryDraft draft, String raw) {
-    String content = raw;
-    List<String> keys = [];
-
-    final memoryMatch = RegExp(
-      r'Memory:\s*(.*?)(?=\nKeys:|$)',
-      dotAll: true,
-    ).firstMatch(raw);
-    final keysMatch = RegExp(r'Keys:\s*(.*?)$', dotAll: true).firstMatch(raw);
-
-    if (memoryMatch != null) {
-      content = memoryMatch.group(1)!.trim();
-    }
-    if (keysMatch != null) {
-      keys = keysMatch
-          .group(1)!
-          .split(',')
-          .map((k) => k.trim().toLowerCase())
-          .where((k) => k.isNotEmpty)
-          .toList();
-    }
-
-    return draft.copyWith(
-      content: content,
-      keys: keys,
-      status: 'pending_approval',
-      generatedAt: DateTime.now().millisecondsSinceEpoch,
-      updatedAt: DateTime.now().millisecondsSinceEpoch,
-      error: null,
-    );
+    return MemoryDraftResponseParser.parse(draft, result);
   }
 }

--- a/lib/features/chat/services/stages/memory_draft_stage.dart
+++ b/lib/features/chat/services/stages/memory_draft_stage.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart';
 
 import '../../../../core/llm/memory_draft_planner.dart';
-import '../../../../core/llm/auxiliary_timed_history.dart';
 import '../../../../core/models/chat_message.dart';
 import '../../../../core/models/memory_book.dart';
 import '../../../../core/models/pipeline_settings.dart';
@@ -16,7 +15,10 @@ typedef GenerateMemoryDraft =
       required MemoryDraft draft,
       required MemoryBookSettings settings,
       required PipelineSettings pipeline,
-      required String historyText,
+      required List<ChatMessage> messages,
+      required String charId,
+      required String sessionId,
+      required Map<String, String> sessionVars,
     });
 
 /// Stage 9 / 6: Auto-create memory drafts and optionally fill them with the
@@ -32,12 +34,18 @@ class MemoryDraftStage {
             required draft,
             required settings,
             required pipeline,
-            required historyText,
+            required messages,
+            required charId,
+            required sessionId,
+            required sessionVars,
           }) => MemoryDraftGenerator(ctx.ref).generate(
             draft: draft,
             settings: settings,
             pipeline: pipeline,
-            historyText: historyText,
+            messages: messages,
+            charId: charId,
+            sessionId: sessionId,
+            sessionVars: sessionVars,
           ));
 
   MemoryDraftLease? reserveAutoGeneration(ChatSession? session) {
@@ -84,17 +92,15 @@ class MemoryDraftStage {
             .where((message) => draft.messageIds.contains(message.id))
             .toList();
         if (draftMessages.isEmpty) continue;
-        final historyText = draftMessages
-            .map(
-              (message) => '${message.role}: ${auxiliaryTimedContent(message)}',
-            )
-            .join('\n\n');
         try {
           final generated = await _generate(
             draft: draft,
             settings: book.settings,
             pipeline: pipeline,
-            historyText: historyText,
+            messages: draftMessages,
+            charId: ctx.charId,
+            sessionId: session.id,
+            sessionVars: session.sessionVars,
           );
           if (!ctx.ref.mounted) return;
           await repo.mutateDraft(
@@ -103,6 +109,7 @@ class MemoryDraftStage {
             mutate: (current) => current.copyWith(
               content: generated.content,
               keys: generated.keys,
+              keyParagraphs: generated.keyParagraphs,
               status: 'pending_approval',
               generatedAt: generated.generatedAt,
               updatedAt: generated.updatedAt,

--- a/lib/features/chat/widgets/memory_books_tab.dart
+++ b/lib/features/chat/widgets/memory_books_tab.dart
@@ -492,6 +492,7 @@ class _MemoryBooksTabState extends ConsumerState<MemoryBooksTab> {
       title: draft.title,
       content: draft.content,
       keys: draft.keys,
+      keyParagraphs: draft.keyParagraphs,
       messageIds: draft.messageIds,
       status: 'active',
       createdAt: draft.createdAt,

--- a/lib/features/chat/widgets/memory_entry_editor_sheet.dart
+++ b/lib/features/chat/widgets/memory_entry_editor_sheet.dart
@@ -38,13 +38,23 @@ class _MemoryEntryEditorSheetState extends State<MemoryEntryEditorSheet> {
     if (content.isEmpty) return;
     final keys = _keysController.text
         .split(',')
-        .map((k) => k.trim().toLowerCase())
+        .map((k) => k.trim())
         .where((k) => k.isNotEmpty)
         .toList();
+    final contentChanged = content != widget.entry.content.trim();
+    final keyLookup = keys.map((key) => key.toLowerCase()).toSet();
+    final keyParagraphs = contentChanged
+        ? const <String, List<int>>{}
+        : {
+            for (final entry in widget.entry.keyParagraphs.entries)
+              if (keyLookup.contains(entry.key.toLowerCase()))
+                entry.key: entry.value,
+          };
     final entry = widget.entry.copyWith(
       title: _titleController.text.trim(),
       content: content,
       keys: keys,
+      keyParagraphs: keyParagraphs,
     );
     Navigator.pop(context, entry);
   }
@@ -56,16 +66,35 @@ class _MemoryEntryEditorSheetState extends State<MemoryEntryEditorSheet> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _field('label_block_name'.tr(), _titleController, hint: 'placeholder_block_name'.tr()),
+          _field(
+            'label_block_name'.tr(),
+            _titleController,
+            hint: 'placeholder_block_name'.tr(),
+          ),
           const SizedBox(height: 12),
-          _field('search_type_keys'.tr(), _keysController, hint: 'hint_comma_separated'.tr()),
+          _field(
+            'search_type_keys'.tr(),
+            _keysController,
+            hint: 'hint_comma_separated'.tr(),
+          ),
           const SizedBox(height: 4),
           Padding(
             padding: const EdgeInsets.only(left: 4),
-            child: Text('search_type_keys'.tr(), style: TextStyle(fontSize: 11, color: context.cs.onSurfaceVariant.withValues(alpha: 0.6))),
+            child: Text(
+              'search_type_keys'.tr(),
+              style: TextStyle(
+                fontSize: 11,
+                color: context.cs.onSurfaceVariant.withValues(alpha: 0.6),
+              ),
+            ),
           ),
           const SizedBox(height: 12),
-          _field('label_content'.tr(), _contentController, hint: 'placeholder_lore_content'.tr(), maxLines: 8),
+          _field(
+            'label_content'.tr(),
+            _contentController,
+            hint: 'placeholder_lore_content'.tr(),
+            maxLines: 8,
+          ),
           const SizedBox(height: 16),
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
@@ -76,7 +105,10 @@ class _MemoryEntryEditorSheetState extends State<MemoryEntryEditorSheet> {
               ),
               const SizedBox(width: 8),
               FilledButton(
-                style: FilledButton.styleFrom(backgroundColor: context.cs.primary, foregroundColor: Colors.black),
+                style: FilledButton.styleFrom(
+                  backgroundColor: context.cs.primary,
+                  foregroundColor: Colors.black,
+                ),
                 onPressed: _save,
                 child: Text('btn_save'.tr()),
               ),
@@ -87,7 +119,12 @@ class _MemoryEntryEditorSheetState extends State<MemoryEntryEditorSheet> {
     );
   }
 
-  Widget _field(String label, TextEditingController controller, {String? hint, int maxLines = 1}) {
+  Widget _field(
+    String label,
+    TextEditingController controller, {
+    String? hint,
+    int maxLines = 1,
+  }) {
     final isMultiline = maxLines > 1;
     return TextField(
       controller: controller,
@@ -99,7 +136,9 @@ class _MemoryEntryEditorSheetState extends State<MemoryEntryEditorSheet> {
         labelText: label,
         labelStyle: TextStyle(color: context.cs.onSurfaceVariant, fontSize: 12),
         hintText: hint,
-        hintStyle: TextStyle(color: context.cs.onSurfaceVariant.withValues(alpha: 0.4)),
+        hintStyle: TextStyle(
+          color: context.cs.onSurfaceVariant.withValues(alpha: 0.4),
+        ),
         filled: true,
         fillColor: Colors.white.withValues(alpha: 0.05),
         border: OutlineInputBorder(borderRadius: BorderRadius.circular(10)),

--- a/lib/features/memory/controllers/memory_book_controller.dart
+++ b/lib/features/memory/controllers/memory_book_controller.dart
@@ -217,6 +217,7 @@ class MemoryBookController {
       title: draft.title,
       content: draft.content,
       keys: draft.keys,
+      keyParagraphs: draft.keyParagraphs,
       vectorSearch: draft.vectorSearch,
       messageIds: draft.messageIds,
       messageRange: draft.messageRange,
@@ -374,6 +375,7 @@ class MemoryBookController {
         title: result.title,
         content: result.content,
         keys: result.keys,
+        keyParagraphs: result.keyParagraphs,
         updatedAt: DateTime.now().millisecondsSinceEpoch,
       );
     }

--- a/lib/features/memory/controllers/memory_draft_generation_controller.dart
+++ b/lib/features/memory/controllers/memory_draft_generation_controller.dart
@@ -4,7 +4,6 @@ import 'package:dio/dio.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../core/llm/auxiliary_timed_history.dart';
 import '../../../core/models/memory_book.dart';
 import '../../../core/models/pipeline_settings.dart';
 import '../../../core/state/memory_settings_provider.dart';
@@ -125,13 +124,6 @@ class MemoryDraftGenerationController {
       return;
     }
 
-    final historyText = draftMessages
-        .map((m) {
-          // Ledger-stamped game clock travels with the transcript so memory
-          // entries stay time-anchored.
-          return '${m.role}: ${auxiliaryTimedContent(m)}';
-        })
-        .join('\n\n');
     final cancelToken = CancelToken();
     _cancelTokens[draftId] = cancelToken;
 
@@ -150,7 +142,10 @@ class MemoryDraftGenerationController {
         draft: draft,
         settings: _bookSettings,
         pipeline: _pipeline,
-        historyText: historyText,
+        messages: draftMessages,
+        charId: _charId,
+        sessionId: _sessionId,
+        sessionVars: session.sessionVars,
         cancelToken: cancelToken,
       );
 

--- a/lib/features/memory/controllers/memory_draft_generation_update.dart
+++ b/lib/features/memory/controllers/memory_draft_generation_update.dart
@@ -17,6 +17,7 @@ MemoryBook? applyGeneratedMemoryDraft(
   drafts[index] = current.copyWith(
     content: generated.content,
     keys: generated.keys,
+    keyParagraphs: generated.keyParagraphs,
     status: 'pending_approval',
     generatedAt: generated.generatedAt,
     updatedAt: generated.updatedAt,

--- a/lib/features/presets/preset_export.dart
+++ b/lib/features/presets/preset_export.dart
@@ -58,6 +58,7 @@ Future<String> savePresetJson(Preset preset) async {
             'markdownOnly': r.markdownOnly,
             'promptOnly': r.promptOnly,
             'runOnEdit': r.runOnEdit,
+            'memoryBookRetrieval': r.memoryBookRetrieval,
             'substituteRegex': r.substituteRegex,
             if (r.minDepth != null) 'minDepth': r.minDepth,
             if (r.maxDepth != null) 'maxDepth': r.maxDepth,

--- a/lib/features/regex/regex_sheet.dart
+++ b/lib/features/regex/regex_sheet.dart
@@ -1002,6 +1002,12 @@ class _RegexEditViewState extends State<_RegexEditView> {
               value: s.runOnEdit,
               onChanged: (v) => _update(s.copyWith(runOnEdit: v)),
             ),
+            _CheckboxOption(
+              key: const Key('regex_memory_book_retrieval'),
+              label: 'regex_memory_book_retrieval'.tr(),
+              value: s.memoryBookRetrieval,
+              onChanged: (v) => _update(s.copyWith(memoryBookRetrieval: v)),
+            ),
           ],
         ),
         MenuGroup(

--- a/test/characterization/memory_excerpt_selector_test.dart
+++ b/test/characterization/memory_excerpt_selector_test.dart
@@ -9,18 +9,108 @@ MemoryEntry _entry({
   required String title,
   required String content,
   List<String> keys = const [],
+  Map<String, List<int>> keyParagraphs = const {},
   int createdAt = 0,
 }) => MemoryEntry(
   id: id,
   title: title,
   content: content,
   keys: keys,
+  keyParagraphs: keyParagraphs,
   createdAt: createdAt,
   status: 'active',
 );
 
 void main() {
   group('MemoryExcerptSelector', () {
+    test('limits hybrid excerpts to paragraphs mapped by matched keys', () {
+      final entry = _entry(
+        id: 'scoped',
+        title: 'Two scenes',
+        content:
+            'The market sold bread and tea.\n\nRen hid the silver key in the chapel.',
+        keys: const ['market', 'silver key'],
+        keyParagraphs: const {
+          'market': [0],
+          'silver key': [1],
+        },
+      );
+      final selection = MemorySelector.select(
+        MemorySelectionInput(
+          entries: [entry],
+          keywordMatchedTerms: const {
+            'scoped': ['silver key'],
+          },
+          maxInjectionTokens: 100,
+          maxInjectedEntries: 1,
+          recencyBoost: false,
+          importanceBoost: false,
+          diversityAware: false,
+        ),
+      );
+
+      final result = MemoryExcerptSelector.select(
+        selection,
+        packingMode: 'hybrid',
+        tokenCounter: (text) => text.split(RegExp(r'\s+')).length,
+      );
+
+      expect(result.items.single.excerpt, isTrue);
+      expect(result.items.single.text, contains('silver key'));
+      expect(result.items.single.text, isNot(contains('market')));
+    });
+
+    test(
+      'limits chunk-first excerpts to paragraphs mapped by matched keys',
+      () {
+        final entry = _entry(
+          id: 'scoped',
+          title: 'Two scenes',
+          content: 'Market paragraph.\n\nThe chapel held the silver key.',
+          keys: const ['market', 'silver key'],
+          keyParagraphs: const {
+            'market': [0],
+            'silver key': [1],
+          },
+        );
+        final selection = MemorySelection(
+          entries: [entry],
+          allScores: [
+            MemoryCandidateScore(
+              entry: entry,
+              score: 10,
+              matchedKeys: const ['silver key'],
+            ),
+          ],
+          budgetTokens: 100,
+          entryCap: 1,
+        );
+
+        final result = MemoryExcerptSelector.select(
+          selection,
+          packingMode: 'chunk_first',
+          maxExcerptTokensPerEntry: 20,
+          tokenCounter: (text) => text.split(RegExp(r'\s+')).length,
+        );
+
+        expect(result.items.single.text, contains('silver key'));
+        expect(result.items.single.text, isNot(contains('Market')));
+      },
+    );
+
+    test('hard-split chunks preserve every word and paragraph index', () {
+      const text = 'one two three four five six seven eight nine ten';
+      final chunks = MemoryChunker.chunk(
+        text,
+        3,
+        (value) => value.split(RegExp(r'\s+')).length,
+      );
+
+      expect(chunks.map((chunk) => chunk.text).join(' '), text);
+      expect(chunks.every((chunk) => chunk.paragraphIndex == 0), isTrue);
+      expect(chunks.every((chunk) => chunk.tokenCost <= 3), isTrue);
+    });
+
     test('keeps full entries when selected memories fit the token budget', () {
       final selection = MemorySelector.select(
         MemorySelectionInput(
@@ -268,61 +358,62 @@ void main() {
       },
     );
 
-    test('chunk-first global budgets by injected chunk tokens not full entry', () {
-      MemoryEntry bulky(String id, int start, String needle) => MemoryEntry(
-        id: id,
-        title: id,
-        content: List.generate(
-          6,
-          (i) => i == 2 ? '$needle clue chunk $id' : 'filler words $id line $i',
-        ).join('\n\n'),
-        keys: const ['needle'],
-        messageRange: MessageRange(start: start, end: start + 14),
-        status: 'active',
-      );
+    test(
+      'chunk-first global budgets by injected chunk tokens not full entry',
+      () {
+        MemoryEntry bulky(String id, int start, String needle) => MemoryEntry(
+          id: id,
+          title: id,
+          content: List.generate(
+            6,
+            (i) =>
+                i == 2 ? '$needle clue chunk $id' : 'filler words $id line $i',
+          ).join('\n\n'),
+          keys: const ['needle'],
+          messageRange: MessageRange(start: start, end: start + 14),
+          status: 'active',
+        );
 
-      final entries = [
-        bulky('e1', 10, 'alpha'),
-        bulky('e2', 30, 'beta'),
-        bulky('e3', 50, 'gamma'),
-        bulky('e4', 70, 'delta'),
-        bulky('e5', 90, 'epsilon'),
-        bulky('e6', 110, 'zeta'),
-      ];
+        final entries = [
+          bulky('e1', 10, 'alpha'),
+          bulky('e2', 30, 'beta'),
+          bulky('e3', 50, 'gamma'),
+          bulky('e4', 70, 'delta'),
+          bulky('e5', 90, 'epsilon'),
+          bulky('e6', 110, 'zeta'),
+        ];
 
-      final selection = MemorySelector.select(
-        MemorySelectionInput(
-          entries: entries,
-          keywordMatchedTerms: {
-            for (final entry in entries) entry.id: const ['needle'],
-          },
-          maxInjectionTokens: 20,
-          maxInjectedEntries: 3,
-          keywordWeight: 0,
-          vectorWeight: 0,
-          recencyBoost: false,
-          importanceBoost: false,
-          diversityAware: false,
-          chunkBudgeting: true,
-        ),
-        tokenCounter: (entry) => entry.content.split(RegExp(r'\s+')).length,
-      );
+        final selection = MemorySelector.select(
+          MemorySelectionInput(
+            entries: entries,
+            keywordMatchedTerms: {
+              for (final entry in entries) entry.id: const ['needle'],
+            },
+            maxInjectionTokens: 20,
+            maxInjectedEntries: 3,
+            keywordWeight: 0,
+            vectorWeight: 0,
+            recencyBoost: false,
+            importanceBoost: false,
+            diversityAware: false,
+            chunkBudgeting: true,
+          ),
+          tokenCounter: (entry) => entry.content.split(RegExp(r'\s+')).length,
+        );
 
-      final excerpted = MemoryExcerptSelector.selectChunkFirstGlobal(
-        selection,
-        maxExcerptTokensPerChunk: 6,
-        maxExcerptChunksPerEntry: 1,
-        tokenCounter: (text) => text.split(RegExp(r'\s+')).length,
-      );
+        final excerpted = MemoryExcerptSelector.selectChunkFirstGlobal(
+          selection,
+          maxExcerptTokensPerChunk: 6,
+          maxExcerptChunksPerEntry: 1,
+          tokenCounter: (text) => text.split(RegExp(r'\s+')).length,
+        );
 
-      expect(excerpted.items.length, greaterThan(3));
-      expect(excerpted.totalTokens, lessThanOrEqualTo(20));
-      expect(excerpted.items.every((item) => item.excerpt), isTrue);
-      expect(
-        excerpted.items.every((item) => item.tokenCost <= 6),
-        isTrue,
-      );
-    });
+        expect(excerpted.items.length, greaterThan(3));
+        expect(excerpted.totalTokens, lessThanOrEqualTo(20));
+        expect(excerpted.items.every((item) => item.excerpt), isTrue);
+        expect(excerpted.items.every((item) => item.tokenCost <= 6), isTrue);
+      },
+    );
 
     test(
       'chunk-first reserves a chunk for fresh implied entries without keywords',
@@ -381,7 +472,8 @@ void main() {
         expect(
           excerpted.items.map((item) => item.entry.id),
           contains('fresh'),
-          reason: 'fresh implied memory should not lose to keyword-only old arc',
+          reason:
+              'fresh implied memory should not lose to keyword-only old arc',
         );
       },
     );
@@ -402,7 +494,9 @@ void main() {
       final selection = MemorySelector.select(
         MemorySelectionInput(
           entries: [lone],
-          keywordMatchedTerms: {'solo': const ['needle']},
+          keywordMatchedTerms: {
+            'solo': const ['needle'],
+          },
           maxInjectionTokens: 500,
           maxInjectedEntries: 10,
           keywordWeight: 0,

--- a/test/memory_budget_settings_test.dart
+++ b/test/memory_budget_settings_test.dart
@@ -347,4 +347,34 @@ void main() {
 
     expect(entry.messageRange, const MessageRange(start: 91, end: 105));
   });
+
+  test('paragraph key maps default safely and survive JSON round-trip', () {
+    final legacy = MemoryEntry.fromJson({
+      'id': 'legacy',
+      'content': 'old entry',
+    });
+    final malformedDraft = MemoryDraft.fromJson({
+      'id': 'draft',
+      'keyParagraphs': {
+        'key': ['2', -1, 'bad', 2, 1],
+        'invalid': 'not a list',
+      },
+    });
+    const entry = MemoryEntry(
+      id: 'scoped',
+      content: 'First.\n\nSecond.',
+      keys: ['key'],
+      keyParagraphs: {
+        'key': [1],
+      },
+    );
+
+    expect(legacy.keyParagraphs, isEmpty);
+    expect(malformedDraft.keyParagraphs, {
+      'key': [1, 2],
+    });
+    expect(MemoryEntry.fromJson(entry.toJson()).keyParagraphs, {
+      'key': [1],
+    });
+  });
 }

--- a/test/memory_draft_generation_update_test.dart
+++ b/test/memory_draft_generation_update_test.dart
@@ -28,6 +28,9 @@ void main() {
       title: 'stale request title',
       content: 'new content',
       keys: ['new'],
+      keyParagraphs: {
+        'new': [0],
+      },
       status: 'pending_approval',
       generatedAt: 20,
       updatedAt: 21,
@@ -43,6 +46,9 @@ void main() {
     final draft = updated.pendingDrafts.last;
     expect(draft.content, 'new content');
     expect(draft.keys, ['new']);
+    expect(draft.keyParagraphs, {
+      'new': [0],
+    });
     expect(draft.title, 'Current title');
     expect(draft.status, 'pending_approval');
     expect(draft.error, isNull);

--- a/test/memory_draft_response_parser_test.dart
+++ b/test/memory_draft_response_parser_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/memory_draft_response_parser.dart';
+import 'package:glaze_flutter/core/models/memory_book.dart';
+
+void main() {
+  const draft = MemoryDraft(id: 'draft');
+
+  test('parses roleplay-language paragraph keys and preserves casing', () {
+    final result = MemoryDraftResponseParser.parse(
+      draft,
+      '''{"paragraphs":[{"text":"Алиса спрятала Серебряный Ключ.","keys":["Серебряный Ключ","часовня"]},{"text":"Борис запер хранилище.","keys":["хранилище","Часовня"]}]}''',
+      nowMillis: 10,
+    );
+
+    expect(result.content, contains('\n\n'));
+    expect(result.keys, ['Серебряный Ключ', 'часовня', 'хранилище']);
+    expect(result.keyParagraphs['часовня'], [0, 1]);
+    expect(result.generatedAt, 10);
+  });
+
+  test('supports fenced JSON and legacy Memory/Keys responses', () {
+    final structured = MemoryDraftResponseParser.parse(
+      draft,
+      '```json\n{"paragraphs":[{"text":"記憶。","keys":["鍵"]}]}\n```',
+    );
+    final legacy = MemoryDraftResponseParser.parse(
+      draft,
+      'Memory: Старый формат.\nKeys: Ключ, Место',
+    );
+
+    expect(structured.keyParagraphs, {
+      '鍵': [0],
+    });
+    expect(legacy.content, 'Старый формат.');
+    expect(legacy.keys, ['Ключ', 'Место']);
+    expect(legacy.keyParagraphs, isEmpty);
+  });
+
+  test('maps keys across blank-line paragraphs inside one JSON item', () {
+    final result = MemoryDraftResponseParser.parse(
+      draft,
+      '{"paragraphs":['
+      '{"text":"First.\\n\\nSecond.","keys":["pair"]},'
+      '{"text":"Third.","keys":["third"]}'
+      ']}',
+      nowMillis: 1,
+    );
+
+    expect(result.content, 'First.\n\nSecond.\n\nThird.');
+    expect(result.keyParagraphs, {
+      'pair': [0, 1],
+      'third': [2],
+    });
+  });
+}

--- a/test/memory_draft_stage_test.dart
+++ b/test/memory_draft_stage_test.dart
@@ -123,11 +123,17 @@ Future<_Harness> _createHarness({
             required draft,
             required settings,
             required pipeline,
-            required historyText,
+            required messages,
+            required charId,
+            required sessionId,
+            required sessionVars,
           }) async {
             calls++;
             if (generationError != null) throw generationError;
-            expect(historyText, contains('User turn'));
+            expect(messages.map((message) => message.id), ['u1', 'a1']);
+            expect(charId, 'c1');
+            expect(sessionId, 's1');
+            expect(sessionVars, isEmpty);
             return draft.copyWith(
               content: 'Generated memory',
               keys: ['memory'],

--- a/test/memory_draft_transcript_builder_test.dart
+++ b/test/memory_draft_transcript_builder_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/llm/memory_draft_transcript_builder.dart';
+import 'package:glaze_flutter/core/llm/regex_service.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/models/preset.dart';
+
+void main() {
+  test('applies opted-in draft regexes without mutating source messages', () {
+    const source = ChatMessage(
+      id: 'user',
+      role: 'user',
+      content: 'hello\u2800world',
+    );
+    const script = PresetRegex(
+      id: 'spaces',
+      name: 'Restore spaces',
+      regex: r'/\u2800/g',
+      replacement: ' ',
+      placement: [1],
+      ephemerality: [1],
+      memoryBookRetrieval: true,
+    );
+
+    final transcript = MemoryDraftTranscriptBuilder.build(
+      messages: const [source],
+      scripts: const [script],
+      context: const RegexApplyContext(),
+    );
+
+    expect(transcript, 'user: hello world');
+    expect(source.content, 'hello\u2800world');
+  });
+
+  test('applies preset, global, and Studio scripts in supplied order', () {
+    const messages = [ChatMessage(id: 'user', role: 'user', content: 'A')];
+    PresetRegex append(String id, String from, String to) => PresetRegex(
+      id: id,
+      name: id,
+      regex: '/$from/g',
+      replacement: to,
+      placement: const [1],
+      memoryBookRetrieval: true,
+    );
+
+    final transcript = MemoryDraftTranscriptBuilder.build(
+      messages: messages,
+      scripts: [
+        append('preset', 'A', 'B'),
+        append('global', 'B', 'C'),
+        append('studio', 'C', 'D'),
+      ],
+      context: const RegexApplyContext(),
+    );
+
+    expect(transcript, 'user: D');
+  });
+
+  test('ignores scripts without draft-generation opt-in', () {
+    final transcript = MemoryDraftTranscriptBuilder.build(
+      messages: const [
+        ChatMessage(id: 'user', role: 'user', content: 'original'),
+      ],
+      scripts: const [
+        PresetRegex(
+          id: 'normal',
+          name: 'Normal prompt regex',
+          regex: '/original/g',
+          replacement: 'changed',
+          placement: [1],
+        ),
+      ],
+      context: const RegexApplyContext(),
+    );
+
+    expect(transcript, 'user: original');
+  });
+}

--- a/test/regex_service_test.dart
+++ b/test/regex_service_test.dart
@@ -5,6 +5,24 @@ import 'package:glaze_flutter/core/models/persona.dart';
 import 'package:glaze_flutter/core/models/preset.dart';
 
 void main() {
+  test('Memory Book retrieval flag defaults false and round-trips aliases', () {
+    final legacy = PresetRegex.fromJson({
+      'id': 'legacy',
+      'scriptName': 'Legacy',
+      'findRegex': '/x/g',
+    });
+    final optedIn = PresetRegex.fromJson({
+      'id': 'opted-in',
+      'scriptName': 'Opted in',
+      'findRegex': '/x/g',
+      'memory_book_retrieval': 1,
+    });
+
+    expect(legacy.memoryBookRetrieval, isFalse);
+    expect(optedIn.memoryBookRetrieval, isTrue);
+    expect(PresetRegex.fromJson(optedIn.toJson()).memoryBookRetrieval, isTrue);
+  });
+
   group('RegexService — ST compatibility (backrefs, flags, substituteRegex)', () {
     RegexApplyContext ctx() => const RegexApplyContext();
 
@@ -19,7 +37,8 @@ void main() {
         'isEnabled': true,
       });
 
-      const input = 'See <div class="x">hello <b>world</b></div> and <br/> and <img src="a.png">';
+      const input =
+          'See <div class="x">hello <b>world</b></div> and <br/> and <img src="a.png">';
       final out = applyRegexes(input, 2, 2, [script], ctx());
 
       expect(out, equals('See  and  and '));
@@ -55,21 +74,24 @@ void main() {
       expect(out, equals('hello world'));
     });
 
-    test('ReplaceSpace with substituteRegex:1 — U+3164 (hangul filler) -> space', () {
-      final script = PresetRegex.fromJson({
-        'id': 'replace-space',
-        'scriptName': 'ReplaceSpace',
-        'findRegex': r'/ㅤ/g',
-        'replaceString': ' ',
-        'substituteRegex': 1,
-        'placement': [1, 2, 5],
-        'isEnabled': true,
-      });
+    test(
+      'ReplaceSpace with substituteRegex:1 — U+3164 (hangul filler) -> space',
+      () {
+        final script = PresetRegex.fromJson({
+          'id': 'replace-space',
+          'scriptName': 'ReplaceSpace',
+          'findRegex': r'/ㅤ/g',
+          'replaceString': ' ',
+          'substituteRegex': 1,
+          'placement': [1, 2, 5],
+          'isEnabled': true,
+        });
 
-      const input = 'helloㅤworld';
-      final out = applyRegexes(input, 2, 2, [script], ctx());
-      expect(out, equals('hello world'));
-    });
+        const input = 'helloㅤworld';
+        final out = applyRegexes(input, 2, 2, [script], ctx());
+        expect(out, equals('hello world'));
+      },
+    );
 
     test('markdownOnly applies only when isMarkdown is true', () {
       final script = PresetRegex.fromJson({
@@ -117,8 +139,14 @@ void main() {
       });
 
       const input = 'foo';
-      expect(applyRegexes(input, 4, 2, [script], ctx(), isPrompt: true), equals('foo'));
-      expect(applyRegexes(input, 5, 2, [script], ctx(), isPrompt: true), equals('bar'));
+      expect(
+        applyRegexes(input, 4, 2, [script], ctx(), isPrompt: true),
+        equals('foo'),
+      );
+      expect(
+        applyRegexes(input, 5, 2, [script], ctx(), isPrompt: true),
+        equals('bar'),
+      );
     });
 
     test('{{match}} in replacement', () {
@@ -146,7 +174,10 @@ void main() {
 
       expect(script.placement, contains(5));
       const input = 'x';
-      expect(applyRegexes(input, 5, 2, [script], ctx(), isPrompt: true), equals('Z'));
+      expect(
+        applyRegexes(input, 5, 2, [script], ctx(), isPrompt: true),
+        equals('Z'),
+      );
     });
 
     test('HEADER-style: multiline capture groups are resolved', () {
@@ -154,12 +185,14 @@ void main() {
       final script = PresetRegex.fromJson({
         'id': 'header-test',
         'name': 'HEADER',
-        'regex': r'/\[HEADER\]\s*name:\s*([^\n]+?)\s*status:\s*([^\n]+?)\s*\[\/HEADER\]/g',
+        'regex':
+            r'/\[HEADER\]\s*name:\s*([^\n]+?)\s*status:\s*([^\n]+?)\s*\[\/HEADER\]/g',
         'replacement': r'<div>Name=$1 Status=$2</div>',
         'placement': [2],
       });
 
-      const input = '[HEADER]\nname: Элай Марш\nstatus: idle\n[/HEADER]\nSome text.';
+      const input =
+          '[HEADER]\nname: Элай Марш\nstatus: idle\n[/HEADER]\nSome text.';
       final out = applyRegexes(input, 2, 2, [script], ctx());
       expect(out, equals('<div>Name=Элай Марш Status=idle</div>\nSome text.'));
     });
@@ -173,9 +206,15 @@ void main() {
         'placement': [2],
       });
 
-      const input = '[BOOTS]\ntitle: My Title\nreflection: deep thoughts\n[/BOOTS]';
+      const input =
+          '[BOOTS]\ntitle: My Title\nreflection: deep thoughts\n[/BOOTS]';
       final out = applyRegexes(input, 2, 2, [script], ctx());
-      expect(out, equals('<div class="boots">\ntitle: My Title\nreflection: deep thoughts\n</div>'));
+      expect(
+        out,
+        equals(
+          '<div class="boots">\ntitle: My Title\nreflection: deep thoughts\n</div>',
+        ),
+      );
     });
 
     test('backrefs work even with substituteRegex != 0', () {
@@ -232,12 +271,7 @@ void main() {
       Map<String, String> sessionVars = const {},
       Map<String, String> globalVars = const {},
     }) => RegexApplyContext(
-      char: Character(
-        id: 'char_1',
-        name: 'Alise',
-        createdAt: 0,
-        updatedAt: 0,
-      ),
+      char: Character(id: 'char_1', name: 'Alise', createdAt: 0, updatedAt: 0),
       persona: Persona(id: 'persona_1', name: 'Иван'),
       sessionVars: sessionVars,
       globalVars: globalVars,
@@ -252,37 +286,43 @@ void main() {
       'placement': [2],
     });
 
-    test('{{user}} / {{char}} in the replacement expand without macroRules',
-        () {
-      final out = applyRegexes(
-        '{TRK|jacket}',
-        2,
-        1,
-        [cardScript()],
-        charCtx(),
-        isMarkdown: true,
-      );
+    test(
+      '{{user}} / {{char}} in the replacement expand without macroRules',
+      () {
+        final out = applyRegexes(
+          '{TRK|jacket}',
+          2,
+          1,
+          [cardScript()],
+          charCtx(),
+          isMarkdown: true,
+        );
 
-      expect(
-        out,
-        equals('<div><b>Иван</b>: jacket</div><div><b>Alise</b>: jacket</div>'),
-      );
-    });
+        expect(
+          out,
+          equals(
+            '<div><b>Иван</b>: jacket</div><div><b>Alise</b>: jacket</div>',
+          ),
+        );
+      },
+    );
 
-    test('macros stay literal when no character/macro context is available',
-        () {
-      final out = applyRegexes(
-        '{TRK|jacket}',
-        2,
-        1,
-        [cardScript()],
-        const RegexApplyContext(),
-        isMarkdown: true,
-      );
+    test(
+      'macros stay literal when no character/macro context is available',
+      () {
+        final out = applyRegexes(
+          '{TRK|jacket}',
+          2,
+          1,
+          [cardScript()],
+          const RegexApplyContext(),
+          isMarkdown: true,
+        );
 
-      expect(out, contains('{{user}}'));
-      expect(out, contains('{{char}}'));
-    });
+        expect(out, contains('{{user}}'));
+        expect(out, contains('{{char}}'));
+      },
+    );
 
     test('macros are substituted after capture groups, like ST', () {
       // A macro carried in by a capture group is expanded too: ST runs
@@ -308,13 +348,9 @@ void main() {
         'placement': [2],
       });
 
-      final out = applyRegexes(
-        '{LOC}',
-        2,
-        1,
-        [script],
-        charCtx(sessionVars: {'location': 'Квартира бабы Нели'}),
-      );
+      final out = applyRegexes('{LOC}', 2, 1, [
+        script,
+      ], charCtx(sessionVars: {'location': 'Квартира бабы Нели'}));
       expect(out, equals('Квартира бабы Нели'));
     });
 
@@ -330,13 +366,9 @@ void main() {
         'placement': [2],
       });
 
-      final out = applyRegexes(
-        'noise {TRK|noise jacket} noise',
-        2,
-        1,
-        [script],
-        charCtx(),
-      );
+      final out = applyRegexes('noise {TRK|noise jacket} noise', 2, 1, [
+        script,
+      ], charCtx());
 
       expect(out, equals('noise <b> jacket</b> noise'));
     });


### PR DESCRIPTION
## Memory draft generation
- Make Detailed Beats return structured paragraphs and paragraph-specific keys in the roleplay language, while retaining the legacy response parser as a fallback.
- Add an opt-in regex target for Memory Book draft generation and apply effective preset, global, and Studio scripts to ephemeral transcript copies without mutating chat history.
- Preserve generated paragraph-key mappings through draft updates, approval, editing, preset export, and legacy JS import.

## Memory packing
- Associate runtime chunks with stable paragraph indexes and constrain hybrid/chunk-first packing to paragraphs mapped by fully resolved keyword matches.
- Preserve legacy behavior for old, partial, or stale mappings and keep explicit full-entry packing unchanged.
- Fix long-sentence chunking so hard splits retain the complete paragraph text.

## Verification
- Added parser, transcript-regex, serialization, draft lifecycle, chunking, and paragraph-scoping coverage.
- Ran the full Flutter test suite: 3,596 tests passed.
- Ran flutter analyze: no errors; 7 pre-existing non-fatal issues remain in unchanged files.
- Ran git diff --check successfully.