### PR TITLE
feat(desktop): port the Vue desktop UI details across seven surfaces

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -37,6 +37,7 @@ import 'shared/theme/theme_provider.dart';
 import 'features/chat/widgets/chat_webview_preload.dart';
 import 'features/chat/widgets/lorebook_vector_search_diagnostic_listener.dart';
 import 'shared/widgets/app_launch_splash.dart';
+import 'shared/shell/desktop/desktop_glossary_popup.dart';
 import 'shared/widgets/build_watermark.dart';
 import 'shared/widgets/glaze_toast.dart' show toastOverlayKey;
 import 'shared/widgets/stretch_overscroll.dart';
@@ -347,6 +348,10 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
           child: Stack(
             children: [
               Positioned.fill(child: appChild),
+              // Above the router, so the draggable glossary window a help tip
+              // opens floats over every route, sheet and dialog rather than
+              // being buried by the one it was opened from.
+              const DesktopGlossaryPopup(),
               const BuildWatermark(),
             ],
           ),

--- a/lib/features/character_list/character_list_screen.dart
+++ b/lib/features/character_list/character_list_screen.dart
@@ -17,6 +17,7 @@ import '../../core/services/character_import_persistence_coordinator.dart';
 import '../../core/state/character_folder_provider.dart';
 import '../../core/state/character_provider.dart';
 import '../../core/state/db_provider.dart';
+import '../../shared/shell/desktop/desktop_layout_provider.dart';
 import '../../shared/shell/header_scroll_hider.dart';
 import '../../shared/shell/nav_height_provider.dart';
 import '../../shared/shell/nav_retap_provider.dart';
@@ -79,6 +80,10 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
   // step with the shell header. This constant is the block it occupies (its top
   // padding + the bar itself) so content can reserve room.
   static const double _kTabBarBlock = 52.0;
+
+  /// Width the desktop tab strip settles at, leaving the rest of the row to
+  /// the Add button. Full-width on mobile, where the strip is the whole row.
+  static const double _kTabStripWidth = 420.0;
 
   // Owns the scroll position of whichever list view is currently shown (the
   // grids attach via PrimaryScrollController), so tapping the active tab can
@@ -174,9 +179,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     return ShellHeaderConfig(
       title: inSearch
           ? null
-          : (inPicks
-                ? _picksTitle
-                : (folderTitle ?? 'header_characters'.tr())),
+          : (inPicks ? _picksTitle : (folderTitle ?? 'header_characters'.tr())),
       titleWidget: inSearch ? _buildSearchField(context) : null,
       showBack: inFolder,
       onBack: inFolder ? _handleFolderBack : null,
@@ -200,8 +203,12 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
             ],
       // The tabs ride inside the header (only at the top level) so they hide and
       // reveal as a single unit with it — one animation, not two. Dropped
-      // entirely when the catalog is disabled (only "My Characters" remains).
-      below: (catalogVisible && !inFolder) ? _buildTabBar() : null,
+      // entirely when the catalog is disabled (only "My Characters" remains) —
+      // except on desktop, where the same row also carries the Add button and
+      // so survives a hidden catalog.
+      below: (!inFolder && (catalogVisible || isDesktopLayout(context)))
+          ? _buildTabBar()
+          : null,
     );
   }
 
@@ -405,7 +412,11 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     // extra room for the tabs row when it's present so content clears it.
     final inFolder = effectiveTab == 0 && _currentFolderId != null;
     final showTabBar = catalogVisible && !inFolder;
-    final contentTopPad = showTabBar ? topPad + _kTabBarBlock : topPad;
+    // The desktop row is present at the top level even without the catalog,
+    // because the Add button lives in it.
+    final showHeaderRow =
+        !inFolder && (catalogVisible || isDesktopLayout(context));
+    final contentTopPad = showHeaderRow ? topPad + _kTabBarBlock : topPad;
 
     // While inside a folder, intercept the system/gesture back so it pops out to
     // the top-level grid instead of bubbling up to the shell (which would exit
