### PR TITLE
feat(chat): send messages without asking for a reply

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1373,6 +1373,7 @@
   "chat_message_title": "Message",
   "chat_long_message_hint": "Write a long message here...",
   "chat_guidance_message_hint": "Message with guidance...",
+  "chat_no_reply_hint": "Message without a reply...",
   "authors_note_placeholder": "Enter author's note...",
   "authors_note_role_hint": "Role, depth and insertion mode are set per preset, in the preset editor.",
   "tokenizer_history_limit_warning": "History is near its limit",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -1239,6 +1239,7 @@
   "chat_message_title": "Сообщение",
   "chat_long_message_hint": "Напишите длинное сообщение...",
   "chat_guidance_message_hint": "Сообщение с указанием...",
+  "chat_no_reply_hint": "Сообщение без ответа...",
   "authors_note_placeholder": "Введите заметку автора...",
   "authors_note_role_hint": "Роль, глубина и режим вставки настраиваются в редакторе пресетов.",
   "tokenizer_history_limit_warning": "История близка к лимиту",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -481,6 +481,15 @@ toast. See `docs/INVARIANTS.md` INV-CM1–INV-CM6.
 **Talkativeness:** `sendMessage()` may skip generation when
 `character.extensions['talkativeness']` rolls above the configured threshold.
 
+**Send without a reply:** `ChatNotifier.tryAppendMessage()` runs the send path
+with `generateReply: false` — the composer's "no reply" toggle, used to write
+several user turns in a row. A run in flight is aborted first, the message is
+appended through the same durable write, and no pipeline starts. Consecutive
+`user` messages are left untouched in the history and in the assembled prompt;
+the connection's prompt post-processing mode decides whether they go out as
+separate turns or squashed into one (`PromptPostProcessing`). See
+`docs/rules/generation.md` § Entry paths.
+
 ### Prompt composition boundary
 
 `PromptInputsCollector` and `PromptPayloadBuilder` do not import feature modules

--- a/docs/rules/generation.md
+++ b/docs/rules/generation.md
@@ -29,8 +29,20 @@ Full formal invariants with code references: `docs/INVARIANTS.md`
 | User action | Orchestrator | Post-SSE (`GenerationPipeline`) |
 |-------------|--------------|----------------------------------|
 | Send message | `_runGeneration` → `GenerationPipeline.run()` | Yes — image tags, extensions, sync |
+| Send without a reply | `_sendMessage(generateReply: false)` — durable append only | **No run at all** |
 | Regenerate | `_runGeneration` → `GenerationPipeline.run()` | Yes |
 | Continue | `ChatGenerationService.generate()` directly | **No** — see INV-CM2 |
+
+`ChatNotifier.tryAppendMessage` is the no-reply half of a send: the composer's
+"no reply" toggle uses it to write several user turns in a row. It aborts a run
+in flight first (the send *is* the Stop press), appends the message through the
+same durable path as an ordinary send, commits the accepted variation and
+dispatches `afterUser` blocks — then stops, leaving the chat idle with a
+trailing user message. The queued turns stay separate `user` messages in the
+history; how they reach the provider is the connection's prompt
+post-processing mode's call (`none` sends them as-is, the merge family squashes
+them into one turn). The reply is asked for later by Regenerate on the trailing
+user message, by Continue, or by the next ordinary send.
 
 ---
 

--- a/lib/features/chat/chat_provider.dart
+++ b/lib/features/chat/chat_provider.dart
@@ -427,6 +427,62 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     return durableAcceptance.future;
   }
 
