### PR TITLE
refactor(render): take style markers from a run, not from the message

### DIFF
--- a/assets/chat_webview/formatter/dom_format.js
+++ b/assets/chat_webview/formatter/dom_format.js
@@ -15,9 +15,9 @@
 //     paragraph wrapped around someone's card is what breaks `~` and `+`.
 
 import { isKnownElement, RAW_TEXT_ELEMENTS } from './html_scan.js';
-import { SENTINEL } from './protect.js';
+import { SENTINEL, createStore, extractMarkers } from './protect.js';
 import { applyBlockSyntax } from './block_syntax.js';
-import { applyInlineSyntax, escapeText } from './inline_syntax.js';
+import { applyInlineSyntax, escapeText, formatInlineMasked } from './inline_syntax.js';
 
 /** Elements that flow with the text around them, so they join its run. */
 const PHRASING = new Set([
@@ -145,10 +145,19 @@ function formatRun(run, container, context) {
 
   if (!masked.trim()) return;
 
-  const inline = (line) => applyInlineSyntax(line, context.inlineContext);
+  // Style markers come out of the run before the block pass splits it into
+  // lines, because a colour marker may wrap more than one. This is the only
+  // place they are taken, and by the time the run exists there is no markup
+  // in the string to take by accident: text is escaped, elements are `E_n`.
+  // A marker therefore holds what the author already had inside one container
+  // — never a block element, never the inside of a `<pre>`.
+  const markers = createStore('S');
+  const staged = extractMarkers(masked, markers);
+
+  const inline = (line) => applyInlineSyntax(line, { markers, inner: formatInlineMasked });
   const html = context.allowBlocks
-    ? applyBlockSyntax(masked, { inline, paragraphs: context.paragraphs })
-    : inline(masked).replace(/\n/g, '<br>');
+    ? applyBlockSyntax(staged, { inline, paragraphs: context.paragraphs })
+    : inline(staged).replace(/\n/g, '<br>');
 
   // Detach the run before the formatted tree is built: the elements it kept
   // are moved into that tree, and removing "what the run used to be"
@@ -166,14 +175,13 @@ function formatRun(run, container, context) {
  * Formats the text inside one container: first its element children (each in
  * its own context), then the runs of text between them.
  */
-export function formatContainer(container, { isRoot, allowBlocks, inlineContext }) {
+export function formatContainer(container, { isRoot, allowBlocks }) {
   for (const child of Array.from(container.children)) {
     const name = child.localName;
     if (OPAQUE.has(name)) continue;
     formatContainer(child, {
       isRoot: false,
       allowBlocks: canHoldBlocks(name),
-      inlineContext,
     });
   }
 
@@ -194,7 +202,6 @@ export function formatContainer(container, { isRoot, allowBlocks, inlineContext 
     formatRun(current, container, {
       allowBlocks,
       paragraphs: isRoot && !touchesBlockSibling(current),
-      inlineContext,
     });
   }
 }

--- a/assets/chat_webview/formatter/formatter.js
+++ b/assets/chat_webview/formatter/formatter.js
@@ -22,7 +22,6 @@ import { escapeProseTags, styledElementNames } from './html_scan.js';
 import {
   ANY_PLACEHOLDER,
   createStore,
-  extractMarkers,
   maskCodeElements,
   protectRegions,
 } from './protect.js';
@@ -32,7 +31,6 @@ import {
   parseHtml,
   replacePlaceholders,
 } from './dom_format.js';
-import { formatInlineRaw } from './inline_syntax.js';
 import { renderImageBlock } from './image_blocks.js';
 
 export {
@@ -94,32 +92,21 @@ export class Formatter {
       .trim();
 
     const regions = createStore('P');
-    const markers = createStore('S');
 
-    let staged = protectRegions(source, { store: regions, inReasoning });
-    // `<style>` and `<script>` bodies are code, and both string passes below
-    // would read them as prose: a `*` in a selector is not an italic marker,
-    // and `i<n; i++) { if (i>` in a script is not a tag. They are masked for
-    // the length of both, and put back for the parser.
+    const staged = protectRegions(source, { store: regions, inReasoning });
+    // `<style>` and `<script>` bodies are code, and the tag scan below would
+    // read them as prose: `i<n; i++) { if (i>` in a script is a tag to it, and
+    // escaping that corrupts the script. They are masked for its length and
+    // put back for the parser.
     const styled = styledElementNames(staged);
     const code = maskCodeElements(staged);
-    // Style markers come out before the parse, because html_to_markdown writes
-    // rich content inside them and a parsed marker is two text nodes with an
-    // element between them. `styled` goes along so the balance check there
-    // reads the message's tags exactly as `escapeProseTags` will below — the
-    // `<style>` bodies that declare them are masked out of `code.masked`.
-    staged = extractMarkers(code.masked, markers, styled);
 
-    const tree = parseHtml(code.unmask(escapeProseTags(staged, styled)), document);
+    // Nothing has read this string as markdown. The parse comes first, and
+    // every markdown pass — style markers included — runs in phase B, on a run
+    // of one container's text with its elements already masked out.
+    const tree = parseHtml(code.unmask(escapeProseTags(code.masked, styled)), document);
 
-    formatContainer(tree, {
-      isRoot: true,
-      allowBlocks: true,
-      inlineContext: {
-        markers,
-        inner: (raw, skipQuotes = true) => formatInlineRaw(raw, { skipQuotes }),
-      },
-    });
+    formatContainer(tree, { isRoot: true, allowBlocks: true });
 
     let imageIndex = 0;
     replacePlaceholders(tree, 'P', (index) => {

--- a/assets/chat_webview/formatter/html_scan.js
+++ b/assets/chat_webview/formatter/html_scan.js
@@ -72,16 +72,6 @@ export const RAW_TEXT_ELEMENTS = new Set([
   'script', 'style', 'pre', 'code', 'textarea', 'title', 'xmp', 'plaintext',
 ]);
 
-/**
- * Elements that close themselves. Not a list of what is block or inline — the
- * parser still answers that — only of the names for which a lone `<x>` is a
- * complete element, so a balance count must not wait for a `</x>`.
- */
-export const VOID_ELEMENTS = new Set([
-  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta',
-  'param', 'source', 'track', 'wbr',
-]);
-
 /** Element names a `<style>` block in the message uses as a type selector. */
 export function styledElementNames(text) {
   const names = new Set();
@@ -115,24 +105,6 @@ export function styledElementNames(text) {
  * a tag to this scan, and escaping it corrupts the script.
  */
 export function escapeProseTags(text, styledNames) {
-  const isMarkup = markupTagTest(text, styledNames);
-  return text.replace(TAG_REGEX, (tag) => (
-    isMarkup(tag)
-      ? tag
-      : tag.replace(/</g, '&lt;').replace(/>/g, '&gt;')
-  ));
-}
-
-/**
- * The same question `escapeProseTags` answers, as a predicate other passes can
- * ask before the parse: will this tag survive as an element, or is it a word
- * the author wrote in angle brackets?
- *
- * Keep the two together — a pass that guesses differently from the escape is a
- * pass that reasons about a tree the parser never builds. A tag with no name
- * (a comment, a doctype, a stray `<`) is not an element either way.
- */
-export function markupTagTest(text, styledNames) {
   const styled = styledNames || styledElementNames(text);
   const opened = new Set();
   const closed = new Set();
@@ -144,34 +116,12 @@ export function markupTagTest(text, styledNames) {
     (isClosingTag(match[0]) ? closed : opened).add(name);
   }
 
-  return (tag) => {
+  return text.replace(TAG_REGEX, (tag) => {
     const name = tagName(tag);
-    if (!name) return false;
-    if (isKnownElement(name)) return true;
-    if (styled.has(name)) return true;
-    return opened.has(name) && closed.has(name);
-  };
-}
-
-/**
- * Replaces every tag with an opaque placeholder and hands back the restore.
- *
- * Used where a string pass must not read inside a tag: markdown markers are
- * matched across a message that still contains raw HTML, and `*` inside
- * `<div style="a*b">` is not an italic marker. Markers that *span* tags
- * (`==hc:#fff==<b>x</b>==`, which is how html_to_markdown writes rich colour)
- * still match, because the tag is one opaque character run rather than a
- * boundary.
- */
-export function maskTags(text, sentinel) {
-  const tags = [];
-  const masked = text.replace(TAG_REGEX, (tag) => {
-    tags.push(tag);
-    return `${sentinel}TAG_${tags.length - 1}${sentinel}`;
+    if (!name) return tag;
+    if (isKnownElement(name)) return tag;
+    if (styled.has(name)) return tag;
+    if (opened.has(name) && closed.has(name)) return tag;
+    return tag.replace(/</g, '&lt;').replace(/>/g, '&gt;');
   });
-  const pattern = new RegExp(`${sentinel}TAG_(\\d+)${sentinel}`, 'g');
-  return {
-    masked,
-    unmask: (value) => String(value).replace(pattern, (_m, i) => tags[Number(i)]),
-  };
 }

--- a/assets/chat_webview/formatter/inline_syntax.js
+++ b/assets/chat_webview/formatter/inline_syntax.js
@@ -8,7 +8,6 @@
 // and the markdown kept eating the markup.
 
 import { renderStyledSegment } from './text_format.js';
-import { maskTags } from './html_scan.js';
 import { SENTINEL, createStore, extractMarkers } from './protect.js';
 
 /**
@@ -107,22 +106,25 @@ export function applyInlineSyntax(text, { markers, inner, skipQuotes = false }) 
 }
 
 /**
- * Formats a raw fragment of message source as inline content: the inside of a
- * style marker, which may carry its own tags and its own nested markers.
+ * Formats the inside of one style marker, which may carry its own nested
+ * markers and the `E_n` placeholders of elements it wrapped.
+ *
+ * The string is already what `formatRun` built — escaped text and masked
+ * elements — so nothing here escapes or masks again: doing either would show
+ * the author's own `<b>` as `&lt;b&gt;` on screen. Its only job is the passes
+ * a marker's content still needs.
  *
  * Always inline — a marker is a `<span>`, and a `<p>` inside one is what the
  * browser throws straight back out, leaving the marker empty on screen.
  */
-export function formatInlineRaw(raw, { skipQuotes = false } = {}) {
-  if (!raw) return '';
+export function formatInlineMasked(text, { skipQuotes = false } = {}) {
+  if (!text) return '';
   const markers = createStore('S');
-  const held = extractMarkers(String(raw), markers);
-  const { masked, unmask } = maskTags(held, SENTINEL);
-  const formatted = applyInlineSyntax(escapeText(masked), {
+  const held = extractMarkers(String(text), markers);
+  return applyInlineSyntax(held, {
     markers,
     skipQuotes,
     inner: (nested, nestedSkipQuotes = true) =>
-      formatInlineRaw(nested, { skipQuotes: nestedSkipQuotes }),
+      formatInlineMasked(nested, { skipQuotes: nestedSkipQuotes }),
   });
-  return unmask(formatted);
 }

--- a/assets/chat_webview/formatter/protect.js
+++ b/assets/chat_webview/formatter/protect.js
@@ -14,14 +14,6 @@
 // which survives HTML parsing as ordinary text and cannot appear in a message.
 
 import { extractImageBlocks } from './image_blocks.js';
-import {
-  TAG_REGEX,
-  VOID_ELEMENTS,
-  isClosingTag,
-  markupTagTest,
-  maskTags,
-  tagName,
-} from './html_scan.js';
 
 /** Wraps every placeholder. U+0001 is not writable in a chat message. */
 export const SENTINEL = '\u0001';
@@ -168,77 +160,26 @@ export function maskCodeElements(text) {
 /** Glaze colour markers and the markdown emphasis run that follows them. */
 const MARKER_REGEX = /(==hc:#[0-9a-fA-F]{3,8}==.+?==|==glow:#[0-9a-fA-F]{3,8},\d+==.+?==|==cg:#[0-9a-fA-F]{3,8},#[0-9a-fA-F]{3,8},\d+==.+?==|==grad:#[0-9a-fA-F]{3,8}(?:,#[0-9a-fA-F]{3,8})+==.+?==|==bg:#[0-9a-fA-F]{3,8}==.+?==|==mark==.+?==|==active==.+?==|==accent==.+?==|\*\*[^*\n]+?\*\*|(?<!\*)\*(?=[^*\n]*[^ \t*\n])[^*\n]+?\*(?!\*)|__[^_\n]+?__|(?<!\w)_[^_\n]+?_(?!\w)|~~[^~\n]+?~~)/gs;
 
-/** A masked `<style>` / `<script>` body, as maskCodeElements leaves it. */
-const CODE_PLACEHOLDER = new RegExp(`${SENTINEL}RAW_\\d+${SENTINEL}`);
-
 /**
- * True when the markup a candidate marker covers is the marker's own.
+ * Pulls the style markers out of one *run* of message text.
  *
- * A marker is inline and always will be (`renderStyledSegment` renders its
- * content through `formatInlineRaw`), so the only content it can carry is
- * content it fully contains. A `*` written before a card and a `*` that lands
- * somewhere inside it are not an emphasis run — they are two asterisks with a
- * card between them, and holding that span hands the whole card to an inline
- * pass, which drops its `<style>` and lets the browser throw its block
- * elements back out of the `<em>` as siblings of the message.
+ * [text] is what `formatRun` built: the run's text nodes escaped, its inline
+ * elements replaced by opaque `E_n` placeholders. There is no markup left in
+ * it, which is the whole reason this scan is safe — a marker can only ever
+ * hold text and elements that were already siblings inside one container, so
+ * it cannot reach across a block element, into a card, or inside a `<pre>`.
  *
- * The count asks the same question `escapeProseTags` does — a `<вздох>` the
- * parse will escape into a word is not an open element here either — so an
- * italic run around prose that merely looks like a tag still matches.
+ * It still runs before the block pass rather than per line, because a colour
+ * marker may wrap several lines (`==hc:#fff==` matches with `s`), and the
+ * block pass splits the run into lines before it formats them.
  */
-function holdsOwnMarkup(segment, isMarkup) {
-  const open = [];
-  TAG_REGEX.lastIndex = 0;
-  let match;
-  while ((match = TAG_REGEX.exec(segment)) !== null) {
-    const tag = match[0];
-    if (!isMarkup(tag)) continue;
-    const name = tagName(tag);
-    if (VOID_ELEMENTS.has(name) || /\/\s*>$/.test(tag)) continue;
-    if (!isClosingTag(tag)) {
-      open.push(name);
-      continue;
-    }
-    const at = open.lastIndexOf(name);
-    // Closing what the marker never opened: the run reaches out of its own
-    // element, which is the half-span case above seen from the other side.
-    if (at < 0) return false;
-    open.length = at;
-  }
-  return open.length === 0;
-}
-
-/**
- * Pulls the style markers out of [text] before it is parsed.
- *
- * They have to come out here, not from the parsed tree: html_to_markdown puts
- * rich content inside a colour marker (`==hc:#fff==<b>x</b>==`), and once that
- * is parsed the marker's two halves live in two different text nodes with an
- * element between them. Tags are masked for the scan so a `*` inside an
- * attribute cannot open an emphasis run, while a marker that spans a tag still
- * matches.
- *
- * [styledNames] is the set of element names the message's CSS styles, as
- * `styledElementNames` reads them off the source — the same set the caller
- * hands `escapeProseTags`. Only the balance check below uses it.
- */
-export function extractMarkers(text, markers, styledNames) {
-  const { masked, unmask } = maskTags(text, SENTINEL);
-  const isMarkup = markupTagTest(text, styledNames);
-  const held = masked.replace(MARKER_REGEX, (segment) => {
-    const raw = unmask(segment);
-    // A stylesheet is not emphasis. Its body is masked for this scan, and a
-    // held segment never gets unmasked — the marker would take the card's CSS
-    // out of the message with it.
-    if (CODE_PLACEHOLDER.test(raw)) return segment;
-    if (!holdsOwnMarkup(raw, isMarkup)) return segment;
-    return markers.hold(raw);
-  });
+export function extractMarkers(text, markers) {
+  const held = text.replace(MARKER_REGEX, (segment) => markers.hold(segment));
   // Models occasionally emit `».* *action*`: the first `*` is an orphan
   // marker, not an empty italic segment. Drop it once the real action is
   // safely stashed, otherwise it steals that action's opening marker.
-  return unmask(held.replace(
+  return held.replace(
     new RegExp(`\\*([ \\t]+)(?=${SENTINEL}S_\\d+${SENTINEL})`, 'g'),
     '$1',
-  ));
+  );
 }

--- a/docs/markdown-markers.md
+++ b/docs/markdown-markers.md
@@ -4,7 +4,7 @@ The app extends GptMarkdown with custom `==...==` inline markers. When adding a
 new marker, update all of the following in sync:
 
 1. **Converter:** `lib/core/utils/html_to_markdown.dart` — produces marker syntax from HTML
-2. **JS formatter extraction:** `assets/chat_webview/formatter/protect.js` — `MARKER_REGEX`, which pulls markers out before the message is parsed (a marker may span a tag). `assets/chat_webview/formatter/formatter.js` drives the passes.
+2. **JS formatter extraction:** `assets/chat_webview/formatter/protect.js` — `MARKER_REGEX`, matched by `extractMarkers`. It runs in phase B, from `formatRun` in `assets/chat_webview/formatter/dom_format.js`, over one container's run of text with its inline elements masked — so a marker may still span a `<b>`, but never a block element or the inside of a `<pre>`. `assets/chat_webview/formatter/formatter.js` drives the passes.
 3. **JS marker rendering:** `assets/chat_webview/formatter/text_format.js` — `renderStyledSegment()` HTML output
 4. **JS CSS:** `assets/chat_webview/renderer/shadow_style.js` — `SHADOW_STYLE` styling for marker classes
 5. **Dart renderer:** `lib/shared/widgets/colored_markdown.dart` — `InlineMd` subclass for Flutter-native rendering
@@ -32,9 +32,9 @@ into the stored text, so a marker written once follows theme changes.
 five styling markers above.
 
 `==mark==`, `==active==` and `==accent==` render their inner content raw. Every
-other marker renders its content through `formatInlineRaw()`, which is inline
-by construction: a marker is a `<span>`, and a `<p>` inside one is markup the
-browser throws straight back out, leaving the marker empty on screen.
+other marker renders its content through `formatInlineMasked()`, which is
+inline by construction: a marker is a `<span>`, and a `<p>` inside one is markup
+the browser throws straight back out, leaving the marker empty on screen.
 
 ## Additional Custom InlineMd/BlockMd Classes
 

--- a/docs/rules/message-rendering.md
+++ b/docs/rules/message-rendering.md
@@ -92,34 +92,39 @@ text mid-pipeline: whatever pass runs next will take it apart.
 
 ---
 
-## Markers are inline, always
+## Markers are inline, always — and they come from a run, not from the message
 
-`renderStyledSegment()` renders a marker's content through `formatInlineRaw()`,
-which cannot produce a block element. A `<p>` inside a marker's `<span>` is
-markup the browser throws straight back out — the marker then shows as empty
-text. See `docs/markdown-markers.md` for the marker list itself.
+`renderStyledSegment()` renders a marker's content through
+`formatInlineMasked()`, which cannot produce a block element. A `<p>` inside a
+marker's `<span>` is markup the browser throws straight back out — the marker
+then shows as empty text. See `docs/markdown-markers.md` for the marker list
+itself.
 
-Which is why **a marker only holds markup it opened and closed itself**
-(`holdsOwnMarkup` in `protect.js`). Tags are one opaque run to the marker scan,
-so a `*` a model wrote before a card and a `*` that landed inside it — which is
-what a display regex does when its capture group swallows the closing marker —
-match as one emphasis run over the whole card. Holding that span hands the card
-to the inline pass: its `<style>` goes with it (a held segment is never
-unmasked, so the leak sweep deletes the stylesheet) and the browser throws the
-card's block elements back out of the `<em>` as siblings of the message.
+Markers are taken in `formatRun` (`dom_format.js`), from the string that pass
+has already built: one container's text nodes escaped, its inline elements
+replaced by `E_n` placeholders. That string holds no markup at all, which is
+what makes the scan safe. Three properties follow from *where* it runs, not
+from anything the scan checks:
 
-Two rules keep that from happening, both on the way *into* the marker store:
+* a marker cannot reach across a block element, because a block element ends
+  the run;
+* a marker cannot open inside an element and close outside it, because those
+  are two different runs;
+* a marker cannot reach inside `<pre>`, `<script>` or `<style>`, because those
+  are `OPAQUE` and never get a run.
 
-* a candidate whose tags do not nest to zero is not a marker — the asterisks
-  stay literal text, and the card renders as the card it is;
-* a candidate carrying a masked `<style>` / `<script>` body is not a marker
-  either. A stylesheet is not emphasis.
+It still runs before `applyBlockSyntax`, not per line: `==hc:#fff==` matches
+with `s` and may wrap several lines, and the block pass formats a line at a
+time.
 
-Balance is counted with `markupTagTest` — the same answer `escapeProseTags`
-gives — so `*он прошептал <вздох> тихо*` is still one italic run, and void
-elements (`<br>`, `<img>`) never leave anything open. A marker that spans
-*balanced* markup, which is how `html_to_markdown` writes rich colour
-(`==hc:#fff==<b>x</b>==`), matches exactly as before.
+**This is the pass that used to be the exception.** It ran before the parse, on
+the raw message, with tags masked — and every property above was something it
+had to guess. A `*` a model wrote before a regex-built card and the `*` the
+script's capture pulled into the card matched as one emphasis run over the
+whole card, taking its `<style>` with it; the same scan reached inside a `<pre>`
+the block pass never formats, so the run it held was never restored and the
+leak sweep deleted it. Do not move it back in front of the parse: there is now
+no markdown pass anywhere that reads a string containing live HTML.
 
 ---
 

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -831,11 +831,11 @@ void main() {
     test('a style marker is rendered by an inline-only pass', () {
       // A marker is a <span>. A <p> inside one is markup the browser throws
       // straight back out, which used to leave a coloured marker showing as
-      // empty text. Its content goes through formatInlineRaw, which cannot
+      // empty text. Its content goes through formatInlineMasked, which cannot
       // emit a paragraph: it never reaches the block pass at all.
       expect(
         formatterInlineSyntaxJs,
-        contains('export function formatInlineRaw('),
+        contains('export function formatInlineMasked('),
       );
       expect(formatterInlineSyntaxJs, isNot(contains('block_syntax.js')));
       expect(formatterTextFormatJs, contains('processRichText'));
@@ -859,28 +859,32 @@ void main() {
       );
     });
 
-    test('a style marker only holds markup it opened and closed itself', () {
-      // `*` before a card and `*` somewhere inside it are two asterisks with
-      // a card between them, not an emphasis run. Holding that span hands the
-      // card to the inline pass, which drops its <style> and lets the browser
-      // throw its block elements back out of the <em> as siblings.
+    test('style markers are taken from a run, never from the message', () {
+      // The one pass that used to read markdown out of a string with live
+      // HTML in it. A `*` before a card and a `*` inside it matched as one
+      // emphasis run over the whole card; the same scan reached inside a
+      // <pre> the block pass never formats and lost what it held there.
+      // It now runs in formatRun, where the string is one container's text
+      // with its elements already masked — so a marker cannot leave the
+      // container it was written in, and the tree enforces that, not a count.
+      expect(formatterFormatterJs, isNot(contains('extractMarkers')));
       final body = _extractBlockBody(
-        formatterProtectJs,
-        formatterProtectJs.indexOf('function holdsOwnMarkup('),
+        formatterDomFormatJs,
+        formatterDomFormatJs.indexOf('function formatRun('),
       );
-      expect(body, contains('VOID_ELEMENTS.has(name)'));
-      expect(body, contains('open.lastIndexOf(name)'));
-      expect(body, contains('return open.length === 0;'));
-      expect(
-        formatterProtectJs,
-        contains('if (!holdsOwnMarkup(raw, isMarkup)) return segment;'),
-      );
-      // A stylesheet is not emphasis: its body is masked for this scan and a
-      // held segment is never unmasked, so a marker over one loses the CSS.
-      expect(
-        formatterProtectJs,
-        contains('if (CODE_PLACEHOLDER.test(raw)) return segment;'),
-      );
+      final masked = body.indexOf(r'`${SENTINEL}E_${kept.length - 1}${SENTINEL}`');
+      final markers = body.indexOf('extractMarkers(masked, markers)');
+      final block = body.indexOf('applyBlockSyntax(staged');
+      expect(masked, isNonNegative);
+      expect(markers, greaterThan(masked));
+      // Before the block pass, not per line: a colour marker may wrap more
+      // than one, and applyBlockSyntax formats a line at a time.
+      expect(block, greaterThan(markers));
+
+      // Nothing masks tags for a markdown pass any more, because no markdown
+      // pass ever sees one.
+      expect(formatterHtmlScanJs, isNot(contains('export function maskTags(')));
+      expect(formatterProtectJs, isNot(contains('holdsOwnMarkup')));
     });
 
     test('nested guillemets cannot consume styled-segment placeholders', () {
@@ -902,7 +906,7 @@ void main() {
     test('the message is parsed before anything formats its text', () {
       final protect = formatterFormatterJs.indexOf('protectRegions(source');
       final parse = formatterFormatterJs.indexOf(
-        'parseHtml(code.unmask(escapeProseTags(',
+        'parseHtml(code.unmask(escapeProseTags(code.masked, styled))',
       );
       final format = formatterFormatterJs.indexOf('formatContainer(tree');
       expect(protect, isNonNegative);
@@ -926,22 +930,12 @@ void main() {
       // closing tag — not how many times the name occurs.
       final body = _extractBlockBody(
         formatterHtmlScanJs,
-        formatterHtmlScanJs.indexOf('export function markupTagTest('),
+        formatterHtmlScanJs.indexOf('export function escapeProseTags('),
       );
       expect(body, contains('isKnownElement(name)'));
       expect(body, contains('styled.has(name)'));
       expect(body, contains('opened.has(name) && closed.has(name)'));
-
-      // One answer, two callers: the escape and the marker balance check both
-      // ask `markupTagTest`, so neither can reason about a tree the parser
-      // will not build.
-      final escape = _extractBlockBody(
-        formatterHtmlScanJs,
-        formatterHtmlScanJs.indexOf('export function escapeProseTags('),
-      );
-      expect(escape, contains('markupTagTest(text, styledNames)'));
-      expect(escape, contains(r"tag.replace(/</g, '&lt;')"));
-      expect(formatterProtectJs, contains('markupTagTest(text, styledNames)'));
+      expect(body, contains(r"tag.replace(/</g, '&lt;')"));
     });
 
     test('a void element needs no exemption from anything', () {
@@ -961,17 +955,17 @@ void main() {
     });
 
     test('a <style> or <script> body is never read as prose', () {
-      // Both string passes before the parse would misread code: a `*` in a
-      // selector is not an italic marker, and `i<n; i++) { if (i>` in a
-      // script is not a tag. They are masked for the length of both.
+      // The tag scan before the parse would misread code — `i<n; i++) { if (i>`
+      // inside a script is a tag to it, and escaping that corrupts the script.
+      // The body is masked for its length and put back for the parser. The
+      // markdown passes need no such guard: they run after the parse, and
+      // <style> / <script> are OPAQUE to them.
       final mask = formatterFormatterJs.indexOf('maskCodeElements(staged)');
-      final markers = formatterFormatterJs.indexOf('extractMarkers(code.masked');
       final escape = formatterFormatterJs.indexOf(
-        'code.unmask(escapeProseTags(staged, styled))',
+        'code.unmask(escapeProseTags(code.masked, styled))',
       );
       expect(mask, isNonNegative);
-      expect(markers, greaterThan(mask));
-      expect(escape, greaterThan(markers));
+      expect(escape, greaterThan(mask));
       expect(
         formatterProtectJs,
         contains(r'/<(style|script)\b[^>]*>[\s\S]*?(?:<\/\1\s*>|$)/gi'),
@@ -990,7 +984,6 @@ void main() {
         formatterDomFormatJs,
         contains(r'`${SENTINEL}E_${kept.length - 1}${SENTINEL}`'),
       );
-      expect(formatterHtmlScanJs, contains('export function maskTags('));
     });
 
     test('inline code is protected before the message is parsed', () {

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -815,11 +815,14 @@ void main() {
         './html_scan.js',
         './protect.js',
         './dom_format.js',
-        './inline_syntax.js',
         './image_blocks.js',
       ]) {
         expect(formatterFormatterJs, contains("'$module'"));
       }
+      // The inline pass is reached through phase B, which owns the run it
+      // formats. The entrypoint stopped wiring it directly when style markers
+      // moved out of the pre-parse stage and into formatRun.
+      expect(formatterDomFormatJs, contains("'./inline_syntax.js'"));
       expect(formatterInlineSyntaxJs, contains("'./text_format.js'"));
       expect(formatterInlineSyntaxJs, contains('renderStyledSegment('));
     });

--- a/test/webview_js/corpus/cards.js
+++ b/test/webview_js/corpus/cards.js
@@ -286,6 +286,24 @@ document.getElementById('sc-out').textContent='ok'+o;
 </script>`,
   },
   {
+    id: 'pre-with-emphasis',
+    title: 'Code in a <pre> that uses * and _ as operators',
+    origin: 'the pre-parse marker scan reached inside a raw-text element the ' +
+      'block pass never formats, so the run it held was never restored and ' +
+      'the leak sweep deleted it: `<pre>if (*p) *p = 1;</pre>` rendered as ' +
+      '`if (p = 1;`',
+    text: `<pre>int *p = &n;
+if (*p) *p = 1;
+long _t_ = a * b * c;</pre>`,
+  },
+  {
+    id: 'emphasis-across-element-boundary',
+    title: 'Emphasis that opens inside an element and closes outside it',
+    origin: 'the boundary the marker pass is now bound by: the two asterisks ' +
+      'are in different containers, so they are not one run',
+    text: `<span>*начало</span> конец* и <b>жирно *курсив* внутри</b>`,
+  },
+  {
     id: 'regex-card-in-emphasis',
     title: 'Regex-built card with the model\'s asterisks around it',
     origin: 'a display regex turns `(out) Name | text` lines into this card, ' +
@@ -340,6 +358,7 @@ export const streamingCards = [
   'svg-icon',
   'br-in-card',
   'regex-card-in-emphasis',
+  'pre-with-emphasis',
 ];
 
 export function card(id) {

--- a/test/webview_js/specs/cards.spec.js
+++ b/test/webview_js/specs/cards.spec.js
@@ -418,6 +418,42 @@ test('emphasis around a regex-built card leaves the card alone', async ({ page }
   expect(shape.arrowWidth).toBe('11px');
 });
 
+test('code in a <pre> is never read as markdown', async ({ page }) => {
+  await render(page, card('pre-with-emphasis').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const pre = root.querySelector('pre');
+    return {
+      text: pre ? pre.textContent : '',
+      // Nothing inside a raw-text element may have been turned into markup.
+      elements: pre ? pre.children.length : -1,
+    };
+  });
+  expect(shape.text).toBe('int *p = &n;\nif (*p) *p = 1;\nlong _t_ = a * b * c;');
+  expect(shape.elements).toBe(0);
+});
+
+test('a marker cannot open inside an element and close outside it', async ({ page }) => {
+  await render(page, card('emphasis-across-element-boundary').text);
+  const shape = await page.evaluate(() => {
+    const root = window.harness.currentRoot();
+    const span = root.querySelector('span');
+    const bold = root.querySelector('b');
+    return {
+      // Two asterisks in two containers are two asterisks, not an italic run.
+      spanText: span ? span.textContent : '',
+      spanEms: span ? span.querySelectorAll('em').length : -1,
+      strayAfter: root.textContent.includes('конец*'),
+      // A run that opens and closes inside one element still works.
+      boldEm: bold ? bold.querySelector('em.chat-italic')?.textContent : '',
+    };
+  });
+  expect(shape.spanText).toBe('*начало');
+  expect(shape.spanEms).toBe(0);
+  expect(shape.strayAfter).toBe(true);
+  expect(shape.boldEm).toBe('курсив');
+});
+
 test('a marker that spans balanced inline markup still holds it', async ({ page }) => {
   await render(page, card('emphasis-over-inline-tag').text);
   const shape = await page.evaluate(() => {


### PR DESCRIPTION
The marker scan was the one markdown pass that still read a string with live
HTML in it. It ran before the parse, with tags masked, so every property that
kept it honest was a guess — and two of them were wrong.

## What was broken

- A `*` a model wrote before a regex-built card and the `*` a display script's
  capture pulled into that card matched as one emphasis run over the whole
  card. #355 rejected that span by counting tag balance, but the count was a
  heuristic standing in for structure.
- The same scan reached inside `<pre>` and `<textarea>`, which phase B never
  formats. The segment it held there was never restored and the leak sweep
  deleted it, so `<pre>if (*p) *p = 1;</pre>` rendered as
  `<pre>if (p = 1;</pre>` with a `Formatter LEAK` in the console. Still live on
  `nightly` today; this PR is what fixes it.

## What changed

Markers now come out in `formatRun`, from the string that pass already builds:
one container's text escaped, its inline elements masked as `E_n`. There is no
markup in it to take by accident, and the three properties the old scan had to
guess at are now consequences of where it runs — a block element ends the run,
an element's inside is its own run, and `OPAQUE` elements never get one.

- `dom_format.js`: `formatRun` extracts markers before the block pass, not per
  line — a colour marker may wrap several lines and `applyBlockSyntax` formats
  one at a time.
- `inline_syntax.js`: `formatInlineRaw` becomes `formatInlineMasked`. A
  marker's content now arrives already escaped and masked, so it must not
  escape or mask again — doing either showed the author's own `<b>` as text.
- `formatter.js`: no marker pass before the parse, and `formatContainer` no
  longer threads an inline context.
- `protect.js`: `extractMarkers` is a plain scan again. The balance guard and
  the code-placeholder guard added in #355 are gone — the tree enforces both.
- `html_scan.js`: `maskTags` and `VOID_ELEMENTS` had no callers left, and the
  `markupTagTest` split from #355 folds back into `escapeProseTags`.
- `docs/rules/message-rendering.md`, `docs/markdown-markers.md`: record where
  markers are taken and what that buys, and say not to move the pass back in
  front of the parse.

Net −60 lines, and the phase-B rule ("never a markdown pass over a string
containing live HTML") now holds with no exception.

## Verification

- `test/webview_js`: 57 passed, was 54. New corpus entries `pre-with-emphasis`
  (also in the streaming set) and `emphasis-across-element-boundary`.
- `pre-with-emphasis` fails on `nightly` — the `<pre>` comes back missing its
  code. The other 55, including `regex-card-in-emphasis` from #355, pass before
  and after; that card now passes structurally rather than through the guard
  this PR removes.
- `test/webview_assets_test.dart`: the static guards follow the new shape —
  `extractMarkers` must not appear in `formatter.js`, and in `formatRun` the
  order masking → markers → block pass is pinned.
- `flutter analyze` / `flutter test` were **not** run — this branch was
  prepared in an environment with no Flutter SDK. Only the Dart test file was
  touched on that side, and its string assertions were checked against the
  sources by hand; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1uHg76qWvWrDTGXPuUDDp

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1uHg76qWvWrDTGXPuUDDp)_