@@ -420,88 +431,94 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
       child: Scaffold(
         backgroundColor: Colors.transparent,
         body: Stack(
-        children: [
-          Positioned.fill(
-            child: NotificationListener<ScrollNotification>(
-              onNotification: _onScrollNotification,
-              child: PrimaryScrollController(
-                controller: _listScrollController,
-                child: SwipeTabSwitcher(
-                  // Only the top-level My/Catalog split is swipeable; inside a
-                  // folder the strip is hidden and horizontal drags belong to
-                  // the folder content.
-                  enabled: showTabBar,
-                  index: effectiveTab,
-                  length: 2,
-                  onChanged: _onTabSwipe,
-                  child: TabSlideSwitcher(
-                  index: effectiveTab,
-                  child: effectiveTab == 1
-                      ? CatalogGrid(
-                          key: const ValueKey('catalog_grid'),
-                          topPadding: contentTopPad,
-                          bottomPadding: navHeight + 20,
+          children: [
+            Positioned.fill(
+              child: NotificationListener<ScrollNotification>(
+                onNotification: _onScrollNotification,
+                child: PrimaryScrollController(
+                  controller: _listScrollController,
+                  child: SwipeTabSwitcher(
+                    // Only the top-level My/Catalog split is swipeable; inside a
+                    // folder the strip is hidden and horizontal drags belong to
+                    // the folder content.
+                    enabled: showTabBar,
+                    index: effectiveTab,
+                    length: 2,
+                    onChanged: _onTabSwipe,
+                    child: TabSlideSwitcher(
+                      index: effectiveTab,
+                      child: effectiveTab == 1
+                          ? CatalogGrid(
+                              key: const ValueKey('catalog_grid'),
+                              topPadding: contentTopPad,
+                              bottomPadding: navHeight + 20,
+                            )
+                          : KeyedSubtree(
+                              key: const ValueKey('my_characters'),
+                              child: _buildMyCharacters(
+                                context,
+                                contentTopPad,
+                                navHeight,
+                              ),
+                            ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            // The selection bar and the add button share the same bottom slot and
+            // cross-fade/slide between each other so the panel glides in and out
+            // instead of popping.
+            if (effectiveTab == 0 && _currentFolderId != kPicksFolderId)
+              Positioned(
+                left: 16,
+                right: 16,
+                bottom: navHeight + 16,
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 280),
+                  switchInCurve: Curves.easeOut,
+                  switchOutCurve: Curves.easeIn,
+                  transitionBuilder: (child, animation) {
+                    final slide =
+                        Tween<Offset>(
+                          begin: const Offset(0, 0.5),
+                          end: Offset.zero,
+                        ).animate(
+                          CurvedAnimation(
+                            parent: animation,
+                            curve: Curves.easeOutBack,
+                          ),
+                        );
+                    return FadeTransition(
+                      opacity: animation,
+                      child: SlideTransition(position: slide, child: child),
+                    );
+                  },
+                  child: selection.active
+                      ? _SelectionBar(
+                          key: const ValueKey('selection_bar'),
+                          count: selection.count,
+                          onCancel: () => ref
+                              .read(characterSelectionProvider.notifier)
+                              .clear(),
+                          onMore: () =>
+                              _showSelectionActions(context, selection),
                         )
-                      : KeyedSubtree(
-                          key: const ValueKey('my_characters'),
-                          child: _buildMyCharacters(
-                            context,
-                            contentTopPad,
-                            navHeight,
+                      // On desktop the Add button sits in the tabs row instead,
+                      // so the slot holds only the selection bar there.
+                      : isDesktopLayout(context)
+                      ? const SizedBox.shrink(
+                          key: ValueKey('add_button_hidden'),
+                        )
+                      : Align(
+                          key: const ValueKey('add_button'),
+                          alignment: Alignment.centerRight,
+                          child: _AddButton(
+                            onTap: () => _showAddSheet(context, ref),
                           ),
                         ),
                 ),
-                ),
               ),
-            ),
-          ),
-          // The selection bar and the add button share the same bottom slot and
-          // cross-fade/slide between each other so the panel glides in and out
-          // instead of popping.
-          if (effectiveTab == 0 && _currentFolderId != kPicksFolderId)
-            Positioned(
-              left: 16,
-              right: 16,
-              bottom: navHeight + 16,
-              child: AnimatedSwitcher(
-                duration: const Duration(milliseconds: 280),
-                switchInCurve: Curves.easeOut,
-                switchOutCurve: Curves.easeIn,
-                transitionBuilder: (child, animation) {
-                  final slide =
-                      Tween<Offset>(
-                        begin: const Offset(0, 0.5),
-                        end: Offset.zero,
-                      ).animate(
-                        CurvedAnimation(
-                          parent: animation,
-                          curve: Curves.easeOutBack,
-                        ),
-                      );
-                  return FadeTransition(
-                    opacity: animation,
-                    child: SlideTransition(position: slide, child: child),
-                  );
-                },
-                child: selection.active
-                    ? _SelectionBar(
-                        key: const ValueKey('selection_bar'),
-                        count: selection.count,
-                        onCancel: () => ref
-                            .read(characterSelectionProvider.notifier)
-                            .clear(),
-                        onMore: () =>
-                            _showSelectionActions(context, selection),
-                      )
-                    : Align(
-                        key: const ValueKey('add_button'),
-                        alignment: Alignment.centerRight,
-                        child: _AddButton(
-                          onTap: () => _showAddSheet(context, ref),
-                        ),
-                      ),
-              ),
-            ),
           ],
         ),
       ),
@@ -569,8 +586,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     final infinite = ref.watch(infiniteCharactersProvider(key));
 
     return infinite.when(
-      loading: () =>
-          Center(child: GlazeSpinner(color: context.cs.primary)),
+      loading: () => Center(child: GlazeSpinner(color: context.cs.primary)),
       error: (e, _) => Center(
         child: Text(
           '${'title_error'.tr()}: $e',
@@ -678,8 +694,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
   ) {
     final chars = ref.watch(charactersProvider);
     return chars.when(
-      loading: () =>
-          Center(child: GlazeSpinner(color: context.cs.primary)),
+      loading: () => Center(child: GlazeSpinner(color: context.cs.primary)),
       error: (e, _) => Center(
         child: Text(
           '${'title_error'.tr()}: $e',
@@ -763,8 +778,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     final isFavorites = folderId == kFavoritesFolderId;
     final chars = ref.watch(charactersProvider);
     return chars.when(
-      loading: () =>
-          Center(child: GlazeSpinner(color: context.cs.primary)),
+      loading: () => Center(child: GlazeSpinner(color: context.cs.primary)),
       error: (e, _) => Center(
         child: Text(
           '${'title_error'.tr()}: $e',
@@ -875,35 +889,70 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
   }
 
   Widget _buildTabBar() {
+    final isDesktop = isDesktopLayout(context);
     // Rendered in the shell header's `below` slot, which already supplies the
     // horizontal padding — only the gap under the app bar is needed here.
     return Padding(
       padding: const EdgeInsets.only(top: 10),
-      child: GlazeTabBar(
-        tabs: [
-          GlazeTabItem(
-            label: 'tab_my_characters'.tr(),
-            icon: Icons.person_rounded,
+      child: isDesktop ? _buildDesktopTabsRow() : _buildTabStrip(),
+    );
+  }
+
+  /// Vue's `.tabs-row`: the tab strip keeps its natural width on the left and
+  /// the Add button sits at the far right, instead of the strip spanning the
+  /// window and the Add button floating over the grid.
+  Widget _buildDesktopTabsRow() {
+    final catalogVisible = ref.watch(catalogVisibleProvider);
+    return Row(
+      children: [
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: catalogVisible
+                ? ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      maxWidth: _kTabStripWidth,
+                    ),
+                    child: _buildTabStrip(),
+                  )
+                : const SizedBox.shrink(),
           ),
-          GlazeTabItem(label: 'tab_catalog'.tr(), icon: Icons.public_rounded),
+        ),
+        // Mirrors `v-if="activeTab === 'characters'"` — Discover has nothing
+        // of the user's to add to.
+        if (_tabIndex == 0 || !catalogVisible) ...[
+          const SizedBox(width: 12),
+          _AddButton(height: 42, onTap: () => _showAddSheet(context, ref)),
         ],
-        activeIndex: _tabIndex,
-        onChanged: (i) {
-          // Tapping the already-active tab scrolls its list back to the top.
-          if (i == _tabIndex) {
-            _scrollToTop();
-            _showHeader();
-            return;
-          }
-          ref.read(characterSelectionProvider.notifier).clear();
+      ],
+    );
+  }
+
+  Widget _buildTabStrip() {
+    return GlazeTabBar(
+      tabs: [
+        GlazeTabItem(
+          label: 'tab_my_characters'.tr(),
+          icon: Icons.person_rounded,
+        ),
+        GlazeTabItem(label: 'tab_catalog'.tr(), icon: Icons.public_rounded),
+      ],
+      activeIndex: _tabIndex,
+      onChanged: (i) {
+        // Tapping the already-active tab scrolls its list back to the top.
+        if (i == _tabIndex) {
+          _scrollToTop();
           _showHeader();
-          setState(() {
-            _tabIndex = i;
-            if (_searchExpanded) _applySearchForActiveTab();
-          });
-          refreshShellHeader();
-        },
-      ),
+          return;
+        }
+        ref.read(characterSelectionProvider.notifier).clear();
+        _showHeader();
+        setState(() {
+          _tabIndex = i;
+          if (_searchExpanded) _applySearchForActiveTab();
+        });
+        refreshShellHeader();
+      },
     );
   }
 
@@ -1125,8 +1174,7 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
       backgroundColor: Colors.transparent,
       builder: (_) => AddCharactersToFolderSheet(
         characterIds: ids,
-        onDone: () =>
-            ref.read(characterSelectionProvider.notifier).clear(),
+        onDone: () => ref.read(characterSelectionProvider.notifier).clear(),
       ),
     );
   }
@@ -1340,18 +1388,24 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
 
 class _AddButton extends StatelessWidget {
   final VoidCallback onTap;
-  const _AddButton({required this.onTap});
+
+  /// 48 as the button floating over the grid; 42 inline in the desktop tabs
+  /// row, where it lines up with the tab strip.
+  final double height;
+
+  const _AddButton({required this.onTap, this.height = 48});
 
   @override
   Widget build(BuildContext context) {
+    final compact = height < 48;
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 48,
-        padding: const EdgeInsets.symmetric(horizontal: 20),
+        height: height,
+        padding: EdgeInsets.symmetric(horizontal: compact ? 16 : 20),
         decoration: BoxDecoration(
           color: context.cs.primary,
-          borderRadius: BorderRadius.circular(24),
+          borderRadius: BorderRadius.circular(height / 2),
           boxShadow: [
             BoxShadow(
               color: Colors.black.withValues(alpha: 0.3),
@@ -1363,13 +1417,17 @@ class _AddButton extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.add_rounded, color: Colors.white, size: 24),
-            const SizedBox(width: 8),
+            Icon(
+              Icons.add_rounded,
+              color: Colors.white,
+              size: compact ? 20 : 24,
+            ),
+            SizedBox(width: compact ? 6 : 8),
             Text(
               'btn_add'.tr(),
               style: TextStyle(
                 color: Colors.white,
-                fontSize: 16,
+                fontSize: compact ? 14 : 16,
                 fontWeight: FontWeight.w500,
               ),
             ),
@@ -1453,9 +1511,7 @@ class _CircleIconBtn extends StatelessWidget {
         child: GlassSurface(
           borderRadius: BorderRadius.circular(20),
           tint: context.cs.surface,
-          border: Border.all(
-            color: context.cs.primary.withValues(alpha: 0.18),
-          ),
+          border: Border.all(color: context.cs.primary.withValues(alpha: 0.18)),
           child: Center(
             child: Icon(
               icon,

--- a/lib/features/character_list/widgets/character_grid.dart
+++ b/lib/features/character_list/widgets/character_grid.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/models/character.dart';
+import '../../../shared/shell/desktop/desktop_layout_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../../shared/widgets/glass_surface.dart';
@@ -97,6 +98,69 @@ class CharacterGrid extends StatelessWidget {
     }
   }
 
+  /// The dice / filter / sort row.
+  ///
+  /// Desktop mirrors Vue's `.desktop-mode .sort-controls`: the row starts at
+  /// the left edge and the sort-type pill leads the direction toggle (CSS
+  /// `justify-content: flex-start` plus `order: 1 / 2`). Everywhere else it
+  /// stays right-aligned with the toggle first, as the mobile build has it.
+  Widget _buildControlsRow(BuildContext context) {
+    final isDesktop = isDesktopLayout(context);
+
+    final leading = <Widget>[
+      if (characters.isNotEmpty)
+        Consumer(
+          builder: (context, ref, _) {
+            final standard = ref.watch(
+              appSettingsProvider.select(
+                (s) => s.value?.useStandardRandomizer ?? false,
+              ),
+            );
+            return _DiceButton(
+              standard: standard,
+              onTap: () => standard
+                  ? _openStandardRandom(context)
+                  : _openRandomizing(context),
+            );
+          },
+        ),
+      if (onFilterTap != null)
+        _FilterButton(count: filterCount, onTap: onFilterTap!),
+    ];
+
+    final sortDirButton = _SortDirButton(
+      isAsc: sortDir == SortDir.asc,
+      onTap: onSortDirToggle,
+    );
+    final sortTypePill = _SortTypePill(
+      sortBy: sortBy,
+      onChanged: onSortTypeChanged,
+    );
+
+    final children = <Widget>[
+      ...leading,
+      if (isDesktop) ...[
+        sortTypePill,
+        sortDirButton,
+      ] else ...[
+        sortDirButton,
+        sortTypePill,
+      ],
+    ];
+
+    return Row(
+      mainAxisAlignment: isDesktop
+          ? MainAxisAlignment.start
+          : MainAxisAlignment.end,
+      children: [
+        for (var i = 0; i < children.length; i++) ...[
+          if (i > 0) const SizedBox(width: 10),
+          children[i],
+        ],
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return CustomScrollView(
@@ -107,39 +171,7 @@ class CharacterGrid extends StatelessWidget {
         SliverToBoxAdapter(
           child: Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                if (characters.isNotEmpty) ...[
-                  Consumer(
-                    builder: (context, ref, _) {
-                      final standard = ref.watch(
-                        appSettingsProvider.select(
-                          (s) => s.value?.useStandardRandomizer ?? false,
-                        ),
-                      );
-                      return _DiceButton(
-                        standard: standard,
-                        onTap: () => standard
-                            ? _openStandardRandom(context)
-                            : _openRandomizing(context),
-                      );
-                    },
-                  ),
-                  const SizedBox(width: 10),
-                ],
-                if (onFilterTap != null) ...[
-                  _FilterButton(count: filterCount, onTap: onFilterTap!),
-                  const SizedBox(width: 10),
-                ],
-                _SortDirButton(
-                  isAsc: sortDir == SortDir.asc,
-                  onTap: onSortDirToggle,
-                ),
-                const SizedBox(width: 10),
-                _SortTypePill(sortBy: sortBy, onChanged: onSortTypeChanged),
-              ],
-            ),
+            child: _buildControlsRow(context),
           ),
         ),
         SliverToBoxAdapter(

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -341,6 +341,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
         // reproduced by an in-WebView CSS strip (mirrored via the 'header'
         // blur region in _measureBlurRegions), so drop the Flutter blur pass.
         headerBlurViaWebView: true,
+        // Desktop paints a tab's header edge to edge (see the shell's
+        // _DesktopHeader); chat matches it instead of floating a pill.
+        flushHeader: isDesktopLayout(context),
         hideHeader: _isHeaderHidden,
         title: title,
         titleWidget: _search.showSearch
@@ -592,6 +595,11 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
 
   /// `MediaQuery.padding.top` captured in build for the analytic header rect.
   double _blurSafeTop = 0;
+
+  /// Desktop layout flag, captured in build alongside [_blurSafeTop] — the
+  /// header rect below is measured post-frame, where reading an inherited
+  /// widget would register a dependency outside the build phase.
+  bool _blurIsDesktop = false;
 
   /// Keyboard-inset settle tracking for the WebView-bound bottom inset.
   /// While the keyboard animates, the WebView receives the predicted end
@@ -983,20 +991,33 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
     if (box is! RenderBox || !box.attached || !box.hasSize) return;
     final origin = box.localToGlobal(Offset.zero);
     final regions = <ChatOverlayBlurRegion>[
-      // The floating header is not a descendant (it lives in GlazeScaffold's
-      // stack), but its geometry is fixed: SafeArea + fromLTRB(16, 10, 16, 0)
-      // + 56px GlazeAppBar with radius 20 (glaze_scaffold.dart).
+      // The header is not a descendant (it lives in GlazeScaffold's stack),
+      // but its geometry is fixed: SafeArea + fromLTRB(16, 10, 16, 0) + 56px
+      // GlazeAppBar with radius 20 (glaze_scaffold.dart) — or, with
+      // `flushHeader` on desktop, edge to edge with square corners.
       if (!widget.isHeaderHidden)
-        ChatOverlayBlurRegion(
-          id: 'header',
-          rect: Rect.fromLTWH(
-            16 - origin.dx,
-            _blurSafeTop + 10 - origin.dy,
-            box.size.width - 32,
-            56,
+        if (_blurIsDesktop)
+          ChatOverlayBlurRegion(
+            id: 'header',
+            rect: Rect.fromLTWH(
+              -origin.dx,
+              _blurSafeTop - origin.dy,
+              box.size.width,
+              56,
+            ),
+            radius: 0,
+          )
+        else
+          ChatOverlayBlurRegion(
+            id: 'header',
+            rect: Rect.fromLTWH(
+              16 - origin.dx,
+              _blurSafeTop + 10 - origin.dy,
+              box.size.width - 32,
+              56,
+            ),
+            radius: 20,
           ),
-          radius: 20,
-        ),
       ..._blurRegistry.measure(box),
     ];
     regions.sort((a, b) => a.id.compareTo(b.id));
@@ -1128,6 +1149,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
     final safeBottom = MediaQuery.paddingOf(context).bottom;
     final messageListTop = MediaQuery.paddingOf(context).top + 10 + 56;
     _blurSafeTop = MediaQuery.paddingOf(context).top;
+    _blurIsDesktop = isDesktopLayout(context);
 
     final bgBlur = preset.bgBlur > 0 ? preset.bgBlur : 0.0;
     final fontStyle = batteryAware(
@@ -1706,43 +1728,47 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                 ),
               ),
             ),
-            // Top gradient for fade effect under the header
-            Positioned(
-              top: 0,
-              left: 0,
-              right: 0,
-              height: MediaQuery.paddingOf(context).top + 20,
-              child: IgnorePointer(
-                child: Container(
-                  decoration: const BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [Colors.black54, Colors.transparent],
+            // Top/bottom fade under the header and the input area. Dropped on
+            // desktop: the flush header is opaque enough on its own, and the
+            // two bands read as a darkened top and bottom edge against the
+            // otherwise even chat background.
+            if (!isDesktopLayout(context)) ...[
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                height: MediaQuery.paddingOf(context).top + 20,
+                child: IgnorePointer(
+                  child: Container(
+                    decoration: const BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [Colors.black54, Colors.transparent],
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-            // Bottom gradient for fade effect under the input area
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: messageListBottom + 40,
-              child: IgnorePointer(
-                child: Container(
-                  decoration: const BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.bottomCenter,
-                      end: Alignment.topCenter,
-                      colors: [Colors.black54, Colors.transparent],
-                      stops: [0.0, 1.0],
+              Positioned(
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: messageListBottom + 40,
+                child: IgnorePointer(
+                  child: Container(
+                    decoration: const BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [Colors.black54, Colors.transparent],
+                        stops: [0.0, 1.0],
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
+            ],
             Positioned(
               right: 16,
               bottom: messageListBottom + 16,

--- a/lib/features/chat/services/magic_drawer_actions.dart
+++ b/lib/features/chat/services/magic_drawer_actions.dart
@@ -1,0 +1,386 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/services/chat_import_export.dart';
+import '../../../shared/theme/app_colors.dart';
+import '../../../shared/widgets/glaze_error_dialog.dart';
+import '../../../shared/widgets/glaze_toast.dart';
+import '../../card_rewrite/card_rewriter_studio_sheet.dart';
+import '../../character_list/character_detail_screen.dart';
+import '../../extensions/widgets/ext_blocks_settings_sheet.dart';
+import '../../glossary/glossary_sheet.dart';
+import '../../image_gen/widgets/image_gen_sheet.dart';
+import '../../lorebooks/lorebook_list_screen.dart';
+import '../../personas/persona_list_screen.dart';
+import '../../presets/preset_list_screen.dart';
+import '../../regex/regex_sheet.dart';
+import '../../settings/api_settings_screen.dart';
+import '../chat_actions_service.dart';
+import '../chat_provider.dart';
+import '../widgets/agentic_operations_log_dialog.dart';
+import '../widgets/authors_note_sheet.dart';
+import '../widgets/magic_drawer_models.dart';
+import '../widgets/memory_sheet.dart';
+import '../widgets/prompt_inspector_sheet.dart';
+import '../widgets/session_picker_sheet.dart';
+
+/// The Quick Access catalogue and the sheet each entry opens.
+///
+/// Both surfaces that offer Quick Access go through this: the full
+/// [MagicDrawerPanel] grid, and the collapsed icon strip in the desktop right
+/// sidebar. Keeping the catalogue and the dispatch here is what lets the strip
+/// open exactly the same sheets as the panel without duplicating either list.
+class MagicDrawerActions {
+  final String charId;
+
+  /// Asks the host to hide the panel before an action navigates away from the
+  /// chat. The sidebar strip has nothing to hide and leaves it null.
+  final VoidCallback? onClose;
+
+  /// Scrolls the chat webview to a message id, when the host has a webview.
+  final Future<void> Function(String messageId)? onScrollToMessage;
+
+  const MagicDrawerActions({
+    required this.charId,
+    this.onClose,
+    this.onScrollToMessage,
+  });
+
+  /// Every Quick Access entry, in default order.
+  static final all = <MagicDrawerItemDef>[
+    MagicDrawerItemDef(
+      id: 'inspector',
+      label: 'prompt_inspector_title'.tr(),
+      icon: Icons.travel_explore,
+      category: MagicDrawerCategory.tools,
+    ),
+    MagicDrawerItemDef(
+      id: 'memory',
+      label: 'Memory',
+      icon: Icons.subject,
+      category: MagicDrawerCategory.session,
+    ),
+    MagicDrawerItemDef(
+      id: 'sessions',
+      label: 'history_title'.tr(),
+      icon: Icons.history,
+      category: MagicDrawerCategory.session,
+    ),
+    MagicDrawerItemDef(
+      id: 'char-card',
+      label: 'menu_characters'.tr(),
+      icon: Icons.account_box,
+      category: MagicDrawerCategory.library,
+    ),
+    MagicDrawerItemDef(
+      id: 'lorebooks',
+      label: 'label_lorebooks'.tr(),
+      icon: Icons.library_books,
+      category: MagicDrawerCategory.library,
+    ),
+    MagicDrawerItemDef(
+      id: 'regex',
+      label: 'menu_regex'.tr(),
+      icon: Icons.code,
+      category: MagicDrawerCategory.config,
+    ),
+    MagicDrawerItemDef(
+      id: 'api',
+      label: 'tab_api'.tr(),
+      icon: Icons.cloud,
+      category: MagicDrawerCategory.config,
+    ),
+    MagicDrawerItemDef(
+      id: 'presets',
+      label: 'tab_presets'.tr(),
+      icon: Icons.description,
+      category: MagicDrawerCategory.config,
+    ),
+    MagicDrawerItemDef(
+      id: 'personas',
+      label: 'menu_personas'.tr(),
+      icon: Icons.manage_accounts,
+      category: MagicDrawerCategory.library,
+    ),
+    MagicDrawerItemDef(
+      id: 'image-gen',
+      label: 'imggen_title'.tr(),
+      icon: Icons.image,
+      category: MagicDrawerCategory.tools,
+    ),
+    MagicDrawerItemDef(
+      id: 'authors-note',
+      label: 'magic_authors_notes'.tr(),
+      icon: Icons.edit_note,
+      category: MagicDrawerCategory.session,
+    ),
+    MagicDrawerItemDef(
+      id: 'glossary',
+      label: 'menu_glossary'.tr(),
+      icon: Icons.menu_book,
+      category: MagicDrawerCategory.library,
+    ),
+    MagicDrawerItemDef(
+      id: 'ext-blocks',
+      label: 'Ext Blocks',
+      icon: Icons.extension_outlined,
+      category: MagicDrawerCategory.config,
+    ),
+    MagicDrawerItemDef(
+      id: 'agent-ops',
+      label: 'agent_ops_title'.tr(),
+      icon: Icons.smart_toy_outlined,
+      category: MagicDrawerCategory.tools,
+    ),
+    MagicDrawerItemDef(
+      id: 'card-rewriter',
+      label: 'magic_card_rewriter'.tr(),
+      icon: Icons.auto_fix_high_outlined,
+      category: MagicDrawerCategory.tools,
+    ),
+  ];
+
+  /// Runs the action behind [item]. [onFinished] runs once the action
+  /// resolves, whether it completed or threw — the panel uses it to refresh
+  /// its stats; the sidebar strip has none to refresh and passes null.
+  Future<void> handleTap(
+    BuildContext context,
+    WidgetRef ref,
+    MagicDrawerItemDef item, {
+    Future<void> Function()? onFinished,
+  }) async {
+    try {
+      switch (item.id) {
+        case 'inspector':
+          await showPromptInspectorSheet(context, charId);
+          break;
+        case 'memory':
+          await showMemorySheet(context, charId);
+          break;
+        case 'sessions':
+          await _showSessionsSheet(context, ref);
+          break;
+        case 'char-card':
+          final result = await showModalBottomSheet<String>(
+            context: context,
+            isScrollControlled: true,
+            useRootNavigator: true,
+            backgroundColor: Colors.transparent,
+            builder: (_) => CharacterDetailScreen(charId: charId),
+          );
+          if (result != null && result.isNotEmpty && context.mounted) {
+            // Real navigation away from the chat - close the panel first.
+            onClose?.call();
+            context.go(result);
+          }
+          break;
+        case 'lorebooks':
+          await showModalBottomSheet<void>(
+            context: context,
+            useRootNavigator: true,
+            backgroundColor: Colors.transparent,
+            barrierColor: Colors.black54,
+            isScrollControlled: true,
+            builder: (_) => const LorebookListScreen(),
+          );
+          break;
+        case 'regex':
+          await showModalBottomSheet<void>(
+            context: context,
+            useRootNavigator: true,
+            backgroundColor: Colors.transparent,
+            barrierColor: Colors.black54,
+            isScrollControlled: true,
+            builder: (_) => const RegexSheet(),
+          );
+          break;
+        case 'api':
+          await showModalBottomSheet<void>(
+            context: context,
+            useRootNavigator: true,
+            backgroundColor: Colors.transparent,
+            barrierColor: Colors.black54,
+            isScrollControlled: true,
+            builder: (_) => const ApiSettingsScreen(),
+          );
+          break;
+        case 'presets':
+          await showModalBottomSheet<void>(
+            context: context,
+            useRootNavigator: true,
+            backgroundColor: Colors.transparent,
+            barrierColor: Colors.black54,
+            isScrollControlled: true,
+            builder: (_) => PresetListScreen(charId: charId),
+          );
+          break;
+        case 'personas':
+          await showModalBottomSheet<void>(
+            context: context,
+            useRootNavigator: true,
+            isScrollControlled: true,
+            backgroundColor: Colors.transparent,
+            builder: (_) => const PersonaListScreen(),
+          );
+          break;
+        case 'image-gen':
+          await showModalBottomSheet<void>(
+            context: context,
+            useRootNavigator: true,
+            isScrollControlled: true,
+            backgroundColor: Colors.transparent,
+            builder: (_) => ImageGenSheet(charId: charId),
+          );
+          break;
+        case 'authors-note':
+          await showAuthorsNoteSheet(context, charId);
+          break;
+        case 'glossary':
+          await GlossarySheet.show(context);
+          break;
+        case 'ext-blocks':
+          await _showExtBlocksSheet(context, ref);
+          break;
+        case 'agent-ops':
+          await _showAgentOpsLog(context, ref);
+          break;
+        case 'card-rewriter':
+          await _showCardRewriter(context, ref);
+          break;
+      }
+    } finally {
+      if (onFinished != null) await onFinished();
+    }
+  }
+
+  Future<void> _showCardRewriter(BuildContext context, WidgetRef ref) async {
+    final session = ref.read(chatProvider(charId)).value?.session;
+    if (session == null) return;
+    final route = await CardRewriterStudioSheet.show(
+      context,
+      charId: charId,
+      sessionId: session.id,
+    );
+    if (!context.mounted) return;
+    if (route != null && route.isNotEmpty) {
+      onClose?.call();
+      context.go(route);
+    }
+  }
+
+  Future<void> _showAgentOpsLog(BuildContext context, WidgetRef ref) async {
+    final session = ref.read(chatProvider(charId)).value?.session;
+    final route = await AgenticOperationsLogDialog.show(
+      context,
+      sessionId: session?.id,
+      characterId: charId,
+    );
+    if (!context.mounted) return;
+    if (route != null && route.isNotEmpty) {
+      onClose?.call();
+      context.go(route);
+    }
+  }
+
+  Future<void> _showExtBlocksSheet(BuildContext context, WidgetRef ref) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      useRootNavigator: true,
+      backgroundColor: context.cs.surfaceContainerHigh,
+      isScrollControlled: true,
+      builder: (_) => const ExtBlocksSettingsSheet(),
+    );
+  }
+
+  Future<void> _showSessionsSheet(BuildContext context, WidgetRef ref) async {
+    final currentSession = ref.read(chatProvider(charId)).value?.session;
+    if (currentSession == null) return;
+
+    if (!context.mounted) return;
+    // The same picker the character catalog opens — see
+    // `showSessionPickerSheet`. Only what a pick does differs: here it switches
+    // the open chat in place instead of routing to it.
+    final result = await showSessionPickerSheet(context, charId: charId);
+    if (result == null || !context.mounted) return;
+    switch (result.action) {
+      case SessionPickerAction.open:
+        final target = result.session!.sessionIndex;
+        final current = ref
+            .read(chatProvider(charId))
+            .value
+            ?.session
+            ?.sessionIndex;
+        if (target == current) return;
+        try {
+          await ref
+              .read(chatProvider(charId).notifier)
+              .switchSession(target)
+              .timeout(const Duration(seconds: 30));
+        } catch (error) {
+          if (context.mounted) {
+            GlazeErrorDialog.show(
+              context,
+              error,
+              prefix: 'Failed to switch chat session',
+            );
+          }
+        }
+      case SessionPickerAction.newSession:
+        await ref.read(chatProvider(charId).notifier).newSession();
+      case SessionPickerAction.importChat:
+        await _importChat(context, ref);
+    }
+  }
+
+  Future<void> _importChat(BuildContext context, WidgetRef ref) async {
+    final result = await FilePicker.pickFiles(
+      type: Platform.isIOS ? FileType.any : FileType.custom,
+      allowedExtensions: Platform.isIOS ? null : ['jsonl', 'json'],
+      allowMultiple: false,
+      withData: false,
+    );
+    if (result == null || result.files.isEmpty) return;
+    final file = result.files.first;
+    final filePath = file.path;
+    try {
+      ChatImportSaveResult saveResult;
+      if (file.bytes != null) {
+        final importResult = importChatFromJsonlString(
+          utf8.decode(file.bytes!),
+        );
+        saveResult = await ref
+            .read(chatActionsServiceProvider)
+            .importChatFromResult(charId, importResult);
+      } else if (filePath != null) {
+        saveResult = await ref
+            .read(chatActionsServiceProvider)
+            .importChat(charId, filePath);
+      } else {
+        return;
+      }
+      if (!context.mounted) return;
+      final count = saveResult.count;
+      final sessionIndex = saveResult.sessionIndex;
+      if (count > 0 && sessionIndex != null) {
+        // The sessions sheet has already resolved and closed itself by the
+        // time this runs (`showSessionPickerSheet` pops with the picked
+        // action), so there is nothing left here to pop.
+        context.go('/chat/$charId?session=$sessionIndex');
+      }
+      GlazeToast.show(
+        context,
+        count == 0 ? 'No messages found in file' : 'Imported $count messages',
+      );
+    } catch (e) {
+      if (context.mounted) {
+        GlazeErrorDialog.show(context, e, prefix: 'Import failed: ');
+      }
+    }
+  }
+}

--- a/lib/features/chat/widgets/magic_drawer.dart
+++ b/lib/features/chat/widgets/magic_drawer.dart
@@ -1,54 +1,31 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
 
 import 'package:easy_localization/easy_localization.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import '../../../core/platform/haptics.dart';
-import '../../../core/services/chat_import_export.dart';
 import '../../../core/state/lorebook_provider.dart';
 import '../../../features/settings/app_settings_provider.dart';
 import '../../../core/state/active_selection_provider.dart';
 import '../../../core/state/active_studio_preset_provider.dart';
 import '../../../core/state/studio_feature_provider.dart';
 import '../../../core/state/summary_providers.dart';
-import '../../../shared/theme/app_colors.dart';
 
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
-import '../../../shared/widgets/glaze_error_dialog.dart';
-import '../../../shared/widgets/glaze_toast.dart';
-import '../../image_gen/widgets/image_gen_sheet.dart';
-import '../chat_actions_service.dart';
 import '../chat_provider.dart';
-import '../../card_rewrite/card_rewriter_studio_sheet.dart';
-import '../../character_list/character_detail_screen.dart';
-import '../../lorebooks/lorebook_list_screen.dart';
-import '../../personas/persona_list_screen.dart';
-import '../../presets/preset_list_screen.dart';
-import '../../regex/regex_sheet.dart';
-import '../../settings/api_settings_screen.dart';
-import 'authors_note_sheet.dart';
-import 'agentic_operations_log_dialog.dart';
 import 'drawer_panel_scaffold.dart';
 import 'magic_drawer_models.dart';
+import '../services/magic_drawer_actions.dart';
 import '../services/magic_drawer_layout_service.dart';
 import '../services/magic_drawer_stats_service.dart';
 import 'magic_drawer_widgets.dart';
-import 'memory_sheet.dart';
-import 'prompt_inspector_sheet.dart';
-import 'session_picker_sheet.dart';
 import '../state/magic_drawer_stats_cache.dart';
 import '../state/token_breakdown_cache.dart';
-import '../../glossary/glossary_sheet.dart';
 import '../../extensions/models/extension_preset.dart';
 import '../../extensions/models/extensions_settings.dart';
 import '../../extensions/providers/extension_presets_provider.dart';
 import '../../extensions/providers/extensions_settings_provider.dart';
-import '../../extensions/widgets/ext_blocks_settings_sheet.dart';
 
 class MagicDrawerPanel extends ConsumerStatefulWidget {
   final String charId;
@@ -79,98 +56,9 @@ class MagicDrawerPanel extends ConsumerStatefulWidget {
 }
 
 class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
-  static final _allItems = <MagicDrawerItemDef>[
-    MagicDrawerItemDef(
-      id: 'inspector',
-      label: 'prompt_inspector_title'.tr(),
-      icon: Icons.travel_explore,
-      category: MagicDrawerCategory.tools,
-    ),
-    MagicDrawerItemDef(
-      id: 'memory',
-      label: 'Memory',
-      icon: Icons.subject,
-      category: MagicDrawerCategory.session,
-    ),
-    MagicDrawerItemDef(
-      id: 'sessions',
-      label: 'history_title'.tr(),
-      icon: Icons.history,
-      category: MagicDrawerCategory.session,
-    ),
-    MagicDrawerItemDef(
-      id: 'char-card',
-      label: 'menu_characters'.tr(),
-      icon: Icons.account_box,
-      category: MagicDrawerCategory.library,
-    ),
-    MagicDrawerItemDef(
-      id: 'lorebooks',
-      label: 'label_lorebooks'.tr(),
-      icon: Icons.library_books,
-      category: MagicDrawerCategory.library,
-    ),
-    MagicDrawerItemDef(
-      id: 'regex',
-      label: 'menu_regex'.tr(),
-      icon: Icons.code,
-      category: MagicDrawerCategory.config,
-    ),
-    MagicDrawerItemDef(
-      id: 'api',
-      label: 'tab_api'.tr(),
-      icon: Icons.cloud,
-      category: MagicDrawerCategory.config,
-    ),
-    MagicDrawerItemDef(
-      id: 'presets',
-      label: 'tab_presets'.tr(),
-      icon: Icons.description,
-      category: MagicDrawerCategory.config,
-    ),
-    MagicDrawerItemDef(
-      id: 'personas',
-      label: 'menu_personas'.tr(),
-      icon: Icons.manage_accounts,
-      category: MagicDrawerCategory.library,
-    ),
-    MagicDrawerItemDef(
-      id: 'image-gen',
-      label: 'imggen_title'.tr(),
-      icon: Icons.image,
-      category: MagicDrawerCategory.tools,
-    ),
-    MagicDrawerItemDef(
-      id: 'authors-note',
-      label: 'magic_authors_notes'.tr(),
-      icon: Icons.edit_note,
-      category: MagicDrawerCategory.session,
-    ),
-    MagicDrawerItemDef(
-      id: 'glossary',
-      label: 'menu_glossary'.tr(),
-      icon: Icons.menu_book,
-      category: MagicDrawerCategory.library,
-    ),
-    MagicDrawerItemDef(
-      id: 'ext-blocks',
-      label: 'Ext Blocks',
-      icon: Icons.extension_outlined,
-      category: MagicDrawerCategory.config,
-    ),
-    MagicDrawerItemDef(
-      id: 'agent-ops',
-      label: 'agent_ops_title'.tr(),
-      icon: Icons.smart_toy_outlined,
-      category: MagicDrawerCategory.tools,
-    ),
-    MagicDrawerItemDef(
-      id: 'card-rewriter',
-      label: 'magic_card_rewriter'.tr(),
-      icon: Icons.auto_fix_high_outlined,
-      category: MagicDrawerCategory.tools,
-    ),
-  ];
+  /// Quick Access catalogue + dispatch, shared with the desktop sidebar
+  /// strip — see [MagicDrawerActions].
+  late final MagicDrawerActions _actions;
 
   final List<String> _itemIds = [];
   final Set<String> _deletedIds = {};
@@ -188,6 +76,11 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
   @override
   void initState() {
     super.initState();
+    _actions = MagicDrawerActions(
+      charId: widget.charId,
+      onClose: widget.onClose,
+      onScrollToMessage: widget.onScrollToMessage,
+    );
     _statsService = MagicDrawerStatsService(ref);
     // Stale-while-revalidate. The panel is destroyed on every drawer close, so
     // without a cache each open would sit behind the spinner until a full
@@ -232,7 +125,9 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
   }
 
   Future<void> _loadLayout() async {
-    final layout = await MagicDrawerLayoutService(ref).loadLayout(_allItems);
+    final layout = await MagicDrawerLayoutService(
+      ref,
+    ).loadLayout(MagicDrawerActions.all);
     _deletedIds
       ..clear()
       ..addAll(layout.deletedIds);
@@ -325,7 +220,10 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
     bool studioFeatureEnabled,
   ) {
     final list = _itemIds
-        .map((id) => _allItems.where((item) => item.id == id).firstOrNull)
+        .map(
+          (id) =>
+              MagicDrawerActions.all.where((item) => item.id == id).firstOrNull,
+        )
         .whereType<MagicDrawerItemDef>()
         .where(
           (def) => _featureVisible(def.id, extSettings, studioFeatureEnabled),
@@ -355,7 +253,7 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
   }
 
   bool _canAddMore(ExtensionsSettings extSettings, bool studioFeatureEnabled) =>
-      _allItems.any(
+      MagicDrawerActions.all.any(
         (item) =>
             !_itemIds.contains(item.id) &&
             _featureVisible(item.id, extSettings, studioFeatureEnabled),
@@ -448,7 +346,7 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
   Future<void> _showAddItemSheet() async {
     final extSettings = ref.read(extensionsSettingsProvider);
     final studioFeatureEnabled = ref.read(studioFeatureEnabledProvider);
-    final available = _allItems
+    final available = MagicDrawerActions.all
         .where((item) => !_itemIds.contains(item.id))
         .where(
           (item) => _featureVisible(item.id, extSettings, studioFeatureEnabled),
@@ -472,236 +370,6 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
       });
       await _saveLayout();
     });
-  }
-
-  Future<void> _handleTap(MagicDrawerItemDef item) async {
-    if (_editing) return;
-
-    try {
-      switch (item.id) {
-        case 'inspector':
-          await showPromptInspectorSheet(context, widget.charId);
-          break;
-        case 'memory':
-          await showMemorySheet(context, widget.charId);
-          break;
-        case 'sessions':
-          await _showSessionsSheet();
-          break;
-        case 'char-card':
-          final result = await showModalBottomSheet<String>(
-            context: context,
-            isScrollControlled: true,
-            useRootNavigator: true,
-            backgroundColor: Colors.transparent,
-            builder: (_) => CharacterDetailScreen(charId: widget.charId),
-          );
-          if (result != null && result.isNotEmpty && mounted) {
-            // Real navigation away from the chat - close the panel first.
-            widget.onClose?.call();
-            context.go(result);
-          }
-          break;
-        case 'lorebooks':
-          await showModalBottomSheet<void>(
-            context: context,
-            useRootNavigator: true,
-            backgroundColor: Colors.transparent,
-            barrierColor: Colors.black54,
-            isScrollControlled: true,
-            builder: (_) => const LorebookListScreen(),
-          );
-          break;
-        case 'regex':
-          await showModalBottomSheet<void>(
-            context: context,
-            useRootNavigator: true,
-            backgroundColor: Colors.transparent,
-            barrierColor: Colors.black54,
-            isScrollControlled: true,
-            builder: (_) => const RegexSheet(),
-          );
-          break;
-        case 'api':
-          await showModalBottomSheet<void>(
-            context: context,
-            useRootNavigator: true,
-            backgroundColor: Colors.transparent,
-            barrierColor: Colors.black54,
-            isScrollControlled: true,
-            builder: (_) => const ApiSettingsScreen(),
-          );
-          break;
-        case 'presets':
-          await showModalBottomSheet<void>(
-            context: context,
-            useRootNavigator: true,
-            backgroundColor: Colors.transparent,
-            barrierColor: Colors.black54,
-            isScrollControlled: true,
-            builder: (_) => PresetListScreen(charId: widget.charId),
-          );
-          break;
-        case 'personas':
-          await showModalBottomSheet<void>(
-            context: context,
-            useRootNavigator: true,
-            isScrollControlled: true,
-            backgroundColor: Colors.transparent,
-            builder: (_) => const PersonaListScreen(),
-          );
-          break;
-        case 'image-gen':
-          await showModalBottomSheet<void>(
-            context: context,
-            useRootNavigator: true,
-            isScrollControlled: true,
-            backgroundColor: Colors.transparent,
-            builder: (_) => ImageGenSheet(charId: widget.charId),
-          );
-          break;
-        case 'authors-note':
-          await showAuthorsNoteSheet(context, widget.charId);
-          break;
-        case 'glossary':
-          await GlossarySheet.show(context);
-          break;
-        case 'ext-blocks':
-          await _showExtBlocksSheet();
-          break;
-        case 'agent-ops':
-          await _showAgentOpsLog();
-          break;
-        case 'card-rewriter':
-          await _showCardRewriter();
-          break;
-      }
-    } finally {
-      if (mounted) await _refreshStats();
-    }
-  }
-
-  Future<void> _showCardRewriter() async {
-    final session = ref.read(chatProvider(widget.charId)).value?.session;
-    if (session == null) return;
-    final route = await CardRewriterStudioSheet.show(
-      context,
-      charId: widget.charId,
-      sessionId: session.id,
-    );
-    if (!mounted) return;
-    if (route != null && route.isNotEmpty) {
-      widget.onClose?.call();
-      context.go(route);
-    }
-  }
-
-  Future<void> _showAgentOpsLog() async {
-    final session = ref.read(chatProvider(widget.charId)).value?.session;
-    final route = await AgenticOperationsLogDialog.show(
-      context,
-      sessionId: session?.id,
-      characterId: widget.charId,
-    );
-    if (!mounted) return;
-    if (route != null && route.isNotEmpty) {
-      widget.onClose?.call();
-      context.go(route);
-    }
-  }
-
-  Future<void> _showExtBlocksSheet() async {
-    await showModalBottomSheet<void>(
-      context: context,
-      useRootNavigator: true,
-      backgroundColor: context.cs.surfaceContainerHigh,
-      isScrollControlled: true,
-      builder: (_) => const ExtBlocksSettingsSheet(),
-    );
-  }
-
-  Future<void> _showSessionsSheet() async {
-    final currentSession = ref.read(chatProvider(widget.charId)).value?.session;
-    if (currentSession == null) return;
-
-    if (!mounted) return;
-    // The same picker the character catalog opens — see
-    // `showSessionPickerSheet`. Only what a pick does differs: here it switches
-    // the open chat in place instead of routing to it.
-    final result = await showSessionPickerSheet(context, charId: widget.charId);
-    if (result == null || !mounted) return;
-    switch (result.action) {
-      case SessionPickerAction.open:
-        final target = result.session!.sessionIndex;
-        final current = ref
-            .read(chatProvider(widget.charId))
-            .value
-            ?.session
-            ?.sessionIndex;
-        if (target == current) return;
-        try {
-          await ref
-              .read(chatProvider(widget.charId).notifier)
-              .switchSession(target)
-              .timeout(const Duration(seconds: 30));
-        } catch (error) {
-          if (mounted) {
-            GlazeErrorDialog.show(
-              context,
-              error,
-              prefix: 'Failed to switch chat session',
-            );
-          }
-        }
-      case SessionPickerAction.newSession:
-        await ref.read(chatProvider(widget.charId).notifier).newSession();
-      case SessionPickerAction.importChat:
-        await _importChat();
-    }
-  }
-
-  Future<void> _importChat() async {
-    final result = await FilePicker.pickFiles(
-      type: Platform.isIOS ? FileType.any : FileType.custom,
-      allowedExtensions: Platform.isIOS ? null : ['jsonl', 'json'],
-      allowMultiple: false,
-      withData: false,
-    );
-    if (result == null || result.files.isEmpty) return;
-    final file = result.files.first;
-    final filePath = file.path;
-    try {
-      ChatImportSaveResult saveResult;
-      if (file.bytes != null) {
-        final importResult = importChatFromJsonlString(
-          utf8.decode(file.bytes!),
-        );
-        saveResult = await ref
-            .read(chatActionsServiceProvider)
-            .importChatFromResult(widget.charId, importResult);
-      } else if (filePath != null) {
-        saveResult = await ref
-            .read(chatActionsServiceProvider)
-            .importChat(widget.charId, filePath);
-      } else {
-        return;
-      }
-      if (!mounted) return;
-      final count = saveResult.count;
-      final sessionIndex = saveResult.sessionIndex;
-      if (count > 0 && sessionIndex != null) {
-        // The sessions sheet has already resolved and closed itself by the
-        // time this runs (`showSessionPickerSheet` pops with the picked
-        // action), so there is nothing left here to pop.
-        context.go('/chat/${widget.charId}?session=$sessionIndex');
-      }
-      GlazeToast.show(
-        context,
-        count == 0 ? 'No messages found in file' : 'Imported $count messages',
-      );
-    } catch (e) {
-      if (mounted) GlazeErrorDialog.show(context, e, prefix: 'Import failed: ');
-    }
   }
 
   @override
@@ -798,7 +466,16 @@ class _MagicDrawerPanelState extends ConsumerState<MagicDrawerPanel> {
                     item: item,
                     editing: _editing,
                     hovered: _hoverIndex == index && _draggingIndex != index,
-                    onTap: () => _handleTap(item.def),
+                    onTap: () => _editing
+                        ? null
+                        : _actions.handleTap(
+                            context,
+                            ref,
+                            item.def,
+                            onFinished: () async {
+                              if (mounted) await _refreshStats();
+                            },
+                          ),
                     onDelete: () => _removeItem(item.def.id),
                   );
 

--- a/lib/features/onboarding/onboarding_models.dart
+++ b/lib/features/onboarding/onboarding_models.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+// ---------------------------------------------------------------------------
+// Onboarding slide data — the flow's content, shared by the phone layout and
+// the desktop wizard.
+// ---------------------------------------------------------------------------
+
+enum OnboardingSlideType {
+  welcome,
+  features,
+  dataImport,
+  api,
+  persona,
+  layout,
+  allSet,
+}
+
+class OnboardingSlideData {
+  final OnboardingSlideType type;
+  final String title;
+  final String? desc;
+  final IconData? icon;
+  const OnboardingSlideData({
+    required this.type,
+    required this.title,
+    this.desc,
+    this.icon,
+  });
+}
+
+class OnboardingInfoBlock {
+  final IconData icon;
+  final String title;
+  final String desc;
+  const OnboardingInfoBlock({
+    required this.icon,
+    required this.title,
+    required this.desc,
+  });
+}
+
+const onboardingSlides = <OnboardingSlideData>[
+  OnboardingSlideData(
+    type: OnboardingSlideType.welcome,
+    title: 'onboarding_welcome_title',
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.features,
+    title: 'onboarding_features_title',
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.dataImport,
+    title: 'onboarding_import_title',
+    desc: 'onboarding_import_slide_desc',
+    icon: Icons.download_rounded,
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.api,
+    title: 'onboarding_api_title',
+    desc: 'onboarding_preset_slide_desc',
+    icon: Icons.dns_outlined,
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.persona,
+    title: 'onboarding_persona_title',
+    desc: 'onboarding_persona_slide_desc',
+    icon: Icons.person_outline_rounded,
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.layout,
+    title: 'onboarding_layout_title',
+    desc: 'onboarding_layout_slide_desc',
+    icon: Icons.view_quilt_outlined,
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.allSet,
+    title: 'onboarding_allset_title',
+    desc: 'onboarding_allset_slide_desc',
+    icon: Icons.check_circle_outline_rounded,
+  ),
+];
+
+const onboardingIntroContent = <OnboardingInfoBlock>[
+  OnboardingInfoBlock(
+    icon: Icons.layers_outlined,
+    title: 'onboarding_feature_roleplay_title',
+    desc: 'onboarding_feature_roleplay_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.link_rounded,
+    title: 'onboarding_feature_rules_title',
+    desc: 'onboarding_feature_rules_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.verified_outlined,
+    title: 'onboarding_feature_privacy_title',
+    desc: 'onboarding_feature_privacy_desc',
+  ),
+];
+
+const onboardingFeaturesContent = <OnboardingInfoBlock>[
+  OnboardingInfoBlock(
+    icon: Icons.image_outlined,
+    title: 'onboarding_feature_imggen_title',
+    desc: 'onboarding_feature_imggen_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.menu_book_outlined,
+    title: 'onboarding_feature_glossary_title',
+    desc: 'onboarding_feature_glossary_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.palette_outlined,
+    title: 'onboarding_feature_custom_title',
+    desc: 'onboarding_feature_custom_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.description_outlined,
+    title: 'onboarding_feature_st_title',
+    desc: 'onboarding_feature_st_desc',
+  ),
+];

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -14,103 +12,10 @@ import '../settings/api_list_provider.dart';
 import '../settings/api_settings_screen.dart';
 import '../settings/widgets/chat_layout_picker.dart';
 import '../personas/persona_list_screen.dart';
-
-// ---------------------------------------------------------------------------
-// Slide data
-// ---------------------------------------------------------------------------
-
-enum OnboardingSlideType { welcome, features, dataImport, api, persona, layout, allSet }
-
-class _SlideData {
-  final OnboardingSlideType type;
-  final String title;
-  final String? desc;
-  final IconData? icon;
-  const _SlideData({required this.type, required this.title, this.desc, this.icon});
-}
-
-class _InfoBlock {
-  final IconData icon;
-  final String title;
-  final String desc;
-  const _InfoBlock({required this.icon, required this.title, required this.desc});
-}
-
-const _slides = <_SlideData>[
-  _SlideData(type: OnboardingSlideType.welcome, title: 'onboarding_welcome_title'),
-  _SlideData(type: OnboardingSlideType.features, title: 'onboarding_features_title'),
-  _SlideData(
-    type: OnboardingSlideType.dataImport,
-    title: 'onboarding_import_title',
-    desc: 'onboarding_import_slide_desc',
-    icon: Icons.download_rounded,
-  ),
-  _SlideData(
-    type: OnboardingSlideType.api,
-    title: 'onboarding_api_title',
-    desc: 'onboarding_preset_slide_desc',
-    icon: Icons.dns_outlined,
-  ),
-  _SlideData(
-    type: OnboardingSlideType.persona,
-    title: 'onboarding_persona_title',
-    desc: 'onboarding_persona_slide_desc',
-    icon: Icons.person_outline_rounded,
-  ),
-  _SlideData(
-    type: OnboardingSlideType.layout,
-    title: 'onboarding_layout_title',
-    desc: 'onboarding_layout_slide_desc',
-    icon: Icons.view_quilt_outlined,
-  ),
-  _SlideData(
-    type: OnboardingSlideType.allSet,
-    title: 'onboarding_allset_title',
-    desc: 'onboarding_allset_slide_desc',
-    icon: Icons.check_circle_outline_rounded,
-  ),
-];
-
-const _introContent = <_InfoBlock>[
-  _InfoBlock(
-    icon: Icons.layers_outlined,
-    title: 'onboarding_feature_roleplay_title',
-    desc: 'onboarding_feature_roleplay_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.link_rounded,
-    title: 'onboarding_feature_rules_title',
-    desc: 'onboarding_feature_rules_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.verified_outlined,
-    title: 'onboarding_feature_privacy_title',
-    desc: 'onboarding_feature_privacy_desc',
-  ),
-];
-
-const _featuresContent = <_InfoBlock>[
-  _InfoBlock(
-    icon: Icons.image_outlined,
-    title: 'onboarding_feature_imggen_title',
-    desc: 'onboarding_feature_imggen_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.menu_book_outlined,
-    title: 'onboarding_feature_glossary_title',
-    desc: 'onboarding_feature_glossary_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.palette_outlined,
-    title: 'onboarding_feature_custom_title',
-    desc: 'onboarding_feature_custom_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.description_outlined,
-    title: 'onboarding_feature_st_title',
-    desc: 'onboarding_feature_st_desc',
-  ),
-];
+import '../../shared/shell/desktop/desktop_layout_provider.dart';
+import 'onboarding_models.dart';
+import 'widgets/onboarding_desktop_wizard.dart';
+import 'widgets/onboarding_widgets.dart';
 
 // ---------------------------------------------------------------------------
 // Flow widget
@@ -127,11 +32,11 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   int _currentSlide = 0;
   int _direction = 1;
 
-  bool get _isLastSlide => _currentSlide == _slides.length - 1;
+  bool get _isLastSlide => _currentSlide == onboardingSlides.length - 1;
 
   String get _buttonLabel {
     if (_isLastSlide) return 'onboarding_btn_start'.tr();
-    switch (_slides[_currentSlide].type) {
+    switch (onboardingSlides[_currentSlide].type) {
       case OnboardingSlideType.dataImport:
         return 'onboarding_btn_skip'.tr();
       case OnboardingSlideType.persona:
@@ -157,13 +62,19 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     if (_isLastSlide) {
       _finish();
     } else {
-      setState(() { _direction = 1; _currentSlide++; });
+      setState(() {
+        _direction = 1;
+        _currentSlide++;
+      });
     }
   }
 
   void _prev() {
     if (_currentSlide > 0) {
-      setState(() { _direction = -1; _currentSlide--; });
+      setState(() {
+        _direction = -1;
+        _currentSlide--;
+      });
     }
   }
 
@@ -177,7 +88,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     GlazeBottomSheet.show<void>(
       context,
       title: 'onboarding_skip_confirm_title'.tr(),
-      child: _SkipConfirmSheet(
+      child: OnboardingSkipConfirmSheet(
         onCancel: () => Navigator.of(context, rootNavigator: true).pop(),
         onConfirm: () {
           Navigator.of(context, rootNavigator: true).pop();
@@ -197,8 +108,17 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     );
   }
 
+  /// Onboarding is pushed on the root navigator, above the shell, so there is
+  /// no `DesktopScope` to read here — apply the shell's own rule directly
+  /// (see `DesktopShell.build`).
+  bool _isDesktop(BuildContext context) =>
+      MediaQuery.sizeOf(context).width >= 768 &&
+      !ref.watch(forceMobileLayoutProvider);
+
   @override
   Widget build(BuildContext context) {
+    if (_isDesktop(context)) return _buildDesktop(context);
+
     final topPad = MediaQuery.of(context).padding.top;
     final bottomPad = MediaQuery.of(context).padding.bottom;
 
@@ -222,14 +142,13 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 layoutBuilder: (currentChild, previousChildren) {
                   return Stack(
                     alignment: Alignment.topCenter,
-                    children: <Widget>[
-                      ...previousChildren,
-                      ?currentChild,
-                    ],
+                    children: <Widget>[...previousChildren, ?currentChild],
                   );
                 },
                 transitionBuilder: (child, anim) {
-                  final dir = (child.key == ValueKey(_currentSlide)) ? _direction : -_direction;
+                  final dir = (child.key == ValueKey(_currentSlide))
+                      ? _direction
+                      : -_direction;
                   return FadeTransition(
                     opacity: anim,
                     child: SlideTransition(
@@ -243,7 +162,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 },
                 child: KeyedSubtree(
                   key: ValueKey(_currentSlide),
-                  child: _buildSlide(_slides[_currentSlide]),
+                  child: _buildSlide(onboardingSlides[_currentSlide]),
                 ),
               ),
             ),
@@ -251,7 +170,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
           // ── Header gradient ──
           Positioned(
-            top: 0, left: 0, right: 0,
+            top: 0,
+            left: 0,
+            right: 0,
             child: IgnorePointer(
               child: Container(
                 height: topPad + 84,
@@ -268,9 +189,11 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
           // ── Stories progress bar ──
           Positioned(
-            top: topPad + 16, left: 20, right: 20,
-            child: _StoriesBar(
-              total: _slides.length,
+            top: topPad + 16,
+            left: 20,
+            right: 20,
+            child: OnboardingStoriesBar(
+              total: onboardingSlides.length,
               current: _currentSlide,
             ),
           ),
@@ -278,20 +201,24 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
           // ── Back button ──
           if (_currentSlide > 0)
             Positioned(
-              top: topPad + 36, left: 12,
-              child: _GlassBackButton(onTap: _prev),
+              top: topPad + 36,
+              left: 12,
+              child: OnboardingGlassBackButton(onTap: _prev),
             ),
 
           // ── Skip onboarding (top-right) ──
           if (!_isLastSlide)
             Positioned(
-              top: topPad + 36, right: 12,
-              child: _SkipOnboardingButton(onTap: _confirmSkipOnboarding),
+              top: topPad + 36,
+              right: 12,
+              child: OnboardingSkipButton(onTap: _confirmSkipOnboarding),
             ),
 
           // ── Footer gradient ──
           Positioned(
-            bottom: 0, left: 0, right: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
             child: IgnorePointer(
               child: Container(
                 height: 120 + bottomPad,
@@ -308,12 +235,14 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
           // ── Footer button ──
           Positioned(
-            bottom: 0, left: 0, right: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
             child: SafeArea(
               top: false,
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(24, 24, 24, 24),
-                child: _PrimaryButton(
+                child: OnboardingPrimaryButton(
                   label: _buttonLabel,
                   onTap: _next,
                 ),
@@ -325,37 +254,107 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     );
   }
 
+  /// The wide-window flow: the same slides, laid out as the Vue wizard.
+  Widget _buildDesktop(BuildContext context) {
+    final slide = onboardingSlides[_currentSlide];
+    return Scaffold(
+      backgroundColor: const Color(0xFF0D0D0E),
+      body: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 320),
+        switchInCurve: Curves.easeOutCubic,
+        switchOutCurve: Curves.easeInCubic,
+        transitionBuilder: (child, anim) {
+          final dir = (child.key == ValueKey(_currentSlide))
+              ? _direction
+              : -_direction;
+          return FadeTransition(
+            opacity: anim,
+            child: SlideTransition(
+              position: Tween(
+                begin: Offset(0.04 * dir, 0),
+                end: Offset.zero,
+              ).animate(anim),
+              child: child,
+            ),
+          );
+        },
+        child: KeyedSubtree(
+          key: ValueKey(_currentSlide),
+          child: OnboardingDesktopWizard(
+            slideIndex: _currentSlide,
+            slideCount: onboardingSlides.length,
+            icon: _slideIcon(slide),
+            title: slide.title,
+            description: slide.desc,
+            body: _slideBody(slide),
+            buttonLabel: _buttonLabel,
+            onNext: _next,
+            onBack: _currentSlide > 0 ? _prev : null,
+            onSkip: _isLastSlide ? null : _confirmSkipOnboarding,
+          ),
+        ),
+      ),
+    );
+  }
+
   // ── Slide builders ──
 
-  Widget _buildSlide(_SlideData slide) {
+  /// The one thing a slide asks the user to open, when it has one. Shared by
+  /// the phone slide and the desktop wizard so the two never drift apart.
+  ({IconData icon, String title, String sub, VoidCallback onTap})? _slideAction(
+    OnboardingSlideData slide,
+  ) {
     switch (slide.type) {
-      case OnboardingSlideType.welcome:
-        return _buildBlocksSlide(slide.title, _introContent);
-      case OnboardingSlideType.features:
-        return _buildBlocksSlide(slide.title, _featuresContent);
       case OnboardingSlideType.dataImport:
-        return _buildActionSlide(
-          slide: slide,
-          actionIcon: Icons.download_rounded,
-          actionTitle: 'onboarding_action_restore'.tr(),
-          actionSub: 'onboarding_action_restore_sub'.tr(),
-          onAction: () => _openSheet(const BackupScreen(fromOnboarding: true)),
+        return (
+          icon: Icons.download_rounded,
+          title: 'onboarding_action_restore'.tr(),
+          sub: 'onboarding_action_restore_sub'.tr(),
+          onTap: () => _openSheet(const BackupScreen(fromOnboarding: true)),
         );
       case OnboardingSlideType.api:
-        return _buildActionSlide(
-          slide: slide,
-          actionIcon: Icons.settings_outlined,
-          actionTitle: 'onboarding_action_configure_api'.tr(),
-          actionSub: 'onboarding_action_configure_sub'.tr(),
-          onAction: () => _openSheet(const ApiSettingsScreen(startExpanded: true)),
+        return (
+          icon: Icons.settings_outlined,
+          title: 'onboarding_action_configure_api'.tr(),
+          sub: 'onboarding_action_configure_sub'.tr(),
+          onTap: () => _openSheet(const ApiSettingsScreen(startExpanded: true)),
         );
       case OnboardingSlideType.persona:
+        return (
+          icon: Icons.person_add_outlined,
+          title: 'onboarding_action_setup_persona'.tr(),
+          sub: 'onboarding_action_setup_sub'.tr(),
+          onTap: () => _openSheet(const PersonaListScreen()),
+        );
+      default:
+        return null;
+    }
+  }
+
+  /// The info blocks a slide lists, when it lists any.
+  List<OnboardingInfoBlock>? _slideBlocks(OnboardingSlideData slide) {
+    return switch (slide.type) {
+      OnboardingSlideType.welcome => onboardingIntroContent,
+      OnboardingSlideType.features => onboardingFeaturesContent,
+      _ => null,
+    };
+  }
+
+  Widget _buildSlide(OnboardingSlideData slide) {
+    switch (slide.type) {
+      case OnboardingSlideType.welcome:
+      case OnboardingSlideType.features:
+        return _buildBlocksSlide(slide.title, _slideBlocks(slide)!);
+      case OnboardingSlideType.dataImport:
+      case OnboardingSlideType.api:
+      case OnboardingSlideType.persona:
+        final action = _slideAction(slide)!;
         return _buildActionSlide(
           slide: slide,
-          actionIcon: Icons.person_add_outlined,
-          actionTitle: 'onboarding_action_setup_persona'.tr(),
-          actionSub: 'onboarding_action_setup_sub'.tr(),
-          onAction: () => _openSheet(const PersonaListScreen()),
+          actionIcon: action.icon,
+          actionTitle: action.title,
+          actionSub: action.sub,
+          onAction: action.onTap,
         );
       case OnboardingSlideType.layout:
         return _buildLayoutSlide(slide);
@@ -364,42 +363,84 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     }
   }
 
+  /// The right-hand pane's content in the desktop wizard: whatever the slide
+  /// offers below its title and description.
+  Widget? _slideBody(OnboardingSlideData slide) {
+    final blocks = _slideBlocks(slide);
+    if (blocks != null) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: blocks
+            .map(
+              (b) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: OnboardingIntroBlockCard(block: b),
+              ),
+            )
+            .toList(),
+      );
+    }
+    final action = _slideAction(slide);
+    if (action != null) {
+      return OnboardingClickableBlock(
+        icon: action.icon,
+        title: action.title,
+        subtitle: action.sub,
+        onTap: action.onTap,
+      );
+    }
+    if (slide.type == OnboardingSlideType.layout) return _buildLayoutPicker();
+    return null;
+  }
+
+  /// Icon shown in the wizard's visual pane. Welcome and Features carry no
+  /// icon of their own, so they borrow their first block's — the same
+  /// fallback the Vue wizard used (`slides[i].icon || introContent[0].icon`).
+  IconData _slideIcon(OnboardingSlideData slide) =>
+      slide.icon ?? _slideBlocks(slide)?.first.icon ?? Icons.layers_outlined;
+
   /// Welcome / Features — title + list of info blocks
-  Widget _buildBlocksSlide(String title, List<_InfoBlock> blocks) {
+  Widget _buildBlocksSlide(String title, List<OnboardingInfoBlock> blocks) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           title.tr(),
           style: const TextStyle(
-            fontSize: 32, fontWeight: FontWeight.w800,
-            color: Colors.white, height: 1.2,
+            fontSize: 32,
+            fontWeight: FontWeight.w800,
+            color: Colors.white,
+            height: 1.2,
           ),
         ),
         const SizedBox(height: 16),
-        ...blocks.map((b) => Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: _IntroBlockCard(block: b),
-        )),
+        ...blocks.map(
+          (b) => Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: OnboardingIntroBlockCard(block: b),
+          ),
+        ),
       ],
     );
   }
 
   /// Standard centered slide — icon + title + description
-  Widget _buildStandardSlide(_SlideData slide) {
+  Widget _buildStandardSlide(OnboardingSlideData slide) {
     return SizedBox(
       width: double.infinity,
       child: Column(
         children: [
           const SizedBox(height: 40),
-          _IconBubble(icon: slide.icon ?? Icons.check),
+          OnboardingIconBubble(icon: slide.icon ?? Icons.check),
           const SizedBox(height: 24),
           Text(
             slide.title.tr(),
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 28, fontWeight: FontWeight.w800,
-              color: Colors.white, height: 1.3,
+              fontSize: 28,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+              height: 1.3,
             ),
           ),
           if (slide.desc != null) ...[
@@ -410,7 +451,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 slide.desc!.tr(),
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontSize: 16, color: context.cs.onSurfaceVariant, height: 1.5,
+                  fontSize: 16,
+                  color: context.cs.onSurfaceVariant,
+                  height: 1.5,
                 ),
               ),
             ),
@@ -422,7 +465,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   /// Standard slide + clickable action card
   Widget _buildActionSlide({
-    required _SlideData slide,
+    required OnboardingSlideData slide,
     required IconData actionIcon,
     required String actionTitle,
     required String actionSub,
@@ -433,14 +476,16 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       child: Column(
         children: [
           const SizedBox(height: 40),
-          _IconBubble(icon: slide.icon ?? Icons.settings),
+          OnboardingIconBubble(icon: slide.icon ?? Icons.settings),
           const SizedBox(height: 24),
           Text(
             slide.title.tr(),
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 28, fontWeight: FontWeight.w800,
-              color: Colors.white, height: 1.3,
+              fontSize: 28,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+              height: 1.3,
             ),
           ),
           if (slide.desc != null) ...[
@@ -451,13 +496,15 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 slide.desc!.tr(),
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontSize: 16, color: context.cs.onSurfaceVariant, height: 1.5,
+                  fontSize: 16,
+                  color: context.cs.onSurfaceVariant,
+                  height: 1.5,
                 ),
               ),
             ),
           ],
           const SizedBox(height: 24),
-          _ClickableBlock(
+          OnboardingClickableBlock(
             icon: actionIcon,
             title: actionTitle,
             subtitle: actionSub,
@@ -470,22 +517,22 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   /// Chat layout picker slide — inline `default` / `bubble` thumbnails reused
   /// from the theme editor's layout picker.
-  Widget _buildLayoutSlide(_SlideData slide) {
-    final currentLayout =
-        ref.watch(themeProvider.select((s) => s.activePreset.chatLayout));
+  Widget _buildLayoutSlide(OnboardingSlideData slide) {
     return SizedBox(
       width: double.infinity,
       child: Column(
         children: [
           const SizedBox(height: 40),
-          _IconBubble(icon: slide.icon ?? Icons.view_quilt_outlined),
+          OnboardingIconBubble(icon: slide.icon ?? Icons.view_quilt_outlined),
           const SizedBox(height: 24),
           Text(
             slide.title.tr(),
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 28, fontWeight: FontWeight.w800,
-              color: Colors.white, height: 1.3,
+              fontSize: 28,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+              height: 1.3,
             ),
           ),
           if (slide.desc != null) ...[
@@ -496,390 +543,57 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 slide.desc!.tr(),
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontSize: 16, color: context.cs.onSurfaceVariant, height: 1.5,
+                  fontSize: 16,
+                  color: context.cs.onSurfaceVariant,
+                  height: 1.5,
                 ),
               ),
             ),
           ],
           const SizedBox(height: 24),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: LayoutPreviewCard(
-                  title: 'layout_default'.tr(),
-                  subtitle: 'layout_default_desc'.tr(),
-                  isActive: currentLayout == 'default',
-                  onTap: () => _setChatLayout('default'),
-                  child: const LayoutMiniPreview(layout: 'default'),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: LayoutPreviewCard(
-                  title: 'layout_bubble'.tr(),
-                  subtitle: 'layout_bubble_desc'.tr(),
-                  isActive: currentLayout == 'bubble',
-                  onTap: () => _setChatLayout('bubble'),
-                  child: const LayoutMiniPreview(layout: 'bubble'),
-                ),
-              ),
-            ],
-          ),
+          _buildLayoutPicker(),
         ],
       ),
+    );
+  }
+
+  /// The `default` / `bubble` thumbnails, shared by the phone slide and the
+  /// desktop wizard's content pane.
+  Widget _buildLayoutPicker() {
+    final currentLayout = ref.watch(
+      themeProvider.select((s) => s.activePreset.chatLayout),
+    );
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: LayoutPreviewCard(
+            title: 'layout_default'.tr(),
+            subtitle: 'layout_default_desc'.tr(),
+            isActive: currentLayout == 'default',
+            onTap: () => _setChatLayout('default'),
+            child: const LayoutMiniPreview(layout: 'default'),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: LayoutPreviewCard(
+            title: 'layout_bubble'.tr(),
+            subtitle: 'layout_bubble_desc'.tr(),
+            isActive: currentLayout == 'bubble',
+            onTap: () => _setChatLayout('bubble'),
+            child: const LayoutMiniPreview(layout: 'bubble'),
+          ),
+        ),
+      ],
     );
   }
 
   Future<void> _setChatLayout(String layout) async {
     final preset = ref.read(themeProvider).activePreset;
     if (preset.chatLayout == layout) return;
-    await ref.read(themeProvider.notifier).updatePreset(
-          preset.copyWith(chatLayout: layout),
-        );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Reusable sub-widgets
-// ---------------------------------------------------------------------------
-
-/// Stories-style progress bar (Instagram / Telegram-like)
-class _StoriesBar extends StatelessWidget {
-  final int total;
-  final int current;
-  const _StoriesBar({required this.total, required this.current});
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: List.generate(total, (i) {
-        final filled = i <= current;
-        return Expanded(
-          child: Padding(
-            padding: EdgeInsets.only(left: i == 0 ? 0 : 3, right: i == total - 1 ? 0 : 3),
-            child: Container(
-              height: 4,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(2),
-                color: const Color(0x33808080),
-              ),
-              child: AnimatedFractionallySizedBox(
-                duration: const Duration(milliseconds: 300),
-                curve: Curves.easeOut,
-                alignment: Alignment.centerLeft,
-                widthFactor: filled ? 1.0 : 0.0,
-                child: Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(2),
-                     color: context.cs.primary,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        );
-      }),
-    );
-  }
-}
-
-/// Glass-morphism pill button to skip the entire onboarding (top-right)
-class _SkipOnboardingButton extends StatelessWidget {
-  final VoidCallback onTap;
-  const _SkipOnboardingButton({required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(20),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-          child: Container(
-            height: 40,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              color: context.cs.surface.withValues(alpha: 0.8),
-              borderRadius: BorderRadius.circular(20),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-              boxShadow: const [
-                BoxShadow(color: Color(0x4D000000), blurRadius: 15, offset: Offset(0, 4)),
-              ],
-            ),
-            child: Text(
-              'onboarding_btn_skip_onboarding'.tr(),
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: context.cs.onSurfaceVariant,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Confirmation body shown inside the "Skip Onboarding?" bottom sheet.
-class _SkipConfirmSheet extends StatelessWidget {
-  final VoidCallback onCancel;
-  final VoidCallback onConfirm;
-  const _SkipConfirmSheet({required this.onCancel, required this.onConfirm});
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 4, 20, 20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text(
-            'onboarding_skip_confirm_desc'.tr(),
-            style: TextStyle(
-              fontSize: 15,
-              height: 1.5,
-              color: context.cs.onSurfaceVariant,
-            ),
-          ),
-          const SizedBox(height: 20),
-          GestureDetector(
-            onTap: onConfirm,
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 15),
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: const Color(0xFFFF4444).withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(
-                  color: const Color(0xFFFF4444).withValues(alpha: 0.4),
-                ),
-              ),
-              child: Text(
-                'onboarding_skip_confirm_confirm'.tr(),
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: Color(0xFFFF6B6B),
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(height: 10),
-          GestureDetector(
-            onTap: onCancel,
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 15),
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.06),
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-              ),
-              child: Text(
-                'onboarding_skip_confirm_cancel'.tr(),
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: context.cs.onSurface,
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Glass-morphism circular back button
-class _GlassBackButton extends StatelessWidget {
-  final VoidCallback onTap;
-  const _GlassBackButton({required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(20),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-          child: Container(
-            width: 40, height: 40,
-            decoration: BoxDecoration(
-              color: context.cs.surface.withValues(alpha: 0.8),
-              borderRadius: BorderRadius.circular(20),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-              boxShadow: const [
-                BoxShadow(color: Color(0x4D000000), blurRadius: 15, offset: Offset(0, 4)),
-              ],
-            ),
-            child: Icon(Icons.arrow_back, size: 20, color: context.cs.primary),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Accent-tinted circular icon bubble (100×100)
-class _IconBubble extends StatelessWidget {
-  final IconData icon;
-  const _IconBubble({required this.icon});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 100, height: 100,
-      decoration: BoxDecoration(
-        color: context.cs.primary.withValues(alpha: 0.1),
-        shape: BoxShape.circle,
-      ),
-      child: Icon(icon, size: 48, color: context.cs.primary),
-    );
-  }
-}
-
-/// Info block card (column layout) — for welcome/features slides
-class _IntroBlockCard extends StatelessWidget {
-  final _InfoBlock block;
-  const _IntroBlockCard({required this.block});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: const Color(0x14808080),
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(block.icon, size: 48, color: context.cs.primary),
-          const SizedBox(height: 8),
-          Text(
-            block.title.tr(),
-            style: const TextStyle(
-              fontSize: 20, fontWeight: FontWeight.w700, color: Colors.white,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            block.desc.tr(),
-            style: TextStyle(
-              fontSize: 15, color: context.cs.onSurfaceVariant, height: 1.5,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Clickable action card — for data import / api / persona slides
-class _ClickableBlock extends StatefulWidget {
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final VoidCallback onTap;
-  const _ClickableBlock({
-    required this.icon, required this.title,
-    required this.subtitle, required this.onTap,
-  });
-
-  @override
-  State<_ClickableBlock> createState() => _ClickableBlockState();
-}
-
-class _ClickableBlockState extends State<_ClickableBlock> {
-  bool _pressed = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapDown: (_) => setState(() => _pressed = true),
-      onTapUp: (_) { setState(() => _pressed = false); widget.onTap(); },
-      onTapCancel: () => setState(() => _pressed = false),
-      child: AnimatedScale(
-        scale: _pressed ? 0.98 : 1.0,
-        duration: const Duration(milliseconds: 100),
-        child: Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: _pressed ? const Color(0x26808080) : const Color(0x14808080),
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(widget.icon, size: 48, color: context.cs.primary),
-              const SizedBox(height: 8),
-              Text(
-                widget.title,
-                style: const TextStyle(
-                  fontSize: 20, fontWeight: FontWeight.w700, color: Colors.white,
-                ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                widget.subtitle,
-                style: TextStyle(
-                  fontSize: 15, color: context.cs.onSurfaceVariant, height: 1.5,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Full-width accent primary button
-class _PrimaryButton extends StatefulWidget {
-  final String label;
-  final VoidCallback onTap;
-  const _PrimaryButton({required this.label, required this.onTap});
-
-  @override
-  State<_PrimaryButton> createState() => _PrimaryButtonState();
-}
-
-class _PrimaryButtonState extends State<_PrimaryButton> {
-  bool _pressed = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapDown: (_) => setState(() => _pressed = true),
-      onTapUp: (_) { setState(() => _pressed = false); widget.onTap(); },
-      onTapCancel: () => setState(() => _pressed = false),
-      child: AnimatedScale(
-        scale: _pressed ? 0.96 : 1.0,
-        duration: const Duration(milliseconds: 150),
-        child: Container(
-          width: double.infinity,
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          decoration: BoxDecoration(
-            color: context.cs.primary,
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Text(
-            widget.label,
-            textAlign: TextAlign.center,
-            style: const TextStyle(
-              fontSize: 17, fontWeight: FontWeight.w600, color: Colors.white,
-            ),
-          ),
-        ),
-      ),
-    );
+    await ref
+        .read(themeProvider.notifier)
+        .updatePreset(preset.copyWith(chatLayout: layout));
   }
 }

--- a/lib/features/onboarding/widgets/onboarding_desktop_wizard.dart
+++ b/lib/features/onboarding/widgets/onboarding_desktop_wizard.dart
@@ -1,0 +1,204 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_colors.dart';
+import 'onboarding_widgets.dart';
+
+/// Desktop onboarding — a 1:1 port of the Vue wizard (`OnboardingView.vue`,
+/// `.desktop-layout`).
+///
+/// The phone flow stacks everything into one scrolling column under a stories
+/// bar. On a wide window that leaves a narrow ribbon of content in the middle
+/// of an empty screen, so the desktop build instead centres a fixed card and
+/// splits it in two: a visual pane carrying the slide's icon, and a content
+/// pane with the title, description, whatever the slide offers, and the
+/// primary button pinned to its bottom.
+class OnboardingDesktopWizard extends StatelessWidget {
+  /// Zero-based index of the visible slide, and how many there are — together
+  /// they drive the stories bar in the top bar.
+  final int slideIndex;
+  final int slideCount;
+
+  final IconData icon;
+  final String title;
+  final String? description;
+
+  /// Slide-specific content under the description: the info-block list, the
+  /// single action card, or the chat-layout picker. Null on a slide that is
+  /// only a title and a description.
+  final Widget? body;
+
+  final String buttonLabel;
+  final VoidCallback onNext;
+
+  /// Null on the first slide, where there is nothing to go back to. The button
+  /// keeps its slot either way so the stories bar does not shift.
+  final VoidCallback? onBack;
+
+  /// Null on the last slide, which has nothing left to skip.
+  final VoidCallback? onSkip;
+
+  const OnboardingDesktopWizard({
+    super.key,
+    required this.slideIndex,
+    required this.slideCount,
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.body,
+    required this.buttonLabel,
+    required this.onNext,
+    required this.onBack,
+    required this.onSkip,
+  });
+
+  /// `.onboarding-card { width: min(1180px, 100%); height: min(820px, …) }`.
+  static const double _cardMaxWidth = 1180;
+  static const double _cardMaxHeight = 820;
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: SizedBox(
+          width: size.width.clamp(0.0, _cardMaxWidth),
+          height: (size.height - 40).clamp(0.0, _cardMaxHeight),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: context.cs.surface.withValues(alpha: 0.96),
+              borderRadius: BorderRadius.circular(18),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.2),
+                  blurRadius: 40,
+                  offset: const Offset(0, 16),
+                ),
+              ],
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(18),
+              child: Column(
+                children: [
+                  _buildTopBar(),
+                  Expanded(child: _buildSlide(context)),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// `.onboarding-topbar` — back button, then the stories bar filling the
+  /// rest, with the skip affordance at the far end.
+  Widget _buildTopBar() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 0),
+      child: SizedBox(
+        height: 42,
+        child: Row(
+          children: [
+            // The slot is held even on the first slide (`.nav-back-btn` starts
+            // at width 0 but keeps its place), so the bar does not jump.
+            SizedBox(
+              width: 42,
+              child: onBack == null
+                  ? null
+                  : OnboardingGlassBackButton(onTap: onBack!),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: OnboardingStoriesBar(
+                total: slideCount,
+                current: slideIndex,
+              ),
+            ),
+            if (onSkip != null) ...[
+              const SizedBox(width: 16),
+              OnboardingSkipButton(onTap: onSkip!),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// `.wizard-layout` — the visual pane at `0.95fr`, the content at `1.15fr`.
+  Widget _buildSlide(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 18, 24, 24),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(flex: 95, child: _buildVisual(context)),
+          const SizedBox(width: 28),
+          Expanded(flex: 115, child: _buildContent(context)),
+        ],
+      ),
+    );
+  }
+
+  /// `.wizard-visual` — a tinted panel holding the slide's icon.
+  Widget _buildVisual(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.03),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.06)),
+      ),
+      child: Center(child: OnboardingIconBubble(icon: icon)),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.only(top: 20, right: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title.tr(),
+                  style: const TextStyle(
+                    fontSize: 38,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                    height: 1.12,
+                  ),
+                ),
+                if (description != null) ...[
+                  const SizedBox(height: 12),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 640),
+                    child: Text(
+                      description!.tr(),
+                      style: TextStyle(
+                        fontSize: 16,
+                        height: 1.6,
+                        color: context.cs.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+                if (body != null) ...[const SizedBox(height: 22), body!],
+              ],
+            ),
+          ),
+        ),
+        // `.onboarding-footer` — the primary button spans the content pane.
+        Padding(
+          padding: const EdgeInsets.only(top: 16, right: 8),
+          child: OnboardingPrimaryButton(label: buttonLabel, onTap: onNext),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/onboarding/widgets/onboarding_widgets.dart
+++ b/lib/features/onboarding/widgets/onboarding_widgets.dart
@@ -1,0 +1,398 @@
+import 'dart:ui';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_colors.dart';
+import '../onboarding_models.dart';
+
+// ---------------------------------------------------------------------------
+// Reusable onboarding sub-widgets — shared by the phone flow and the desktop
+// wizard (see onboarding_desktop_wizard.dart).
+// ---------------------------------------------------------------------------
+
+/// Stories-style progress bar (Instagram / Telegram-like)
+class OnboardingStoriesBar extends StatelessWidget {
+  final int total;
+  final int current;
+  const OnboardingStoriesBar({
+    super.key,
+    required this.total,
+    required this.current,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: List.generate(total, (i) {
+        final filled = i <= current;
+        return Expanded(
+          child: Padding(
+            padding: EdgeInsets.only(
+              left: i == 0 ? 0 : 3,
+              right: i == total - 1 ? 0 : 3,
+            ),
+            child: Container(
+              height: 4,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(2),
+                color: const Color(0x33808080),
+              ),
+              child: AnimatedFractionallySizedBox(
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeOut,
+                alignment: Alignment.centerLeft,
+                widthFactor: filled ? 1.0 : 0.0,
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(2),
+                    color: context.cs.primary,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+/// Glass-morphism pill button to skip the entire onboarding (top-right)
+class OnboardingSkipButton extends StatelessWidget {
+  final VoidCallback onTap;
+  const OnboardingSkipButton({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(20),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+          child: Container(
+            height: 40,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: context.cs.surface.withValues(alpha: 0.8),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+              boxShadow: const [
+                BoxShadow(
+                  color: Color(0x4D000000),
+                  blurRadius: 15,
+                  offset: Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Text(
+              'onboarding_btn_skip_onboarding'.tr(),
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: context.cs.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Confirmation body shown inside the "Skip Onboarding?" bottom sheet.
+class OnboardingSkipConfirmSheet extends StatelessWidget {
+  final VoidCallback onCancel;
+  final VoidCallback onConfirm;
+  const OnboardingSkipConfirmSheet({
+    super.key,
+    required this.onCancel,
+    required this.onConfirm,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 4, 20, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'onboarding_skip_confirm_desc'.tr(),
+            style: TextStyle(
+              fontSize: 15,
+              height: 1.5,
+              color: context.cs.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 20),
+          GestureDetector(
+            onTap: onConfirm,
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 15),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: const Color(0xFFFF4444).withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: const Color(0xFFFF4444).withValues(alpha: 0.4),
+                ),
+              ),
+              child: Text(
+                'onboarding_skip_confirm_confirm'.tr(),
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: Color(0xFFFF6B6B),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          GestureDetector(
+            onTap: onCancel,
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 15),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+              ),
+              child: Text(
+                'onboarding_skip_confirm_cancel'.tr(),
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: context.cs.onSurface,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Glass-morphism circular back button
+class OnboardingGlassBackButton extends StatelessWidget {
+  final VoidCallback onTap;
+  const OnboardingGlassBackButton({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(20),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+          child: Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: context.cs.surface.withValues(alpha: 0.8),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+              boxShadow: const [
+                BoxShadow(
+                  color: Color(0x4D000000),
+                  blurRadius: 15,
+                  offset: Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Icon(Icons.arrow_back, size: 20, color: context.cs.primary),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Accent-tinted circular icon bubble (100×100)
+class OnboardingIconBubble extends StatelessWidget {
+  final IconData icon;
+  const OnboardingIconBubble({super.key, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 100,
+      height: 100,
+      decoration: BoxDecoration(
+        color: context.cs.primary.withValues(alpha: 0.1),
+        shape: BoxShape.circle,
+      ),
+      child: Icon(icon, size: 48, color: context.cs.primary),
+    );
+  }
+}
+
+/// Info block card (column layout) — for welcome/features slides
+class OnboardingIntroBlockCard extends StatelessWidget {
+  final OnboardingInfoBlock block;
+  const OnboardingIntroBlockCard({super.key, required this.block});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0x14808080),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(block.icon, size: 48, color: context.cs.primary),
+          const SizedBox(height: 8),
+          Text(
+            block.title.tr(),
+            style: const TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            block.desc.tr(),
+            style: TextStyle(
+              fontSize: 15,
+              color: context.cs.onSurfaceVariant,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Clickable action card — for data import / api / persona slides
+class OnboardingClickableBlock extends StatefulWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+  const OnboardingClickableBlock({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  @override
+  State<OnboardingClickableBlock> createState() =>
+      _OnboardingClickableBlockState();
+}
+
+class _OnboardingClickableBlockState extends State<OnboardingClickableBlock> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _pressed = true),
+      onTapUp: (_) {
+        setState(() => _pressed = false);
+        widget.onTap();
+      },
+      onTapCancel: () => setState(() => _pressed = false),
+      child: AnimatedScale(
+        scale: _pressed ? 0.98 : 1.0,
+        duration: const Duration(milliseconds: 100),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: _pressed ? const Color(0x26808080) : const Color(0x14808080),
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(widget.icon, size: 48, color: context.cs.primary),
+              const SizedBox(height: 8),
+              Text(
+                widget.title,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                widget.subtitle,
+                style: TextStyle(
+                  fontSize: 15,
+                  color: context.cs.onSurfaceVariant,
+                  height: 1.5,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Full-width accent primary button
+class OnboardingPrimaryButton extends StatefulWidget {
+  final String label;
+  final VoidCallback onTap;
+  const OnboardingPrimaryButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  State<OnboardingPrimaryButton> createState() =>
+      _OnboardingPrimaryButtonState();
+}
+
+class _OnboardingPrimaryButtonState extends State<OnboardingPrimaryButton> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _pressed = true),
+      onTapUp: (_) {
+        setState(() => _pressed = false);
+        widget.onTap();
+      },
+      onTapCancel: () => setState(() => _pressed = false),
+      child: AnimatedScale(
+        scale: _pressed ? 0.96 : 1.0,
+        duration: const Duration(milliseconds: 150),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          decoration: BoxDecoration(
+            color: context.cs.primary,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Text(
+            widget.label,
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              fontSize: 17,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/shell/desktop/desktop_glossary_popup.dart
+++ b/lib/shared/shell/desktop/desktop_glossary_popup.dart
@@ -6,6 +6,20 @@ import '../../../features/glossary/glossary_sheet.dart';
 
 final glossaryPopupVisibleProvider = StateProvider<bool>((ref) => false);
 
+/// Term the popup should open on, set by a [HelpTip] tap. Null opens the
+/// glossary at its category list.
+final glossaryPopupTermProvider = StateProvider<String?>((ref) => null);
+
+/// Opens the floating glossary window, optionally jumped straight to [term].
+///
+/// The window is mounted above the router (see `app.dart`), so it stays on top
+/// of whatever opened it — including the modal sheets that most help tips live
+/// in, which used to cover it when the popup rendered inside the shell.
+void openGlossaryPopup(WidgetRef ref, {String? term}) {
+  ref.read(glossaryPopupTermProvider.notifier).state = term;
+  ref.read(glossaryPopupVisibleProvider.notifier).state = true;
+}
+
 class DesktopGlossaryPopup extends ConsumerStatefulWidget {
   const DesktopGlossaryPopup({super.key});
 
@@ -23,7 +37,10 @@ class _DesktopGlossaryPopupState extends ConsumerState<DesktopGlossaryPopup> {
       _position += details.delta;
       _position = Offset(
         _position.dx.clamp(0, MediaQuery.of(context).size.width - _size.width),
-        _position.dy.clamp(0, MediaQuery.of(context).size.height - _size.height),
+        _position.dy.clamp(
+          0,
+          MediaQuery.of(context).size.height - _size.height,
+        ),
       );
     });
   }
@@ -32,6 +49,7 @@ class _DesktopGlossaryPopupState extends ConsumerState<DesktopGlossaryPopup> {
   Widget build(BuildContext context) {
     final visible = ref.watch(glossaryPopupVisibleProvider);
     if (!visible) return const SizedBox.shrink();
+    final term = ref.watch(glossaryPopupTermProvider);
 
     return Positioned(
       left: _position.dx,
@@ -73,17 +91,15 @@ class _DesktopGlossaryPopupState extends ConsumerState<DesktopGlossaryPopup> {
                         style: TextStyle(
                           fontSize: 14,
                           fontWeight: FontWeight.w600,
-                          color:
-                              Theme.of(context).colorScheme.onSurface,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                       ),
                     ),
                     IconButton(
                       icon: const Icon(Icons.close, size: 18),
                       onPressed: () {
-                        ref
-                            .read(glossaryPopupVisibleProvider.notifier)
-                            .state = false;
+                        ref.read(glossaryPopupVisibleProvider.notifier).state =
+                            false;
                       },
                       padding: EdgeInsets.zero,
                       constraints: const BoxConstraints(
@@ -97,7 +113,15 @@ class _DesktopGlossaryPopupState extends ConsumerState<DesktopGlossaryPopup> {
               ),
             ),
             // Content
-            Expanded(child: GlossarySheet(startExpanded: true)),
+            Expanded(
+              child: GlossarySheet(
+                // Keyed by term so re-opening on a different term rebuilds the
+                // sheet at that article instead of keeping the old one.
+                key: ValueKey(term),
+                initialTerm: term,
+                startExpanded: true,
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/shared/shell/desktop/desktop_left_sidebar.dart
+++ b/lib/shared/shell/desktop/desktop_left_sidebar.dart
@@ -27,8 +27,7 @@ class DesktopLeftSidebar extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState<DesktopLeftSidebar> createState() =>
-      _DesktopLeftSidebarState();
+  ConsumerState<DesktopLeftSidebar> createState() => _DesktopLeftSidebarState();
 }
 
 class _DesktopLeftSidebarState extends ConsumerState<DesktopLeftSidebar> {
@@ -92,7 +91,13 @@ class _DesktopLeftSidebarState extends ConsumerState<DesktopLeftSidebar> {
         icon: Icons.info_outline_rounded,
         onTap: () {
           if (isDesktopLayout(context)) {
-            ref.read(glossaryPopupVisibleProvider.notifier).update((v) => !v);
+            // Toggle; opening from here starts at the category list, so clear
+            // any term a help tip left behind.
+            if (ref.read(glossaryPopupVisibleProvider)) {
+              ref.read(glossaryPopupVisibleProvider.notifier).state = false;
+            } else {
+              openGlossaryPopup(ref);
+            }
           } else {
             context.go('/menu/glossary');
           }
@@ -114,9 +119,15 @@ class _DesktopLeftSidebarState extends ConsumerState<DesktopLeftSidebar> {
       ),
     ];
 
+    // Same as the right sidebar: chat runs its background edge to edge, so the
+    // gutters must not tint it darker at the sides.
+    final inChat = GoRouterState.of(
+      context,
+    ).uri.toString().startsWith('/chat/');
+
     return Container(
       width: controller.width,
-      color: Colors.black.withValues(alpha: 0.2),
+      color: inChat ? null : Colors.black.withValues(alpha: 0.2),
       child: Stack(
         children: [
           if (collapsed)
@@ -214,26 +225,30 @@ class _DesktopLeftSidebarState extends ConsumerState<DesktopLeftSidebar> {
     return Column(
       children: [
         const SizedBox(height: 8),
-        ...items.sublist(0, 2).map(
-          (item) => _CollapsedIcon(
-            icon: item.icon,
-            label: item.label,
-            active: item.active,
-            onTap: item.onTap,
-          ),
-        ),
+        ...items
+            .sublist(0, 2)
+            .map(
+              (item) => _CollapsedIcon(
+                icon: item.icon,
+                label: item.label,
+                active: item.active,
+                onTap: item.onTap,
+              ),
+            ),
         const SizedBox(height: 4),
         Divider(height: 1, color: context.cs.outlineVariant),
         Expanded(child: ChatHistoryList(collapsed: true)),
         Divider(height: 1, color: context.cs.outlineVariant),
-        ...items.sublist(2).map(
-          (item) => _CollapsedIcon(
-            icon: item.icon,
-            label: item.label,
-            active: item.active,
-            onTap: item.onTap,
-          ),
-        ),
+        ...items
+            .sublist(2)
+            .map(
+              (item) => _CollapsedIcon(
+                icon: item.icon,
+                label: item.label,
+                active: item.active,
+                onTap: item.onTap,
+              ),
+            ),
         const SizedBox(height: 8),
       ],
     );
@@ -285,8 +300,9 @@ class _HoverGlowButtonState extends State<_HoverGlowButton> {
   @override
   Widget build(BuildContext context) {
     final primary = context.cs.primary;
-    final inactive =
-        widget.prominent ? context.cs.onSurface : context.cs.onSurfaceVariant;
+    final inactive = widget.prominent
+        ? context.cs.onSurface
+        : context.cs.onSurfaceVariant;
     final color = widget.active ? primary : inactive;
 
     return MouseRegion(
@@ -332,10 +348,11 @@ class _HoverGlowButtonState extends State<_HoverGlowButton> {
                       const SizedBox(width: 10),
                       Text(
                         widget.label,
-                        style: (widget.prominent
-                                ? Theme.of(context).textTheme.labelLarge
-                                : Theme.of(context).textTheme.labelMedium)
-                            ?.copyWith(color: color),
+                        style:
+                            (widget.prominent
+                                    ? Theme.of(context).textTheme.labelLarge
+                                    : Theme.of(context).textTheme.labelMedium)
+                                ?.copyWith(color: color),
                       ),
                     ],
                   ),
@@ -451,8 +468,7 @@ class _CollapsedIconState extends State<_CollapsedIcon> {
                       child: Icon(
                         widget.icon,
                         size: 22,
-                        color:
-                            widget.active ? primary : context.cs.onSurface,
+                        color: widget.active ? primary : context.cs.onSurface,
                       ),
                     ),
                   ],

--- a/lib/shared/shell/desktop/desktop_right_sidebar.dart
+++ b/lib/shared/shell/desktop/desktop_right_sidebar.dart
@@ -2,9 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../features/chat/services/magic_drawer_actions.dart';
+import '../../../features/chat/services/magic_drawer_layout_service.dart';
+import '../../../features/chat/state/magic_drawer_stats_cache.dart';
 import '../../../features/chat/widgets/magic_drawer.dart';
+import '../../../features/chat/widgets/magic_drawer_models.dart';
 import '../../../features/tools/tools_screen.dart';
-import '../../../shared/theme/app_colors.dart';
+import 'desktop_tool_strip.dart';
 import 'sidebar_drag_handle.dart';
 import 'sidebar_resizer.dart';
 import 'sidebar_sheet_provider.dart';
@@ -18,6 +22,30 @@ class DesktopRightSidebar extends ConsumerStatefulWidget {
 }
 
 class _DesktopRightSidebarState extends ConsumerState<DesktopRightSidebar> {
+  /// Quick Access order, resolved once so the chat strip can show the same
+  /// entries (and the same order) as the full panel. Null until the first load
+  /// lands; the strip falls back to the default catalogue meanwhile.
+  List<String>? _quickAccessIds;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadQuickAccessLayout();
+  }
+
+  Future<void> _loadQuickAccessLayout() async {
+    final cached = ref.read(magicDrawerLayoutCacheProvider);
+    if (cached != null) {
+      setState(() => _quickAccessIds = cached.itemIds);
+      return;
+    }
+    final layout = await MagicDrawerLayoutService(
+      ref,
+    ).loadLayout(MagicDrawerActions.all);
+    if (!mounted) return;
+    setState(() => _quickAccessIds = layout.itemIds);
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = ref.watch(rightSidebarControllerProvider);
@@ -25,6 +53,14 @@ class _DesktopRightSidebarState extends ConsumerState<DesktopRightSidebar> {
     final location = GoRouterState.of(context).uri.toString();
     final isChat = location.startsWith('/chat/');
     final collapsed = controller.collapsed;
+
+    // Keep the strip's copy of the Quick Access order in step with edits made
+    // in the full panel (reorder, remove, re-add).
+    ref.listen(magicDrawerLayoutCacheProvider, (_, next) {
+      if (next != null && mounted) {
+        setState(() => _quickAccessIds = next.itemIds);
+      }
+    });
 
     // Auto-expand / restore for sheets
     if (sheet != null && collapsed) {
@@ -42,22 +78,22 @@ class _DesktopRightSidebarState extends ConsumerState<DesktopRightSidebar> {
       listenable: controller,
       builder: (context, _) => Container(
         width: controller.width,
-        color: Colors.black.withValues(alpha: 0.2),
+        // No extra tint in chat: it would band the chat's own background at
+        // the left and right edges instead of carrying straight through.
+        color: isChat ? null : Colors.black.withValues(alpha: 0.2),
         child: Stack(
           children: [
             if (sheet != null)
-              _buildSheetHost(sheet)
+              _buildSheetHost(sheet, isChat, location, controller.collapsed)
             else if (controller.collapsed)
-              _buildCollapsed(isChat)
+              _buildStrip(isChat, location)
             else
               _buildExpanded(isChat, location),
             Positioned(
               top: 0,
               bottom: 0,
               left: 0,
-              child: SidebarDragHandle.right(
-                rightController: controller,
-              ),
+              child: SidebarDragHandle.right(rightController: controller),
             ),
           ],
         ),
@@ -65,8 +101,45 @@ class _DesktopRightSidebarState extends ConsumerState<DesktopRightSidebar> {
     );
   }
 
-  Widget _buildSheetHost(Widget sheet) {
-    return Material(color: Colors.transparent, child: sheet);
+  /// A sheet open in the sidebar. While the sidebar is expanded the icon strip
+  /// pins itself to the sheet's left edge (Vue's `.left-icon-strip`) so the
+  /// other entries stay reachable — Tools and chat Quick Access alike. A
+  /// collapsed sidebar has no room for both, so the sheet takes it all.
+  Widget _buildSheetHost(
+    Widget sheet,
+    bool isChat,
+    String location,
+    bool collapsed,
+  ) {
+    final host = Material(color: Colors.transparent, child: sheet);
+    if (collapsed) return host;
+
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Padding(
+            padding: const EdgeInsets.only(left: DesktopToolStrip.overlayWidth),
+            child: host,
+          ),
+        ),
+        Positioned(
+          top: 0,
+          bottom: 0,
+          left: 0,
+          width: DesktopToolStrip.overlayWidth,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              border: Border(
+                right: BorderSide(color: Colors.white.withValues(alpha: 0.05)),
+              ),
+            ),
+            // Clears the sheet header, exactly as `.left-icon-strip`'s 56px
+            // top padding does in the Vue build.
+            child: _buildStrip(isChat, location, topPadding: 56),
+          ),
+        ),
+      ],
+    );
   }
 
   Widget _buildExpanded(bool isChat, String location) {
@@ -84,112 +157,79 @@ class _DesktopRightSidebarState extends ConsumerState<DesktopRightSidebar> {
     return MagicDrawerPanel(charId: charId);
   }
 
-  Widget _buildCollapsed(bool isChat) {
-    if (isChat) {
-      return Center(
-        child: Icon(
-          Icons.auto_awesome,
-          size: 28,
-          color: context.cs.onSurface.withValues(alpha: 0.5),
-        ),
-      );
+  /// The icon strip for whichever mode the sidebar is in. Chat shows Quick
+  /// Access, everything else shows Tools — the two were built separately
+  /// before, which is why only Tools had a working strip.
+  Widget _buildStrip(bool isChat, String location, {double topPadding = 0}) {
+    final items = isChat
+        ? _quickAccessItems(location)
+        : _toolStripItems(location);
+    return DesktopToolStrip(
+      items: items,
+      activeId: isChat ? null : _activeToolId(location),
+      topPadding: topPadding,
+    );
+  }
+
+  // ── Tools mode ──────────────────────────────────────────────────────────
+
+  static const _toolRoutes = <({String id, IconData icon, String label})>[
+    (id: 'personas', icon: Icons.manage_accounts, label: 'Personas'),
+    (id: 'presets', icon: Icons.description, label: 'Presets'),
+    (id: 'api', icon: Icons.cloud, label: 'API'),
+    (id: 'lorebooks', icon: Icons.library_books, label: 'Lorebooks'),
+    (id: 'regex', icon: Icons.code, label: 'Regex'),
+  ];
+
+  List<DesktopToolStripItem> _toolStripItems(String location) {
+    return _toolRoutes
+        .map(
+          (tool) => DesktopToolStripItem(
+            id: tool.id,
+            icon: tool.icon,
+            label: tool.label,
+            onTap: () => context.push('/tools/${tool.id}'),
+          ),
+        )
+        .toList();
+  }
+
+  String? _activeToolId(String location) {
+    for (final tool in _toolRoutes) {
+      if (location.contains('/tools/${tool.id}')) return tool.id;
     }
-    return _buildToolStrip();
+    return null;
   }
 
-  /// Port of Vue `.tools-strip` (DesktopRightSidebar.vue lines 418-517).
-  /// 5 icons: Personas, Presets, API, Lorebook, Regex.
-  Widget _buildToolStrip() {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _buildStripIcon(
-            _ToolStripSvg.personas,
-            'Personas',
-            active: _isActiveRoute('/tools/personas'),
-            onTap: () => context.push('/tools/personas'),
-          ),
-          _buildStripIcon(
-            _ToolStripSvg.presets,
-            'Presets',
-            active: _isActiveRoute('/tools/presets'),
-            onTap: () => context.push('/tools/presets'),
-          ),
-          _buildStripIcon(
-            _ToolStripSvg.api,
-            'API',
-            active: _isActiveRoute('/tools/api'),
-            onTap: () => context.push('/tools/api'),
-          ),
-          _buildStripIcon(
-            _ToolStripSvg.lorebook,
-            'Lorebooks',
-            active: _isActiveRoute('/tools/lorebooks'),
-            onTap: () => context.push('/tools/lorebooks'),
-          ),
-          _buildStripIcon(
-            _ToolStripSvg.regex,
-            'Regex',
-            active: _isActiveRoute('/tools/regex'),
-            onTap: () => context.push('/tools/regex'),
-          ),
-        ],
-      ),
-    );
-  }
+  // ── Chat mode (Quick Access) ────────────────────────────────────────────
 
-  bool _isActiveRoute(String path) {
-    final location = GoRouterState.of(context).uri.toString();
-    return location.contains(path);
-  }
+  List<DesktopToolStripItem> _quickAccessItems(String location) {
+    final charId = _extractCharId(location);
+    if (charId == null) return const [];
 
-  Widget _buildStripIcon(
-    String svgPath,
-    String tooltip, {
-    bool active = false,
-    VoidCallback? onTap,
-  }) {
-    return Tooltip(
-      message: tooltip,
-      preferBelow: false,
-      child: GestureDetector(
-        onTap: onTap,
-        child: Container(
-          width: 64,
-          height: 48,
-          decoration: BoxDecoration(
-            color: active
-                ? const Color(0x14528BCC) // rgba(82,139,204,0.08)
-                : Colors.transparent,
-            border: Border(
-              bottom: BorderSide(color: Colors.white.withValues(alpha: 0.05)),
-            ),
-          ),
-          child: Center(
-            child: Container(
-              width: 28,
-              height: 28,
-              padding: const EdgeInsets.all(5),
-              decoration: BoxDecoration(
-                color: active
-                    ? const Color(0x26528BCC) // rgba(82,139,204,0.15)
-                    : Colors.white.withValues(alpha: 0.1),
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: _svgIcon(svgPath),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+    final ids = _quickAccessIds;
+    final defs = ids == null
+        ? MagicDrawerActions.all
+        : ids
+              .map(
+                (id) => MagicDrawerActions.all
+                    .where((item) => item.id == id)
+                    .firstOrNull,
+              )
+              .whereType<MagicDrawerItemDef>()
+              .toList();
 
-  Widget _svgIcon(String path) {
-    return CustomPaint(
-      size: const Size(18, 18),
-      painter: _SvgPathPainter(path),
-    );
+    final actions = MagicDrawerActions(charId: charId);
+    return defs
+        .map(
+          (def) => DesktopToolStripItem(
+            id: def.id,
+            icon: def.icon,
+            label: def.label,
+            onTap: () => actions.handleTap(context, ref, def),
+          ),
+        )
+        .toList();
   }
 
   String? _extractCharId(String location) {
@@ -204,74 +244,4 @@ class _DesktopRightSidebarState extends ConsumerState<DesktopRightSidebar> {
     }
     return null;
   }
-}
-
-/// Minimal SVG path painter for tool strip icons.
-class _SvgPathPainter extends CustomPainter {
-  final String path;
-  _SvgPathPainter(this.path);
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final paint =
-        Paint()
-          ..color = Colors.white.withValues(alpha: 0.8)
-          ..style = PaintingStyle.fill;
-    // Scale to fit
-    canvas.save();
-    canvas.scale(size.width / 24, size.height / 24);
-    _drawSvgPath(canvas, paint, path);
-    canvas.restore();
-  }
-
-  @override
-  bool shouldRepaint(covariant _SvgPathPainter oldDelegate) =>
-      oldDelegate.path != path;
-}
-
-/// Simple SVG path parser — handles M, C, L, Z commands.
-void _drawSvgPath(Canvas canvas, Paint paint, String d) {
-  final path = Path();
-  final parts = d.split(RegExp(r'[,\s]+'));
-  int i = 0;
-  while (i < parts.length) {
-    final cmd = parts[i];
-    if (cmd == 'M') {
-      path.moveTo(double.parse(parts[i + 1]), double.parse(parts[i + 2]));
-      i += 3;
-    } else if (cmd == 'C') {
-      path.cubicTo(
-        double.parse(parts[i + 1]),
-        double.parse(parts[i + 2]),
-        double.parse(parts[i + 3]),
-        double.parse(parts[i + 4]),
-        double.parse(parts[i + 5]),
-        double.parse(parts[i + 6]),
-      );
-      i += 7;
-    } else if (cmd == 'L') {
-      path.lineTo(double.parse(parts[i + 1]), double.parse(parts[i + 2]));
-      i += 3;
-    } else if (cmd == 'Z' || cmd == 'z') {
-      path.close();
-      i += 1;
-    } else {
-      i += 1; // Skip unknown
-    }
-  }
-  canvas.drawPath(path, paint);
-}
-
-/// SVG paths matching ToolsView.vue icons.
-abstract final class _ToolStripSvg {
-  static const personas =
-      'M19 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm6 12H6v-1c0-2 4-3.1 6-3.1s6 1.1 6 3.1v1z';
-  static const presets =
-      'M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6h-6V2zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z';
-  static const api =
-      'M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96z';
-  static const lorebook =
-      'M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z';
-  static const regex =
-      'M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z';
 }

--- a/lib/shared/shell/desktop/desktop_shell.dart
+++ b/lib/shared/shell/desktop/desktop_shell.dart
@@ -8,7 +8,6 @@ import '../../widgets/glaze_scaffold.dart' show GlazeAppBar;
 import '../animated_header_below.dart';
 import '../shell_header_provider.dart';
 import 'desktop_floating_provider.dart';
-import 'desktop_glossary_popup.dart';
 import 'desktop_layout_provider.dart';
 import 'desktop_left_sidebar.dart';
 import 'desktop_right_sidebar.dart';
@@ -60,11 +59,11 @@ class _DesktopShellState extends ConsumerState<DesktopShell> {
           isDesktop: true,
           child: ProviderScope(
             overrides: [
-              leftSidebarControllerProvider
-                  .overrideWithValue(_leftController!),
+              leftSidebarControllerProvider.overrideWithValue(_leftController!),
               if (_rightController != null)
-                rightSidebarControllerProvider
-                    .overrideWithValue(_rightController!),
+                rightSidebarControllerProvider.overrideWithValue(
+                  _rightController!,
+                ),
             ],
             child: _buildDesktopLayout(context),
           ),
@@ -106,8 +105,6 @@ class _DesktopShellState extends ConsumerState<DesktopShell> {
               ref.read(desktopFloatingProvider).close();
             },
           ),
-          // Glossary corner popup
-          const DesktopGlossaryPopup(),
         ],
       ),
     );
@@ -138,10 +135,7 @@ class _DesktopHeader extends ConsumerWidget {
       // rows stay flush with the header's top edge during the cross-fade.
       layoutBuilder: (currentChild, previousChildren) => Stack(
         alignment: Alignment.topCenter,
-        children: [
-          ...previousChildren,
-          ?currentChild,
-        ],
+        children: [...previousChildren, ?currentChild],
       ),
       child: entry == null || entry.config.hidden
           ? const SizedBox.shrink(key: ValueKey('desktop-header-empty'))

--- a/lib/shared/shell/desktop/desktop_tool_strip.dart
+++ b/lib/shared/shell/desktop/desktop_tool_strip.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_colors.dart';
+
+/// One entry of a [DesktopToolStrip].
+class DesktopToolStripItem {
+  final String id;
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const DesktopToolStripItem({
+    required this.id,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+}
+
+/// The narrow icon column of the desktop right sidebar — port of Vue's
+/// `.tools-strip` (DesktopRightSidebar.vue).
+///
+/// It stands in for the sidebar's full content in two situations, and both
+/// modes of the sidebar (Tools and chat Quick Access) use it the same way:
+///
+/// * the sidebar is collapsed, so the strip *is* the sidebar; and
+/// * a sheet is open in an expanded sidebar, where the strip pins itself to
+///   the sheet's left edge so the other entries stay one click away.
+///
+/// Items stack from the **top**, matching the Vue original — the column used
+/// to be vertically centred here, which floated the icons away from the header
+/// and left a gap the reference build never had.
+class DesktopToolStrip extends StatelessWidget {
+  final List<DesktopToolStripItem> items;
+
+  /// Id of the entry whose sheet is currently open, tinted like Vue's
+  /// `.magic-item.active`. Null when nothing is open.
+  final String? activeId;
+
+  /// Room left above the first icon so the strip clears the sheet header when
+  /// it overlays one. Mirrors `.left-icon-strip { padding-top: 56px }`.
+  final double topPadding;
+
+  const DesktopToolStrip({
+    super.key,
+    required this.items,
+    this.activeId,
+    this.topPadding = 0,
+  });
+
+  /// Width of the strip when it overlays an open sheet
+  /// (`.left-icon-strip { width: 60px }`).
+  static const double overlayWidth = 60;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      // Top-aligned: the column starts under [topPadding] and grows down.
+      padding: EdgeInsets.only(top: topPadding),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: items
+            .map((item) => _StripIcon(item: item, active: item.id == activeId))
+            .toList(),
+      ),
+    );
+  }
+}
+
+class _StripIcon extends StatefulWidget {
+  final DesktopToolStripItem item;
+  final bool active;
+
+  const _StripIcon({required this.item, required this.active});
+
+  @override
+  State<_StripIcon> createState() => _StripIconState();
+}
+
+class _StripIconState extends State<_StripIcon> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    // `.tools-strip .magic-item` — a full-width row, bottom-ruled, whose
+    // background tints on hover and while its sheet is open.
+    final Color background = widget.active
+        ? const Color(0x14528BCC) // rgba(82,139,204,0.08)
+        : _hovered
+        ? Colors.white.withValues(alpha: 0.04)
+        : Colors.transparent;
+
+    return Tooltip(
+      message: widget.item.label,
+      preferBelow: false,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setState(() => _hovered = true),
+        onExit: (_) => setState(() => _hovered = false),
+        child: GestureDetector(
+          onTap: widget.item.onTap,
+          child: Container(
+            width: double.infinity,
+            height: 48,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: background,
+              border: Border(
+                bottom: BorderSide(color: Colors.white.withValues(alpha: 0.05)),
+              ),
+            ),
+            child: Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: widget.active
+                    ? const Color(0x26528BCC) // rgba(82,139,204,0.15)
+                    : Colors.white.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(
+                widget.item.icon,
+                size: 18,
+                color: widget.active
+                    ? context.cs.primary
+                    : Colors.white.withValues(alpha: 0.8),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/shell/desktop/desktop_window_view.dart
+++ b/lib/shared/shell/desktop/desktop_window_view.dart
@@ -5,6 +5,7 @@ import '../../../features/cloud_sync/widgets/sync_sheet.dart';
 import '../../../features/menu/menu_screen.dart';
 import '../../../features/settings/app_settings_screen.dart';
 import '../../../features/settings/theme_preset_screen.dart';
+import '../../widgets/menu_group.dart';
 import 'desktop_floating_provider.dart';
 
 class DesktopWindowView extends ConsumerWidget {
@@ -45,7 +46,9 @@ class DesktopWindowView extends ConsumerWidget {
             ),
             child: ClipRRect(
               borderRadius: BorderRadius.circular(16),
-              child: _buildContent(viewId),
+              // The window is itself a framed panel, so the menu groups inside
+              // drop their own cards and run edge to edge.
+              child: MenuGroupFlatScope(child: _buildContent(viewId)),
             ),
           ),
         ),

--- a/lib/shared/widgets/glaze_scaffold.dart
+++ b/lib/shared/widgets/glaze_scaffold.dart
@@ -31,6 +31,13 @@ class GlazeScaffold extends StatelessWidget {
   /// strip reproduce it (see [GlassSurface.blurViaWebView]).
   final bool headerBlurViaWebView;
 
+  /// Draws the header edge to edge with square corners, the way the desktop
+  /// shell paints a tab's header, instead of as an inset floating pill.
+  ///
+  /// Chat uses it on desktop so its header matches the Characters tab beside
+  /// it; the pill treatment stays everywhere else.
+  final bool flushHeader;
+
   /// When true, this scaffold does not draw its own floating header. Instead it
   /// publishes its title/actions/back into the shell's persistent header (see
   /// [shellHeaderProvider]) and reserves the same vertical space. Only set this
@@ -57,6 +64,7 @@ class GlazeScaffold extends StatelessWidget {
     this.useShellHeader = false,
     this.headerBranchIndex,
     this.headerBlurViaWebView = false,
+    this.flushHeader = false,
   });
 
   @override
@@ -80,7 +88,9 @@ class GlazeScaffold extends StatelessWidget {
     final header = SafeArea(
       bottom: false,
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+        padding: flushHeader
+            ? EdgeInsets.zero
+            : const EdgeInsets.fromLTRB(16, 10, 16, 0),
         child: GlazeAppBar(
           title: title,
           titleWidget: titleWidget,
@@ -88,6 +98,9 @@ class GlazeScaffold extends StatelessWidget {
           showBack: showBack,
           onBack: backHandler,
           blurViaWebView: headerBlurViaWebView,
+          borderRadius: flushHeader
+              ? BorderRadius.zero
+              : const BorderRadius.all(Radius.circular(20)),
         ),
       ),
     );
@@ -149,9 +162,7 @@ class GlazeScaffold extends StatelessWidget {
     );
 
     final withBackground = showBackground
-        ? GlazeBackground(
-            child: scaffold,
-          )
+        ? GlazeBackground(child: scaffold)
         : scaffold;
 
     if (!useShellHeader) return withBackground;
@@ -301,10 +312,7 @@ class GlazeAppBar extends ConsumerWidget {
             if (actions != null)
               Padding(
                 padding: const EdgeInsets.only(right: 4),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: actions!,
-                ),
+                child: Row(mainAxisSize: MainAxisSize.min, children: actions!),
               )
             else
               const SizedBox(width: 12),

--- a/lib/shared/widgets/help_tip.dart
+++ b/lib/shared/widgets/help_tip.dart
@@ -3,9 +3,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../features/glossary/glossary_sheet.dart';
 import '../../features/settings/app_settings_provider.dart';
+import '../shell/desktop/desktop_glossary_popup.dart';
+import '../shell/desktop/desktop_layout_provider.dart';
 
-/// Small inline help button — opens the [GlossarySheet] at a specific term.
-/// Hidden globally when `hideTooltips` is on in app settings.
+/// Small inline help button — opens the glossary at a specific term.
+///
+/// On desktop that is the floating glossary window, which outlives the sheet
+/// the tip was tapped in and stays on top of it; elsewhere it is the usual
+/// modal [GlossarySheet]. Hidden globally when `hideTooltips` is on in app
+/// settings.
 class HelpTip extends ConsumerWidget {
   final String term;
   final double size;
@@ -30,7 +36,9 @@ class HelpTip extends ConsumerWidget {
         shape: const CircleBorder(),
         child: InkWell(
           customBorder: const CircleBorder(),
-          onTap: () => GlossarySheet.show(context, initialTerm: term),
+          onTap: () => isDesktopLayout(context)
+              ? openGlossaryPopup(ref, term: term)
+              : GlossarySheet.show(context, initialTerm: term),
           child: SizedBox(
             width: 20,
             height: 20,

--- a/lib/shared/widgets/menu_group.dart
+++ b/lib/shared/widgets/menu_group.dart
@@ -5,6 +5,23 @@ import '../theme/app_colors.dart';
 import 'glass_surface.dart';
 import 'help_tip.dart';
 
+/// Marks a subtree as living inside the desktop floating window, where
+/// [MenuGroup] drops its side gutters and left/right edges.
+///
+/// A window is already a framed, fixed-width panel; the groups' own rounded
+/// cards repeated that frame one level in, so the content read as a card of
+/// cards. Inside one, groups run edge to edge and separate with plain rules
+/// instead — see [MenuGroup.build].
+class MenuGroupFlatScope extends InheritedWidget {
+  const MenuGroupFlatScope({super.key, required super.child});
+
+  static bool of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<MenuGroupFlatScope>() != null;
+
+  @override
+  bool updateShouldNotify(MenuGroupFlatScope oldWidget) => false;
+}
+
 enum MenuGroupHeaderVariant { standard, accentCaps }
 
 // ── Collapsible section ────────────────────────────────────────────────────────
@@ -36,17 +53,23 @@ class _MenuCollapsibleSectionState extends State<MenuCollapsibleSection> {
 
   @override
   Widget build(BuildContext context) {
+    final flat = MenuGroupFlatScope.of(context);
+    final radius = flat ? BorderRadius.zero : BorderRadius.circular(20);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+          padding: flat
+              ? EdgeInsets.zero
+              : const EdgeInsets.fromLTRB(16, 0, 16, 12),
           child: GlassSurface(
             enableRipple: true,
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(color: context.cs.outlineVariant),
+            borderRadius: radius,
+            border: flat
+                ? Border(bottom: BorderSide(color: context.cs.outlineVariant))
+                : Border.all(color: context.cs.outlineVariant),
             child: InkWell(
-              borderRadius: BorderRadius.circular(20),
+              borderRadius: radius,
               onTap: () {
                 Haptics.selectionClick();
                 setState(() => _expanded = !_expanded);
@@ -122,20 +145,39 @@ class MenuGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final flat = MenuGroupFlatScope.of(context);
+    final body = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (header != null) _buildHeader(context),
+        ...items,
+        const SizedBox(height: 6),
+      ],
+    );
+
+    // Inside a desktop window the group runs edge to edge: no side gutters, no
+    // left/right edges, and no corner rounding — only the rules above and
+    // below still separate one group from the next.
+    if (flat) {
+      return DecoratedBox(
+        decoration: BoxDecoration(
+          border: Border(bottom: BorderSide(color: context.cs.outlineVariant)),
+        ),
+        child: GlassSurface(
+          enableRipple: true,
+          borderRadius: BorderRadius.zero,
+          child: body,
+        ),
+      );
+    }
+
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
       child: GlassSurface(
         enableRipple: true,
         borderRadius: BorderRadius.circular(20),
         border: Border.all(color: context.cs.outlineVariant),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (header != null) _buildHeader(context),
-            ...items,
-            const SizedBox(height: 6),
-          ],
-        ),
+        child: body,
       ),
     );
   }

--- a/test/magic_drawer_refresh_test.dart
+++ b/test/magic_drawer_refresh_test.dart
@@ -20,23 +20,34 @@ void main() {
     });
 
     test('refreshes stats after every action route closes', () {
-      final source = File(
-        'lib/features/chat/widgets/magic_drawer.dart',
+      // The dispatch lives in MagicDrawerActions, shared with the desktop
+      // sidebar strip. Its half of the contract is that every action is
+      // awaited inside a try/finally that runs the caller's [onFinished].
+      final actions = File(
+        'lib/features/chat/services/magic_drawer_actions.dart',
       ).readAsStringSync();
 
-      final handlerStart = source.indexOf(
-        'Future<void> _handleTap(MagicDrawerItemDef item)',
-      );
-      final nextMethod = source.indexOf(
-        'Future<void> _showAgentOpsLog()',
+      final handlerStart = actions.indexOf('Future<void> handleTap(');
+      final nextMethod = actions.indexOf(
+        'Future<void> _showCardRewriter(',
         handlerStart,
       );
-      final handler = source.substring(handlerStart, nextMethod);
+      expect(handlerStart, isNonNegative);
+      expect(nextMethod, greaterThan(handlerStart));
+      final handler = actions.substring(handlerStart, nextMethod);
 
       expect(handler, contains('try {'));
       expect(handler, contains('finally {'));
-      expect(handler, contains('if (mounted) await _refreshStats();'));
+      expect(handler, contains('if (onFinished != null) await onFinished();'));
       expect(handler, contains('await showPromptInspectorSheet('));
+
+      // The panel's half: it hands in a refresh, so a closed route still
+      // brings the card subtitles back up to date.
+      final panel = File(
+        'lib/features/chat/widgets/magic_drawer.dart',
+      ).readAsStringSync();
+      expect(panel, contains('_actions.handleTap('));
+      expect(panel, contains('if (mounted) await _refreshStats();'));
     });
 
     test('rejects token results calculated from an older stats snapshot', () {


### PR DESCRIPTION
Closed in favour of hydall/Glaze#366.

This branch was cut from `b40587a` (25 Aug, #311) because the session's workspace was a stale shallow clone whose `origin/nightly` ref sat 52 commits behind the real branch. The diff was therefore computed against a week-old tree, which is where the conflicts came from — and worse, #352 and #363 had since landed much of the same ground, so parts of this PR were a competing reimplementation rather than a change.

#366 redoes the work on top of the current `nightly` and only covers what is actually still missing.