### PR TITLE
feat(desktop): finish the PC-interface parity pass against legacy-vue

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -39,6 +39,7 @@ import 'features/chat/widgets/chat_webview_preload.dart';
 import 'features/chat/widgets/continue_failure_listener.dart';
 import 'features/chat/widgets/lorebook_vector_search_diagnostic_listener.dart';
 import 'shared/widgets/app_launch_splash.dart';
+import 'shared/shell/desktop/desktop_glossary_popup.dart';
 import 'shared/widgets/build_watermark.dart';
 import 'shared/widgets/glaze_toast.dart' show toastOverlayKey;
 import 'shared/widgets/stretch_overscroll.dart';
@@ -367,6 +368,10 @@ class _GlazeAppState extends ConsumerState<GlazeApp>
             child: Stack(
               children: [
                 Positioned.fill(child: appChild),
+                // Above the router, so the glossary window a help tip opens
+                // floats over every route, sheet and dialog rather than being
+                // buried by the one it was opened from.
+                const DesktopGlossaryPopup(),
                 const BuildWatermark(),
               ],
             ),

--- a/lib/features/character_list/character_list_screen.dart
+++ b/lib/features/character_list/character_list_screen.dart
@@ -15,6 +15,7 @@ import '../../core/services/character_export_helper.dart';
 import '../../core/services/character_bulk_import_service.dart';
 import '../../core/state/character_folder_provider.dart';
 import '../../core/state/character_provider.dart';
+import '../../shared/shell/desktop/desktop_layout_provider.dart';
 import '../../shared/shell/header_scroll_hider.dart';
 import '../../shared/shell/nav_height_provider.dart';
 import '../../shared/shell/nav_retap_provider.dart';
@@ -80,6 +81,10 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
   // step with the shell header. This constant is the block it occupies (its top
   // padding + the bar itself) so content can reserve room.
   static const double _kTabBarBlock = 52.0;
+
+  /// Width the desktop tab strip settles at, leaving the rest of the row to
+  /// the Add button (Vue's `.tabs-row`). Mobile keeps a full-width strip.
+  static const double _kTabStripWidth = 420.0;
 
   // Owns one scroll position per sub-tab (the grids attach via
   // PrimaryScrollController), so tapping the active tab can animate it back to
@@ -204,8 +209,12 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
             ],
       // The tabs ride inside the header (only at the top level) so they hide and
       // reveal as a single unit with it — one animation, not two. Dropped
-      // entirely when the catalog is disabled (only "My Characters" remains).
-      below: (catalogVisible && !inFolder) ? _buildTabBar() : null,
+      // entirely when the catalog is disabled (only "My Characters" remains) —
+      // except on desktop, where the same row also carries the Add button and
+      // so outlives a hidden catalog.
+      below: (!inFolder && (catalogVisible || isDesktopLayout(context)))
+          ? _buildTabBar()
+          : null,
     );
   }
 
@@ -424,7 +433,11 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     // extra room for the tabs row when it's present so content clears it.
     final inFolder = effectiveTab == 0 && _currentFolderId != null;
     final showTabBar = catalogVisible && !inFolder;
-    final contentTopPad = showTabBar ? topPad + _kTabBarBlock : topPad;
+    // The desktop row survives a hidden catalog because Add lives in it, so
+    // the content below still has to clear it.
+    final showHeaderRow =
+        !inFolder && (catalogVisible || isDesktopLayout(context));
+    final contentTopPad = showHeaderRow ? topPad + _kTabBarBlock : topPad;
 
     // While inside a folder, intercept the system/gesture back so it pops out to
     // the top-level grid instead of bubbling up to the shell (which would exit
@@ -518,6 +531,12 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
                               .clear(),
                           onMore: () =>
                               _showSelectionActions(context, selection),
+                        )
+                      // Desktop moves Add into the tabs row, so the slot
+                      // there holds nothing but the selection bar.
+                      : isDesktopLayout(context)
+                      ? const SizedBox.shrink(
+                          key: ValueKey('add_button_hidden'),
                         )
                       : Align(
                           key: const ValueKey('add_button'),
@@ -925,31 +944,67 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
     // horizontal padding — only the gap under the app bar is needed here.
     return Padding(
       padding: const EdgeInsets.only(top: 10),
-      child: GlazeTabBar(
-        tabs: [
-          GlazeTabItem(
-            label: 'tab_my_characters'.tr(),
-            icon: Icons.person_rounded,
+      child: isDesktopLayout(context)
+          ? _buildDesktopTabsRow()
+          : _buildTabStrip(),
+    );
+  }
+
+  /// Vue's `.tabs-row`: the strip keeps its natural width on the left and the
+  /// Add button sits at the far right, instead of the strip spanning the whole
+  /// window with Add floating over the grid.
+  Widget _buildDesktopTabsRow() {
+    final catalogVisible = ref.watch(catalogVisibleProvider);
+    return Row(
+      children: [
+        Expanded(
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: catalogVisible
+                ? ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      maxWidth: _kTabStripWidth,
+                    ),
+                    child: _buildTabStrip(),
+                  )
+                : const SizedBox.shrink(),
           ),
-          GlazeTabItem(label: 'tab_catalog'.tr(), icon: Icons.public_rounded),
+        ),
+        // Mirrors `v-if="activeTab === 'characters'"` — Discover holds nothing
+        // of the user's to add to.
+        if (_tabIndex == 0 || !catalogVisible) ...[
+          const SizedBox(width: 12),
+          _AddButton(height: 42, onTap: () => _showAddSheet(context, ref)),
         ],
-        activeIndex: _tabIndex,
-        onChanged: (i) {
-          // Tapping the already-active tab scrolls its list back to the top.
-          if (i == _tabIndex) {
-            _scrollToTop();
-            _showHeader();
-            return;
-          }
-          ref.read(characterSelectionProvider.notifier).clear();
+      ],
+    );
+  }
+
+  Widget _buildTabStrip() {
+    return GlazeTabBar(
+      tabs: [
+        GlazeTabItem(
+          label: 'tab_my_characters'.tr(),
+          icon: Icons.person_rounded,
+        ),
+        GlazeTabItem(label: 'tab_catalog'.tr(), icon: Icons.public_rounded),
+      ],
+      activeIndex: _tabIndex,
+      onChanged: (i) {
+        // Tapping the already-active tab scrolls its list back to the top.
+        if (i == _tabIndex) {
+          _scrollToTop();
           _showHeader();
-          setState(() {
-            _switchTab(i);
-            if (_searchExpanded) _applySearchForActiveTab();
-          });
-          refreshShellHeader();
-        },
-      ),
+          return;
+        }
+        ref.read(characterSelectionProvider.notifier).clear();
+        _showHeader();
+        setState(() {
+          _switchTab(i);
+          if (_searchExpanded) _applySearchForActiveTab();
+        });
+        refreshShellHeader();
+      },
     );
   }
 
