### PR TITLE
perf(ui): keep the sheet's header inset stable while it resizes

### DIFF
--- a/docs/UI_KIT.md
+++ b/docs/UI_KIT.md
@@ -104,6 +104,13 @@ ListView(
 The bottom padding is the nav-bar / keyboard inset, delivered the same way so
 list rows scroll *behind* the nav bar while the last row rests above it.
 
+That inset is deliberately **stable**: the status-bar pad the sheet fades in as
+it approaches fullscreen is applied as an outer inset, not folded into the
+`MediaQuery`. A `MediaQuery` that moved with the sheet rebuilt every body that
+reads it, once per frame of a resize — for a big eagerly-built form that is a
+whole widget tree per frame. Keep it that way: nothing that animates belongs in
+the inset the body reads.
+
 ### The keyboard
 
 A `SheetView` answers the on-screen keyboard by **tracking the inset**: it grows

--- a/lib/shared/widgets/sheet_view.dart
+++ b/lib/shared/widgets/sheet_view.dart
@@ -822,22 +822,35 @@ class _SheetViewState extends ConsumerState<SheetView>
             child: innerChild,
           );
 
+          // The header inset the body reads stays put; the status-bar pad
+          // that grows as the sheet approaches fullscreen is applied around it
+          // as an outer inset instead of being folded into it.
+          //
+          // Folded in, it changed the MediaQuery on every frame of a resize,
+          // and every body that reads the inset rebuilt with it — for a big
+          // form whose list is built eagerly (the API sheet) that is a full
+          // widget-tree rebuild per frame of the keyboard animation, which is
+          // what dropped frames there. As an outer inset it costs the relayout
+          // the body pays anyway, and nothing rebuilds. The body still starts
+          // at the same place: the header carries the same pad above its own
+          // content.
+          final insetBody = MediaQuery(
+            data: mediaQuery.copyWith(
+              padding: mediaQuery.padding.copyWith(
+                top: _hasHeader ? _headerBaseH : 0.0,
+                bottom: navInset,
+              ),
+            ),
+            child: scrollChild,
+          );
+
           return ValueListenableBuilder<double>(
             valueListenable: _heightN,
-            child: scrollChild,
-            builder: (context, height, child) {
-              final topPad = _topPad(_lifted(height));
-              final extraTop = _hasHeader ? _headerBaseH + topPad : topPad;
-              return MediaQuery(
-                data: mediaQuery.copyWith(
-                  padding: mediaQuery.padding.copyWith(
-                    top: extraTop,
-                    bottom: navInset,
-                  ),
-                ),
-                child: child!,
-              );
-            },
+            child: insetBody,
+            builder: (context, height, child) => Padding(
+              padding: EdgeInsets.only(top: _topPad(_lifted(height))),
+              child: child!,
+            ),
           );
         },
       ),

--- a/lib/shared/widgets/sheet_view.dart
+++ b/lib/shared/widgets/sheet_view.dart
@@ -162,6 +162,12 @@ class _SheetViewState extends ConsumerState<SheetView>
   /// [_commitKeyboardLift] once the user takes the height over by hand.
   bool _kbAnchored = false;
 
+  /// Sub-pixel slack for the measured header base. Subtracting the animated
+  /// top pad back out of a measured height cannot be exact in binary floating
+  /// point, and a base that wobbles in the last bits would republish the body's
+  /// inset — and rebuild every body that reads it — on every frame of a resize.
+  static const double _kHeaderBaseEpsilon = 0.01;
+
   /// Top padding the header was last built with, so [_measureHeader] can
   /// subtract exactly what that frame added instead of re-deriving it from a
   /// height that may already have ticked on — which made the padding-free base
@@ -278,12 +284,14 @@ class _SheetViewState extends ConsumerState<SheetView>
       // The measured box includes the animated top padding; keep the raw
       // value for the blur strip and the padding-free base for the body inset.
       final base = h - _headerTopPad;
-      if (h != _headerH || base != _headerBaseH) {
-        setState(() {
-          _headerH = h;
-          _headerBaseH = base;
-        });
-      }
+      final baseMoved = (base - _headerBaseH).abs() > _kHeaderBaseEpsilon;
+      if (h == _headerH && !baseMoved) return;
+      setState(() {
+        _headerH = h;
+        // Only when the header's own content actually changed height: this is
+        // the value the body's inset is published from.
+        if (baseMoved) _headerBaseH = base;
+      });
     });
   }
 

