### PR TITLE
fix(image-gen): keep the stored image block away from the model

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -147,6 +147,10 @@ the next generation (`extractImageResultPaths`), and `rewriteResultPaths`
 resolves every variant so the switcher can page through them without a round
 trip to Dart.
 
+What a block keeps is images it actually has: a regeneration drops the paths
+whose file is gone (`ImageRecoveryService.dropMissingImages`) before it carries
+the rest forward, so a switcher never pages onto a picture that cannot load.
+
 ### INV-IG9: An image block is stored as an `<img>` element with a relative src
 
 A finished block is written by `ImageTagMarkup.encodeResultElement()` only:
@@ -225,6 +229,37 @@ formatter either, so a tag after one still generates.
 Finished `<img data-iig-…>` blocks are deliberately *not* filtered: they are
 pictures that already exist, and `scanResultElements()` is what keeps their
 paths resolving and strips them from a sync payload.
+
+### INV-IG12: A model never reads or writes a finished image block
+
+Glaze is the only writer of a finished block: `encodeResultElement()` runs the
+moment the image file has been saved, so the `src` and `data-iig-variants` of a
+stored block always name files that exist on *this* device.
+
+Neither is any use to a model, and handing them over is actively harmful. The
+history used to carry the stored element verbatim, and a model that reads one
+writes one back: a block pointing at files nobody generated, which renders as
+the browser's broken-image icon under a variant switcher counting pictures that
+never existed — one more of them with every turn, until the count reads like
+the length of the chat.
+
+`ImageTagMarkup.reduceBlocksToInstructions()` is the single gate. Whatever
+state a block is in, it comes out as `[IMG:GEN:<instruction>]` — the tag that
+asked for the picture, and the only spelling a model may see or write:
+
+* chat text on its way **into** a prompt goes through it — `HistoryAssembler`
+  (main model and Studio), `ExtensionContextAssembler` and the
+  `InfoBlockService` prompt builders;
+* a reply on its way **into** storage goes through it in
+  `SavedMessageWriter.writeAssistant()`, so a finished block a model wrote by
+  hand lands as a pending one and the post-gen image stage generates a real
+  picture for it (INV-IG1);
+* the cloud-sync payload uses the same reduction
+  (`SyncSerialization.normalizeImageGenContent`), for the same reason — a path
+  into one device's data root means nothing on another.
+
+A tag inside a reasoning block is still left alone (INV-IG11): the reduction
+reads the message through `scanImageBlocks()` like everything else.
 
 ### INV-IG7: Regenerating an image never adds a message swipe
 

--- a/lib/core/llm/history_assembler.dart
+++ b/lib/core/llm/history_assembler.dart
@@ -1,3 +1,4 @@
+import '../../features/image_gen/services/image_tag_markup.dart';
 import '../models/chat_message.dart';
 import 'macro_engine.dart';
 