+  /// Appends a user message and asks for **no** reply, so the user can write
+  /// several turns in a row. A run already in flight is aborted first — "let
+  /// me keep writing" is exactly the Stop button plus a send.
+  ///
+  /// The queued turns stay separate `user` messages in the history: how they
+  /// reach the provider is the connection's prompt post-processing mode's
+  /// call (`PromptPostProcessing` — `none` sends them as-is, the merge family
+  /// squashes them into one turn). The trailing user message keeps its
+  /// Regenerate button, which is how the reply is finally asked for.
+  ///
+  /// Resolves true once the message is durably appended, same contract as
+  /// [trySendMessage]: UI callers keep the composer intact on false.
+  Future<bool> tryAppendMessage(String text, {String? imageDataUrl}) async {
+    if (!ref.mounted) return false;
+    final running = state.value;
+    if (running != null &&
+        (running.isGenerating ||
+            running.isGeneratingImage ||
+            running.isPostGenRunning)) {
+      // Awaited: the aborted run finalizes its own session write (partial
+      // text, restoration), and this message has to land on top of that row,
+      // never race it.
+      await abortGeneration();
+      if (!ref.mounted) return false;
+    }
+    if (_sendInFlight ||
+        _sessionChangesInFlight > 0 ||
+        ref.read(editingMessageIdProvider(arg)) != null) {
+      return false;
+    }
+    final current = state.value;
+    if (current == null ||
+        current.isGenerating ||
+        current.isGeneratingImage ||
+        current.isPostGenRunning ||
+        _isMemoryDraftActive(current)) {
+      return false;
+    }
+
+    final durableAcceptance = Completer<bool>();
+    unawaited(
+      _sendMessage(
+        text,
+        imageDataUrl: imageDataUrl,
+        generateReply: false,
+        durableAcceptance: durableAcceptance,
+      ).catchError((Object error, StackTrace stackTrace) {
+        debugPrint('[ChatNotifier] queued send failed: $error\n$stackTrace');
+        if (!durableAcceptance.isCompleted) {
+          durableAcceptance.complete(false);
+        }
+      }),
+    );
+    return durableAcceptance.future;
+  }
+
   Future<void> sendMessage(
     String text, {
     String? guidanceText,
@@ -441,6 +497,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
     String text, {
     String? guidanceText,
     String? imageDataUrl,
+    bool generateReply = true,
     Completer<bool>? durableAcceptance,
   }) async {
     if (!ref.mounted) {
@@ -491,9 +548,13 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         imagePath: imageDataUrl,
       );
 
-      final acceptedAssistant = current.messages.reversed
-          .where((message) => message.role == 'assistant')
-          .firstOrNull;
+      // Only the assistant *immediately* before the new message is accepted —
+      // `ChatRepo.appendUserMessageAndAcceptCurrentVariation` enforces exactly
+      // that and refuses the whole write otherwise. Scanning back past a
+      // trailing user message (an aborted send, or a queued turn) would name
+      // an older variation and the append would be silently dropped.
+      final trailing = current.messages.isEmpty ? null : current.messages.last;
+      final acceptedAssistant = trailing?.role == 'assistant' ? trailing : null;
       final expectedAcceptedVariation = acceptedAssistant == null
           ? null
           : LorebookUseGenerationIdentity(
@@ -513,6 +574,10 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       // button under a message it is about to answer. Cleared atomically with
       // the `isGenerating` publish below, and swept in this method's `finally`
       // for the paths that return before ever reaching it.
+      //
+      // A no-reply send ([generateReply] false) claims neither: nothing is on
+      // its way, so the chat stays idle and the trailing user message keeps
+      // the Regenerate button that asks for the reply later.
       final optimisticSession = current.session!.copyWith(
         messages: [...current.messages, userMsg],
         draft: '',
@@ -521,9 +586,14 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       // The typing bubble goes up with this paint, so name the phase now —
       // otherwise it shows the default "Generating…" for the whole durable
       // write, which is the claim this label exists to stop making.
-      setGenerationPhase(ref, arg, GenerationPhase.preparing);
+      if (generateReply) {
+        setGenerationPhase(ref, arg, GenerationPhase.preparing);
+      }
       state = AsyncData(
-        current.copyWith(session: optimisticSession, isSendPending: true),
+        current.copyWith(
+          session: optimisticSession,
+          isSendPending: generateReply,
+        ),
       );
       await _yieldToFrame();
       if (!ref.mounted) return;
@@ -568,12 +638,19 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         return;
       }
       state = AsyncData(
-        afterWrite.copyWith(
-          session: updatedSession,
-          isGenerating: true,
-          isSendPending: false,
-          generationStartTime: DateTime.now(),
-        ),
+        generateReply
+            ? afterWrite.copyWith(
+                session: updatedSession,
+                isGenerating: true,
+                isSendPending: false,
+                generationStartTime: DateTime.now(),
+              )
+            // No reply was asked for: publish the appended message and leave
+            // the chat idle, ready for the next one.
+            : afterWrite.copyWith(
+                session: updatedSession,
+                isSendPending: false,
+              ),
       );
 
       // Dispatch `afterUser` extension blocks. This is fire-and-forget — the
@@ -595,6 +672,10 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
         // `isGenerating` stuck true.
         await _commitAcceptedVariation(current.session!.id, acceptedAssistant);
         if (!ref.mounted) return;
+        // The variation the user was looking at is committed either way — the
+        // message lands after it — but a no-reply send stops here: no
+        // talkativeness roll, no pipeline.
+        if (!generateReply) return;
 
         final charRepo = ref.read(characterRepoProvider);
         final character = await charRepo.getById(arg);

--- a/lib/features/chat/chat_screen.dart
+++ b/lib/features/chat/chat_screen.dart
@@ -2260,6 +2260,29 @@ class _ChatBodyState extends ConsumerState<_ChatBody>
                                         // write and missed that append.
                                         return accepted;
                                       },
+                                      onSendWithoutReply:
+                                          (text, imageDataUrl) async {
+                                            if (text.trim().isEmpty &&
+                                                imageDataUrl == null) {
+                                              return false;
+                                            }
+                                            if (!await _maybeSeedGameTime()) {
+                                              return false;
+                                            }
+                                            // Appends only — a reply is asked
+                                            // for later, with Regenerate or
+                                            // the next ordinary send.
+                                            return ref
+                                                .read(
+                                                  chatProvider(
+                                                    widget.charId,
+                                                  ).notifier,
+                                                )
+                                                .tryAppendMessage(
+                                                  text,
+                                                  imageDataUrl: imageDataUrl,
+                                                );
+                                          },
                                       onSendWithImage:
                                           (
                                             text,

--- a/lib/features/chat/widgets/chat_input_bar.dart
+++ b/lib/features/chat/widgets/chat_input_bar.dart
@@ -37,6 +37,12 @@ class ChatInputBar extends ConsumerStatefulWidget {
   final bool Function()? canSend;
   final Future<bool> Function(String text, String? guidance)?
   onSendWithGuidance;
+
+  /// Appends the message without asking for a reply, so several turns can be
+  /// written in a row. Same contract as [onSend]: true only when the host took
+  /// ownership. When null the "no reply" toggle is not offered at all.
+  final Future<bool> Function(String text, String? imageDataUrl)?
+  onSendWithoutReply;
   final bool isGenerating;
   final bool isGeneratingImage;
 
@@ -97,6 +103,7 @@ class ChatInputBar extends ConsumerStatefulWidget {
     required this.onSend,
     this.canSend,
     this.onSendWithGuidance,
+    this.onSendWithoutReply,
     required this.isGenerating,
     this.isGeneratingImage = false,
     this.isPostGenRunning = false,
@@ -138,6 +145,11 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
   late final TextEditingController _controller;
   final _guidanceController = TextEditingController();
   bool _guidanceMode = false;
+
+  /// "Write several turns in a row" mode: a send appends the message and asks
+  /// for no reply. Sticky until toggled back off — queuing messages is a
+  /// stretch of writing, not a single tap.
+  bool _noReplyMode = false;
   Timer? _debounce;
   final _internalFocusNode = FocusNode();
   Uint8List? _attachedImageBytes;
@@ -310,7 +322,11 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
     _isDispatchingSend = true;
     bool accepted;
     try {
-      if (imageDataUrl != null) {
+      if (_noReplyMode && widget.onSendWithoutReply != null) {
+        // Queue the turn: no guidance (there is no generation to steer) and no
+        // reply — the host appends it and stays idle.
+        accepted = await widget.onSendWithoutReply!(text, imageDataUrl);
+      } else if (imageDataUrl != null) {
         final guidance =
             _guidanceMode && _guidanceController.text.trim().isNotEmpty
             ? _guidanceController.text.trim()
@@ -535,6 +551,13 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
         widget.isGenerating ||
         widget.isGeneratingImage ||
         widget.isPostGenRunning;
+    final canQueue = widget.onSendWithoutReply != null;
+    final queueing = canQueue && _noReplyMode;
+    // The button is Stop while a reply is in flight — except when the user is
+    // queuing turns and has something written: there the send *is* the stop
+    // (the host cancels the run, then appends), which is what "several
+    // messages in a row, no reply" means mid-stream.
+    final showStop = isGenerating && !(queueing && hasContent);
 
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
@@ -625,6 +648,11 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
                           color: Colors.orange.withValues(alpha: 0.3),
                           width: preset.borderWidth.clamp(1.0, double.infinity),
                         )
+                      : queueing
+                      ? Border.all(
+                          color: Colors.lightBlueAccent.withValues(alpha: 0.3),
+                          width: preset.borderWidth.clamp(1.0, double.infinity),
+                        )
                       : uiBorder,
                   child: ConstrainedBox(
                     constraints: const BoxConstraints(minHeight: 56),
@@ -652,6 +680,8 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
                       decoration: InputDecoration(
                         hintText: _guidanceMode
                             ? 'chat_guidance_message_hint'.tr()
+                            : queueing
+                            ? 'chat_no_reply_hint'.tr()
                             : 'chat_placeholder'.tr(),
                         hintStyle: TextStyle(
                           color: secondaryColor,
@@ -711,24 +741,45 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
                       onTap: () => setState(() {
                         _guidanceMode = !_guidanceMode;
                         if (!_guidanceMode) _guidanceController.clear();
+                        // Guidance steers a generation; the no-reply mode asks
+                        // for none. Only one of the two can be armed.
+                        if (_guidanceMode) _noReplyMode = false;
                       }),
                       color: _guidanceMode ? Colors.orange : null,
                       batterySaver: widget.batterySaver,
                       blurRegionId: 'btn-guidance',
                     ),
+                    if (canQueue) ...[
+                      const SizedBox(width: 8),
+                      _CircleBtn(
+                        icon: Icons.speaker_notes_off_outlined,
+                        onTap: () => setState(() {
+                          _noReplyMode = !_noReplyMode;
+                          if (_noReplyMode) {
+                            _guidanceMode = false;
+                            _guidanceController.clear();
+                          }
+                        }),
+                        color: _noReplyMode ? Colors.lightBlueAccent : null,
+                        batterySaver: widget.batterySaver,
+                        blurRegionId: 'btn-no-reply',
+                      ),
+                    ],
                   ],
                 ),
                 _SendBtn(
-                  icon: isGenerating
+                  icon: showStop
                       ? Icons.stop_rounded
                       : hasContent
-                      ? (_guidanceMode && _controller.text.trim().isEmpty
+                      ? (queueing
+                            ? Icons.playlist_add_rounded
+                            : _guidanceMode && _controller.text.trim().isEmpty
                             ? Icons.check_rounded
                             : Icons.send_rounded)
                       : Icons.account_circle_rounded,
                   batterySaver: widget.batterySaver,
                   onTap: () {
-                    if (isGenerating) {
+                    if (showStop) {
                       widget.onStop?.call();
                     } else if (widget.isEditingMessage) {
                       return;

--- a/test/chat_input_bar_test.dart
+++ b/test/chat_input_bar_test.dart
@@ -14,19 +14,23 @@ void main() {
 
   group('ChatInputBar', () {
     late List<String> sentMessages;
+    late List<String> queuedMessages;
 
     Widget buildChatInputBar({
       FocusNode? focusNode,
       bool virtualKeyboardSend = false,
       bool enterToSend = true,
       bool isEditingMessage = false,
+      bool isGenerating = false,
       bool isGeneratingImage = false,
       String initialDraft = '',
       void Function(String? guidance)? onImpersonate,
       VoidCallback? onStop,
       bool acceptSend = true,
+      bool canQueue = false,
     }) {
       sentMessages = [];
+      queuedMessages = [];
       return ProviderScope(
         child: MaterialApp(
           home: Scaffold(
@@ -35,7 +39,13 @@ void main() {
                 sentMessages.add(text);
                 return acceptSend;
               },
-              isGenerating: false,
+              onSendWithoutReply: canQueue
+                  ? (text, imageDataUrl) async {
+                      queuedMessages.add(text);
+                      return acceptSend;
+                    }
+                  : null,
+              isGenerating: isGenerating,
               isGeneratingImage: isGeneratingImage,
               focusNode: focusNode,
               virtualKeyboardSend: virtualKeyboardSend,
@@ -167,6 +177,67 @@ void main() {
       await tester.pump();
       textField = tester.widget<TextField>(find.byType(TextField));
       expect(textField.controller!.text, isEmpty);
+    });
+
+    testWidgets('no-reply toggle is hidden when the host cannot queue', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildChatInputBar(initialDraft: 'hello'));
+
+      expect(find.byIcon(Icons.speaker_notes_off_outlined), findsNothing);
+      expect(find.byIcon(Icons.send_rounded), findsOneWidget);
+    });
+
+    testWidgets('no-reply toggle routes the send past generation', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildChatInputBar(initialDraft: 'no answer please', canQueue: true),
+      );
+
+      await tester.tap(find.byIcon(Icons.speaker_notes_off_outlined));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // The send button says what it will do: append, not ask for a reply.
+      await tester.tap(find.byIcon(Icons.playlist_add_rounded));
+      await tester.pump();
+
+      expect(queuedMessages, ['no answer please']);
+      expect(sentMessages, isEmpty);
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.controller!.text, isEmpty);
+    });
+
+    testWidgets('queuing a turn mid-stream sends instead of stopping', (
+      tester,
+    ) async {
+      var stopCalls = 0;
+      await tester.pumpWidget(
+        buildChatInputBar(
+          initialDraft: 'keep writing',
+          canQueue: true,
+          isGenerating: true,
+          onStop: () => stopCalls++,
+        ),
+      );
+
+      // Stop while the composer is the default mode …
+      expect(find.byIcon(Icons.stop_rounded), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.speaker_notes_off_outlined));
+      // The send button cross-fades between icons; let that finish before
+      // asserting which one is on screen.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // … and a send once queuing is armed: the host cancels the run itself.
+      expect(find.byIcon(Icons.stop_rounded), findsNothing);
+      await tester.tap(find.byIcon(Icons.playlist_add_rounded));
+      await tester.pump();
+
+      expect(queuedMessages, ['keep writing']);
+      expect(stopCalls, 0);
     });
 
     testWidgets('image generation stop button remains tappable', (

--- a/test/queued_user_messages_test.dart
+++ b/test/queued_user_messages_test.dart
@@ -1,0 +1,275 @@
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/llm/converters/prompt_post_processing.dart';
+import 'package:glaze_flutter/core/llm/history_assembler.dart';
+import 'package:glaze_flutter/core/llm/macro_engine.dart';
+import 'package:glaze_flutter/core/llm/studio_turn_config_snapshot.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:glaze_flutter/features/chat/chat_generation_service.dart';
+import 'package:glaze_flutter/features/chat/chat_provider.dart';
+import 'package:glaze_flutter/features/chat/chat_session_service.dart';
+import 'package:glaze_flutter/features/chat/chat_state.dart';
+
+/// Generation stub: records whether a run was requested at all, and hands the
+/// test control while it is "streaming".
+class _HookGenerationService extends ChatGenerationService {
+  _HookGenerationService(super.ref, this._onGenerate);
+
+  final Future<ChatState> Function(ChatSession session) _onGenerate;
+  int calls = 0;
+
+  @override
+  Future<ChatState> generate({
+    required ChatSession session,
+    ChatSession? saveSession,
+    required String charId,
+    required int genId,
+    required ChatState currentState,
+    required void Function(ChatState) onStateUpdate,
+    required bool Function() isAborted,
+    List<String>? previousSwipes,
+    int previousSwipeId = 0,
+    String? previousReasoning,
+    String? previousGenTime,
+    int? previousTokens,
+    List<Map<String, dynamic>>? previousSwipesMeta,
+    String? guidanceText,
+    String? regenTargetId,
+    String? continueTargetId,
+    StudioTurnConfigSnapshot? studioTurnConfig,
+  }) async {
+    calls++;
+    return _onGenerate(session);
+  }
+}
+
+void main() {
+  // The send path pings the notification service (haptics → platform channel),
+  // which needs a binding to no-op instead of throwing.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('queued user messages', () {
+    late AppDatabase db;
+    late ProviderContainer container;
+    late _HookGenerationService generationService;
+
+    Future<ChatNotifier> setUpChat(
+      List<ChatMessage> messages, {
+      Future<ChatState> Function(ChatSession session)? onGenerate,
+    }) async {
+      SharedPreferences.setMockInitialValues({});
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      container = ProviderContainer(
+        overrides: [
+          appDbProvider.overrideWithValue(db),
+          chatGenerationServiceProvider.overrideWith((ref) {
+            return generationService = _HookGenerationService(
+              ref,
+              // Every generating test here asserts *whether* a run was
+              // requested, never its output, so the default stub fails the
+              // run instead of faking a reply: the send path settles the
+              // state and leaves the messages exactly as written.
+              onGenerate ??
+                  (session) async => throw StateError('generation stub'),
+            );
+          }),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        ChatSessionService.clearCache();
+        await db.close();
+      });
+
+      // The generation service is created lazily, and a queued send never asks
+      // for one — read it up front so `calls` is observable at 0.
+      container.read(chatGenerationServiceProvider);
+
+      final session = ChatSession(
+        id: 's1',
+        characterId: 'c1',
+        sessionIndex: 0,
+        messages: messages,
+        draft: 'typed text',
+      );
+      await container
+          .read(characterRepoProvider)
+          .put(const Character(id: 'c1', name: 'Alice'));
+      await container.read(chatRepoProvider).put(session);
+      await container.read(chatProvider('c1').future);
+      return container.read(chatProvider('c1').notifier);
+    }
+
+    test('appends the turn and asks for no reply', () async {
+      final notifier = await setUpChat(const [
+        ChatMessage(id: 'm1', role: 'assistant', content: 'Hi', timestamp: 1),
+      ]);
+
+      final accepted = await notifier.tryAppendMessage('First');
+
+      expect(accepted, isTrue);
+      expect(generationService.calls, 0);
+      final state = container.read(chatProvider('c1')).requireValue;
+      expect(state.messages.map((m) => m.role), ['assistant', 'user']);
+      expect(state.messages.last.content, 'First');
+      expect(state.isGenerating, isFalse);
+      // Nothing is on its way, so the trailing user message keeps the
+      // Regenerate button that asks for the reply later.
+      expect(state.isSendPending, isFalse);
+      final persisted = await container.read(chatRepoProvider).getById('s1');
+      expect(persisted!.messages.map((m) => m.id), [
+        'm1',
+        state.messages.last.id,
+      ]);
+      expect(persisted.draft, '');
+    });
+
+    test('several turns in a row stay separate user messages', () async {
+      final notifier = await setUpChat(const [
+        ChatMessage(id: 'm1', role: 'assistant', content: 'Hi', timestamp: 1),
+      ]);
+
+      expect(await notifier.tryAppendMessage('First'), isTrue);
+      expect(await notifier.tryAppendMessage('Second'), isTrue);
+      expect(await notifier.tryAppendMessage('Third'), isTrue);
+
+      expect(generationService.calls, 0);
+      final persisted = await container.read(chatRepoProvider).getById('s1');
+      expect(persisted!.messages.map((m) => m.role), [
+        'assistant',
+        'user',
+        'user',
+        'user',
+      ]);
+      expect(persisted.messages.map((m) => m.content), [
+        'Hi',
+        'First',
+        'Second',
+        'Third',
+      ]);
+    });
+
+    test('a queued turn sent mid-stream cancels the run first', () async {
+      // The stub parks the run: `generate()` stays pending, so the chat is
+      // genuinely mid-generation while the test writes the next turn.
+      final reachedGeneration = Completer<ChatSession>();
+      final releaseGeneration = Completer<ChatState>();
+      final notifier = await setUpChat(
+        const [
+          ChatMessage(id: 'm1', role: 'assistant', content: 'Hi', timestamp: 1),
+        ],
+        onGenerate: (session) {
+          if (!reachedGeneration.isCompleted)
+            reachedGeneration.complete(session);
+          return releaseGeneration.future;
+        },
+      );
+
+      final send = notifier.sendMessage('First');
+      final generatingSession = await reachedGeneration.future;
+      expect(
+        container.read(chatProvider('c1')).requireValue.isGenerating,
+        isTrue,
+      );
+
+      final accepted = await notifier.tryAppendMessage('Second');
+
+      expect(accepted, isTrue);
+      // One run only: the queued turn stopped it instead of starting another.
+      expect(generationService.calls, 1);
+      final state = container.read(chatProvider('c1')).requireValue;
+      expect(state.isGenerating, isFalse);
+      expect(state.messages.map((m) => m.content), ['Hi', 'First', 'Second']);
+      expect(state.messages.last.role, 'user');
+
+      // Let the cancelled run unwind; it is stale, so it writes nothing.
+      releaseGeneration.complete(
+        ChatState(session: generatingSession, isGenerating: false),
+      );
+      await send;
+      expect(
+        container
+            .read(chatProvider('c1'))
+            .requireValue
+            .messages
+            .map((m) => m.content),
+        ['Hi', 'First', 'Second'],
+      );
+    });
+
+    test('the reply is generated once an ordinary send follows', () async {
+      final notifier = await setUpChat(const [
+        ChatMessage(id: 'm1', role: 'assistant', content: 'Hi', timestamp: 1),
+      ]);
+
+      await notifier.tryAppendMessage('First');
+      await notifier.sendMessage('Second');
+
+      expect(generationService.calls, 1);
+      final state = container.read(chatProvider('c1')).requireValue;
+      expect(state.messages.map((m) => m.content), ['Hi', 'First', 'Second']);
+    });
+
+    test('regenerate answers a run of queued turns', () async {
+      final notifier = await setUpChat(const [
+        ChatMessage(id: 'm1', role: 'assistant', content: 'Hi', timestamp: 1),
+      ]);
+
+      await notifier.tryAppendMessage('First');
+      await notifier.tryAppendMessage('Second');
+      await notifier.regenerateLastAssistant();
+
+      expect(generationService.calls, 1);
+    });
+  });
+
+  group('queued turns in the prompt', () {
+    const macroCtx = MacroContext(
+      charName: 'Alice',
+      charId: 'c1',
+      sessionId: 's1',
+    );
+
+    List<Map<String, dynamic>> apiMessages() => buildApiMessages(
+      HistoryAssembler(macroCtx).assemble(const [
+        ChatMessage(id: 'm1', role: 'assistant', content: 'Hi', timestamp: 1),
+        ChatMessage(id: 'm2', role: 'user', content: 'First', timestamp: 2),
+        ChatMessage(id: 'm3', role: 'user', content: 'Second', timestamp: 3),
+      ]),
+    );
+
+    test('reach the prompt as separate user turns', () {
+      expect(apiMessages().map((m) => m['role']), [
+        'assistant',
+        'user',
+        'user',
+      ]);
+    });
+
+    test('the post-processing mode decides how they go out', () {
+      // `none` — exactly as written.
+      expect(
+        postProcessPrompt(
+          apiMessages(),
+          PromptPostProcessing.none,
+        ).map((m) => m['content']).toList(),
+        ['Hi', 'First', 'Second'],
+      );
+      // The merge family squashes the run into one turn.
+      final merged = postProcessPrompt(
+        apiMessages(),
+        PromptPostProcessing.merge,
+      );
+      expect(merged.map((m) => m['role']), ['assistant', 'user']);
+      expect(merged.last['content'], 'First\n\nSecond');
+    });
+  });
+}


### PR DESCRIPTION
Adds a "no reply" mode to the composer so several user turns can be written in a row, and leaves it to the connection's prompt post-processing mode to decide how that run of turns goes out.

## Changes

- `ChatNotifier.tryAppendMessage` runs the send path with the new `generateReply: false` flag: the message goes through the same durable append (draft cleared, accepted variation committed, `afterUser` blocks dispatched), no pipeline starts, and neither `ChatState.isSendPending` nor the generation phase is claimed — so the chat stays idle and the trailing user message keeps the Regenerate button that asks for the reply later.
- A run already in flight is aborted and awaited first, so the queued turn lands on top of the row the cancelled run finalizes (partial text, restoration) instead of racing it.
- `ChatInputBar` gains an `onSendWithoutReply` callback and a toggle button next to the guidance one. While it is armed the send button shows `playlist_add` and, mid-stream, replaces Stop — the send *is* the cancel. Guidance and no-reply are mutually exclusive: guidance steers a generation, this mode asks for none. Hosts that pass no callback (the theme preview) get the old composer unchanged.
- Fixes the accepted-variation selection in `ChatNotifier._sendMessage`: it scanned back past a trailing user message and named an older assistant, which `ChatRepo.appendUserMessageAndAcceptCurrentVariation` refuses ("a user send accepts only the assistant immediately before it"), so the whole append was silently dropped. It now takes the trailing message only when it is an assistant. This was already reachable without the new mode — abort a send before anything streamed, then send again.
- Consecutive `user` messages are left untouched by `HistoryAssembler` / `buildApiMessages`; `PromptPostProcessing` decides whether they reach the provider as separate turns (`none`) or squashed into one (the merge family). The Claude and Gemini converters squash same-role runs on their own, so no provider sees an illegal shape.
- Documents the new entry path in `docs/rules/generation.md` § Entry paths and `docs/ARCHITECTURE.md`; adds `chat_no_reply_hint` to EN/RU.

## Verification

- `flutter analyze --no-fatal-infos --no-fatal-warnings` — 28 issues, all pre-existing warnings/infos, none in the changed files.
- `flutter test` — full suite run. New `test/queued_user_messages_test.dart` (append without a run, three turns in a row, a queued turn cancelling a live run, an ordinary send and Regenerate answering the queue, and the post-processing shape of a queued run) plus three new cases in `test/chat_input_bar_test.dart`.
- One pre-existing failure, unrelated to this change and equally red on `nightly` without it: `test/characterization/bridge_selection_edit_swipe_test.dart` — *MessageUpdateBatcher `_executeUpdateMessage` contains update logic*. The assertion slices 1200 characters from `_executeUpdateMessage(msg) {` and looks for `updateMessageContent`, which the method has since outgrown. Left alone here rather than widened as a drive-by.
- Not run: the app itself (no device in this environment) and the WebView render suite, which this change does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qqb9PLs1uTjS34Dt8YFLDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qqb9PLs1uTjS34Dt8YFLDB)_