@@ -1441,18 +1496,24 @@ class _CharacterListScreenState extends ConsumerState<CharacterListScreen>
 
 class _AddButton extends StatelessWidget {
   final VoidCallback onTap;
-  const _AddButton({required this.onTap});
+
+  /// 48 as the button floating over the grid on mobile; 42 inline in the
+  /// desktop tabs row, where it lines up with the tab strip beside it.
+  final double height;
+
+  const _AddButton({required this.onTap, this.height = 48});
 
   @override
   Widget build(BuildContext context) {
+    final compact = height < 48;
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        height: 48,
-        padding: const EdgeInsets.symmetric(horizontal: 20),
+        height: height,
+        padding: EdgeInsets.symmetric(horizontal: compact ? 16 : 20),
         decoration: BoxDecoration(
           color: context.cs.primary,
-          borderRadius: BorderRadius.circular(24),
+          borderRadius: BorderRadius.circular(height / 2),
           boxShadow: [
             BoxShadow(
               color: Colors.black.withValues(alpha: 0.3),
@@ -1464,13 +1525,17 @@ class _AddButton extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.add_rounded, color: Colors.white, size: 24),
-            const SizedBox(width: 8),
+            Icon(
+              Icons.add_rounded,
+              color: Colors.white,
+              size: compact ? 20 : 24,
+            ),
+            SizedBox(width: compact ? 6 : 8),
             Text(
               'btn_add'.tr(),
               style: TextStyle(
                 color: Colors.white,
-                fontSize: 16,
+                fontSize: compact ? 14 : 16,
                 fontWeight: FontWeight.w500,
               ),
             ),

--- a/lib/features/character_list/widgets/character_grid.dart
+++ b/lib/features/character_list/widgets/character_grid.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../shared/widgets/responsive_grid.dart';
 import '../../../core/models/character.dart';
+import '../../../shared/shell/desktop/desktop_layout_provider.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/widgets/glaze_bottom_sheet.dart';
 import '../../../shared/widgets/glass_surface.dart';
@@ -98,6 +99,64 @@ class CharacterGrid extends StatelessWidget {
     }
   }
 
+  /// The dice / filter / sort row.
+  ///
+  /// Desktop mirrors Vue's `.desktop-mode .sort-controls`: the row starts at
+  /// the left edge and the sort-type pill leads the direction toggle (CSS
+  /// `justify-content: flex-start` with `order: 1 / 2`). Elsewhere it stays
+  /// right-aligned with the toggle first, as the phone build has it.
+  ///
+  /// Wrap, not Row: the sort pill carries a translated label, so in a narrow
+  /// column (a small desktop window, where the middle column gives up width to
+  /// the sidebars) a Row overflowed instead of moving the controls onto a
+  /// second line.
+  Widget _buildControls(BuildContext context) {
+    final isDesktop = isDesktopLayout(context);
+
+    final sortDirButton = _SortDirButton(
+      isAsc: sortDir == SortDir.asc,
+      onTap: onSortDirToggle,
+    );
+    final sortTypePill = _SortTypePill(
+      sortBy: sortBy,
+      onChanged: onSortTypeChanged,
+    );
+
+    return Wrap(
+      alignment: isDesktop ? WrapAlignment.start : WrapAlignment.end,
+      spacing: 10,
+      runSpacing: 8,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        if (characters.isNotEmpty)
+          Consumer(
+            builder: (context, ref, _) {
+              final standard = ref.watch(
+                appSettingsProvider.select(
+                  (s) => s.value?.useStandardRandomizer ?? false,
+                ),
+              );
+              return _DiceButton(
+                standard: standard,
+                onTap: () => standard
+                    ? _openStandardRandom(context)
+                    : _openRandomizing(context),
+              );
+            },
+          ),
+        if (onFilterTap != null)
+          _FilterButton(count: filterCount, onTap: onFilterTap!),
+        if (isDesktop) ...[
+          sortTypePill,
+          sortDirButton,
+        ] else ...[
+          sortDirButton,
+          sortTypePill,
+        ],
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return CustomScrollView(
@@ -108,42 +167,7 @@ class CharacterGrid extends StatelessWidget {
         SliverToBoxAdapter(
           child: Padding(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-            // Wrap, not Row: the sort pill carries a translated label, so in a
-            // narrow column (a small desktop window, where the middle column
-            // gives up width to the sidebars) a Row overflowed instead of
-            // moving the controls onto a second line.
-            child: Wrap(
-              alignment: WrapAlignment.end,
-              spacing: 10,
-              runSpacing: 8,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              children: [
-                if (characters.isNotEmpty) ...[
-                  Consumer(
-                    builder: (context, ref, _) {
-                      final standard = ref.watch(
-                        appSettingsProvider.select(
-                          (s) => s.value?.useStandardRandomizer ?? false,
-                        ),
-                      );
-                      return _DiceButton(
-                        standard: standard,
-                        onTap: () => standard
-                            ? _openStandardRandom(context)
-                            : _openRandomizing(context),
-                      );
-                    },
-                  ),
-                ],
-                if (onFilterTap != null)
-                  _FilterButton(count: filterCount, onTap: onFilterTap!),
-                _SortDirButton(
-                  isAsc: sortDir == SortDir.asc,
-                  onTap: onSortDirToggle,
-                ),
-                _SortTypePill(sortBy: sortBy, onChanged: onSortTypeChanged),
-              ],
-            ),
+            child: _buildControls(context),
           ),
         ),
         SliverToBoxAdapter(

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -60,6 +60,7 @@ import 'state/memory_activity_provider.dart';
 import 'state/studio_history_rotation_provider.dart';
 import 'bridge/chat_overlay_blur_region.dart';
 import 'widgets/chat_blur_region_tracker.dart';
+import 'widgets/chat_background.dart';
 import 'widgets/chat_header.dart';
 import 'widgets/chat_input_bar.dart';
 import 'widgets/magic_drawer.dart';
@@ -277,6 +278,27 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
     }
   }
 
+  /// The chat's background, painted full width behind [ChatColumnWidth]'s
+  /// side gutters. Mirrors what [ChatWebViewSurface] paints behind the
+  /// WebView, from the same inputs, through the shared [ChatBackground].
+  Widget _buildChatBackground() {
+    final preset = ref.watch(themeProvider).activePreset;
+    final character = ref.watch(characterByIdProvider(widget.charId));
+    final bytes = switch (preset.chatBgMode) {
+      'custom' => ref.watch(chatBgImageBytesProvider),
+      'inherit' => ref.watch(effectiveBgImageBytesProvider),
+      _ => null,
+    };
+    return ChatBackground(
+      mode: preset.chatBgMode,
+      color: preset.chatBgColorParsed,
+      avatarPath: character?.avatarPath,
+      imageBytes: bytes,
+      blur: preset.bgBlur,
+      dim: preset.bgDim,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     PerfDebug.chatScreenBuilt();
@@ -373,6 +395,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
         // reproduced by an in-WebView CSS strip (mirrored via the 'header'
         // blur region in _measureBlurRegions), so drop the Flutter blur pass.
         headerBlurViaWebView: true,
+        // Desktop paints a tab's header edge to edge (see the shell's
+        // _DesktopHeader); chat matches it instead of floating a pill.
+        flushHeader: isDesktopLayout(context),
         hideHeader: _isHeaderHidden,
         title: title,
         // Desktop never swaps the header for a search field — it has a
@@ -509,6 +534,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
             }
             _everBuiltBody = true;
             return ChatColumnWidth(
+              // The capped column would otherwise sit as a lighter strip
+              // between two bands of the app background; painting the chat's
+              // own background across the whole width keeps the two even.
+              background: _buildChatBackground(),
               child: Stack(
                 children: [
                   _ChatBody(
@@ -707,6 +736,11 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
 
   /// `MediaQuery.padding.top` captured in build for the analytic header rect.
   double _blurSafeTop = 0;
+
+  /// Desktop layout flag, captured in build alongside [_blurSafeTop]. The
+  /// header rect below is measured post-frame, where reading an inherited
+  /// widget would register a dependency outside the build phase.
+  bool _blurFlushHeader = false;
 
   /// Keyboard-inset settle tracking for the WebView-bound bottom inset.
   /// While the keyboard animates, the WebView receives the predicted end
@@ -1148,20 +1182,33 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
     if (box is! RenderBox || !box.attached || !box.hasSize) return;
     final origin = box.localToGlobal(Offset.zero);
     final regions = <ChatOverlayBlurRegion>[
-      // The floating header is not a descendant (it lives in GlazeScaffold's
-      // stack), but its geometry is fixed: SafeArea + fromLTRB(16, 10, 16, 0)
-      // + 56px GlazeAppBar with radius 20 (glaze_scaffold.dart).
+      // The header is not a descendant (it lives in GlazeScaffold's stack),
+      // but its geometry is fixed: SafeArea + fromLTRB(16, 10, 16, 0) + 56px
+      // GlazeAppBar with radius 20 (glaze_scaffold.dart) — or, with
+      // `flushHeader` on desktop, edge to edge with square corners.
       if (!widget.isHeaderHidden)
-        ChatOverlayBlurRegion(
-          id: 'header',
-          rect: Rect.fromLTWH(
-            16 - origin.dx,
-            _blurSafeTop + 10 - origin.dy,
-            box.size.width - 32,
-            56,
+        if (_blurFlushHeader)
+          ChatOverlayBlurRegion(
+            id: 'header',
+            rect: Rect.fromLTWH(
+              -origin.dx,
+              _blurSafeTop - origin.dy,
+              box.size.width,
+              56,
+            ),
+            radius: 0,
+          )
+        else
+          ChatOverlayBlurRegion(
+            id: 'header',
+            rect: Rect.fromLTWH(
+              16 - origin.dx,
+              _blurSafeTop + 10 - origin.dy,
+              box.size.width - 32,
+              56,
+            ),
+            radius: 20,
           ),
-          radius: 20,
-        ),
       ..._blurRegistry.measure(box),
     ];
     regions.sort((a, b) => a.id.compareTo(b.id));
@@ -1293,6 +1340,7 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
     final safeBottom = MediaQuery.paddingOf(context).bottom;
     final messageListTop = MediaQuery.paddingOf(context).top + 10 + 56;
     _blurSafeTop = MediaQuery.paddingOf(context).top;
+    _blurFlushHeader = isDesktopLayout(context);
 
     final bgBlur = preset.bgBlur > 0 ? preset.bgBlur : 0.0;
     final fontStyle = batteryAware(
@@ -1870,43 +1918,47 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                 ),
               ),
             ),
-            // Top gradient for fade effect under the header
-            Positioned(
-              top: 0,
-              left: 0,
-              right: 0,
-              height: MediaQuery.paddingOf(context).top + 20,
-              child: IgnorePointer(
-                child: Container(
-                  decoration: const BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [Colors.black54, Colors.transparent],
+            // Fades under the header and the input area. Dropped on desktop:
+            // the flush header is opaque enough on its own, and against the
+            // now-even chat background the two bands only read as a darkened
+            // top and bottom edge.
+            if (!isDesktopLayout(context)) ...[
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                height: MediaQuery.paddingOf(context).top + 20,
+                child: IgnorePointer(
+                  child: Container(
+                    decoration: const BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [Colors.black54, Colors.transparent],
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-            // Bottom gradient for fade effect under the input area
-            Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: messageListBottom + 40,
-              child: IgnorePointer(
-                child: Container(
-                  decoration: const BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.bottomCenter,
-                      end: Alignment.topCenter,
-                      colors: [Colors.black54, Colors.transparent],
-                      stops: [0.0, 1.0],
+              Positioned(
+                bottom: 0,
+                left: 0,
+                right: 0,
+                height: messageListBottom + 40,
+                child: IgnorePointer(
+                  child: Container(
+                    decoration: const BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [Colors.black54, Colors.transparent],
+                        stops: [0.0, 1.0],
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
+            ],
             Positioned(
               right: 16,
               bottom: messageListBottom + 16,

--- a/lib/features/chat/widgets/chat_background.dart
+++ b/lib/features/chat/widgets/chat_background.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+/// The chat's own background — base colour, optional image, blur and dim.
+///
+/// Painted in two places, which is what keeps the desktop layout even: behind
+/// the WebView (which is transparent, so the background has to come from
+/// Flutter), and across the full column behind [ChatColumnWidth]'s side
+/// gutters. Without the second one the capped chat column carried the chat's
+/// background while the gutters beside it showed the app's, so the chat read
+/// as a lighter strip between two darker bands.
+///
+/// The two overlap over the column itself, but the upper copy is opaque, so
+/// the result is the same as painting it once.
+class ChatBackground extends StatelessWidget {
+  /// One of `color`, `avatar`, `custom` or `inherit`.
+  final String mode;
+
+  /// Base fill, used when [mode] is `color`. Falls back to the theme surface.
+  final Color? color;
+
+  /// Character avatar file, used when [mode] is `avatar`.
+  final String? avatarPath;
+
+  /// Decoded image for `custom` and `inherit`.
+  final Uint8List? imageBytes;
+
+  final double blur;
+  final double dim;
+
+  const ChatBackground({
+    super.key,
+    required this.mode,
+    required this.color,
+    required this.avatarPath,
+    required this.imageBytes,
+    required this.blur,
+    required this.dim,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final base = mode == 'color' && color != null
+        ? color!
+        : Theme.of(context).colorScheme.surface;
+
+    Widget? image;
+    if (mode == 'avatar') {
+      final path = avatarPath;
+      if (path != null && path.isNotEmpty) {
+        image = Image.file(
+          File(path),
+          fit: BoxFit.cover,
+          gaplessPlayback: true,
+        );
+      }
+    } else if (mode != 'color' && imageBytes != null) {
+      image = Image.memory(
+        imageBytes!,
+        fit: BoxFit.cover,
+        gaplessPlayback: true,
+      );
+    }
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        ColoredBox(color: base),
+        if (image != null) ...[
+          if (blur > 0)
+            ImageFiltered(
+              imageFilter: ui.ImageFilter.blur(
+                sigmaX: blur,
+                sigmaY: blur,
+                tileMode: TileMode.clamp,
+              ),
+              child: image,
+            )
+          else
+            image,
+          if (dim > 0) ColoredBox(color: Colors.black.withValues(alpha: dim)),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/features/chat/widgets/chat_column_width.dart
+++ b/lib/features/chat/widgets/chat_column_width.dart
@@ -14,11 +14,16 @@ import '../../settings/app_settings_provider.dart';
 class ChatColumnWidth extends ConsumerStatefulWidget {
   final Widget child;
 
+  /// Painted across the full column, behind the capped child and its gutters,
+  /// so the chat's background carries edge to edge instead of stopping at the
+  /// column and leaving the app's background showing at the sides.
+  final Widget? background;
+
   static const double minWidth = 400;
   static const double maxWidth = 1600;
   static const double handleWidth = 8;
 
-  const ChatColumnWidth({super.key, required this.child});
+  const ChatColumnWidth({super.key, required this.child, this.background});
 
   @override
   ConsumerState<ChatColumnWidth> createState() => _ChatColumnWidthState();
@@ -74,6 +79,8 @@ class _ChatColumnWidthState extends ConsumerState<ChatColumnWidth> {
         final gutter = (constraints.maxWidth - width) / 2;
         return Stack(
           children: [
+            if (widget.background != null)
+              Positioned.fill(child: IgnorePointer(child: widget.background!)),
             Positioned(
               left: gutter,
               right: gutter,

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+
+import 'chat_background.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -105,46 +106,13 @@ class _ChatWebViewSurfaceState extends ConsumerState<ChatWebViewSurface> {
   }
 
   Widget _background(BuildContext context) {
-    final base = widget.chatBgMode == 'color' && widget.chatBgColor != null
-        ? widget.chatBgColor!
-        : Theme.of(context).colorScheme.surface;
-    Widget? image;
-    if (widget.chatBgMode == 'avatar') {
-      final path = widget.chatBgAvatarPath;
-      if (path != null && path.isNotEmpty) {
-        image = Image.file(
-          File(path),
-          fit: BoxFit.cover,
-          gaplessPlayback: true,
-        );
-      }
-    } else if (widget.chatBgMode != 'color' && widget.bgImageBytes != null) {
-      image = Image.memory(
-        widget.bgImageBytes!,
-        fit: BoxFit.cover,
-        gaplessPlayback: true,
-      );
-    }
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        ColoredBox(color: base),
-        if (image != null) ...[
-          if (widget.bgBlur > 0)
-            ImageFiltered(
-              imageFilter: ui.ImageFilter.blur(
-                sigmaX: widget.bgBlur,
-                sigmaY: widget.bgBlur,
-                tileMode: TileMode.clamp,
-              ),
-              child: image,
-            )
-          else
-            image,
-          if (widget.bgDim > 0)
-            Container(color: Colors.black.withValues(alpha: widget.bgDim)),
-        ],
-      ],
+    return ChatBackground(
+      mode: widget.chatBgMode,
+      color: widget.chatBgColor,
+      avatarPath: widget.chatBgAvatarPath,
+      imageBytes: widget.bgImageBytes,
+      blur: widget.bgBlur,
+      dim: widget.bgDim,
     );
   }
 

--- a/lib/features/menu/menu_screen.dart
+++ b/lib/features/menu/menu_screen.dart
@@ -432,11 +432,16 @@ class _MenuScreenState extends ConsumerState<MenuScreen> with ShellHeaderMixin {
                     icon: Icons.menu_book_rounded,
                     label: 'menu_glossary'.tr(),
                     subtitle: 'menu_glossary_hint'.tr(),
-                    onTap: () => isDesktopLayout(context)
-                        ? ref
-                              .read(glossaryPopupVisibleProvider.notifier)
-                              .update((v) => !v)
-                        : context.push('/menu/glossary'),
+                    onTap: () {
+                      if (!isDesktopLayout(context)) {
+                        context.push('/menu/glossary');
+                      } else if (ref.read(glossaryPopupVisibleProvider)) {
+                        ref.read(glossaryPopupVisibleProvider.notifier).state =
+                            false;
+                      } else {
+                        openGlossaryPopup(ref);
+                      }
+                    },
                   ),
                   if (lang == 'en')
                     MenuItem(

--- a/lib/features/onboarding/onboarding_models.dart
+++ b/lib/features/onboarding/onboarding_models.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+// ---------------------------------------------------------------------------
+// Onboarding slide data — the flow's content, shared by the phone layout and
+// the desktop wizard.
+// ---------------------------------------------------------------------------
+
+enum OnboardingSlideType {
+  welcome,
+  features,
+  dataImport,
+  api,
+  persona,
+  layout,
+  allSet,
+}
+
+class OnboardingSlideData {
+  final OnboardingSlideType type;
+  final String title;
+  final String? desc;
+  final IconData? icon;
+  const OnboardingSlideData({
+    required this.type,
+    required this.title,
+    this.desc,
+    this.icon,
+  });
+}
+
+class OnboardingInfoBlock {
+  final IconData icon;
+  final String title;
+  final String desc;
+  const OnboardingInfoBlock({
+    required this.icon,
+    required this.title,
+    required this.desc,
+  });
+}
+
+const onboardingSlides = <OnboardingSlideData>[
+  OnboardingSlideData(
+    type: OnboardingSlideType.welcome,
+    title: 'onboarding_welcome_title',
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.features,
+    title: 'onboarding_features_title',
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.dataImport,
+    title: 'onboarding_import_title',
+    desc: 'onboarding_import_slide_desc',
+    icon: Icons.download_rounded,
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.api,
+    title: 'onboarding_api_title',
+    desc: 'onboarding_preset_slide_desc',
+    icon: Icons.dns_outlined,
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.persona,
+    title: 'onboarding_persona_title',
+    desc: 'onboarding_persona_slide_desc',
+    icon: Icons.person_outline_rounded,
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.layout,
+    title: 'onboarding_layout_title',
+    desc: 'onboarding_layout_slide_desc',
+    icon: Icons.view_quilt_outlined,
+  ),
+  OnboardingSlideData(
+    type: OnboardingSlideType.allSet,
+    title: 'onboarding_allset_title',
+    desc: 'onboarding_allset_slide_desc',
+    icon: Icons.check_circle_outline_rounded,
+  ),
+];
+
+const onboardingIntroContent = <OnboardingInfoBlock>[
+  OnboardingInfoBlock(
+    icon: Icons.layers_outlined,
+    title: 'onboarding_feature_roleplay_title',
+    desc: 'onboarding_feature_roleplay_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.link_rounded,
+    title: 'onboarding_feature_rules_title',
+    desc: 'onboarding_feature_rules_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.verified_outlined,
+    title: 'onboarding_feature_privacy_title',
+    desc: 'onboarding_feature_privacy_desc',
+  ),
+];
+
+const onboardingFeaturesContent = <OnboardingInfoBlock>[
+  OnboardingInfoBlock(
+    icon: Icons.image_outlined,
+    title: 'onboarding_feature_imggen_title',
+    desc: 'onboarding_feature_imggen_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.menu_book_outlined,
+    title: 'onboarding_feature_glossary_title',
+    desc: 'onboarding_feature_glossary_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.palette_outlined,
+    title: 'onboarding_feature_custom_title',
+    desc: 'onboarding_feature_custom_desc',
+  ),
+  OnboardingInfoBlock(
+    icon: Icons.description_outlined,
+    title: 'onboarding_feature_st_title',
+    desc: 'onboarding_feature_st_desc',
+  ),
+];

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -14,103 +12,10 @@ import '../settings/api_list_provider.dart';
 import '../settings/api_settings_screen.dart';
 import '../settings/widgets/chat_layout_picker.dart';
 import '../personas/persona_list_screen.dart';
-
-// ---------------------------------------------------------------------------
-// Slide data
-// ---------------------------------------------------------------------------
-
-enum OnboardingSlideType { welcome, features, dataImport, api, persona, layout, allSet }
-
-class _SlideData {
-  final OnboardingSlideType type;
-  final String title;
-  final String? desc;
-  final IconData? icon;
-  const _SlideData({required this.type, required this.title, this.desc, this.icon});
-}
-
-class _InfoBlock {
-  final IconData icon;
-  final String title;
-  final String desc;
-  const _InfoBlock({required this.icon, required this.title, required this.desc});
-}
-
-const _slides = <_SlideData>[
-  _SlideData(type: OnboardingSlideType.welcome, title: 'onboarding_welcome_title'),
-  _SlideData(type: OnboardingSlideType.features, title: 'onboarding_features_title'),
-  _SlideData(
-    type: OnboardingSlideType.dataImport,
-    title: 'onboarding_import_title',
-    desc: 'onboarding_import_slide_desc',
-    icon: Icons.download_rounded,
-  ),
-  _SlideData(
-    type: OnboardingSlideType.api,
-    title: 'onboarding_api_title',
-    desc: 'onboarding_preset_slide_desc',
-    icon: Icons.dns_outlined,
-  ),
-  _SlideData(
-    type: OnboardingSlideType.persona,
-    title: 'onboarding_persona_title',
-    desc: 'onboarding_persona_slide_desc',
-    icon: Icons.person_outline_rounded,
-  ),
-  _SlideData(
-    type: OnboardingSlideType.layout,
-    title: 'onboarding_layout_title',
-    desc: 'onboarding_layout_slide_desc',
-    icon: Icons.view_quilt_outlined,
-  ),
-  _SlideData(
-    type: OnboardingSlideType.allSet,
-    title: 'onboarding_allset_title',
-    desc: 'onboarding_allset_slide_desc',
-    icon: Icons.check_circle_outline_rounded,
-  ),
-];
-
-const _introContent = <_InfoBlock>[
-  _InfoBlock(
-    icon: Icons.layers_outlined,
-    title: 'onboarding_feature_roleplay_title',
-    desc: 'onboarding_feature_roleplay_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.link_rounded,
-    title: 'onboarding_feature_rules_title',
-    desc: 'onboarding_feature_rules_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.verified_outlined,
-    title: 'onboarding_feature_privacy_title',
-    desc: 'onboarding_feature_privacy_desc',
-  ),
-];
-
-const _featuresContent = <_InfoBlock>[
-  _InfoBlock(
-    icon: Icons.image_outlined,
-    title: 'onboarding_feature_imggen_title',
-    desc: 'onboarding_feature_imggen_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.menu_book_outlined,
-    title: 'onboarding_feature_glossary_title',
-    desc: 'onboarding_feature_glossary_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.palette_outlined,
-    title: 'onboarding_feature_custom_title',
-    desc: 'onboarding_feature_custom_desc',
-  ),
-  _InfoBlock(
-    icon: Icons.description_outlined,
-    title: 'onboarding_feature_st_title',
-    desc: 'onboarding_feature_st_desc',
-  ),
-];
+import '../../shared/shell/desktop/desktop_layout_provider.dart';
+import 'onboarding_models.dart';
+import 'widgets/onboarding_desktop_wizard.dart';
+import 'widgets/onboarding_widgets.dart';
 
 // ---------------------------------------------------------------------------
 // Flow widget
@@ -127,11 +32,11 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   int _currentSlide = 0;
   int _direction = 1;
 
-  bool get _isLastSlide => _currentSlide == _slides.length - 1;
+  bool get _isLastSlide => _currentSlide == onboardingSlides.length - 1;
 
   String get _buttonLabel {
     if (_isLastSlide) return 'onboarding_btn_start'.tr();
-    switch (_slides[_currentSlide].type) {
+    switch (onboardingSlides[_currentSlide].type) {
       case OnboardingSlideType.dataImport:
         return 'onboarding_btn_skip'.tr();
       case OnboardingSlideType.persona:
@@ -157,13 +62,19 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     if (_isLastSlide) {
       _finish();
     } else {
-      setState(() { _direction = 1; _currentSlide++; });
+      setState(() {
+        _direction = 1;
+        _currentSlide++;
+      });
     }
   }
 
   void _prev() {
     if (_currentSlide > 0) {
-      setState(() { _direction = -1; _currentSlide--; });
+      setState(() {
+        _direction = -1;
+        _currentSlide--;
+      });
     }
   }
 
@@ -177,7 +88,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     GlazeBottomSheet.show<void>(
       context,
       title: 'onboarding_skip_confirm_title'.tr(),
-      child: _SkipConfirmSheet(
+      child: OnboardingSkipConfirmSheet(
         onCancel: () => Navigator.of(context, rootNavigator: true).pop(),
         onConfirm: () {
           Navigator.of(context, rootNavigator: true).pop();
@@ -197,8 +108,17 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     );
   }
 
+  /// Onboarding is pushed on the root navigator, above the shell, so there is
+  /// no `DesktopScope` to read here — apply the shell's own rule directly
+  /// (see `DesktopShell.build`).
+  bool _isDesktop(BuildContext context) =>
+      MediaQuery.sizeOf(context).width >= 768 &&
+      !ref.watch(forceMobileLayoutProvider);
+
   @override
   Widget build(BuildContext context) {
+    if (_isDesktop(context)) return _buildDesktop(context);
+
     final topPad = MediaQuery.of(context).padding.top;
     final bottomPad = MediaQuery.of(context).padding.bottom;
 
@@ -222,14 +142,13 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 layoutBuilder: (currentChild, previousChildren) {
                   return Stack(
                     alignment: Alignment.topCenter,
-                    children: <Widget>[
-                      ...previousChildren,
-                      ?currentChild,
-                    ],
+                    children: <Widget>[...previousChildren, ?currentChild],
                   );
                 },
                 transitionBuilder: (child, anim) {
-                  final dir = (child.key == ValueKey(_currentSlide)) ? _direction : -_direction;
+                  final dir = (child.key == ValueKey(_currentSlide))
+                      ? _direction
+                      : -_direction;
                   return FadeTransition(
                     opacity: anim,
                     child: SlideTransition(
@@ -243,7 +162,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 },
                 child: KeyedSubtree(
                   key: ValueKey(_currentSlide),
-                  child: _buildSlide(_slides[_currentSlide]),
+                  child: _buildSlide(onboardingSlides[_currentSlide]),
                 ),
               ),
             ),
@@ -251,7 +170,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
           // ── Header gradient ──
           Positioned(
-            top: 0, left: 0, right: 0,
+            top: 0,
+            left: 0,
+            right: 0,
             child: IgnorePointer(
               child: Container(
                 height: topPad + 84,
@@ -268,9 +189,11 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
           // ── Stories progress bar ──
           Positioned(
-            top: topPad + 16, left: 20, right: 20,
-            child: _StoriesBar(
-              total: _slides.length,
+            top: topPad + 16,
+            left: 20,
+            right: 20,
+            child: OnboardingStoriesBar(
+              total: onboardingSlides.length,
               current: _currentSlide,
             ),
           ),
@@ -278,20 +201,24 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
           // ── Back button ──
           if (_currentSlide > 0)
             Positioned(
-              top: topPad + 36, left: 12,
-              child: _GlassBackButton(onTap: _prev),
+              top: topPad + 36,
+              left: 12,
+              child: OnboardingGlassBackButton(onTap: _prev),
             ),
 
           // ── Skip onboarding (top-right) ──
           if (!_isLastSlide)
             Positioned(
-              top: topPad + 36, right: 12,
-              child: _SkipOnboardingButton(onTap: _confirmSkipOnboarding),
+              top: topPad + 36,
+              right: 12,
+              child: OnboardingSkipButton(onTap: _confirmSkipOnboarding),
             ),
 
           // ── Footer gradient ──
           Positioned(
-            bottom: 0, left: 0, right: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
             child: IgnorePointer(
               child: Container(
                 height: 120 + bottomPad,
@@ -308,12 +235,14 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
           // ── Footer button ──
           Positioned(
-            bottom: 0, left: 0, right: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
             child: SafeArea(
               top: false,
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(24, 24, 24, 24),
-                child: _PrimaryButton(
+                child: OnboardingPrimaryButton(
                   label: _buttonLabel,
                   onTap: _next,
                 ),
@@ -325,37 +254,107 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     );
   }
 
+  /// The wide-window flow: the same slides, laid out as the Vue wizard.
+  Widget _buildDesktop(BuildContext context) {
+    final slide = onboardingSlides[_currentSlide];
+    return Scaffold(
+      backgroundColor: const Color(0xFF0D0D0E),
+      body: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 320),
+        switchInCurve: Curves.easeOutCubic,
+        switchOutCurve: Curves.easeInCubic,
+        transitionBuilder: (child, anim) {
+          final dir = (child.key == ValueKey(_currentSlide))
+              ? _direction
+              : -_direction;
+          return FadeTransition(
+            opacity: anim,
+            child: SlideTransition(
+              position: Tween(
+                begin: Offset(0.04 * dir, 0),
+                end: Offset.zero,
+              ).animate(anim),
+              child: child,
+            ),
+          );
+        },
+        child: KeyedSubtree(
+          key: ValueKey(_currentSlide),
+          child: OnboardingDesktopWizard(
+            slideIndex: _currentSlide,
+            slideCount: onboardingSlides.length,
+            icon: _slideIcon(slide),
+            title: slide.title,
+            description: slide.desc,
+            body: _slideBody(slide),
+            buttonLabel: _buttonLabel,
+            onNext: _next,
+            onBack: _currentSlide > 0 ? _prev : null,
+            onSkip: _isLastSlide ? null : _confirmSkipOnboarding,
+          ),
+        ),
+      ),
+    );
+  }
+
   // ── Slide builders ──
 
-  Widget _buildSlide(_SlideData slide) {
+  /// The one thing a slide asks the user to open, when it has one. Shared by
+  /// the phone slide and the desktop wizard so the two never drift apart.
+  ({IconData icon, String title, String sub, VoidCallback onTap})? _slideAction(
+    OnboardingSlideData slide,
+  ) {
     switch (slide.type) {
-      case OnboardingSlideType.welcome:
-        return _buildBlocksSlide(slide.title, _introContent);
-      case OnboardingSlideType.features:
-        return _buildBlocksSlide(slide.title, _featuresContent);
       case OnboardingSlideType.dataImport:
-        return _buildActionSlide(
-          slide: slide,
-          actionIcon: Icons.download_rounded,
-          actionTitle: 'onboarding_action_restore'.tr(),
-          actionSub: 'onboarding_action_restore_sub'.tr(),
-          onAction: () => _openSheet(const BackupScreen(fromOnboarding: true)),
+        return (
+          icon: Icons.download_rounded,
+          title: 'onboarding_action_restore'.tr(),
+          sub: 'onboarding_action_restore_sub'.tr(),
+          onTap: () => _openSheet(const BackupScreen(fromOnboarding: true)),
         );
       case OnboardingSlideType.api:
-        return _buildActionSlide(
-          slide: slide,
-          actionIcon: Icons.settings_outlined,
-          actionTitle: 'onboarding_action_configure_api'.tr(),
-          actionSub: 'onboarding_action_configure_sub'.tr(),
-          onAction: () => _openSheet(const ApiSettingsScreen(startExpanded: true)),
+        return (
+          icon: Icons.settings_outlined,
+          title: 'onboarding_action_configure_api'.tr(),
+          sub: 'onboarding_action_configure_sub'.tr(),
+          onTap: () => _openSheet(const ApiSettingsScreen(startExpanded: true)),
         );
       case OnboardingSlideType.persona:
+        return (
+          icon: Icons.person_add_outlined,
+          title: 'onboarding_action_setup_persona'.tr(),
+          sub: 'onboarding_action_setup_sub'.tr(),
+          onTap: () => _openSheet(const PersonaListScreen()),
+        );
+      default:
+        return null;
+    }
+  }
+
+  /// The info blocks a slide lists, when it lists any.
+  List<OnboardingInfoBlock>? _slideBlocks(OnboardingSlideData slide) {
+    return switch (slide.type) {
+      OnboardingSlideType.welcome => onboardingIntroContent,
+      OnboardingSlideType.features => onboardingFeaturesContent,
+      _ => null,
+    };
+  }
+
+  Widget _buildSlide(OnboardingSlideData slide) {
+    switch (slide.type) {
+      case OnboardingSlideType.welcome:
+      case OnboardingSlideType.features:
+        return _buildBlocksSlide(slide.title, _slideBlocks(slide)!);
+      case OnboardingSlideType.dataImport:
+      case OnboardingSlideType.api:
+      case OnboardingSlideType.persona:
+        final action = _slideAction(slide)!;
         return _buildActionSlide(
           slide: slide,
-          actionIcon: Icons.person_add_outlined,
-          actionTitle: 'onboarding_action_setup_persona'.tr(),
-          actionSub: 'onboarding_action_setup_sub'.tr(),
-          onAction: () => _openSheet(const PersonaListScreen()),
+          actionIcon: action.icon,
+          actionTitle: action.title,
+          actionSub: action.sub,
+          onAction: action.onTap,
         );
       case OnboardingSlideType.layout:
         return _buildLayoutSlide(slide);
@@ -364,42 +363,84 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     }
   }
 
+  /// The right-hand pane's content in the desktop wizard: whatever the slide
+  /// offers below its title and description.
+  Widget? _slideBody(OnboardingSlideData slide) {
+    final blocks = _slideBlocks(slide);
+    if (blocks != null) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: blocks
+            .map(
+              (b) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: OnboardingIntroBlockCard(block: b),
+              ),
+            )
+            .toList(),
+      );
+    }
+    final action = _slideAction(slide);
+    if (action != null) {
+      return OnboardingClickableBlock(
+        icon: action.icon,
+        title: action.title,
+        subtitle: action.sub,
+        onTap: action.onTap,
+      );
+    }
+    if (slide.type == OnboardingSlideType.layout) return _buildLayoutPicker();
+    return null;
+  }
+
+  /// Icon shown in the wizard's visual pane. Welcome and Features carry no
+  /// icon of their own, so they borrow their first block's — the same
+  /// fallback the Vue wizard used (`slides[i].icon || introContent[0].icon`).
+  IconData _slideIcon(OnboardingSlideData slide) =>
+      slide.icon ?? _slideBlocks(slide)?.first.icon ?? Icons.layers_outlined;
+
   /// Welcome / Features — title + list of info blocks
-  Widget _buildBlocksSlide(String title, List<_InfoBlock> blocks) {
+  Widget _buildBlocksSlide(String title, List<OnboardingInfoBlock> blocks) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           title.tr(),
           style: const TextStyle(
-            fontSize: 32, fontWeight: FontWeight.w800,
-            color: Colors.white, height: 1.2,
+            fontSize: 32,
+            fontWeight: FontWeight.w800,
+            color: Colors.white,
+            height: 1.2,
           ),
         ),
         const SizedBox(height: 16),
-        ...blocks.map((b) => Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: _IntroBlockCard(block: b),
-        )),
+        ...blocks.map(
+          (b) => Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: OnboardingIntroBlockCard(block: b),
+          ),
+        ),
       ],
     );
   }
 
   /// Standard centered slide — icon + title + description
-  Widget _buildStandardSlide(_SlideData slide) {
+  Widget _buildStandardSlide(OnboardingSlideData slide) {
     return SizedBox(
       width: double.infinity,
       child: Column(
         children: [
           const SizedBox(height: 40),
-          _IconBubble(icon: slide.icon ?? Icons.check),
+          OnboardingIconBubble(icon: slide.icon ?? Icons.check),
           const SizedBox(height: 24),
           Text(
             slide.title.tr(),
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 28, fontWeight: FontWeight.w800,
-              color: Colors.white, height: 1.3,
+              fontSize: 28,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+              height: 1.3,
             ),
           ),
           if (slide.desc != null) ...[
@@ -410,7 +451,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 slide.desc!.tr(),
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontSize: 16, color: context.cs.onSurfaceVariant, height: 1.5,
+                  fontSize: 16,
+                  color: context.cs.onSurfaceVariant,
+                  height: 1.5,
                 ),
               ),
             ),
@@ -422,7 +465,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   /// Standard slide + clickable action card
   Widget _buildActionSlide({
-    required _SlideData slide,
+    required OnboardingSlideData slide,
     required IconData actionIcon,
     required String actionTitle,
     required String actionSub,
@@ -433,14 +476,16 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       child: Column(
         children: [
           const SizedBox(height: 40),
-          _IconBubble(icon: slide.icon ?? Icons.settings),
+          OnboardingIconBubble(icon: slide.icon ?? Icons.settings),
           const SizedBox(height: 24),
           Text(
             slide.title.tr(),
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 28, fontWeight: FontWeight.w800,
-              color: Colors.white, height: 1.3,
+              fontSize: 28,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+              height: 1.3,
             ),
           ),
           if (slide.desc != null) ...[
@@ -451,13 +496,15 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 slide.desc!.tr(),
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontSize: 16, color: context.cs.onSurfaceVariant, height: 1.5,
+                  fontSize: 16,
+                  color: context.cs.onSurfaceVariant,
+                  height: 1.5,
                 ),
               ),
             ),
           ],
           const SizedBox(height: 24),
-          _ClickableBlock(
+          OnboardingClickableBlock(
             icon: actionIcon,
             title: actionTitle,
             subtitle: actionSub,
@@ -470,22 +517,22 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   /// Chat layout picker slide — inline `default` / `bubble` thumbnails reused
   /// from the theme editor's layout picker.
-  Widget _buildLayoutSlide(_SlideData slide) {
-    final currentLayout =
-        ref.watch(themeProvider.select((s) => s.activePreset.chatLayout));
+  Widget _buildLayoutSlide(OnboardingSlideData slide) {
     return SizedBox(
       width: double.infinity,
       child: Column(
         children: [
           const SizedBox(height: 40),
-          _IconBubble(icon: slide.icon ?? Icons.view_quilt_outlined),
+          OnboardingIconBubble(icon: slide.icon ?? Icons.view_quilt_outlined),
           const SizedBox(height: 24),
           Text(
             slide.title.tr(),
             textAlign: TextAlign.center,
             style: const TextStyle(
-              fontSize: 28, fontWeight: FontWeight.w800,
-              color: Colors.white, height: 1.3,
+              fontSize: 28,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+              height: 1.3,
             ),
           ),
           if (slide.desc != null) ...[
@@ -496,390 +543,57 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 slide.desc!.tr(),
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  fontSize: 16, color: context.cs.onSurfaceVariant, height: 1.5,
+                  fontSize: 16,
+                  color: context.cs.onSurfaceVariant,
+                  height: 1.5,
                 ),
               ),
             ),
           ],
           const SizedBox(height: 24),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: LayoutPreviewCard(
-                  title: 'layout_default'.tr(),
-                  subtitle: 'layout_default_desc'.tr(),
-                  isActive: currentLayout == 'default',
-                  onTap: () => _setChatLayout('default'),
-                  child: const LayoutMiniPreview(layout: 'default'),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: LayoutPreviewCard(
-                  title: 'layout_bubble'.tr(),
-                  subtitle: 'layout_bubble_desc'.tr(),
-                  isActive: currentLayout == 'bubble',
-                  onTap: () => _setChatLayout('bubble'),
-                  child: const LayoutMiniPreview(layout: 'bubble'),
-                ),
-              ),
-            ],
-          ),
+          _buildLayoutPicker(),
         ],
       ),
+    );
+  }
+
+  /// The `default` / `bubble` thumbnails, shared by the phone slide and the
+  /// desktop wizard's content pane.
+  Widget _buildLayoutPicker() {
+    final currentLayout = ref.watch(
+      themeProvider.select((s) => s.activePreset.chatLayout),
+    );
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: LayoutPreviewCard(
+            title: 'layout_default'.tr(),
+            subtitle: 'layout_default_desc'.tr(),
+            isActive: currentLayout == 'default',
+            onTap: () => _setChatLayout('default'),
+            child: const LayoutMiniPreview(layout: 'default'),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: LayoutPreviewCard(
+            title: 'layout_bubble'.tr(),
+            subtitle: 'layout_bubble_desc'.tr(),
+            isActive: currentLayout == 'bubble',
+            onTap: () => _setChatLayout('bubble'),
+            child: const LayoutMiniPreview(layout: 'bubble'),
+          ),
+        ),
+      ],
     );
   }
 
   Future<void> _setChatLayout(String layout) async {
     final preset = ref.read(themeProvider).activePreset;
     if (preset.chatLayout == layout) return;
-    await ref.read(themeProvider.notifier).updatePreset(
-          preset.copyWith(chatLayout: layout),
-        );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Reusable sub-widgets
-// ---------------------------------------------------------------------------
-
-/// Stories-style progress bar (Instagram / Telegram-like)
-class _StoriesBar extends StatelessWidget {
-  final int total;
-  final int current;
-  const _StoriesBar({required this.total, required this.current});
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: List.generate(total, (i) {
-        final filled = i <= current;
-        return Expanded(
-          child: Padding(
-            padding: EdgeInsets.only(left: i == 0 ? 0 : 3, right: i == total - 1 ? 0 : 3),
-            child: Container(
-              height: 4,
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(2),
-                color: const Color(0x33808080),
-              ),
-              child: AnimatedFractionallySizedBox(
-                duration: const Duration(milliseconds: 300),
-                curve: Curves.easeOut,
-                alignment: Alignment.centerLeft,
-                widthFactor: filled ? 1.0 : 0.0,
-                child: Container(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(2),
-                     color: context.cs.primary,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        );
-      }),
-    );
-  }
-}
-
-/// Glass-morphism pill button to skip the entire onboarding (top-right)
-class _SkipOnboardingButton extends StatelessWidget {
-  final VoidCallback onTap;
-  const _SkipOnboardingButton({required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(20),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-          child: Container(
-            height: 40,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              color: context.cs.surface.withValues(alpha: 0.8),
-              borderRadius: BorderRadius.circular(20),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-              boxShadow: const [
-                BoxShadow(color: Color(0x4D000000), blurRadius: 15, offset: Offset(0, 4)),
-              ],
-            ),
-            child: Text(
-              'onboarding_btn_skip_onboarding'.tr(),
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                color: context.cs.onSurfaceVariant,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Confirmation body shown inside the "Skip Onboarding?" bottom sheet.
-class _SkipConfirmSheet extends StatelessWidget {
-  final VoidCallback onCancel;
-  final VoidCallback onConfirm;
-  const _SkipConfirmSheet({required this.onCancel, required this.onConfirm});
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 4, 20, 20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text(
-            'onboarding_skip_confirm_desc'.tr(),
-            style: TextStyle(
-              fontSize: 15,
-              height: 1.5,
-              color: context.cs.onSurfaceVariant,
-            ),
-          ),
-          const SizedBox(height: 20),
-          GestureDetector(
-            onTap: onConfirm,
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 15),
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: const Color(0xFFFF4444).withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(
-                  color: const Color(0xFFFF4444).withValues(alpha: 0.4),
-                ),
-              ),
-              child: Text(
-                'onboarding_skip_confirm_confirm'.tr(),
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: Color(0xFFFF6B6B),
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(height: 10),
-          GestureDetector(
-            onTap: onCancel,
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 15),
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: Colors.white.withValues(alpha: 0.06),
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-              ),
-              child: Text(
-                'onboarding_skip_confirm_cancel'.tr(),
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: context.cs.onSurface,
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Glass-morphism circular back button
-class _GlassBackButton extends StatelessWidget {
-  final VoidCallback onTap;
-  const _GlassBackButton({required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(20),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-          child: Container(
-            width: 40, height: 40,
-            decoration: BoxDecoration(
-              color: context.cs.surface.withValues(alpha: 0.8),
-              borderRadius: BorderRadius.circular(20),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-              boxShadow: const [
-                BoxShadow(color: Color(0x4D000000), blurRadius: 15, offset: Offset(0, 4)),
-              ],
-            ),
-            child: Icon(Icons.arrow_back, size: 20, color: context.cs.primary),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Accent-tinted circular icon bubble (100×100)
-class _IconBubble extends StatelessWidget {
-  final IconData icon;
-  const _IconBubble({required this.icon});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 100, height: 100,
-      decoration: BoxDecoration(
-        color: context.cs.primary.withValues(alpha: 0.1),
-        shape: BoxShape.circle,
-      ),
-      child: Icon(icon, size: 48, color: context.cs.primary),
-    );
-  }
-}
-
-/// Info block card (column layout) — for welcome/features slides
-class _IntroBlockCard extends StatelessWidget {
-  final _InfoBlock block;
-  const _IntroBlockCard({required this.block});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: const Color(0x14808080),
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(block.icon, size: 48, color: context.cs.primary),
-          const SizedBox(height: 8),
-          Text(
-            block.title.tr(),
-            style: const TextStyle(
-              fontSize: 20, fontWeight: FontWeight.w700, color: Colors.white,
-            ),
-          ),
-          const SizedBox(height: 4),
-          Text(
-            block.desc.tr(),
-            style: TextStyle(
-              fontSize: 15, color: context.cs.onSurfaceVariant, height: 1.5,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Clickable action card — for data import / api / persona slides
-class _ClickableBlock extends StatefulWidget {
-  final IconData icon;
-  final String title;
-  final String subtitle;
-  final VoidCallback onTap;
-  const _ClickableBlock({
-    required this.icon, required this.title,
-    required this.subtitle, required this.onTap,
-  });
-
-  @override
-  State<_ClickableBlock> createState() => _ClickableBlockState();
-}
-
-class _ClickableBlockState extends State<_ClickableBlock> {
-  bool _pressed = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapDown: (_) => setState(() => _pressed = true),
-      onTapUp: (_) { setState(() => _pressed = false); widget.onTap(); },
-      onTapCancel: () => setState(() => _pressed = false),
-      child: AnimatedScale(
-        scale: _pressed ? 0.98 : 1.0,
-        duration: const Duration(milliseconds: 100),
-        child: Container(
-          width: double.infinity,
-          padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: _pressed ? const Color(0x26808080) : const Color(0x14808080),
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Icon(widget.icon, size: 48, color: context.cs.primary),
-              const SizedBox(height: 8),
-              Text(
-                widget.title,
-                style: const TextStyle(
-                  fontSize: 20, fontWeight: FontWeight.w700, color: Colors.white,
-                ),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                widget.subtitle,
-                style: TextStyle(
-                  fontSize: 15, color: context.cs.onSurfaceVariant, height: 1.5,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Full-width accent primary button
-class _PrimaryButton extends StatefulWidget {
-  final String label;
-  final VoidCallback onTap;
-  const _PrimaryButton({required this.label, required this.onTap});
-
-  @override
-  State<_PrimaryButton> createState() => _PrimaryButtonState();
-}
-
-class _PrimaryButtonState extends State<_PrimaryButton> {
-  bool _pressed = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapDown: (_) => setState(() => _pressed = true),
-      onTapUp: (_) { setState(() => _pressed = false); widget.onTap(); },
-      onTapCancel: () => setState(() => _pressed = false),
-      child: AnimatedScale(
-        scale: _pressed ? 0.96 : 1.0,
-        duration: const Duration(milliseconds: 150),
-        child: Container(
-          width: double.infinity,
-          padding: const EdgeInsets.symmetric(vertical: 16),
-          decoration: BoxDecoration(
-            color: context.cs.primary,
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Text(
-            widget.label,
-            textAlign: TextAlign.center,
-            style: const TextStyle(
-              fontSize: 17, fontWeight: FontWeight.w600, color: Colors.white,
-            ),
-          ),
-        ),
-      ),
-    );
+    await ref
+        .read(themeProvider.notifier)
+        .updatePreset(preset.copyWith(chatLayout: layout));
   }
 }

--- a/lib/features/onboarding/widgets/onboarding_desktop_wizard.dart
+++ b/lib/features/onboarding/widgets/onboarding_desktop_wizard.dart
@@ -1,0 +1,204 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_colors.dart';
+import 'onboarding_widgets.dart';
+
+/// Desktop onboarding — a 1:1 port of the Vue wizard (`OnboardingView.vue`,
+/// `.desktop-layout`).
+///
+/// The phone flow stacks everything into one scrolling column under a stories
+/// bar. On a wide window that leaves a narrow ribbon of content in the middle
+/// of an empty screen, so the desktop build instead centres a fixed card and
+/// splits it in two: a visual pane carrying the slide's icon, and a content
+/// pane with the title, description, whatever the slide offers, and the
+/// primary button pinned to its bottom.
+class OnboardingDesktopWizard extends StatelessWidget {
+  /// Zero-based index of the visible slide, and how many there are — together
+  /// they drive the stories bar in the top bar.
+  final int slideIndex;
+  final int slideCount;
+
+  final IconData icon;
+  final String title;
+  final String? description;
+
+  /// Slide-specific content under the description: the info-block list, the
+  /// single action card, or the chat-layout picker. Null on a slide that is
+  /// only a title and a description.
+  final Widget? body;
+
+  final String buttonLabel;
+  final VoidCallback onNext;
+
+  /// Null on the first slide, where there is nothing to go back to. The button
+  /// keeps its slot either way so the stories bar does not shift.
+  final VoidCallback? onBack;
+
+  /// Null on the last slide, which has nothing left to skip.
+  final VoidCallback? onSkip;
+
+  const OnboardingDesktopWizard({
+    super.key,
+    required this.slideIndex,
+    required this.slideCount,
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.body,
+    required this.buttonLabel,
+    required this.onNext,
+    required this.onBack,
+    required this.onSkip,
+  });
+
+  /// `.onboarding-card { width: min(1180px, 100%); height: min(820px, …) }`.
+  static const double _cardMaxWidth = 1180;
+  static const double _cardMaxHeight = 820;
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: SizedBox(
+          width: size.width.clamp(0.0, _cardMaxWidth),
+          height: (size.height - 40).clamp(0.0, _cardMaxHeight),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: context.cs.surface.withValues(alpha: 0.96),
+              borderRadius: BorderRadius.circular(18),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.2),
+                  blurRadius: 40,
+                  offset: const Offset(0, 16),
+                ),
+              ],
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(18),
+              child: Column(
+                children: [
+                  _buildTopBar(),
+                  Expanded(child: _buildSlide(context)),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// `.onboarding-topbar` — back button, then the stories bar filling the
+  /// rest, with the skip affordance at the far end.
+  Widget _buildTopBar() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 0),
+      child: SizedBox(
+        height: 42,
+        child: Row(
+          children: [
+            // The slot is held even on the first slide (`.nav-back-btn` starts
+            // at width 0 but keeps its place), so the bar does not jump.
+            SizedBox(
+              width: 42,
+              child: onBack == null
+                  ? null
+                  : OnboardingGlassBackButton(onTap: onBack!),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: OnboardingStoriesBar(
+                total: slideCount,
+                current: slideIndex,
+              ),
+            ),
+            if (onSkip != null) ...[
+              const SizedBox(width: 16),
+              OnboardingSkipButton(onTap: onSkip!),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// `.wizard-layout` — the visual pane at `0.95fr`, the content at `1.15fr`.
+  Widget _buildSlide(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 18, 24, 24),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(flex: 95, child: _buildVisual(context)),
+          const SizedBox(width: 28),
+          Expanded(flex: 115, child: _buildContent(context)),
+        ],
+      ),
+    );
+  }
+
+  /// `.wizard-visual` — a tinted panel holding the slide's icon.
+  Widget _buildVisual(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.03),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.06)),
+      ),
+      child: Center(child: OnboardingIconBubble(icon: icon)),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.only(top: 20, right: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title.tr(),
+                  style: const TextStyle(
+                    fontSize: 38,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                    height: 1.12,
+                  ),
+                ),
+                if (description != null) ...[
+                  const SizedBox(height: 12),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 640),
+                    child: Text(
+                      description!.tr(),
+                      style: TextStyle(
+                        fontSize: 16,
+                        height: 1.6,
+                        color: context.cs.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+                if (body != null) ...[const SizedBox(height: 22), body!],
+              ],
+            ),
+          ),
+        ),
+        // `.onboarding-footer` — the primary button spans the content pane.
+        Padding(
+          padding: const EdgeInsets.only(top: 16, right: 8),
+          child: OnboardingPrimaryButton(label: buttonLabel, onTap: onNext),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/onboarding/widgets/onboarding_widgets.dart
+++ b/lib/features/onboarding/widgets/onboarding_widgets.dart
@@ -1,0 +1,398 @@
+import 'dart:ui';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/theme/app_colors.dart';
+import '../onboarding_models.dart';
+
+// ---------------------------------------------------------------------------
+// Reusable onboarding sub-widgets — shared by the phone flow and the desktop
+// wizard (see onboarding_desktop_wizard.dart).
+// ---------------------------------------------------------------------------
+
+/// Stories-style progress bar (Instagram / Telegram-like)
+class OnboardingStoriesBar extends StatelessWidget {
+  final int total;
+  final int current;
+  const OnboardingStoriesBar({
+    super.key,
+    required this.total,
+    required this.current,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: List.generate(total, (i) {
+        final filled = i <= current;
+        return Expanded(
+          child: Padding(
+            padding: EdgeInsets.only(
+              left: i == 0 ? 0 : 3,
+              right: i == total - 1 ? 0 : 3,
+            ),
+            child: Container(
+              height: 4,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(2),
+                color: const Color(0x33808080),
+              ),
+              child: AnimatedFractionallySizedBox(
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeOut,
+                alignment: Alignment.centerLeft,
+                widthFactor: filled ? 1.0 : 0.0,
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(2),
+                    color: context.cs.primary,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+/// Glass-morphism pill button to skip the entire onboarding (top-right)
+class OnboardingSkipButton extends StatelessWidget {
+  final VoidCallback onTap;
+  const OnboardingSkipButton({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(20),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+          child: Container(
+            height: 40,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: context.cs.surface.withValues(alpha: 0.8),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+              boxShadow: const [
+                BoxShadow(
+                  color: Color(0x4D000000),
+                  blurRadius: 15,
+                  offset: Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Text(
+              'onboarding_btn_skip_onboarding'.tr(),
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: context.cs.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Confirmation body shown inside the "Skip Onboarding?" bottom sheet.
+class OnboardingSkipConfirmSheet extends StatelessWidget {
+  final VoidCallback onCancel;
+  final VoidCallback onConfirm;
+  const OnboardingSkipConfirmSheet({
+    super.key,
+    required this.onCancel,
+    required this.onConfirm,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 4, 20, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'onboarding_skip_confirm_desc'.tr(),
+            style: TextStyle(
+              fontSize: 15,
+              height: 1.5,
+              color: context.cs.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 20),
+          GestureDetector(
+            onTap: onConfirm,
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 15),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: const Color(0xFFFF4444).withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: const Color(0xFFFF4444).withValues(alpha: 0.4),
+                ),
+              ),
+              child: Text(
+                'onboarding_skip_confirm_confirm'.tr(),
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: Color(0xFFFF6B6B),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          GestureDetector(
+            onTap: onCancel,
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 15),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.06),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+              ),
+              child: Text(
+                'onboarding_skip_confirm_cancel'.tr(),
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: context.cs.onSurface,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Glass-morphism circular back button
+class OnboardingGlassBackButton extends StatelessWidget {
+  final VoidCallback onTap;
+  const OnboardingGlassBackButton({super.key, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(20),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+          child: Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: context.cs.surface.withValues(alpha: 0.8),
+              borderRadius: BorderRadius.circular(20),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+              boxShadow: const [
+                BoxShadow(
+                  color: Color(0x4D000000),
+                  blurRadius: 15,
+                  offset: Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Icon(Icons.arrow_back, size: 20, color: context.cs.primary),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Accent-tinted circular icon bubble (100×100)
+class OnboardingIconBubble extends StatelessWidget {
+  final IconData icon;
+  const OnboardingIconBubble({super.key, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 100,
+      height: 100,
+      decoration: BoxDecoration(
+        color: context.cs.primary.withValues(alpha: 0.1),
+        shape: BoxShape.circle,
+      ),
+      child: Icon(icon, size: 48, color: context.cs.primary),
+    );
+  }
+}
+
+/// Info block card (column layout) — for welcome/features slides
+class OnboardingIntroBlockCard extends StatelessWidget {
+  final OnboardingInfoBlock block;
+  const OnboardingIntroBlockCard({super.key, required this.block});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0x14808080),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(block.icon, size: 48, color: context.cs.primary),
+          const SizedBox(height: 8),
+          Text(
+            block.title.tr(),
+            style: const TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.w700,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            block.desc.tr(),
+            style: TextStyle(
+              fontSize: 15,
+              color: context.cs.onSurfaceVariant,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Clickable action card — for data import / api / persona slides
+class OnboardingClickableBlock extends StatefulWidget {
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+  const OnboardingClickableBlock({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  @override
+  State<OnboardingClickableBlock> createState() =>
+      _OnboardingClickableBlockState();
+}
+
+class _OnboardingClickableBlockState extends State<OnboardingClickableBlock> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _pressed = true),
+      onTapUp: (_) {
+        setState(() => _pressed = false);
+        widget.onTap();
+      },
+      onTapCancel: () => setState(() => _pressed = false),
+      child: AnimatedScale(
+        scale: _pressed ? 0.98 : 1.0,
+        duration: const Duration(milliseconds: 100),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: _pressed ? const Color(0x26808080) : const Color(0x14808080),
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(widget.icon, size: 48, color: context.cs.primary),
+              const SizedBox(height: 8),
+              Text(
+                widget.title,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                widget.subtitle,
+                style: TextStyle(
+                  fontSize: 15,
+                  color: context.cs.onSurfaceVariant,
+                  height: 1.5,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Full-width accent primary button
+class OnboardingPrimaryButton extends StatefulWidget {
+  final String label;
+  final VoidCallback onTap;
+  const OnboardingPrimaryButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  State<OnboardingPrimaryButton> createState() =>
+      _OnboardingPrimaryButtonState();
+}
+
+class _OnboardingPrimaryButtonState extends State<OnboardingPrimaryButton> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _pressed = true),
+      onTapUp: (_) {
+        setState(() => _pressed = false);
+        widget.onTap();
+      },
+      onTapCancel: () => setState(() => _pressed = false),
+      child: AnimatedScale(
+        scale: _pressed ? 0.96 : 1.0,
+        duration: const Duration(milliseconds: 150),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          decoration: BoxDecoration(
+            color: context.cs.primary,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Text(
+            widget.label,
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              fontSize: 17,
+              fontWeight: FontWeight.w600,
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/shell/desktop/desktop_glossary_popup.dart
+++ b/lib/shared/shell/desktop/desktop_glossary_popup.dart
@@ -10,6 +10,16 @@ import '../../widgets/glass_surface.dart';
 
 final glossaryPopupVisibleProvider = StateProvider<bool>((ref) => false);
 
+/// Term the window should open on, set by a [HelpTip] tap. Null opens the
+/// glossary at its category list.
+final glossaryPopupTermProvider = StateProvider<String?>((ref) => null);
+
+/// Opens the floating glossary window, jumped straight to [term] when given.
+void openGlossaryPopup(WidgetRef ref, {String? term}) {
+  ref.read(glossaryPopupTermProvider.notifier).state = term;
+  ref.read(glossaryPopupVisibleProvider.notifier).state = true;
+}
+
 const _prefsKeyX = 'gz_glossary_popup_x';
 const _prefsKeyY = 'gz_glossary_popup_y';
 
@@ -65,6 +75,7 @@ class _DesktopGlossaryPopupState extends ConsumerState<DesktopGlossaryPopup> {
   @override
   Widget build(BuildContext context) {
     final visible = ref.watch(glossaryPopupVisibleProvider);
+    final term = ref.watch(glossaryPopupTermProvider);
     final viewport = MediaQuery.sizeOf(context);
     final size = Size(_width.clamp(0.0, viewport.width), _height(viewport));
 
@@ -113,7 +124,15 @@ class _DesktopGlossaryPopupState extends ConsumerState<DesktopGlossaryPopup> {
                       ref.read(glossaryPopupVisibleProvider.notifier).state =
                           false,
                 ),
-                const Expanded(child: GlossarySheet(startExpanded: true)),
+                Expanded(
+                  child: GlossarySheet(
+                    // Keyed by term so re-opening on a different one rebuilds
+                    // the sheet at that article instead of keeping the old.
+                    key: ValueKey(term),
+                    initialTerm: term,
+                    startExpanded: true,
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/shared/shell/desktop/desktop_left_sidebar.dart
+++ b/lib/shared/shell/desktop/desktop_left_sidebar.dart
@@ -90,7 +90,13 @@ class _DesktopLeftSidebarState extends ConsumerState<DesktopLeftSidebar> {
 
   void _toggleGlossary() {
     if (isDesktopLayout(context)) {
-      ref.read(glossaryPopupVisibleProvider.notifier).update((v) => !v);
+      // Opening from here starts at the category list, so clear whatever term
+      // a help tip left behind.
+      if (ref.read(glossaryPopupVisibleProvider)) {
+        ref.read(glossaryPopupVisibleProvider.notifier).state = false;
+      } else {
+        openGlossaryPopup(ref);
+      }
     } else {
       context.go('/menu/glossary');
     }

--- a/lib/shared/shell/desktop/desktop_right_sidebar.dart
+++ b/lib/shared/shell/desktop/desktop_right_sidebar.dart
@@ -103,6 +103,11 @@ class DesktopRightSidebar extends ConsumerWidget {
     // panel takes the rest, so switching tools never needs a round trip
     // through the hub.
     return Row(
+      // Stretch, not the default centre: the strip shrink-wraps its icons, so
+      // a centred row floated the rail into the middle of the sidebar with a
+      // gap above it. Vue's `.left-icon-strip` is pinned top-to-bottom and its
+      // icons stack from the top.
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         SizedBox(
           width: _stripWidth,

--- a/lib/shared/shell/desktop/desktop_shell.dart
+++ b/lib/shared/shell/desktop/desktop_shell.dart
@@ -237,8 +237,6 @@ class _DesktopShellState extends ConsumerState<DesktopShell> {
               ),
               // Floating window overlay
               const DesktopWindowView(),
-              // Glossary corner popup
-              const DesktopGlossaryPopup(),
             ],
           ),
         ),

--- a/lib/shared/widgets/glaze_scaffold.dart
+++ b/lib/shared/widgets/glaze_scaffold.dart
@@ -58,6 +58,13 @@ class GlazeScaffold extends StatelessWidget {
   /// strip reproduce it (see [GlassSurface.blurViaWebView]).
   final bool headerBlurViaWebView;
 
+  /// Draws the header edge to edge with square corners, the way the desktop
+  /// shell paints a tab's header, instead of as an inset floating pill.
+  ///
+  /// Chat sets it on desktop so its header matches the Characters tab beside
+  /// it; the pill treatment stays everywhere else.
+  final bool flushHeader;
+
   /// When true, this scaffold does not draw its own floating header. Instead it
   /// publishes its title/actions/back into the shell's persistent header (see
   /// [shellHeaderProvider]) and reserves the same vertical space. Only set this
@@ -84,6 +91,7 @@ class GlazeScaffold extends StatelessWidget {
     this.useShellHeader = false,
     this.headerBranchIndex,
     this.headerBlurViaWebView = false,
+    this.flushHeader = false,
   });
 
   @override
@@ -107,7 +115,9 @@ class GlazeScaffold extends StatelessWidget {
     final header = SafeArea(
       bottom: false,
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+        padding: flushHeader
+            ? EdgeInsets.zero
+            : const EdgeInsets.fromLTRB(16, 10, 16, 0),
         child: GlazeAppBar(
           title: title,
           titleWidget: titleWidget,
@@ -115,6 +125,9 @@ class GlazeScaffold extends StatelessWidget {
           showBack: showBack,
           onBack: backHandler,
           blurViaWebView: headerBlurViaWebView,
+          borderRadius: flushHeader
+              ? BorderRadius.zero
+              : const BorderRadius.all(Radius.circular(20)),
         ),
       ),
     );
@@ -178,9 +191,7 @@ class GlazeScaffold extends StatelessWidget {
     );
 
     final withBackground = showBackground
-        ? GlazeBackground(
-            child: scaffold,
-          )
+        ? GlazeBackground(child: scaffold)
         : scaffold;
 
     if (!useShellHeader) return withBackground;
@@ -330,10 +341,7 @@ class GlazeAppBar extends ConsumerWidget {
             if (actions != null)
               Padding(
                 padding: const EdgeInsets.only(right: 4),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: actions!,
-                ),
+                child: Row(mainAxisSize: MainAxisSize.min, children: actions!),
               )
             else
               const SizedBox(width: 12),

--- a/lib/shared/widgets/help_tip.dart
+++ b/lib/shared/widgets/help_tip.dart
@@ -3,9 +3,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../features/glossary/glossary_sheet.dart';
 import '../../features/settings/app_settings_provider.dart';
+import '../shell/desktop/desktop_glossary_popup.dart';
+import '../shell/desktop/desktop_layout_provider.dart';
 
-/// Small inline help button — opens the [GlossarySheet] at a specific term.
-/// Hidden globally when `hideTooltips` is on in app settings.
+/// Small inline help button — opens the glossary at a specific term.
+///
+/// On desktop that is the floating glossary window, which outlives the sheet
+/// the tip was tapped in and keeps sitting on top of it; elsewhere it is the
+/// modal [GlossarySheet]. Hidden globally when `hideTooltips` is on in app
+/// settings.
 class HelpTip extends ConsumerWidget {
   final String term;
   final double size;
@@ -30,7 +36,9 @@ class HelpTip extends ConsumerWidget {
         shape: const CircleBorder(),
         child: InkWell(
           customBorder: const CircleBorder(),
-          onTap: () => GlossarySheet.show(context, initialTerm: term),
+          onTap: () => isDesktopLayout(context)
+              ? openGlossaryPopup(ref, term: term)
+              : GlossarySheet.show(context, initialTerm: term),
           child: SizedBox(
             width: 20,
             height: 20,

--- a/lib/shared/widgets/menu_group.dart
+++ b/lib/shared/widgets/menu_group.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../../core/platform/haptics.dart';
 import '../theme/app_colors.dart';
+import '../shell/shell_header_provider.dart';
 import 'glass_surface.dart';
 import 'help_tip.dart';
 
@@ -36,17 +37,23 @@ class _MenuCollapsibleSectionState extends State<MenuCollapsibleSection> {
 
   @override
   Widget build(BuildContext context) {
+    final flat = DetachedShellHost.drawsChrome(context);
+    final radius = flat ? BorderRadius.zero : BorderRadius.circular(20);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Padding(
-          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+          padding: flat
+              ? EdgeInsets.zero
+              : const EdgeInsets.fromLTRB(16, 0, 16, 12),
           child: GlassSurface(
             enableRipple: true,
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(color: context.cs.outlineVariant),
+            borderRadius: radius,
+            border: flat
+                ? Border(bottom: BorderSide(color: context.cs.outlineVariant))
+                : Border.all(color: context.cs.outlineVariant),
             child: InkWell(
-              borderRadius: BorderRadius.circular(20),
+              borderRadius: radius,
               onTap: () {
                 Haptics.selectionClick();
                 setState(() => _expanded = !_expanded);
@@ -122,20 +129,35 @@ class MenuGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final body = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (header != null) _buildHeader(context),
+        ...items,
+        const SizedBox(height: 6),
+      ],
+    );
+
+    // Inside the floating window the host already draws a frame, so a group
+    // that keeps its own card reads as a card inside a card. There it runs
+    // edge to edge — no side gutters, no left/right edges, no rounding — and
+    // only the rule under it separates one group from the next.
+    if (DetachedShellHost.drawsChrome(context)) {
+      return GlassSurface(
+        enableRipple: true,
+        borderRadius: BorderRadius.zero,
+        border: Border(bottom: BorderSide(color: context.cs.outlineVariant)),
+        child: body,
+      );
+    }
+
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
       child: GlassSurface(
         enableRipple: true,
         borderRadius: BorderRadius.circular(20),
         border: Border.all(color: context.cs.outlineVariant),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (header != null) _buildHeader(context),
-            ...items,
-            const SizedBox(height: 6),
-          ],
-        ),
+        child: body,
       ),
     );
   }

--- a/lib/shared/widgets/sheet_view.dart
+++ b/lib/shared/widgets/sheet_view.dart
@@ -141,6 +141,12 @@ class _SheetViewState extends ConsumerState<SheetView>
   /// handed to the window's title bar instead of being drawn here.
   bool _hostDrawsChrome = false;
 
+  /// Whether the header is drawn edge to edge with square corners, as the
+  /// desktop shell draws a tab's. True for a sheet hosted in the right
+  /// sidebar, where the inset pill of the phone layout left a floating bar
+  /// adrift in a fixed column.
+  bool _flushHeader = false;
+
   /// Whether the app-bar row belongs to this sheet's own header.
   bool get _ownsAppBar => !_hostDrawsChrome;
 
@@ -314,6 +320,12 @@ class _SheetViewState extends ConsumerState<SheetView>
     // A modal bottom sheet is mounted on the root navigator, above any host,
     // so it always keeps its own header.
     _hostDrawsChrome = !_inModalSheet && DetachedShellHost.drawsChrome(context);
+    // Hosted in the desktop right sidebar: a panel filling a fixed column, not
+    // a sheet floating over a phone screen. Its header runs edge to edge with
+    // square corners there, the way the desktop shell paints a tab's header —
+    // the inset pill was left over from the phone layout.
+    _flushHeader =
+        !_inModalSheet && DetachedShellHost.of(context) && !_hostDrawsChrome;
     _syncHeaderSuppression();
     _publishChromeHeader();
     if (!_heightInit) {
@@ -631,7 +643,9 @@ class _SheetViewState extends ConsumerState<SheetView>
                 child: SafeArea(
                   bottom: false,
                   child: Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 10, 16, 0),
+                    padding: _flushHeader
+                        ? EdgeInsets.zero
+                        : const EdgeInsets.fromLTRB(16, 10, 16, 0),
                     child: KeyedSubtree(
                       key: _headerKey,
                       child: Column(
@@ -643,6 +657,9 @@ class _SheetViewState extends ConsumerState<SheetView>
                               titleWidget: widget.titleWidget,
                               showBack: widget.showBack,
                               onBack: widget.onBack,
+                              borderRadius: _flushHeader
+                                  ? BorderRadius.zero
+                                  : const BorderRadius.all(Radius.circular(20)),
                               actions: widget.actions.map((action) {
                                 return _HeaderIconButton(
                                   onPressed: action.onPressed,
@@ -655,7 +672,13 @@ class _SheetViewState extends ConsumerState<SheetView>
                             ),
                           if (widget.tabs.isNotEmpty)
                             Padding(
-                              padding: const EdgeInsets.only(top: 12),
+                              // The outer gutter is dropped when flush, so the
+                              // rows below the app bar carry their own.
+                              padding: EdgeInsets.only(
+                                top: 12,
+                                left: _flushHeader ? 16 : 0,
+                                right: _flushHeader ? 16 : 0,
+                              ),
                               child: Row(
                                 children: widget.tabs
                                     .map(
@@ -682,7 +705,11 @@ class _SheetViewState extends ConsumerState<SheetView>
                             ),
                           if (widget.headerBottom != null)
                             Padding(
-                              padding: const EdgeInsets.only(top: 12),
+                              padding: EdgeInsets.only(
+                                top: 12,
+                                left: _flushHeader ? 16 : 0,
+                                right: _flushHeader ? 16 : 0,
+                              ),
                               child: widget.headerBottom!,
                             ),
                         ],

--- a/test/desktop_right_sidebar_rail_test.dart
+++ b/test/desktop_right_sidebar_rail_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/features/chat/widgets/magic_drawer_widgets.dart';
+import 'package:glaze_flutter/shared/shell/desktop/desktop_right_sidebar.dart';
+import 'package:glaze_flutter/shared/shell/desktop/sidebar_resizer.dart';
+import 'package:glaze_flutter/shared/shell/desktop/sidebar_sheet_provider.dart';
+
+/// Vue pins `.left-icon-strip` top-to-bottom (`top: 0; bottom: 0`) and stacks
+/// its icons from the top. The Flutter rail lives in a `Row` beside the open
+/// panel, and a `Row` centres its children by default — so the strip, which
+/// shrink-wraps its icons, floated into the middle of the sidebar with a gap
+/// above the first icon.
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<void> pumpSidebar(
+    WidgetTester tester, {
+    required bool withPanel,
+    double width = 320,
+  }) async {
+    final controller = RightSidebarController.fromPrefs(null);
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          // Not a /chat/ route, so the sidebar renders the tool strip rather
+          // than the Magic Drawer (which would want a database).
+          path: '/tools',
+          builder: (_, _) => DesktopRightSidebar(width: width),
+        ),
+      ],
+      initialLocation: '/tools',
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          rightSidebarControllerProvider.overrideWithValue(controller),
+        ],
+        child: MaterialApp.router(
+          theme: ThemeData.dark(),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    if (withPanel) {
+      final ref = ProviderScope.containerOf(
+        tester.element(find.byType(DesktopRightSidebar)),
+      );
+      ref.read(rightSidebarPanelProvider.notifier).state = SidebarPanel(
+        id: 'stub',
+        builder: (_) => const Text('panel body'),
+      );
+      await tester.pumpAndSettle();
+    }
+  }
+
+  testWidgets('the rail beside an open panel starts at the top', (
+    tester,
+  ) async {
+    await pumpSidebar(tester, withPanel: true);
+    expect(find.text('panel body'), findsOneWidget);
+
+    final sidebar = tester.getRect(find.byType(DesktopRightSidebar));
+    final firstIcon = tester.getRect(find.byType(MagicDrawerStripIcon).first);
+
+    // The first icon sits flush with the sidebar's top edge, not floated down
+    // by a centred Row.
+    expect(firstIcon.top, moreOrLessEquals(sidebar.top, epsilon: 0.5));
+  });
+
+  testWidgets('the collapsed strip also starts at the top', (tester) async {
+    // Below the collapse threshold the strip is the whole sidebar.
+    await pumpSidebar(tester, withPanel: false, width: kSidebarCollapsedWidth);
+
+    final sidebar = tester.getRect(find.byType(DesktopRightSidebar));
+    final firstIcon = tester.getRect(find.byType(MagicDrawerStripIcon).first);
+
+    expect(firstIcon.top, moreOrLessEquals(sidebar.top, epsilon: 0.5));
+  });
+}

--- a/test/menu_group_window_chrome_test.dart
+++ b/test/menu_group_window_chrome_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/shared/shell/shell_header_provider.dart';
+import 'package:glaze_flutter/shared/widgets/glass_surface.dart';
+import 'package:glaze_flutter/shared/widgets/menu_group.dart';
+
+/// The desktop floating window already frames whatever it hosts, so the menu
+/// groups inside it drop their own rounded cards and side gutters — otherwise
+/// the content reads as a card of cards. Only the rule under each group still
+/// separates one from the next.
+Widget _host({required bool hasChrome}) {
+  return ProviderScope(
+    child: MaterialApp(
+      theme: ThemeData.dark(),
+      home: Scaffold(
+        body: DetachedShellHost(
+          hasChrome: hasChrome,
+          child: const MenuGroup(items: [Text('row')]),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('a group in the floating window runs edge to edge', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(hasChrome: true));
+    await tester.pumpAndSettle();
+
+    final surface = tester.widget<GlassSurface>(find.byType(GlassSurface));
+    expect(surface.borderRadius, BorderRadius.zero);
+    // Only the bottom rule survives — no left/right edges.
+    expect(surface.border, isA<Border>());
+    final border = surface.border! as Border;
+    expect(border.left, BorderSide.none);
+    expect(border.right, BorderSide.none);
+    expect(border.bottom, isNot(BorderSide.none));
+
+    final host = tester.getRect(find.byType(DetachedShellHost));
+    final card = tester.getRect(find.byType(GlassSurface));
+    expect(card.left, moreOrLessEquals(host.left, epsilon: 0.5));
+    expect(card.right, moreOrLessEquals(host.right, epsilon: 0.5));
+  });
+
+  testWidgets('a group outside the window keeps its card', (tester) async {
+    await tester.pumpWidget(_host(hasChrome: false));
+    await tester.pumpAndSettle();
+
+    final surface = tester.widget<GlassSurface>(find.byType(GlassSurface));
+    expect(surface.borderRadius, BorderRadius.circular(20));
+
+    final host = tester.getRect(find.byType(DetachedShellHost));
+    final card = tester.getRect(find.byType(GlassSurface));
+    expect(card.left, greaterThan(host.left));
+    expect(card.right, lessThan(host.right));
+  });
+}

--- a/test/sheet_view_window_chrome_test.dart
+++ b/test/sheet_view_window_chrome_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:glaze_flutter/shared/shell/shell_header_provider.dart';
+import 'package:glaze_flutter/shared/widgets/glaze_scaffold.dart';
 import 'package:glaze_flutter/shared/widgets/sheet_view.dart';
 
 /// The desktop floating window draws its own title bar, so a [SheetView] shown
@@ -103,5 +104,50 @@ void main() {
     expect(find.text('Cloud sync'), findsOneWidget);
     expect(find.byIcon(Icons.arrow_back_ios_new_rounded), findsOneWidget);
     expect(_chromeClaim(tester), isNull);
+  });
+
+  // A sheet hosted in the right sidebar fills a fixed column, so its header
+  // runs edge to edge with square corners like the desktop shell's tab header.
+  // The inset, 20px-rounded pill is the phone treatment and read as a bar
+  // floating loose inside the column.
+  testWidgets('a sheet hosted in the sidebar draws a flush header', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(hasChrome: false));
+    await tester.pumpAndSettle();
+
+    final appBar = tester.widget<GlazeAppBar>(find.byType(GlazeAppBar));
+    expect(appBar.borderRadius, BorderRadius.zero);
+
+    // Edge to edge: no side gutter between the column and the header.
+    final host = tester.getRect(find.byType(SheetView));
+    final bar = tester.getRect(find.byType(GlazeAppBar));
+    expect(bar.left, moreOrLessEquals(host.left, epsilon: 0.5));
+    expect(bar.right, moreOrLessEquals(host.right, epsilon: 0.5));
+  });
+
+  testWidgets('an ordinary route keeps the inset pill header', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: ThemeData.dark(),
+          home: const Scaffold(
+            body: SheetView(
+              title: 'Cloud sync',
+              showBack: true,
+              body: Text('sheet body'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final appBar = tester.widget<GlazeAppBar>(find.byType(GlazeAppBar));
+    expect(appBar.borderRadius, const BorderRadius.all(Radius.circular(20)));
+
+    final host = tester.getRect(find.byType(SheetView));
+    final bar = tester.getRect(find.byType(GlazeAppBar));
+    expect(bar.left, greaterThan(host.left));
   });
 }


### PR DESCRIPTION
Follow-up to #352 and #363, covering the five desktop gaps those left. Every change is desktop-only; the phone layout is untouched throughout.

Supersedes #365, which was branched off a week-stale `nightly` and reimplemented things #352 had already landed.

## Right sidebar

- The icon rail beside an open panel starts at the top again. The rail sits in a `Row`, which centres its children by default, and the strip shrink-wraps its icons — so it floated into the middle of the sidebar with a gap above the first icon. Vue's `.left-icon-strip` is pinned top-to-bottom.
- A sheet hosted in the sidebar draws a flush, square header instead of the inset 20px-rounded pill, which is the phone treatment and read as a bar adrift inside a fixed column. The rows below the app bar carry their own 16px gutter now that the outer one is gone.

## Characters

- The tab strip keeps its natural width on the left and the Add button moves into that row (Vue's `.tabs-row`), instead of the strip spanning the window with Add floating over the grid. The row outlives a hidden catalog on desktop, since it carries Add.
- The sort row starts at the left edge with the sort-type pill ahead of the direction toggle, per `.desktop-mode .sort-controls` (`justify-content: flex-start`, `order: 1 / 2`). It stays a `Wrap`, so a narrow middle column still moves the controls onto a second line.

## MenuGroup

- Inside the floating window a group runs edge to edge — no side gutters, no left/right edges, no rounding — separated only by the rule beneath it. The window already draws a frame, so the per-group cards read as a card of cards. Hooks into the existing `DetachedShellHost.drawsChrome` rather than introducing a second scope.

## Glossary

- A help tip on desktop opens the floating glossary window at that term rather than a modal sheet, and the window is mounted above the router so it stays on top of whatever opened it. It rendered inside the shell before, so any modal sheet covered it.

## Chat

- The header is drawn flush and square, like the tab header the desktop shell paints. The WebView blur region follows the same geometry, read from a flag captured during build so the post-frame measure registers no inherited-widget dependency.
- The chat's background is painted across the full column, behind `ChatColumnWidth`'s side gutters. The width cap added in #352 left the chat's own background on the column and the app's background in the gutters, so the chat read as a lighter strip between two darker bands. Extracted into a shared `ChatBackground`, used by the WebView surface and the column alike.
- The top and bottom darkening bands are gone.

## Onboarding

- Port the legacy-vue desktop wizard: a centred card with a top bar (back, stories bar, skip) and a two-pane slide — the icon in a tinted visual pane on the left, title / description / body and the primary button on the right.
- Slide content is split into `onboarding_models.dart` and `widgets/onboarding_widgets.dart` so the phone flow and the wizard render it from one source rather than two copies.
- Desktop is detected by window width here: onboarding is pushed on the root navigator, above the shell, where there is no `DesktopScope` to read.

## Verification

- `flutter analyze` — no new issues. The 7 remaining are pre-existing, all in files this branch does not touch.
- `flutter test` — 3641 passing.
- `dart format` clean.
- New tests: `desktop_right_sidebar_rail_test.dart` (both rail states start at the top — confirmed failing at 180px against the unfixed code), `menu_group_window_chrome_test.dart` (edge to edge in the window, card kept outside it), plus two cases in `sheet_view_window_chrome_test.dart` for the flush sidebar header.

Not verified at runtime — the agent cannot run `flutter run`, so the visual result of each layout change is still worth a look in a real desktop window.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1S9d6o9kEan6yUoRCTW7M)_