@@ -14,7 +15,15 @@ class HistoryAssembler {
     for (int i = 0; i < history.length; i++) {
       final msg = history[i];
       if (msg.isHidden || msg.isTyping) continue;
-      final macroResult = replaceMacros(msg.content, macroCtx);
+      // A finished image block is stored as an `<img data-iig-…>` element
+      // carrying paths into this device's data root. The model has no use for
+      // them, and a model that reads one writes one back — a block pointing at
+      // files that were never generated (INV-IG12). It reads the tag that asked
+      // for the picture instead.
+      final withoutImagePaths = ImageTagMarkup.reduceBlocksToInstructions(
+        msg.content,
+      );
+      final macroResult = replaceMacros(withoutImagePaths, macroCtx);
       final normalized = _normalizeUnderscoreEmphasis(macroResult.text);
       messages.add(
         PromptMessage(

--- a/lib/features/chat/image_recovery_service.dart
+++ b/lib/features/chat/image_recovery_service.dart
@@ -210,6 +210,27 @@ class ImageRecoveryService {
   static String resetImgTagsToGen(String text) =>
       ImageTagMarkup.resetErrorTags(text);
 
+  /// A regeneration carries forward only the images that are still on disk.
+  ///
+  /// A path that names no file can do nothing but render as a broken picture
+  /// and pad the block's switcher, and a regeneration is the one moment the
+  /// block is rewritten anyway — so this is where such a path is dropped
+  /// instead of being carried through yet another attempt.
+  static String dropMissingImages(String text) =>
+      ImageTagMarkup.dropCarriedImages(text, imageFileExists);
+
+  /// Whether an image a block carries can still be shown. Only local files can
+  /// go missing; a data URL or a remote picture is taken at its word.
+  static bool imageFileExists(String path) {
+    if (path.isEmpty) return false;
+    if (path.startsWith('data:') ||
+        path.startsWith('http://') ||
+        path.startsWith('https://')) {
+      return true;
+    }
+    return File(resolveGlazeFilePath(path) ?? path).existsSync();
+  }
+
   /// Puts another image of one block on screen — the block-level counterpart
   /// of a message swipe.
   ///
@@ -284,7 +305,7 @@ class ImageRecoveryService {
         ImageTagMarkup.scanResultElements(lastMsg.content).isNotEmpty;
     if (!hasRetryableContent) return;
 
-    final resetContent = resetImgTagsToGen(lastMsg.content);
+    final resetContent = dropMissingImages(resetImgTagsToGen(lastMsg.content));
     if (resetContent == lastMsg.content &&
         !ImageTagMarkup.hasImageGenTags(resetContent)) {
       return;
@@ -298,7 +319,9 @@ class ImageRecoveryService {
           updatedAt: currentTimestampSeconds(),
           mutate: (message) {
             if (message.role != 'assistant') return null;
-            final content = resetImgTagsToGen(message.content);
+            final content = dropMissingImages(
+              resetImgTagsToGen(message.content),
+            );
             if (content == message.content &&
                 !ImageTagMarkup.hasImageGenTags(content)) {
               return null;
@@ -374,12 +397,15 @@ class ImageRecoveryService {
     int? blockIndex,
   }) async {
     String reset(String content) {
-      if (blockIndex != null) {
-        return ImageTagMarkup.resetImageBlockAt(content, blockIndex);
-      }
-      return failedOnly
+      final pending = blockIndex != null
+          ? ImageTagMarkup.resetImageBlockAt(content, blockIndex)
+          : failedOnly
           ? resetImgErrorTagsToGen(content)
           : resetImgTagsToGen(content);
+      // An unchanged text is the caller's "nothing to do" signal, so the
+      // pruning below must not be what makes this look like a change.
+      if (pending == content) return content;
+      return dropMissingImages(pending);
     }
 
     var current = _getState().value;

--- a/lib/features/chat/services/saved_message_writer.dart
+++ b/lib/features/chat/services/saved_message_writer.dart
@@ -1,6 +1,7 @@
 import '../../../core/models/chat_message.dart';
 import '../../../core/utils/id_generator.dart';
 import '../../../core/utils/time_helpers.dart';
+import '../../image_gen/services/image_tag_markup.dart';
 import '../chat_state.dart';
 
 /// Pure-function helpers for building the final [ChatState] after one
@@ -46,6 +47,14 @@ class SavedMessageWriter {
     int visibleStartIndex = 0,
     List<Map<String, dynamic>> studioOutputs = const [],
   }) {
+    // A reply can only *ask* for a picture. Glaze is the sole writer of a
+    // finished image block — it writes the `<img data-iig-…>` element the
+    // moment it has saved the file — so one arriving in model output names
+    // files that do not exist: the message would render a broken picture with
+    // a variant switcher counting images that were never generated. Reduced to
+    // the pending tag it should have been, the post-gen image stage picks it up
+    // and produces a real image (INV-IG12).
+    text = ImageTagMarkup.reduceBlocksToInstructions(text);
     final persistedMemoryCoverage = stripEphemeralMemoryCoverage(
       memoryCoverage,
     );

--- a/lib/features/cloud_sync/services/sync_serialization.dart
+++ b/lib/features/cloud_sync/services/sync_serialization.dart
@@ -4,7 +4,6 @@ import 'package:crypto/crypto.dart';
 
 import '../../../core/models/chat_message.dart';
 import '../../../core/models/memory_book.dart';
-import '../../../core/constants/image_gen_patterns.dart';
 import '../../../features/extensions/models/info_block.dart';
 import '../../../features/image_gen/services/image_tag_markup.dart';
 import '../cloud_adapter.dart';
@@ -134,29 +133,8 @@ class SyncSerialization {
   /// The stored `<img data-iig-…>` form of a finished block goes the same way:
   /// the image file itself never leaves the device, so what is uploaded is the
   /// instruction that can produce it again.
-  static String normalizeImageGenContent(String content) {
-    var result = content;
-    // Right to left, so replacing one element leaves the spans of the rest.
-    for (final element in ImageTagMarkup.scanResultElements(result).reversed) {
-      final instruction = element.payload.instruction;
-      result = result.replaceRange(
-        element.start,
-        element.end,
-        instruction.isEmpty ? '[IMG:GEN]' : '[IMG:GEN:$instruction]',
-      );
-    }
-    result = result.replaceAllMapped(ImgGenPatterns.imgResultRegex, (m) {
-      final payload = m.group(1) ?? '';
-      final pipeIdx = payload.indexOf('|');
-      if (pipeIdx >= 0) {
-        final instruction = payload.substring(pipeIdx + 1);
-        return '[IMG:GEN:$instruction]';
-      }
-      return '[IMG:GEN]';
-    });
-    result = result.replaceAll(ImgGenPatterns.imgErrorStripRegex, '[IMG:GEN]');
-    return result;
-  }
+  static String normalizeImageGenContent(String content) =>
+      ImageTagMarkup.reduceBlocksToInstructions(content);
 
   static String computeBinaryHash(List<int> bytes) {
     return sha256.convert(bytes).toString();

--- a/lib/features/extensions/services/extension_context_assembler.dart
+++ b/lib/features/extensions/services/extension_context_assembler.dart
@@ -3,6 +3,7 @@ import '../../../core/llm/prompt/main_model_context_snapshot.dart';
 import '../../../core/models/chat_message.dart';
 import '../../../core/models/character.dart';
 import '../../../core/models/persona.dart';
+import '../../image_gen/services/image_tag_markup.dart';
 import '../models/block_config.dart';
 import '../models/extension_context_policy.dart';
 import 'block_context_builder.dart';
@@ -197,7 +198,10 @@ class ExtensionContextAssembler {
         .map(
           (message) => PromptMessage(
             role: message.role,
-            content: message.content,
+            // Image blocks reach a block agent as the tag that asked for the
+            // picture: the stored element's file paths are this device's, and
+            // an agent that reads one writes one back (INV-IG12).
+            content: ImageTagMarkup.reduceBlocksToInstructions(message.content),
             isHistory: true,
             sourceMessageId: message.id,
           ),
@@ -233,7 +237,10 @@ class ExtensionContextAssembler {
       (message) => message['_sourceMessageId'] == anchorMessageId,
     );
     _stripInternalMetadata(messages);
-    messages.add({'role': 'assistant', 'content': anchor.content});
+    messages.add({
+      'role': 'assistant',
+      'content': ImageTagMarkup.reduceBlocksToInstructions(anchor.content),
+    });
   }
 
   void _appendBlockInstruction(

--- a/lib/features/extensions/services/info_block_service.dart
+++ b/lib/features/extensions/services/info_block_service.dart
@@ -15,6 +15,7 @@ import '../../../core/models/persona.dart';
 import '../../../core/llm/prompt/main_model_context_snapshot.dart';
 import '../../../core/state/db_provider.dart';
 import '../../../core/utils/error_format.dart';
+import '../../image_gen/services/image_tag_markup.dart';
 import '../../settings/api_list_provider.dart';
 import '../models/block_config.dart';
 import '../models/info_block.dart';
@@ -29,6 +30,15 @@ import 'runtime_prompt_injection_service.dart';
 final infoBlockServiceProvider = Provider<InfoBlockService>(
   (ref) => InfoBlockService(ref),
 );
+
+/// Chat text on its way into a block agent's prompt, with every image block
+/// reduced to the tag that asked for the picture.
+///
+/// The stored form of a finished block carries paths into this device's data
+/// root, which mean nothing to a model — and an agent that reads one writes one
+/// back, producing a block that points at files nobody generated (INV-IG12).
+String _withoutImagePaths(String content) =>
+    ImageTagMarkup.reduceBlocksToInstructions(content);
 
 class InfoBlockService {
   InfoBlockService(this._ref);
@@ -400,7 +410,7 @@ class InfoBlockService {
       );
       for (var i = 0; i < previousBlocks.length; i++) {
         buffer.writeln('--- #${i + 1} ---');
-        buffer.writeln(previousBlocks[i].content.trim());
+        buffer.writeln(_withoutImagePaths(previousBlocks[i].content).trim());
       }
       buffer.writeln();
     }
@@ -447,7 +457,7 @@ class InfoBlockService {
       for (var i = 0; i < previousBlocks.length; i++) {
         buffer
           ..writeln('--- #${i + 1} ---')
-          ..writeln(previousBlocks[i].content.trim());
+          ..writeln(_withoutImagePaths(previousBlocks[i].content).trim());
       }
       buffer.writeln();
     }
@@ -472,7 +482,7 @@ class InfoBlockService {
       buffer.writeln('Recent conversation:');
       for (final message in contextMessages) {
         final role = message.role == 'user' ? 'USER' : 'ASSISTANT';
-        buffer.writeln('$role: ${message.content}');
+        buffer.writeln('$role: ${_withoutImagePaths(message.content)}');
       }
       buffer.writeln();
     }

--- a/lib/features/image_gen/services/image_tag_markup.dart
+++ b/lib/features/image_gen/services/image_tag_markup.dart
@@ -635,6 +635,83 @@ class ImageTagMarkup {
     return blocks;
   }
 
+  /// [text] with every image block reduced to the pending tag that asked for
+  /// it: the picture, the block's other images and the position of the visible
+  /// one are dropped, the instruction is kept.
+  ///
+  /// This is the only spelling of an image block a model may read or write.
+  /// Glaze is the sole writer of a finished block — it writes one the moment it
+  /// has saved the file — so an `<img data-iig-…>` element in model output
+  /// names files that do not exist: it renders as a broken picture, and the
+  /// variant list it carries counts images that were never generated. Left in
+  /// the history it also teaches the next reply to write another one, a little
+  /// longer each turn (INV-IG12).
+  ///
+  /// Applied to a reply as it is stored (`SavedMessageWriter`) and to chat
+  /// content on its way into any prompt (`HistoryAssembler` and the extension
+  /// context builders), so the internal form neither leaves nor enters Glaze.
+  static String reduceBlocksToInstructions(String text) {
+    // Every prompt build walks the whole history through here, and most
+    // messages carry no image at all.
+    if (!text.contains('[IMG:') && !text.contains(instructionAttribute)) {
+      return text;
+    }
+    final blocks = scanImageBlocks(text);
+    if (blocks.isEmpty) return text;
+    var result = text;
+    // Right to left: replacing one block must not move the spans of the ones
+    // still to be replaced.
+    for (final block in blocks.reversed) {
+      // A block that is already waiting for its picture and carries none is
+      // left exactly as written. There is nothing in it to strip, and both of
+      // its spellings survive a prompt round trip — where rewriting the
+      // element form into `[IMG:GEN:…]` would end the tag at the first `]` of
+      // an instruction that happens to contain one.
+      if (block.kind == ImageBlockKind.pending && block.paths.isEmpty) {
+        continue;
+      }
+      result = result.replaceRange(
+        block.start,
+        block.end,
+        _pendingTag(ImageBlockPayload(instruction: block.instruction)),
+      );
+    }
+    return result;
+  }
+
+  /// [text] with every image a pending block carries and [keep] rejects
+  /// dropped, the instruction and the surviving images left in place.
+  ///
+  /// A block keeps its earlier images through a regeneration so the reader can
+  /// page back through them, which only holds for images that are still on
+  /// disk. One that is not — a file the user deleted, or a path that never
+  /// named a file at all — can do nothing but render as a broken picture and
+  /// pad the block's switcher, so a regeneration is where it is dropped.
+  static String dropCarriedImages(String text, bool Function(String) keep) {
+    final tags = scanPendingTags(text);
+    if (tags.isEmpty) return text;
+    var result = text;
+    // Right to left: rewriting one tag must not move the spans of the rest.
+    for (final tag in tags.reversed) {
+      final payload = ImageBlockPayload.parsePending(tag.payload);
+      if (payload.paths.isEmpty) continue;
+      final kept = <String>[];
+      var active = 0;
+      for (var i = 0; i < payload.paths.length; i++) {
+        if (!keep(payload.paths[i])) continue;
+        if (i == payload.activeIndex) active = kept.length;
+        kept.add(payload.paths[i]);
+      }
+      if (kept.length == payload.paths.length) continue;
+      result = result.replaceRange(
+        tag.start,
+        tag.end,
+        _pendingTag(payload.withPaths(kept, activeIndex: active)),
+      );
+    }
+    return result;
+  }
+
   static ImageBlock _pendingBlock(PendingImageTag tag) {
     final payload = ImageBlockPayload.parsePending(tag.payload);
     return ImageBlock(

--- a/test/image_model_written_blocks_test.dart
+++ b/test/image_model_written_blocks_test.dart
@@ -1,0 +1,203 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/llm/history_assembler.dart';
+import 'package:glaze_flutter/core/llm/macro_engine.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/features/chat/image_recovery_service.dart';
+import 'package:glaze_flutter/features/chat/services/saved_message_writer.dart';
+import 'package:glaze_flutter/features/image_gen/services/image_tag_markup.dart';
+
+/// A finished image block is Glaze's own bookkeeping: it names files on this
+/// device and lists every image the block has produced. It used to reach the
+/// model in the history and come back written into the reply, which left a
+/// message pointing at pictures nobody ever generated — a broken image with a
+/// switcher counting one more of them every turn (INV-IG12).
+void main() {
+  const instruction = '{"prompt":"a red dragon"}';
+
+  String finishedBlock({
+    List<String> paths = const ['generated/a.png', 'generated/b.png'],
+    int activeIndex = 1,
+  }) => ImageTagMarkup.encodeResultElement(
+    ImageBlockPayload(
+      paths: paths,
+      activeIndex: activeIndex,
+      instruction: instruction,
+    ),
+  );
+
+  group('reduceBlocksToInstructions', () {
+    test('a finished block keeps its prompt and loses its images', () {
+      final reduced = ImageTagMarkup.reduceBlocksToInstructions(
+        'Scene: ${finishedBlock()} — and on.',
+      );
+
+      expect(reduced, 'Scene: [IMG:GEN:$instruction] — and on.');
+      expect(reduced, isNot(contains('generated/')));
+      expect(reduced, isNot(contains('data-iig-variants')));
+      expect(reduced, isNot(contains('data-iig-index')));
+    });
+
+    test('the older tag spellings reduce to the same thing', () {
+      expect(
+        ImageTagMarkup.reduceBlocksToInstructions(
+          '[IMG:RESULT:generated/a.png;;*generated/b.png|$instruction]',
+        ),
+        '[IMG:GEN:$instruction]',
+      );
+      expect(
+        ImageTagMarkup.reduceBlocksToInstructions(
+          '[IMG:GEN:@generated/a.png;;generated/b.png|$instruction]',
+        ),
+        '[IMG:GEN:$instruction]',
+      );
+      expect(
+        ImageTagMarkup.reduceBlocksToInstructions(
+          '[IMG:ERROR:{"error":"boom","instruction":"{}"}]',
+        ),
+        '[IMG:GEN:{}]',
+      );
+    });
+
+    test('a block that never had a prompt reduces to the bare tag', () {
+      expect(
+        ImageTagMarkup.reduceBlocksToInstructions(
+          '[IMG:RESULT:generated/a.png]',
+        ),
+        '[IMG:GEN]',
+      );
+    });
+
+    test('each block of a message is reduced on its own', () {
+      final reduced = ImageTagMarkup.reduceBlocksToInstructions(
+        '${finishedBlock()} middle [IMG:GEN:{"prompt":"second"}]',
+      );
+
+      expect(
+        reduced,
+        '[IMG:GEN:$instruction] middle [IMG:GEN:{"prompt":"second"}]',
+      );
+    });
+
+    test('a tag inside a reasoning block stays the text it is', () {
+      const text = '<think>then [IMG:GEN:{"prompt":"idea"}] here</think>done';
+
+      expect(ImageTagMarkup.reduceBlocksToInstructions(text), text);
+    });
+
+    test('text with no image block comes back unchanged', () {
+      const text = 'She looks up. <b>Really</b>.';
+
+      expect(ImageTagMarkup.reduceBlocksToInstructions(text), same(text));
+    });
+  });
+
+  group('the model never reads a finished block', () {
+    test('history carries the instruction, not the file paths', () {
+      const macroCtx = MacroContext(
+        charName: 'Alison',
+        charId: 'character',
+        sessionId: 'session',
+      );
+
+      final history = HistoryAssembler(macroCtx).assemble([
+        const ChatMessage(id: 'u1', role: 'user', content: 'Draw her'),
+        ChatMessage(
+          id: 'a1',
+          role: 'assistant',
+          content: 'Here. ${finishedBlock()}',
+        ),
+      ]);
+
+      expect(history[1].content, 'Here. [IMG:GEN:$instruction]');
+      expect(history[1].content, isNot(contains('generated/')));
+    });
+  });
+
+  group('the model never writes a finished block', () {
+    const writer = SavedMessageWriter();
+    final session = ChatSession(
+      id: 's1',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: [
+        const ChatMessage(id: 'u1', role: 'user', content: 'Draw her'),
+      ],
+    );
+
+    test('a reply asking for a picture is stored as a pending block', () {
+      final invented = finishedBlock(
+        paths: const ['generated/made-up.png'],
+        activeIndex: 0,
+      );
+      final state = writer.writeAssistant(
+        text: 'Here. $invented',
+        reasoning: null,
+        currentSession: session,
+        isAborted: () => false,
+      );
+
+      final stored = state.session!.messages.last;
+      expect(stored.content, 'Here. [IMG:GEN:$instruction]');
+      expect(stored.content, isNot(contains('made-up.png')));
+      expect(stored.swipes.single, stored.content);
+      expect(stored.agentSwipes.single.content, stored.content);
+      expect(ImageTagMarkup.hasImageGenTags(stored.content), isTrue);
+    });
+
+    test('a reply with no image markup is stored verbatim', () {
+      final state = writer.writeAssistant(
+        text: 'She looks up.',
+        reasoning: null,
+        currentSession: session,
+        isAborted: () => false,
+      );
+
+      expect(state.session!.messages.last.content, 'She looks up.');
+    });
+  });
+
+  group('a regeneration carries forward only what is on disk', () {
+    late Directory dir;
+    late String present;
+
+    setUp(() {
+      dir = Directory.systemTemp.createTempSync('glaze_img_test');
+      present = '${dir.path}/present.png';
+      File(present).writeAsBytesSync([0]);
+    });
+
+    tearDown(() => dir.deleteSync(recursive: true));
+
+    test('a missing image is dropped from the pending block', () {
+      final pending = '[IMG:GEN:@$present;;*${dir.path}/gone.png|$instruction]';
+
+      expect(
+        ImageRecoveryService.dropMissingImages(pending),
+        '[IMG:GEN:@$present|$instruction]',
+      );
+    });
+
+    test('a block whose images all exist is left alone', () {
+      final pending = '[IMG:GEN:@$present|$instruction]';
+
+      expect(ImageRecoveryService.dropMissingImages(pending), pending);
+    });
+
+    test('a remote picture is taken at its word', () {
+      expect(
+        ImageRecoveryService.imageFileExists('https://example.com/a.png'),
+        isTrue,
+      );
+      expect(
+        ImageRecoveryService.imageFileExists('data:image/png;base64,x'),
+        isTrue,
+      );
+      expect(
+        ImageRecoveryService.imageFileExists('${dir.path}/gone.png'),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
A finished image block is stored as an ``'&lt;img data-iig-…&gt;'`` element whose `src` and `data-iig-variants` name files inside *this* device's data root. `HistoryAssembler.assemble` handed `msg.content` to the model verbatim, so every reply read that element — and models write it back, copying and extending the variant list they see. The result is a "finished" block pointing at pictures nobody ever generated: the browser's broken-image icon under an `.imggen-variants` switcher that grows by roughly one entry per turn, until its count reads like the length of the chat (the reported `144/145` in a 145-message chat). Only an explicit Regenerate fixes such a block, because that is the one path where Glaze writes the picture itself.

## Changes

- Add `ImageTagMarkup.reduceBlocksToInstructions()` — whatever state a block is in (stored element, `[IMG:RESULT:…]`, `[IMG:ERROR:…]`, or a pending tag carrying images), it comes out as `[IMG:GEN:<instruction>]`: no path, no variant list, no block index. A block that is already pending and carries no images is left exactly as written, so a model's own spelling survives and an instruction containing `]` is never re-cut by the bracket form. A tag inside a reasoning block is still skipped (INV-IG11).
- Run chat text through it on its way **into a prompt**: `HistoryAssembler.assemble` (main model and Studio), `ExtensionContextAssembler` (history + the canonical assistant turn) and both `InfoBlockService` prompt builders (previous block outputs, legacy conversation dump). No model reads the stored form any more, and the paths stop costing tokens.
- Run a reply through it on its way **into storage**: `SavedMessageWriter.writeAssistant()`. Glaze is the sole writer of a finished block, so one arriving in model output is stored as pending and the post-gen image stage generates a real picture for it (INV-IG1).
- `SyncSerialization.normalizeImageGenContent()` delegates to the same reduction instead of repeating it; an error card now keeps its instruction through a sync, and a pending block stops uploading the paths it carried.
- Add `ImageTagMarkup.dropCarriedImages()` and use it from `ImageRecoveryService` (`dropMissingImages`) so a regeneration carries forward only images that are still on disk — a block that already inherited invented paths stops listing them the first time it is rerolled.
- Document the rule as **INV-IG12** in `docs/INVARIANTS.md`, and note the pruning under INV-IG8.

## Verification

- New `test/image_model_written_blocks_test.dart`: the reduction of every block spelling (including the reasoning-block and no-image cases), the assembled history, the stored reply from `writeAssistant`, and the on-disk pruning against real temp files.
- Existing expectations kept: `test/image_stored_form_test.dart` (cloud sync) and `test/ext_blocks_sync_test.dart` assert the same `[IMG:GEN:<json>]` output the delegated implementation produces.
- **Not run here:** this change was written in an environment with no Flutter SDK, so `flutter analyze` and `flutter test` were not executed locally — CI is the check. No JS assets were touched, so the WebView render suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5hmnLghnuw8ETp9PDpfZT

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5hmnLghnuw8ETp9PDpfZT)_