### PR TITLE
fix(render): keep a regex-built card whole when the model italicises it

### DIFF
--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -105,8 +105,10 @@ export class Formatter {
     const code = maskCodeElements(staged);
     // Style markers come out before the parse, because html_to_markdown writes
     // rich content inside them and a parsed marker is two text nodes with an
-    // element between them.
-    staged = extractMarkers(code.masked, markers);
+    // element between them. `styled` goes along so the balance check there
+    // reads the message's tags exactly as `escapeProseTags` will below — the
+    // `<style>` bodies that declare them are masked out of `code.masked`.
+    staged = extractMarkers(code.masked, markers, styled);
 
     const tree = parseHtml(code.unmask(escapeProseTags(staged, styled)), document);
 

--- a/assets/chat_webview/formatter/html_scan.js
+++ b/assets/chat_webview/formatter/html_scan.js
@@ -72,6 +72,16 @@ export const RAW_TEXT_ELEMENTS = new Set([
   'script', 'style', 'pre', 'code', 'textarea', 'title', 'xmp', 'plaintext',
 ]);
 
+/**
+ * Elements that close themselves. Not a list of what is block or inline — the
+ * parser still answers that — only of the names for which a lone `<x>` is a
+ * complete element, so a balance count must not wait for a `</x>`.
+ */
+export const VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta',
+  'param', 'source', 'track', 'wbr',
+]);
+
 /** Element names a `<style>` block in the message uses as a type selector. */
 export function styledElementNames(text) {
   const names = new Set();
@@ -105,6 +115,24 @@ export function styledElementNames(text) {
  * a tag to this scan, and escaping it corrupts the script.
  */
 export function escapeProseTags(text, styledNames) {
+  const isMarkup = markupTagTest(text, styledNames);
+  return text.replace(TAG_REGEX, (tag) => (
+    isMarkup(tag)
+      ? tag
+      : tag.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  ));
+}
+
+/**
+ * The same question `escapeProseTags` answers, as a predicate other passes can
+ * ask before the parse: will this tag survive as an element, or is it a word
+ * the author wrote in angle brackets?
+ *
+ * Keep the two together — a pass that guesses differently from the escape is a
+ * pass that reasons about a tree the parser never builds. A tag with no name
+ * (a comment, a doctype, a stray `<`) is not an element either way.
+ */
+export function markupTagTest(text, styledNames) {
   const styled = styledNames || styledElementNames(text);
   const opened = new Set();
   const closed = new Set();
@@ -116,14 +144,13 @@ export function escapeProseTags(text, styledNames) {
     (isClosingTag(match[0]) ? closed : opened).add(name);
   }
 
-  return text.replace(TAG_REGEX, (tag) => {
+  return (tag) => {
     const name = tagName(tag);
-    if (!name) return tag;
-    if (isKnownElement(name)) return tag;
-    if (styled.has(name)) return tag;
-    if (opened.has(name) && closed.has(name)) return tag;
-    return tag.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  });
+    if (!name) return false;
+    if (isKnownElement(name)) return true;
+    if (styled.has(name)) return true;
+    return opened.has(name) && closed.has(name);
+  };
 }
 
 /**

--- a/assets/chat_webview/formatter/protect.js
+++ b/assets/chat_webview/formatter/protect.js
@@ -14,7 +14,14 @@
 // which survives HTML parsing as ordinary text and cannot appear in a message.
 
 import { extractImageBlocks } from './image_blocks.js';
-import { maskTags } from './html_scan.js';
+import {
+  TAG_REGEX,
+  VOID_ELEMENTS,
+  isClosingTag,
+  markupTagTest,
+  maskTags,
+  tagName,
+} from './html_scan.js';
 
 /** Wraps every placeholder. U+0001 is not writable in a chat message. */
 export const SENTINEL = '\u0001';
@@ -161,6 +168,46 @@ export function maskCodeElements(text) {
 /** Glaze colour markers and the markdown emphasis run that follows them. */
 const MARKER_REGEX = /(==hc:#[0-9a-fA-F]{3,8}==.+?==|==glow:#[0-9a-fA-F]{3,8},\d+==.+?==|==cg:#[0-9a-fA-F]{3,8},#[0-9a-fA-F]{3,8},\d+==.+?==|==grad:#[0-9a-fA-F]{3,8}(?:,#[0-9a-fA-F]{3,8})+==.+?==|==bg:#[0-9a-fA-F]{3,8}==.+?==|==mark==.+?==|==active==.+?==|==accent==.+?==|\*\*[^*\n]+?\*\*|(?<!\*)\*(?=[^*\n]*[^ \t*\n])[^*\n]+?\*(?!\*)|__[^_\n]+?__|(?<!\w)_[^_\n]+?_(?!\w)|~~[^~\n]+?~~)/gs;
 
+/** A masked `<style>` / `<script>` body, as maskCodeElements leaves it. */
+const CODE_PLACEHOLDER = new RegExp(`${SENTINEL}RAW_\\d+${SENTINEL}`);
+
+/**
+ * True when the markup a candidate marker covers is the marker's own.
+ *
+ * A marker is inline and always will be (`renderStyledSegment` renders its
+ * content through `formatInlineRaw`), so the only content it can carry is
+ * content it fully contains. A `*` written before a card and a `*` that lands
+ * somewhere inside it are not an emphasis run — they are two asterisks with a
+ * card between them, and holding that span hands the whole card to an inline
+ * pass, which drops its `<style>` and lets the browser throw its block
+ * elements back out of the `<em>` as siblings of the message.
+ *
+ * The count asks the same question `escapeProseTags` does — a `<вздох>` the
+ * parse will escape into a word is not an open element here either — so an
+ * italic run around prose that merely looks like a tag still matches.
+ */
+function holdsOwnMarkup(segment, isMarkup) {
+  const open = [];
+  TAG_REGEX.lastIndex = 0;
+  let match;
+  while ((match = TAG_REGEX.exec(segment)) !== null) {
+    const tag = match[0];
+    if (!isMarkup(tag)) continue;
+    const name = tagName(tag);
+    if (VOID_ELEMENTS.has(name) || /\/\s*>$/.test(tag)) continue;
+    if (!isClosingTag(tag)) {
+      open.push(name);
+      continue;
+    }
+    const at = open.lastIndexOf(name);
+    // Closing what the marker never opened: the run reaches out of its own
+    // element, which is the half-span case above seen from the other side.
+    if (at < 0) return false;
+    open.length = at;
+  }
+  return open.length === 0;
+}
+
 /**
  * Pulls the style markers out of [text] before it is parsed.
  *
@@ -170,11 +217,23 @@ const MARKER_REGEX = /(==hc:#[0-9a-fA-F]{3,8}==.+?==|==glow:#[0-9a-fA-F]{3,8},\d
  * element between them. Tags are masked for the scan so a `*` inside an
  * attribute cannot open an emphasis run, while a marker that spans a tag still
  * matches.
+ *
+ * [styledNames] is the set of element names the message's CSS styles, as
+ * `styledElementNames` reads them off the source — the same set the caller
+ * hands `escapeProseTags`. Only the balance check below uses it.
  */
-export function extractMarkers(text, markers) {
+export function extractMarkers(text, markers, styledNames) {
   const { masked, unmask } = maskTags(text, SENTINEL);
-  const held = masked.replace(MARKER_REGEX, (segment) =>
-    markers.hold(unmask(segment)));
+  const isMarkup = markupTagTest(text, styledNames);
+  const held = masked.replace(MARKER_REGEX, (segment) => {
+    const raw = unmask(segment);
+    // A stylesheet is not emphasis. Its body is masked for this scan, and a
+    // held segment never gets unmasked — the marker would take the card's CSS
+    // out of the message with it.
+    if (CODE_PLACEHOLDER.test(raw)) return segment;
+    if (!holdsOwnMarkup(raw, isMarkup)) return segment;
+    return markers.hold(raw);
+  });
   // Models occasionally emit `».* *action*`: the first `*` is an orphan
   // marker, not an empty italic segment. Drop it once the real action is
   // safely stashed, otherwise it steals that action's opening marker.

--- a/docs/rules/message-rendering.md
+++ b/docs/rules/message-rendering.md
@@ -99,6 +99,28 @@ which cannot produce a block element. A `<p>` inside a marker's `<span>` is
 markup the browser throws straight back out — the marker then shows as empty
 text. See `docs/markdown-markers.md` for the marker list itself.
 
+Which is why **a marker only holds markup it opened and closed itself**
+(`holdsOwnMarkup` in `protect.js`). Tags are one opaque run to the marker scan,
+so a `*` a model wrote before a card and a `*` that landed inside it — which is
+what a display regex does when its capture group swallows the closing marker —
+match as one emphasis run over the whole card. Holding that span hands the card
+to the inline pass: its `<style>` goes with it (a held segment is never
+unmasked, so the leak sweep deletes the stylesheet) and the browser throws the
+card's block elements back out of the `<em>` as siblings of the message.
+
+Two rules keep that from happening, both on the way *into* the marker store:
+
+* a candidate whose tags do not nest to zero is not a marker — the asterisks
+  stay literal text, and the card renders as the card it is;
+* a candidate carrying a masked `<style>` / `<script>` body is not a marker
+  either. A stylesheet is not emphasis.
+
+Balance is counted with `markupTagTest` — the same answer `escapeProseTags`
+gives — so `*он прошептал <вздох> тихо*` is still one italic run, and void
+elements (`<br>`, `<img>`) never leave anything open. A marker that spans
+*balanced* markup, which is how `html_to_markdown` writes rich colour
+(`==hc:#fff==<b>x</b>==`), matches exactly as before.
+
 ---
 
 ## The message body renders into a shadow root

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -859,6 +859,30 @@ void main() {
       );
     });
 
+    test('a style marker only holds markup it opened and closed itself', () {
+      // `*` before a card and `*` somewhere inside it are two asterisks with
+      // a card between them, not an emphasis run. Holding that span hands the
+      // card to the inline pass, which drops its <style> and lets the browser
+      // throw its block elements back out of the <em> as siblings.
+      final body = _extractBlockBody(
+        formatterProtectJs,
+        formatterProtectJs.indexOf('function holdsOwnMarkup('),
+      );
+      expect(body, contains('VOID_ELEMENTS.has(name)'));
+      expect(body, contains('open.lastIndexOf(name)'));
+      expect(body, contains('return open.length === 0;'));
+      expect(
+        formatterProtectJs,
+        contains('if (!holdsOwnMarkup(raw, isMarkup)) return segment;'),
+      );
+      // A stylesheet is not emphasis: its body is masked for this scan and a
+      // held segment is never unmasked, so a marker over one loses the CSS.
+      expect(
+        formatterProtectJs,
+        contains('if (CODE_PLACEHOLDER.test(raw)) return segment;'),
+      );
+    });
+
     test('nested guillemets cannot consume styled-segment placeholders', () {
       expect(
         formatterInlineSyntaxJs,
@@ -902,12 +926,22 @@ void main() {
       // closing tag — not how many times the name occurs.
       final body = _extractBlockBody(
         formatterHtmlScanJs,
-        formatterHtmlScanJs.indexOf('export function escapeProseTags('),
+        formatterHtmlScanJs.indexOf('export function markupTagTest('),
       );
       expect(body, contains('isKnownElement(name)'));
       expect(body, contains('styled.has(name)'));
       expect(body, contains('opened.has(name) && closed.has(name)'));
-      expect(body, contains(r"tag.replace(/</g, '&lt;')"));
+
+      // One answer, two callers: the escape and the marker balance check both
+      // ask `markupTagTest`, so neither can reason about a tree the parser
+      // will not build.
+      final escape = _extractBlockBody(
+        formatterHtmlScanJs,
+        formatterHtmlScanJs.indexOf('export function escapeProseTags('),
+      );
+      expect(escape, contains('markupTagTest(text, styledNames)'));
+      expect(escape, contains(r"tag.replace(/</g, '&lt;')"));
+      expect(formatterProtectJs, contains('markupTagTest(text, styledNames)'));
     });
 
     test('a void element needs no exemption from anything', () {

--- a/test/webview_js/corpus/cards.js
+++ b/test/webview_js/corpus/cards.js
@@ -286,6 +286,28 @@ document.getElementById('sc-out').textContent='ok'+o;
 </script>`,
   },
   {
+    id: 'regex-card-in-emphasis',
+    title: 'Regex-built card with the model\'s asterisks around it',
+    origin: 'a display regex turns `(out) Name | text` lines into this card, ' +
+      'and the model wrote the block in italics. The opening `*` sat before ' +
+      'the card and the closing one was pulled into the last bubble, so the ' +
+      'marker held the whole card: its <style> was dropped and <details> ' +
+      'lost everything up to the footer, which the browser reparented as a ' +
+      'sibling.',
+    text: `Он набрал сообщение.
+
+*<div class="imsg-wrap"><style>@import url('https://fonts.example/css2?family=Card');.imsg-wrap{display:flex;justify-content:center}.imsg-details{width:fit-content;border-radius:20px}.imsg-msg{display:none;flex-direction:column}.imsg-msg[data-dir="(out)"]{display:flex;align-items:flex-start}.imsg-bubble{padding:6px 11px;border-radius:16px}.imsg-send svg{width:11px;height:11px;fill:none;stroke:#fff}</style><details class="imsg-details" open><summary class="imsg-summary"><span class="imsg-dot"></span><span class="imsg-label">New Notification</span></summary><div class="imsg-body"><div class="imsg-msg" data-dir="(out)"><span class="imsg-name">Влад</span><div class="imsg-bubble">спокойной кошка</div></div><div class="imsg-msg" data-dir="(out)"><span class="imsg-name">Влад</span><div class="imsg-bubble">🤍*</div></div></div><div class="imsg-footer"><div class="imsg-input">iMessage</div><div class="imsg-send"><svg viewBox="0 0 24 24"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg></div></div></details></div>
+
+Он убрал телефон.`,
+  },
+  {
+    id: 'emphasis-over-inline-tag',
+    title: 'Emphasis and a colour marker that legitimately span a tag',
+    origin: 'the guard for regex-card-in-emphasis must not cost these: the ' +
+      'markup inside is balanced, so the marker still holds it',
+    text: `*шёпот <b>громче</b> и снова тише* — ==hc:#00ff00==<i>зелёный</i>== и <br> подряд.`,
+  },
+  {
     id: 'import-font-card',
     title: 'Card whose CSS imports a web font',
     origin: 'INV-MR5 — @import is ignored inside a shadow root',
@@ -317,6 +339,7 @@ export const streamingCards = [
   'details-block',
   'svg-icon',
   'br-in-card',
+  'regex-card-in-emphasis',
 ];
 
 export function card(id) {

--- a/test/webview_js/specs/cards.spec.js
+++ b/test/webview_js/specs/cards.spec.js
@@ -384,6 +384,61 @@ test('inline tags in prose keep their paragraphs and their markdown', async ({ p
   expect(shape.markerHoldsTag).toBe(true);
 });
 
+test('emphasis around a regex-built card leaves the card alone', async ({ page }) => {
+  await render(page, card('regex-card-in-emphasis').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const wrap = root.querySelector('.imsg-wrap');
+    const details = root.querySelector('.imsg-details');
+    const footer = root.querySelector('.imsg-footer');
+    const bubble = root.querySelector('.imsg-bubble');
+    return {
+      // The card's stylesheet is what the marker used to take with it.
+      styles: root.querySelectorAll('style').length,
+      summaries: details ? details.querySelectorAll('summary').length : -1,
+      // Everything after the point the closing `*` landed used to end up
+      // outside <details>, and the footer outside the wrapper entirely.
+      footerInsideDetails: !!footer && !!footer.closest('.imsg-details'),
+      bodyInsideDetails: !!root.querySelector('.imsg-details .imsg-body'),
+      wrapHoldsCard: !!wrap && wrap.contains(details) && wrap.contains(footer),
+      // A marker never reparents markup: no <em> may hold a block element.
+      emAroundCard: root.querySelectorAll('em .imsg-wrap, em .imsg-details').length,
+      // The CSS still resolves, which is the whole reason it has to survive.
+      bubbleRadius: bubble ? getComputedStyle(bubble).borderRadius : '',
+      arrowWidth: getComputedStyle(root.querySelector('.imsg-send svg')).width,
+    };
+  });
+  expect(shape.styles).toBe(1);
+  expect(shape.summaries).toBe(1);
+  expect(shape.footerInsideDetails).toBe(true);
+  expect(shape.bodyInsideDetails).toBe(true);
+  expect(shape.wrapHoldsCard).toBe(true);
+  expect(shape.emAroundCard).toBe(0);
+  expect(shape.bubbleRadius).toBe('16px');
+  expect(shape.arrowWidth).toBe('11px');
+});
+
+test('a marker that spans balanced inline markup still holds it', async ({ page }) => {
+  await render(page, card('emphasis-over-inline-tag').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const em = root.querySelector('em.chat-italic');
+    const marker = root.querySelector('.glaze-hc');
+    return {
+      emHoldsTag: !!em && !!em.querySelector('b'),
+      emText: em ? em.textContent : '',
+      markerHoldsTag: !!marker && !!marker.querySelector('i'),
+      breaks: root.querySelectorAll('br').length,
+      strayAsterisks: (root.textContent.match(/\*/g) || []).length,
+    };
+  });
+  expect(shape.emHoldsTag, 'balanced markup inside a marker is still a marker').toBe(true);
+  expect(shape.emText).toBe('шёпот громче и снова тише');
+  expect(shape.markerHoldsTag).toBe(true);
+  expect(shape.breaks).toBe(1);
+  expect(shape.strayAsterisks).toBe(0);
+});
+
 test('a gradient <font> carries its fill down to the text', async ({ page }) => {
   await render(page, card('font-gradient').text);
   const shape = await page.evaluate(() => {


### PR DESCRIPTION
A display regex that turns `(out) Name | text` lines into an iMessage-style
card renders as a broken card whenever the model writes the block in italics —
`<details>` shows the browser's default summary, the card's CSS is gone, and
the footer sits outside the card as a sibling of the message.

The regex itself is fine. What breaks is the marker pass in the formatter: the
opening `*` stays before `<div class="imsg-wrap">` while the closing one is
pulled into the last bubble by the script's own `(.*?)` capture. Tags are one
opaque run to the marker scan and the substituted card is a single line, so the
two asterisks match as one emphasis run over the whole card. Holding that span
hands the card to the inline pass: its `<style>` goes into the marker store and
is never unmasked, so the leak sweep deletes the stylesheet, and the browser
throws the card's block elements back out of the `<em>` as siblings. `**`, `~~`
and `==hc:…==` break it the same way.

## Changes

- `formatter/protect.js`: a style marker now only holds markup it opened and
  closed itself (`holdsOwnMarkup`) — an unbalanced span is not a marker, the
  asterisks stay literal text and the card renders as the card it is.
- `formatter/protect.js`: a candidate carrying a masked `<style>` / `<script>`
  body is never a marker either. A stylesheet is not emphasis, and a held
  segment is never unmasked.
- `formatter/html_scan.js`: the "is this tag markup or a word in angle
  brackets" decision moves into `markupTagTest`, which the balance count and
  `escapeProseTags` now share — so `*он прошептал <вздох> тихо*` is still one
  italic run, and neither pass can reason about a tree the parser will not
  build. `VOID_ELEMENTS` keeps `<br>` / `<img>` from leaving anything open.
- `formatter/formatter.js`: passes the message's `styled` element names into
  `extractMarkers`, since the `<style>` bodies that declare them are masked out
  of the string the marker scan sees.
- `docs/rules/message-rendering.md`: the rule under "Markers are inline,
  always" now says what a marker may hold, and why.

## Verification

- `test/webview_js`: 54 passed, was 51. Two new corpus entries —
  `regex-card-in-emphasis` (the card as the regex emits it, inside the model's
  asterisks; also added to the streaming set) and `emphasis-over-inline-tag`
  (a marker that legitimately spans balanced inline markup, so the guard is
  not paid for by the normal case).
- The new card spec fails on the previous formatter with `styles: 0` and a
  `Formatter LEAK` in the console; the balanced-markup spec passes both before
  and after, which is the point of it.
- `test/webview_assets_test.dart`: the source-side guards follow the refactor,
  plus one new test for the marker balance check.
- `flutter analyze` / `flutter test` were **not** run — this branch was
  prepared in an environment with no Flutter SDK. Only the Dart test file was
  touched on that side, and its string assertions were checked against the
  sources by hand; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1uHg76qWvWrDTGXPuUDDp

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1uHg76qWvWrDTGXPuUDDp)_