--- a/test/sheet_view_keyboard_lift_test.dart
+++ b/test/sheet_view_keyboard_lift_test.dart
@@ -94,6 +94,9 @@ void main() {
   testWidgets('the edge blur stays on while the keyboard moves', (
     tester,
   ) async {
+    // Battery saver is on by default (AppSettings.batterySaver), and that is
+    // what switches the blur off — so turn it off to have a blur to watch.
+    SharedPreferences.setMockInitialValues({'batterySaver': false});
     await pumpSheet(tester);
     bool blurOn() =>
         tester.widget<TopEdgeBlur>(find.byType(TopEdgeBlur)).enabled;

--- a/test/sheet_view_keyboard_lift_test.dart
+++ b/test/sheet_view_keyboard_lift_test.dart
@@ -20,11 +20,16 @@ void main() {
   Future<void> pumpSheet(
     WidgetTester tester, {
     bool startExpanded = false,
+    Widget body = const Text('sheet body'),
   }) async {
     tester.view.physicalSize = const Size(700, full);
     tester.view.devicePixelRatio = 1;
+    // A status bar to pad against: the pad the sheet fades in as it reaches
+    // fullscreen is what used to rebuild the body on every frame.
+    tester.view.padding = const FakeViewPadding(top: 60);
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPadding);
     addTearDown(tester.view.resetViewInsets);
 
     await tester.pumpWidget(
@@ -41,7 +46,7 @@ void main() {
                   builder: (_) => SheetView(
                     title: 'Memory',
                     startExpanded: startExpanded,
-                    body: const Text('sheet body'),
+                    body: body,
                   ),
                 ),
                 child: const Text('Open'),
@@ -94,8 +99,8 @@ void main() {
         tester.widget<TopEdgeBlur>(find.byType(TopEdgeBlur)).enabled;
     expect(blurOn(), isTrue);
 
-    // The blur is not something the sheet trades away for frames: it samples
-    // its own strip, so a moving body does not make it expensive.
+    // The blur is not something the sheet trades away for frames — it stays
+    // on through the whole keyboard animation.
     showKeyboard(tester, 100);
     await tester.pump();
     expect(blurOn(), isTrue);
@@ -103,6 +108,36 @@ void main() {
     showKeyboard(tester, 0);
     await tester.pump();
     expect(blurOn(), isTrue);
+  });
+
+  testWidgets('the body is not rebuilt while the keyboard lifts the sheet', (
+    tester,
+  ) async {
+    var builds = 0;
+    await pumpSheet(
+      tester,
+      body: Builder(
+        builder: (context) {
+          builds++;
+          // What a real sheet body does with the inset it is handed.
+          final top = MediaQuery.paddingOf(context).top;
+          return Padding(
+            padding: EdgeInsets.only(top: top),
+            child: const Text('sheet body'),
+          );
+        },
+      ),
+    );
+    final settled = builds;
+
+    // The sheet resizes on every one of these frames. The header inset it
+    // hands the body must not move with it, or a big form rebuilds its whole
+    // tree per frame — which is what dropped frames in the API sheet.
+    for (final inset in [20.0, 60.0, 140.0, 300.0, 0.0]) {
+      showKeyboard(tester, inset);
+      await tester.pump();
+    }
+    expect(builds, settled);
   });
 
   testWidgets('a sheet the user already expanded stays expanded', (


### PR DESCRIPTION
Follow-up to #359. That PR made the sheet track the keyboard inset instead of tweening its own height, which fixed the flicker; this one goes after the frames the same animation drops, and repairs the test #359 merged red.

## Stop rebuilding the body on every frame of a resize

`SheetView` handed the body its header inset through `MediaQuery.padding.top` with the animated status-bar pad folded in (`_topPad`), so the inset moved on every frame the sheet resized and **every body that reads it rebuilt with it**. In a big form built eagerly — `ApiSettingsScreen._buildLlmTab` returns a `ListView(children: [...])` whose whole child list is constructed on each pass — that is a full widget-tree rebuild per frame of the keyboard animation.

- Publish only the stable part (`_headerBaseH`) through the injected `MediaQuery` in `_SheetViewState._buildScrollConfig`, and apply the animated status-bar pad as an outer `Padding` around it. The body starts at the same place, pays the relayout it already paid, and no longer rebuilds.
- Guard `_measureHeader` with a sub-pixel epsilon: subtracting the animated pad back out of a measured height is not exact in binary floating point, and a base wobbling in its last bits would republish the inset — and rebuild every body — on every frame anyway.
- Document the rule in `docs/UI_KIT.md`: nothing that animates belongs in the inset the body reads.

The edge blur is *not* the cost here and is untouched: the sheet drops frames with battery saver on, which switches `TopEdgeBlur` off entirely.

## Fix the red test on nightly

`test/sheet_view_keyboard_lift_test.dart` asserts the blur stays on across a keyboard sweep, but `AppSettings.batterySaver` defaults to `true` and that is exactly what switches `TopEdgeBlur` off — so the test was watching a blur the settings had already disabled. It gets a preferences store with battery saver off.

## Verification

- CI on this branch's content: run [#261](https://github.com/hydall/Glaze/actions/runs/33483948957) — `flutter analyze`, the full `flutter test` suite and the WebView render suite all green (dispatched manually, since #359 was already closed at the time).
- New test `the body is not rebuilt while the keyboard lifts the sheet` counts body builds across an inset sweep of `20 → 60 → 140 → 300 → 0`; it grew once per frame before the change and stays flat after.
- The agent that wrote this has no Flutter SDK, so `flutter analyze` / `flutter test` were never run locally — every check above is CI's.
- Not verified on a device: the on-screen result of the keyboard animation in the API sheet still wants a look with `flutter run -d android`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ni7b78hN6t3WDn6HELkYBH)_