### PR TITLE
feat(characters): remember the scroll position of each sub-tab

### DIFF
--- a/lib/features/character_list/character_list_screen.dart
+++ b/lib/features/character_list/character_list_screen.dart
@@ -25,6 +25,7 @@ import '../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../shared/widgets/glaze_spinner.dart';
 import '../../shared/widgets/glaze_tab_bar.dart';
 import '../../shared/widgets/swipe_tab_switcher.dart';
+import '../../shared/widgets/tab_scroll_memory.dart';
 import '../../shared/widgets/tab_slide_switcher.dart';
 import '../../shared/widgets/glaze_error_dialog.dart';
 import '../../shared/widgets/glaze_toast.dart';
@@ -80,11 +81,15 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
   // padding + the bar itself) so content can reserve room.
   static const double _kTabBarBlock = 52.0;
 
-  // Owns the scroll position of whichever list view is currently shown (the
-  // grids attach via PrimaryScrollController), so tapping the active tab can
-  // animate it back to the top.
-  final ScrollController _listScrollController = ScrollController();
+  // Owns one scroll position per sub-tab (the grids attach via
+  // PrimaryScrollController), so tapping the active tab can animate it back to
+  // the top and switching tabs returns each one to where it was left.
+  final TabScrollMemory _tabScroll = TabScrollMemory(tabCount: 2);
   final HeaderScrollHider _headerScrollHider = HeaderScrollHider();
+
+  /// The controller of the sub-tab currently on screen.
+  ScrollController get _activeScrollController =>
+      _tabScroll.controllerFor(_tabIndex);
 
   @override
   void initState() {
@@ -122,7 +127,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     _catalogDebounce?.cancel();
     _searchCtrl.dispose();
     _searchFocus.dispose();
-    _listScrollController.dispose();
+    _tabScroll.dispose();
     super.dispose();
   }
 
