### PR TITLE
fix(desktop): drop the second header from sheets in the floating window

### DIFF
--- a/lib/shared/shell/desktop/desktop_window_view.dart
+++ b/lib/shared/shell/desktop/desktop_window_view.dart
@@ -109,12 +109,13 @@ class _WindowFrame extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final branch = _shellHeaderBranch[viewId];
-    final entry = branch == null
-        ? null
-        : ref.watch(
-            shellHeaderProvider.select((e) => resolveShellHeader(e, branch)),
-          );
+    // Screens off the menu branch claim their header by branch; everything
+    // else hosted here — the sheets — publishes under the detached-chrome
+    // pseudo-branch so this title bar is the only header the window shows.
+    final branch = _shellHeaderBranch[viewId] ?? kDetachedChromeBranch;
+    final entry = ref.watch(
+      shellHeaderProvider.select((e) => resolveShellHeader(e, branch)),
+    );
 
     return GlassSurface(
       borderRadius: BorderRadius.circular(16),
@@ -139,7 +140,9 @@ class _WindowFrame extends ConsumerWidget {
               onClose: onClose,
             ),
             Divider(height: 1, color: context.cs.outlineVariant),
-            Expanded(child: DetachedShellHost(child: _content())),
+            Expanded(
+              child: DetachedShellHost(hasChrome: true, child: _content()),
+            ),
           ],
         ),
       ),

