### PR TITLE
feat(ledger): derive world:date day-of-month from canonical month+year and world:day

### DIFF
--- a/lib/core/db/studio_preset_seed.dart
+++ b/lib/core/db/studio_preset_seed.dart
@@ -700,7 +700,7 @@ ALLOWED CURRENT-STATE KEYS:
 
 GAME CLOCK:
 - Keep world:time as the current in-game time of day in 24h HH:MM and advance it when narrated events imply elapsed time.
-- Keep one complete tuple: world:date (DD.MM.YYYY), zero-based world:day, and world:time. Never guess a missing date or day.
+- Keep one complete tuple: world:date (DD.MM.YYYY), zero-based world:day, and world:time. Never invent a month or year. When the canonical timeline names only a month and year, derive day-of-month = 1 + world:day (Day 0 = the 1st of that month) and write world:date in DD.MM.YYYY.
 - The clock only moves FORWARD. Never rewind it; flashbacks and memories stay in prose. Past midnight, advance world:day (day 0 = the first story day) and world:date.
 - Do not invent time skips the narrative does not support; an immediately continuing scene moves time by only a few minutes.
 

--- a/lib/core/llm/ledger/ledger_prompt_factory.dart
+++ b/lib/core/llm/ledger/ledger_prompt_factory.dart
@@ -127,7 +127,10 @@ Allowed eventState: planned, suggested, threatened, attempted, completed, failed
 Game clock (world:time, world:date, world:day):
 - Maintain world:time as the current in-game time of day in 24h HH:MM format.
 - Keep one complete tuple: world:date (DD.MM.YYYY), zero-based world:day, and
-  world:time. Never guess a missing date or day.
+  world:time. Never invent a month or year. When the canonical timeline names a
+  month and year but no day-of-month, derive world:date deterministically as
+  day-of-month = 1 + world:day (so Day 0 = the 1st of that month) and advance
+  the day-of-month together with world:day. Always write world:date in DD.MM.YYYY.
 - When the final response or chat implies elapsed time, advance world:time to the
   new in-game time based on how much time the narrated events would take.
 - For an ordinary continuous turn with no explicit duration, advance the clock

--- a/lib/core/llm/studio_ledger_prompt.dart
+++ b/lib/core/llm/studio_ledger_prompt.dart
@@ -389,7 +389,9 @@ Rules:
 - World/scene keys: world:location, world:time, world:date, world:day, world:active_threats, scene.present_entities, scene.absent_backstory_entities
 - Game clock: keep world:time in 24h HH:MM as the current in-game time of day and
   keep it paired with world:date (DD.MM.YYYY) and zero-based world:day. Never
-  guess a missing date or day. When all three are established,
+  invent a month or year; when the canonical timeline names only a month and year,
+  derive day-of-month = 1 + world:day (Day 0 = the 1st of that month) and write
+  world:date in DD.MM.YYYY. When all three are established,
   advance it when narrated events imply elapsed time. The clock only moves
   FORWARD — never rewind it; flashbacks stay in prose. Past midnight, advance
   world:day (day 0 = first story day) and world:date.


### PR DESCRIPTION
## Problem

When a canonical timeline names only a month and year (e.g. \September 2026, Day 0\) with no concrete day-of-month, the Ledger contract said \world:date\ must be \DD.MM.YYYY\ while also forbidding it to guess a missing date. In practice the model wrote \world:date\ as free prose (\September 2026 (Day 0)\) or guessed a day-of-month, so \GameTimeState.format()\ returned \
ull\ and the game clock silently disappeared from the chat.

## Change

Replace \Never guess a missing date or day\ with a deterministic derivation rule: when the canonical timeline names only a month and year, \day-of-month = 1 + world:day\ (so Day 0 = the 1st of that month), and advance day-of-month together with world:day. Updated in the three places the contract is authored:

- \lib/core/llm/ledger/ledger_prompt_factory.dart\
- \lib/core/llm/studio_ledger_prompt.dart\
- \lib/core/db/studio_preset_seed.dart\

## Verification

- \lutter analyze\ clean on all changed files.
- \lutter test test/game_time_test.dart\ — 12/12 passed.
- No test asserted the old \Never guess a missing date\ string.