@@ -152,9 +157,10 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
   /// Animates the active list back to the top. Guarded so it never reads a
   /// position while two scroll views are briefly attached during a tab switch.
   void _scrollToTop() {
-    if (!_listScrollController.hasClients) return;
-    if (_listScrollController.positions.length != 1) return;
-    _listScrollController.animateTo(
+    final controller = _activeScrollController;
+    if (!controller.hasClients) return;
+    if (controller.positions.length != 1) return;
+    controller.animateTo(
       0,
       duration: const Duration(milliseconds: 400),
       curve: Curves.easeOutCubic,
@@ -295,7 +301,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
       if (_tabIndex != 0 || _searchExpanded) {
         _catalogDebounce?.cancel();
         setState(() {
-          _tabIndex = 0;
+          _switchTab(0);
           _searchExpanded = false;
         });
         refreshShellHeader();
@@ -341,10 +347,11 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
       return;
     }
 
+    final controller = _activeScrollController;
     final atTop =
-        !_listScrollController.hasClients ||
-        _listScrollController.positions.length != 1 ||
-        _listScrollController.position.pixels <= 0.5;
+        !controller.hasClients ||
+        controller.positions.length != 1 ||
+        controller.position.pixels <= 0.5;
 
     if (!atTop) {
       _scrollToTop();
@@ -357,7 +364,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     if (_tabIndex == 1) {
       ref.read(characterSelectionProvider.notifier).clear();
       setState(() {
-        _tabIndex = 0;
+        _switchTab(0);
         if (_searchExpanded) _applySearchForActiveTab();
       });
       refreshShellHeader();
@@ -402,7 +409,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     ref.listen(catalogVisibleProvider, (_, visible) {
       if (!visible && _tabIndex != 0) {
         ref.read(characterSelectionProvider.notifier).clear();
-        setState(() => _tabIndex = 0);
+        setState(() => _switchTab(0));
       }
       refreshShellHeader();
     });
@@ -436,25 +443,32 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
             Positioned.fill(
               child: NotificationListener<ScrollNotification>(
                 onNotification: _onScrollNotification,
-                child: PrimaryScrollController(
-                  controller: _listScrollController,
-                  child: SwipeTabSwitcher(
-                    // Only the top-level My/Catalog split is swipeable; inside a
-                    // folder the strip is hidden and horizontal drags belong to
-                    // the folder content.
-                    enabled: showTabBar,
+                child: SwipeTabSwitcher(
+                  // Only the top-level My/Catalog split is swipeable; inside a
+                  // folder the strip is hidden and horizontal drags belong to
+                  // the folder content.
+                  enabled: showTabBar,
+                  index: effectiveTab,
+                  length: 2,
+                  onChanged: _onTabSwipe,
+                  child: TabSlideSwitcher(
                     index: effectiveTab,
-                    length: 2,
-                    onChanged: _onTabSwipe,
-                    child: TabSlideSwitcher(
-                      index: effectiveTab,
-                      child: effectiveTab == 1
-                          ? CatalogGrid(
+                    // Each body carries its own scroll controller instead of
+                    // sharing one above the switcher, so the tab sliding away
+                    // keeps scrolling with the controller it was built with and
+                    // every tab comes back at the offset it was left at.
+                    child: effectiveTab == 1
+                        ? _tabScrollScope(
+                            tab: 1,
+                            child: CatalogGrid(
                               key: const ValueKey('catalog_grid'),
                               topPadding: contentTopPad,
                               bottomPadding: navHeight + 20,
-                            )
-                          : KeyedSubtree(
+                            ),
+                          )
+                        : _tabScrollScope(
+                            tab: 0,
+                            child: KeyedSubtree(
                               key: const ValueKey('my_characters'),
                               child: _buildMyCharacters(
                                 context,
@@ -462,7 +476,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
                                 navHeight,
                               ),
                             ),
-                    ),
+                          ),
                   ),
                 ),
               ),
@@ -869,6 +883,29 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     );
   }
 
+  /// Hands [child] the scroll controller that belongs to [tab].
+  ///
+  /// The grids scroll with the inherited primary controller; the default
+  /// mobile-only inheritance is widened to every platform so the desktop builds
+  /// attach too (otherwise scroll-to-top and the remembered offsets would be
+  /// silent no-ops there).
+  Widget _tabScrollScope({required int tab, required Widget child}) {
+    return PrimaryScrollController(
+      controller: _tabScroll.controllerFor(tab),
+      automaticallyInheritForPlatforms: TargetPlatform.values.toSet(),
+      child: child,
+    );
+  }
+
+  /// Moves the active sub-tab, handing its scroll position over: the tab being
+  /// left remembers where it sits and the one being entered re-attaches at the
+  /// offset it was left at. Callers run it inside their own [setState].
+  void _switchTab(int index) {
+    if (index == _tabIndex) return;
+    _tabScroll.switchTab(from: _tabIndex, to: index);
+    _tabIndex = index;
+  }
+
   /// Switches the active tab in response to a body swipe. Mirrors the tab
   /// strip's `onChanged`, minus the "tap the active tab" branch (a swipe always
   /// resolves to a different tab).
@@ -877,7 +914,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     ref.read(characterSelectionProvider.notifier).clear();
     _showHeader();
     setState(() {
-      _tabIndex = i;
+      _switchTab(i);
       if (_searchExpanded) _applySearchForActiveTab();
     });
     refreshShellHeader();
@@ -907,7 +944,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
           ref.read(characterSelectionProvider.notifier).clear();
           _showHeader();
           setState(() {
-            _tabIndex = i;
+            _switchTab(i);
             if (_searchExpanded) _applySearchForActiveTab();
           });
           refreshShellHeader();

--- a/lib/shared/widgets/tab_scroll_memory.dart
+++ b/lib/shared/widgets/tab_scroll_memory.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+/// Per-tab scroll positions for a tab switcher whose bodies are torn down when
+/// the active tab changes.
+///
+/// Tab bodies that live in an [AnimatedSwitcher] — as `TabSlideSwitcher`'s do
+/// — are disposed once they finish sliding away, so a single shared
+/// [ScrollController] hands every returning tab a fresh position at the very
+/// top. This owns one controller per tab instead: [controllerFor] is provided
+/// *inside* each tab body via [PrimaryScrollController] — not above the
+/// switcher — so the outgoing body keeps scrolling with the controller it was
+/// built with while it animates out, and [switchTab] stashes the offset of the
+/// tab being left so the one being entered re-attaches where the user last saw
+/// it.
+///
+/// The offset is applied when the scroll position is created, i.e. before the
+/// incoming body's first frame, so the tab appears already scrolled instead of
+/// jumping. The restore is one-shot and only arms a tab that has no live
+/// scroll view, so navigation *inside* a tab (opening a folder) still starts at
+/// the top and an interrupted switch animation keeps the position it has.
+class TabScrollMemory {
+  TabScrollMemory({required int tabCount})
+    : assert(tabCount > 0),
+      _controllers = List.generate(
+        tabCount,
+        (_) => _RestoringScrollController(),
+        growable: false,
+      );
+
+  final List<_RestoringScrollController> _controllers;
+
+  /// The controller [tab]'s body scrolls with.
+  ScrollController controllerFor(int tab) => _controllers[tab];
+
+  /// Carries the scroll positions across a tab change: [from] remembers where
+  /// it was left, [to] is armed to open at the offset it was left at.
+  void switchTab({required int from, required int to}) {
+    if (from == to) return;
+    _controllers[from].stash();
+    _controllers[to].arm();
+  }
+
+  void dispose() {
+    for (final controller in _controllers) {
+      controller.dispose();
+    }
+  }
+}
+
+/// A [ScrollController] whose next scroll position can be started at a
+/// remembered offset instead of at the top.
+class _RestoringScrollController extends ScrollController {
+  double _stashed = 0;
+  double? _pending;
+
+  /// Records where the attached scroll view currently sits. Skipped when there
+  /// is no single position to read — none attached, or two while a switch
+  /// animation still holds the previous body.
+  void stash() {
+    if (positions.length == 1 && position.hasPixels) _stashed = position.pixels;
+  }
+
+  /// Makes the next position created by this controller open at the stashed
+  /// offset. A tab that still has a live scroll view keeps its current offset,
+  /// so nothing is armed for it.
+  void arm() {
+    if (positions.isEmpty) _pending = _stashed;
+  }
+
+  @override
+  ScrollPosition createScrollPosition(
+    ScrollPhysics physics,
+    ScrollContext context,
+    ScrollPosition? oldPosition,
+  ) {
+    final restoreTo = _pending;
+    _pending = null;
+    return ScrollPositionWithSingleContext(
+      physics: physics,
+      context: context,
+      initialPixels: restoreTo ?? initialScrollOffset,
+      keepScrollOffset: keepScrollOffset,
+      oldPosition: oldPosition,
+      debugLabel: debugLabel,
+    );
+  }
+}

--- a/test/tab_scroll_memory_test.dart
+++ b/test/tab_scroll_memory_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/shared/widgets/tab_scroll_memory.dart';
+
+/// Two tabs whose bodies are torn down and rebuilt from scratch on every
+/// switch — the shape [TabScrollMemory] exists for.
+class _TabsHarness extends StatefulWidget {
+  const _TabsHarness({required this.memory});
+
+  final TabScrollMemory memory;
+
+  @override
+  State<_TabsHarness> createState() => _TabsHarnessState();
+}
+
+class _TabsHarnessState extends State<_TabsHarness> {
+  int tab = 0;
+  int bodyRevision = 0;
+
+  void switchTo(int next) {
+    setState(() {
+      widget.memory.switchTab(from: tab, to: next);
+      tab = next;
+    });
+  }
+
+  /// Replaces the current tab's body without changing tabs — what opening a
+  /// folder inside "My Characters" does.
+  void rebuildBody() => setState(() => bodyRevision++);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: PrimaryScrollController(
+          controller: widget.memory.controllerFor(tab),
+          automaticallyInheritForPlatforms: TargetPlatform.values.toSet(),
+          child: ListView.builder(
+            key: ValueKey('tab-$tab-$bodyRevision'),
+            itemCount: 100,
+            itemExtent: 50,
+            itemBuilder: (_, i) => Text('tab $tab item $i'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('TabScrollMemory', () {
+    testWidgets('each tab comes back at the offset it was left at', (
+      tester,
+    ) async {
+      final memory = TabScrollMemory(tabCount: 2);
+      addTearDown(memory.dispose);
+
+      await tester.pumpWidget(_TabsHarness(memory: memory));
+      final harness = tester.state<_TabsHarnessState>(
+        find.byType(_TabsHarness),
+      );
+
+      memory.controllerFor(0).jumpTo(500);
+      await tester.pump();
+
+      // A tab opened for the first time starts at the top.
+      harness.switchTo(1);
+      await tester.pump();
+      expect(memory.controllerFor(1).offset, 0);
+
+      memory.controllerFor(1).jumpTo(300);
+      await tester.pump();
+
+      // Both tabs now re-open where they were left, in either direction.
+      harness.switchTo(0);
+      await tester.pump();
+      expect(memory.controllerFor(0).offset, 500);
+
+      harness.switchTo(1);
+      await tester.pump();
+      expect(memory.controllerFor(1).offset, 300);
+    });
+
+    testWidgets('a body rebuilt without a tab switch starts at the top', (
+      tester,
+    ) async {
+      final memory = TabScrollMemory(tabCount: 2);
+      addTearDown(memory.dispose);
+
+      await tester.pumpWidget(_TabsHarness(memory: memory));
+      final harness = tester.state<_TabsHarnessState>(
+        find.byType(_TabsHarness),
+      );
+
+      memory.controllerFor(0).jumpTo(400);
+      await tester.pump();
+
+      harness.rebuildBody();
+      await tester.pump();
+
+      expect(memory.controllerFor(0).offset, 0);
+    });
+  });
+}


### PR DESCRIPTION
Switching between **My Characters** and **Discover** always reopened the entered tab at the very top. Both bodies shared a single `ScrollController` hung above the tab switcher, and the switcher (`TabSlideSwitcher` → `AnimatedSwitcher`) tears the outgoing body down — a controller does not carry an offset across a detach, so every switch started from zero.

## Changes

- Add `TabScrollMemory` (`lib/shared/widgets/tab_scroll_memory.dart`): one `ScrollController` per sub-tab; `switchTab` stashes the offset of the tab being left and arms the one being entered.
- Restore the offset when the incoming `ScrollPosition` is created (`createScrollPosition`'s `initialPixels`), i.e. before the incoming body's first frame — the tab appears already scrolled instead of jumping into place after paint.
- Provide the controllers *inside* each tab body in `CharacterListScreen.build` (`_tabScrollScope`) rather than above `SwipeTabSwitcher`, so the body sliding away keeps scrolling with the controller it was built with.
- Keep the restore one-shot, and skip arming a tab that still has a live scroll view: opening a folder inside a tab still starts at the top, and an interrupted switch animation keeps the position it already has.
- Widen `PrimaryScrollController.automaticallyInheritForPlatforms` to every platform. It defaults to mobile only, so on Windows/Linux/macOS the grids never attached to the primary controller — the remembered offsets *and* the existing "tap the active tab → scroll to top" were silent no-ops there.
- Route every tab change through `_switchTab` (`_onTabSwipe`, the tab strip, the navbar re-tap fallback, the deep-link path in `_maybeOpenInitialCharacter`, and the catalog-disabled listener) so no path bypasses the hand-over.

## Verification

- Added `test/tab_scroll_memory_test.dart`: offsets are restored in both directions across switches, a tab opened for the first time starts at the top, and a body rebuilt *without* a tab switch (what opening a folder does) starts at the top.
- The agent session had no Flutter SDK, so `flutter analyze` and `flutter test` were **not** run locally — bracket/tree structure was checked by hand and the CI job is the first real run of both.
- Runtime behaviour (the actual scroll, the slide animation) has not been observed in a running app.

---
_Generated by [Claude Code](https://claude.ai/code/session_018896YaACTCrJPWueZy7odi)_