--- a/lib/shared/shell/shell_header_provider.dart
+++ b/lib/shared/shell/shell_header_provider.dart
@@ -162,14 +162,40 @@ ShellHeaderEntry? resolveShellHeader(
 /// whichever branch the middle column happens to be showing: opening API
 /// settings in the sidebar blanked the character list's header behind it.
 class DetachedShellHost extends InheritedWidget {
-  const DetachedShellHost({super.key, required super.child});
+  /// Whether the host draws header chrome of its own — the desktop floating
+  /// window's title bar, with the window's back/close buttons in it.
+  ///
+  /// A screen that would otherwise draw its own header (a [SheetView] mounted
+  /// as a page, say) hands its title and actions to that title bar via
+  /// [kDetachedChromeBranch] instead of drawing a second header inside the
+  /// frame. The right sidebar has no title bar, so it leaves this false and its
+  /// panels keep their own headers.
+  final bool hasChrome;
 
-  static bool of(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType<DetachedShellHost>() != null;
+  const DetachedShellHost({
+    super.key,
+    this.hasChrome = false,
+    required super.child,
+  });
+
+  static DetachedShellHost? _of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<DetachedShellHost>();
+
+  static bool of(BuildContext context) => _of(context) != null;
+
+  /// True when the nearest detached host draws its own header chrome.
+  static bool drawsChrome(BuildContext context) =>
+      _of(context)?.hasChrome ?? false;
 
   @override
-  bool updateShouldNotify(DetachedShellHost oldWidget) => false;
+  bool updateShouldNotify(DetachedShellHost oldWidget) =>
+      oldWidget.hasChrome != hasChrome;
 }
+
+/// Pseudo-branch under which a screen hosted by a chrome-drawing
+/// [DetachedShellHost] publishes its header, so the host's title bar can render
+/// it. Negative so it can never collide with a real shell branch index.
+const int kDetachedChromeBranch = -1;
 
 /// Mix into a shell screen's [ConsumerState] to publish a header into
 /// [shellHeaderProvider]. Implement [headerBranchIndex] and [buildShellHeader],

--- a/lib/shared/widgets/sheet_view.dart
+++ b/lib/shared/widgets/sheet_view.dart
@@ -135,6 +135,21 @@ class _SheetViewState extends ConsumerState<SheetView>
   /// (only when presented as a fullscreen route, not a modal bottom sheet).
   int? _suppressedBranch;
 
+  /// Whether the host already draws a title bar around this sheet — the
+  /// desktop floating window. Then the sheet's own app-bar row (back button,
+  /// title, actions) would be a second header inside the frame, so it is
+  /// handed to the window's title bar instead of being drawn here.
+  bool _hostDrawsChrome = false;
+
+  /// Whether the app-bar row belongs to this sheet's own header.
+  bool get _ownsAppBar => !_hostDrawsChrome;
+
+  /// Signature of the header content last published to a chrome-drawing host,
+  /// so a rebuild only republishes when something visible actually changed —
+  /// republishing unconditionally would rebuild the host, which rebuilds this
+  /// sheet, which would republish again.
+  String? _publishedChromeSignature;
+
   /// Cached so it can be used safely in [dispose].
   ShellHeaderRegistry? _headerRegistry;
 
@@ -256,10 +271,7 @@ class _SheetViewState extends ConsumerState<SheetView>
     if (_effectiveShowHandle) {
       h += 24;
     }
-    if (widget.title != null ||
-        widget.titleWidget != null ||
-        widget.showBack ||
-        widget.actions.isNotEmpty) {
+    if (_hasAppBarRow) {
       h += _inModalSheet ? 52 : 56;
     }
     if (widget.tabs.isNotEmpty) {
@@ -299,7 +311,11 @@ class _SheetViewState extends ConsumerState<SheetView>
   void didChangeDependencies() {
     super.didChangeDependencies();
     _inModalSheet = ModalRoute.of(context) is ModalBottomSheetRoute;
+    // A modal bottom sheet is mounted on the root navigator, above any host,
+    // so it always keeps its own header.
+    _hostDrawsChrome = !_inModalSheet && DetachedShellHost.drawsChrome(context);
     _syncHeaderSuppression();
+    _publishChromeHeader();
     if (!_heightInit) {
       _currentHeight = (widget.startExpanded || !_inModalSheet)
           ? _full(context)
@@ -335,6 +351,64 @@ class _SheetViewState extends ConsumerState<SheetView>
     });
   }
 
+  /// Hands the header to a host that draws its own title bar (the desktop
+  /// floating window), so the window shows this sheet's title and actions
+  /// while the sheet itself draws no app-bar row.
+  ///
+  /// The claim goes under [kDetachedChromeBranch] rather than a real shell
+  /// branch: the sheet is mounted outside the branch navigators, and the
+  /// window resolves that pseudo-branch for exactly this purpose.
+  void _publishChromeHeader() {
+    // Cached for [dispose], where reading `ref` is unsafe.
+    final ShellHeaderRegistry registry = ref.read(shellHeaderProvider.notifier);
+    _headerRegistry = registry;
+    if (!_hostDrawsChrome) {
+      if (_publishedChromeSignature == null) return;
+      _publishedChromeSignature = null;
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => registry.remove(this),
+      );
+      return;
+    }
+    final signature = _chromeSignature();
+    if (signature == _publishedChromeSignature) return;
+    _publishedChromeSignature = signature;
+    // Deferred: this runs during the build phase, where modifying a provider
+    // is forbidden — and the host rebuilds on the claim, so it must not be
+    // touched while it is building.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _publishedChromeSignature != signature) return;
+      registry.publish(
+        this,
+        kDetachedChromeBranch,
+        ShellHeaderConfig(
+          title: widget.title,
+          titleWidget: widget.titleWidget,
+          actions: [
+            for (var i = 0; i < widget.actions.length; i++)
+              _ChromeHeaderAction(owner: this, index: i),
+          ],
+        ),
+      );
+    });
+  }
+
+  /// What the host's title bar shows, flattened. Only a change here is worth a
+  /// republish; the callbacks themselves are read live by
+  /// [_ChromeHeaderAction], so they never go stale between publishes.
+  String _chromeSignature() {
+    final buffer = StringBuffer(widget.title ?? '')
+      ..write('|${widget.titleWidget?.runtimeType}');
+    for (final action in widget.actions) {
+      final icon = action.icon;
+      buffer.write(
+        '|${action.tooltip}|${action.color?.toARGB32()}'
+        '|${icon is Icon ? icon.icon?.codePoint : icon.runtimeType}',
+      );
+    }
+    return buffer.toString();
+  }
+
   /// Branch index of the shell this sheet currently lives in, or null when the
   /// sheet is hosted outside GoRouter.
   ///
@@ -354,9 +428,16 @@ class _SheetViewState extends ConsumerState<SheetView>
   }
 
   @override
+  void didUpdateWidget(covariant SheetView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _publishChromeHeader();
+  }
+
+  @override
   void dispose() {
     final registry = _headerRegistry;
-    if (registry != null && _suppressedBranch != null) {
+    if (registry != null &&
+        (_suppressedBranch != null || _publishedChromeSignature != null)) {
       WidgetsBinding.instance.addPostFrameCallback(
         (_) => registry.remove(this),
       );
@@ -443,11 +524,17 @@ class _SheetViewState extends ConsumerState<SheetView>
     }
   }
 
+  /// Whether this sheet draws the title/back/actions row itself. False when a
+  /// chrome-drawing host renders it in its own title bar instead.
+  bool get _hasAppBarRow =>
+      _ownsAppBar &&
+      (widget.title != null ||
+          widget.titleWidget != null ||
+          widget.showBack ||
+          widget.actions.isNotEmpty);
+
   bool get _hasHeader =>
-      widget.title != null ||
-      widget.titleWidget != null ||
-      widget.showBack ||
-      widget.actions.isNotEmpty ||
+      _hasAppBarRow ||
       widget.tabs.isNotEmpty ||
       widget.headerBottom != null ||
       _effectiveShowHandle;
@@ -550,21 +637,22 @@ class _SheetViewState extends ConsumerState<SheetView>
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          GlazeAppBar(
-                            title: widget.title,
-                            titleWidget: widget.titleWidget,
-                            showBack: widget.showBack,
-                            onBack: widget.onBack,
-                            actions: widget.actions.map((action) {
-                              return _HeaderIconButton(
-                                onPressed: action.onPressed,
-                                tooltip: action.tooltip,
-                                foregroundColor:
-                                    action.color ?? context.cs.primary,
-                                child: action.icon,
-                              );
-                            }).toList(),
-                          ),
+                          if (_hasAppBarRow)
+                            GlazeAppBar(
+                              title: widget.title,
+                              titleWidget: widget.titleWidget,
+                              showBack: widget.showBack,
+                              onBack: widget.onBack,
+                              actions: widget.actions.map((action) {
+                                return _HeaderIconButton(
+                                  onPressed: action.onPressed,
+                                  tooltip: action.tooltip,
+                                  foregroundColor:
+                                      action.color ?? context.cs.primary,
+                                  child: action.icon,
+                                );
+                              }).toList(),
+                            ),
                           if (widget.tabs.isNotEmpty)
                             Padding(
                               padding: const EdgeInsets.only(top: 12),
@@ -721,6 +809,7 @@ class _SheetViewState extends ConsumerState<SheetView>
                 child: ValueListenableBuilder<double>(
                   valueListenable: _heightN,
                   child: _SheetViewHeader(
+                    showAppBar: _hasAppBarRow,
                     title: widget.title,
                     titleWidget: widget.titleWidget,
                     showBack: widget.showBack,
@@ -867,6 +956,9 @@ class _SheetViewState extends ConsumerState<SheetView>
 }
 
 class _SheetViewHeader extends StatelessWidget {
+  /// False when the host draws the title/back/actions row itself, leaving this
+  /// header with only the handle, tabs and [headerBottom].
+  final bool showAppBar;
   final String? title;
   final Widget? titleWidget;
   final bool showBack;
@@ -884,6 +976,7 @@ class _SheetViewHeader extends StatelessWidget {
   final GestureDragEndCallback? onDragEnd;
 
   const _SheetViewHeader({
+    required this.showAppBar,
     this.title,
     this.titleWidget,
     required this.showBack,
@@ -934,10 +1027,7 @@ class _SheetViewHeader extends StatelessWidget {
               ),
             ),
           ),
-        if (title != null ||
-            titleWidget != null ||
-            showBack ||
-            actions.isNotEmpty)
+        if (showAppBar)
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
             child: Row(
@@ -1020,6 +1110,35 @@ class _SheetViewHeader extends StatelessWidget {
             child: headerBottom!,
           ),
       ],
+    );
+  }
+}
+
+/// One of the sheet's actions, rendered in a chrome-drawing host's title bar.
+///
+/// It keeps the owning state rather than the action itself, and reads the
+/// action back on every build: the published claim is only refreshed when the
+/// header's visible signature changes, so a captured callback could otherwise
+/// outlive the build that created it.
+class _ChromeHeaderAction extends StatelessWidget {
+  final _SheetViewState owner;
+  final int index;
+
+  const _ChromeHeaderAction({required this.owner, required this.index});
+
+  @override
+  Widget build(BuildContext context) {
+    final actions = owner.widget.actions;
+    if (index >= actions.length) return const SizedBox.shrink();
+    final action = actions[index];
+    return _HeaderIconButton(
+      tooltip: action.tooltip,
+      onPressed: () {
+        final current = owner.widget.actions;
+        if (index < current.length) current[index].onPressed();
+      },
+      foregroundColor: action.color ?? context.cs.primary,
+      child: action.icon,
     );
   }
 }

--- a/test/sheet_view_window_chrome_test.dart
+++ b/test/sheet_view_window_chrome_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/shared/shell/shell_header_provider.dart';
+import 'package:glaze_flutter/shared/widgets/sheet_view.dart';
+
+/// The desktop floating window draws its own title bar, so a [SheetView] shown
+/// inside it (Cloud sync, Backups) must not draw a second header below that
+/// bar — it hands its title and actions to the window instead. The right
+/// sidebar has no title bar and its panels keep their own headers.
+Widget _host({
+  required bool hasChrome,
+  List<SheetViewAction> actions = const [],
+}) {
+  return ProviderScope(
+    child: MaterialApp(
+      theme: ThemeData.dark(),
+      home: Scaffold(
+        body: DetachedShellHost(
+          hasChrome: hasChrome,
+          child: SheetView(
+            title: 'Cloud sync',
+            showBack: true,
+            actions: actions,
+            body: const Text('sheet body'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+ShellHeaderEntry? _chromeClaim(WidgetTester tester) {
+  final container = ProviderScope.containerOf(
+    tester.element(find.text('sheet body')),
+  );
+  return resolveShellHeader(
+    container.read(shellHeaderProvider),
+    kDetachedChromeBranch,
+  );
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('a chrome-drawing host takes over the sheet header', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(hasChrome: true));
+    await tester.pumpAndSettle();
+
+    expect(find.text('sheet body'), findsOneWidget);
+    // Neither the title nor the back button is drawn inside the frame.
+    expect(find.text('Cloud sync'), findsNothing);
+    expect(find.byIcon(Icons.arrow_back_ios_new_rounded), findsNothing);
+
+    final claim = _chromeClaim(tester);
+    expect(claim, isNotNull);
+    expect(claim!.config.title, 'Cloud sync');
+  });
+
+  testWidgets('actions reach the host title bar', (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      _host(
+        hasChrome: true,
+        actions: [
+          SheetViewAction(
+            icon: const Icon(Icons.search),
+            onPressed: () => taps++,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Not in the sheet itself…
+    expect(find.byIcon(Icons.search), findsNothing);
+
+    // …but in the claim the host renders, wired to the sheet's callback.
+    final actions = _chromeClaim(tester)!.config.actions;
+    expect(actions, hasLength(1));
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: ThemeData.dark(),
+          home: Scaffold(body: Row(children: actions!)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.search));
+    expect(taps, 1);
+  });
+
+  testWidgets('a host without chrome leaves the header alone', (tester) async {
+    await tester.pumpWidget(_host(hasChrome: false));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Cloud sync'), findsOneWidget);
+    expect(find.byIcon(Icons.arrow_back_ios_new_rounded), findsOneWidget);
+    expect(_chromeClaim(tester), isNull);
+  });
+}


### PR DESCRIPTION
The desktop floating window draws its own title bar (back / title / close), but a `SheetView` hosted inside it — Cloud sync, Backups — is presented as a page, so it drew its own header underneath: two titles and two back buttons stacked in one frame. Screens off the menu branch (`MenuScreen`, `AppSettingsScreen`, `ThemePresetScreen`, `AboutScreen`) never had this, because they publish into `shellHeaderProvider` and the window renders that claim in its title bar.

## Changes

- Add `DetachedShellHost.hasChrome` (`lib/shared/shell/shell_header_provider.dart`) so a hosted screen can tell whether the frame around it already draws header chrome; `DesktopWindowView`'s `_WindowFrame` sets it, the right sidebar leaves it false — it has no title bar, so its panels keep drawing their own headers.
- `SheetView` inside a chrome-drawing host no longer draws its app-bar row (back button, title, actions) and hands title/actions to the window instead, published under the new `kDetachedChromeBranch` pseudo-branch of the shell header registry. Its drag handle, tabs and `headerBottom` are unaffected — they do not duplicate anything the window draws.
- `_WindowFrame` resolves that pseudo-branch for every view that is not one of the menu-branch screens, so the window's title bar is the single header for the sheets it hosts.
- Publish post-frame and only when the header's visible signature changes (`_chromeSignature`), so the window rebuilding on the claim cannot loop back into another publish; action callbacks are read live through `_ChromeHeaderAction`, so they never go stale between publishes.
- Side effect worth noting: the window title now comes from the sheet itself rather than the per-`viewId` fallback, which removes a wording mismatch on Backups (`menu_backup` fallback vs. the sheet's `menu_backups`).

## Verification

- `flutter analyze` on the changed files — clean (Flutter 3.44.9, SDK fetched for this session).
- New `test/sheet_view_window_chrome_test.dart`: a chrome-drawing host takes the header over (nothing drawn inside the frame, claim published with the title), actions reach the host's title bar and stay wired to the sheet's callback, and a host without chrome leaves the sheet's own header alone.
- Full `flutter test`: 3633 passed, 1 failure in `agent_ops_localization_contract_test.dart` caused by the gitignored `lib/generated/locale_keys.g.dart` not being generated yet — after `dart run easy_localization:generate` that test passes too. Unrelated to this change.
- Not run: the WebView render suite (no JS/rendering changes here) and any on-device check of the window — CI and a manual `flutter run -d windows` cover those.

---
_Generated by [Claude Code](https://claude.ai/code/session_017BXc7nRaKqomvzno7NyPwW)_