### PR TITLE
feat(api): select the embedding preset apart from the chat preset

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -1757,6 +1757,7 @@
   "conn_status_connected": "Connected",
   "conn_status_failed": "Failed",
   "settings_api_configs_title": "API Configs",
+  "settings_embedding_config_title": "Embedding connection",
   "settings_new_config_tooltip": "New config",
   "settings_new_config_title": "New API Config",
   "settings_err_endpoint_key": "Enter endpoint and API key first",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -1768,6 +1768,7 @@
   "conn_status_connected": "Подключено",
   "conn_status_failed": "Ошибка",
   "settings_api_configs_title": "Конфигурации API",
+  "settings_embedding_config_title": "Подключение для эмбеддингов",
   "settings_new_config_tooltip": "Новая конфигурация",
   "settings_new_config_title": "Новая конфигурация API",
   "settings_err_endpoint_key": "Сначала введите эндпоинт и API ключ",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -891,7 +891,7 @@ INV-C5.
 ### Files
 - `lorebook_scanner.dart` — keyword scan: sticky/cooldown/probability/character-filter/recursion
 - `lorebook_merger.dart` — merges keyword + vector results, deduplicates by entry ID
-- `core/state/lorebook_embedding_provider.dart` — Riverpod composition for vector search and embedding
+- `core/state/lorebook_embedding_provider.dart` — Riverpod composition for vector search and embedding. `embeddingConfigProvider` reads the preset selected on the API screen's **Embeddings** tab (`activeEmbeddingConfigProvider`), independent of the chat preset; only the preset's "Use LLM API" toggle borrows the active LLM endpoint (INV-PS2c)
 - `lorebook_coverage.dart` — diagnostic full coverage report
 - `lorebook_vector_search.dart` — cosine similarity, hybrid boost (name/key/hint overlap)
 - `lorebook_embedding_service.dart` — indexes lorebook entries (hash-based dirty check)

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -678,9 +678,9 @@ bubble keeps rendering the image either way — hiding affects the request only.
 `vectorSearchAvailableProvider` (`lib/core/state/lorebook_embedding_provider.dart`)
 is the single source of truth for whether the app shows anything about vectors,
 embeddings or indexes. It mirrors the condition `resolveEmbeddingConfig` uses —
-an active API preset, not itself an `embedding`-mode preset, with
-`embeddingEnabled` on (the **Embeddings → Vector search** switch of the API
-screen).
+an **embedding** preset (`activeEmbeddingConfigProvider`, see INV-PS2c), not
+itself an `embedding`-mode preset, with `embeddingEnabled` on (the
+**Embeddings → Vector search** switch of the API screen).
 
 While it is `false`, these stay hidden rather than disabled: the lorebook
 search-type picker and vector params (list + global + per-book settings), the
@@ -689,6 +689,32 @@ toolbar, the reindex banner, the per-entry vector section and its `vec` / `idx`
 badges, and the memory sheet's retrieval-mode row, reindex / drop-indexes
 actions and index badges. Stored values are never rewritten by the gate — the
 previous choices come back when the toggle is switched on again.
+
+### INV-PS2c: The embedding preset is selected apart from the chat preset
+
+The API screen's **LLM** and **Embeddings** tabs each carry their own preset
+pill. The chat side follows `activeApiPresetIdProvider` (SharedPreferences
+`activeApiConfigId`), the embedding side `activeEmbeddingPresetIdProvider`
+(`activeEmbeddingConfigId`), and switching one never moves the other — a vector
+index is tied to the model that produced it, so it must not follow the chat
+connection around.
+
+`ApiListNotifier.build` seeds `activeEmbeddingConfigId` once, from the saved
+chat preset (or the first preset), so an upgrade keeps running embeddings on
+the preset they were already on. A stored id pointing at a deleted preset is
+re-seeded the same way.
+
+The one remaining link is the preset's **Use LLM API** toggle
+(`embeddingUseSame`, and the same fallback when a dedicated embedding endpoint
+is blank): while it is on, `resolveEmbeddingConfig(embeddingConfig, llmConfig)`
+borrows the endpoint and key of the *active LLM preset* — the model, chunk size
+and rate limit still come from the embedding preset. With the toggle off,
+`embeddingConfigProvider` does not even watch the chat selection.
+
+Saving follows the same split: `ApiConfigDraft.applyLlmTo` writes the
+connection / sampling / reasoning half, `applyEmbeddingTo` the embedding half,
+and the API screen sends each to its own preset (one combined `toConfig` write
+while both tabs sit on the same preset).
 
 ### INV-PS3: History cutoff is oldest-first
 

--- a/lib/core/services/backup/js_backup_importer.dart
+++ b/lib/core/services/backup/js_backup_importer.dart
@@ -190,6 +190,10 @@ class JsBackupImporter extends BackupHelpers {
         ls['gz_active_llm_profile_id'] ?? kv['gz_active_llm_profile_id'];
     if (activeLlmId is String && activeLlmId.isNotEmpty) {
       await prefs.setString('activeApiConfigId', activeLlmId);
+      // The legacy embedding profile is folded into this very preset by the
+      // API-config importer, so the embedding selection — which is its own
+      // thing here — starts out on it too.
+      await prefs.setString('activeEmbeddingConfigId', activeLlmId);
     }
 
     final globalVars = ls['gz_global_vars'];

--- a/lib/core/state/lorebook_embedding_provider.dart
+++ b/lib/core/state/lorebook_embedding_provider.dart
@@ -12,46 +12,73 @@ import '../llm/session_lorebook_embedding_worker.dart';
 import '../models/api_config.dart';
 import 'db_provider.dart';
 
+/// The embedding connection every vector request runs on.
+///
+/// Reads its settings from [activeEmbeddingConfigProvider] — the preset picked
+/// on the API screen's *Embeddings* tab — so switching the chat connection
+/// leaves the vector index alone. The one place the two still meet is the
+/// preset's "Use LLM API" toggle: while it is on the endpoint and key are
+/// borrowed from the active LLM preset, so that (and only that) selection is
+/// watched here.
 final embeddingConfigProvider = Provider<EmbeddingConfig>((ref) {
-  final chatConfig = ref.watch(activeApiConfigProvider);
-  EmbeddingRequestGate.setEnabled(chatConfig?.embeddingEnabled == true);
-  return resolveEmbeddingConfig(chatConfig);
+  final embConfig = ref.watch(activeEmbeddingConfigProvider);
+  EmbeddingRequestGate.setEnabled(embConfig?.embeddingEnabled == true);
+  final borrowsLlmEndpoint =
+      embConfig != null &&
+      (embConfig.embeddingUseSame || embConfig.embeddingEndpoint.isEmpty);
+  final llmConfig = borrowsLlmEndpoint
+      ? ref.watch(activeApiConfigProvider)
+      : null;
+  return resolveEmbeddingConfig(embConfig, llmConfig);
 });
 
-/// True when the active API preset has vector (semantic) search switched on.
+/// True when the preset the embedding side runs on has vector (semantic)
+/// search switched on.
 ///
 /// Every vector / embedding / index affordance in the UI hangs off this: with
 /// embeddings off there is no endpoint to index against, so the buttons and
 /// hints stay hidden instead of failing at tap time. Mirrors the condition
 /// [resolveEmbeddingConfig] uses to decide whether a usable config exists.
 final vectorSearchAvailableProvider = Provider<bool>((ref) {
-  final config = ref.watch(activeApiConfigProvider);
-  return config != null && config.mode != 'embedding' && config.embeddingEnabled;
+  final config = ref.watch(activeEmbeddingConfigProvider);
+  return config != null &&
+      config.mode != 'embedding' &&
+      config.embeddingEnabled;
 });
 
-EmbeddingConfig resolveEmbeddingConfig(ApiConfig? chatConfig) {
-  if (chatConfig == null ||
-      chatConfig.mode == 'embedding' ||
-      !chatConfig.embeddingEnabled) {
+/// Builds the embedding connection out of the embedding preset, borrowing the
+/// endpoint and key from [llmConfig] while "Use LLM API" is on (or while the
+/// dedicated endpoint is still blank). [llmConfig] defaults to the embedding
+/// preset itself, which is what the borrow meant before the two selections
+/// were split.
+EmbeddingConfig resolveEmbeddingConfig(
+  ApiConfig? embeddingConfig, [
+  ApiConfig? llmConfig,
+]) {
+  if (embeddingConfig == null ||
+      embeddingConfig.mode == 'embedding' ||
+      !embeddingConfig.embeddingEnabled) {
     return const EmbeddingConfig(endpoint: '', model: '');
   }
-  if (chatConfig.embeddingUseSame || chatConfig.embeddingEndpoint.isEmpty) {
+  if (embeddingConfig.embeddingUseSame ||
+      embeddingConfig.embeddingEndpoint.isEmpty) {
+    final source = llmConfig ?? embeddingConfig;
     return EmbeddingConfig(
-      endpoint: chatConfig.endpoint,
-      apiKey: chatConfig.apiKey,
-      model: chatConfig.embeddingModel.isNotEmpty
-          ? chatConfig.embeddingModel
-          : chatConfig.model,
-      maxChunkTokens: chatConfig.embeddingMaxChunkTokens,
-      requestsPerMinute: chatConfig.embeddingRequestsPerMinute,
+      endpoint: source.endpoint,
+      apiKey: source.apiKey,
+      model: embeddingConfig.embeddingModel.isNotEmpty
+          ? embeddingConfig.embeddingModel
+          : source.model,
+      maxChunkTokens: embeddingConfig.embeddingMaxChunkTokens,
+      requestsPerMinute: embeddingConfig.embeddingRequestsPerMinute,
     );
   } else {
     return EmbeddingConfig(
-      endpoint: chatConfig.embeddingEndpoint,
-      apiKey: chatConfig.embeddingApiKey,
-      model: chatConfig.embeddingModel,
-      maxChunkTokens: chatConfig.embeddingMaxChunkTokens,
-      requestsPerMinute: chatConfig.embeddingRequestsPerMinute,
+      endpoint: embeddingConfig.embeddingEndpoint,
+      apiKey: embeddingConfig.embeddingApiKey,
+      model: embeddingConfig.embeddingModel,
+      maxChunkTokens: embeddingConfig.embeddingMaxChunkTokens,
+      requestsPerMinute: embeddingConfig.embeddingRequestsPerMinute,
     );
   }
 }

--- a/lib/features/settings/api_config_draft.dart
+++ b/lib/features/settings/api_config_draft.dart
@@ -137,13 +137,19 @@ class ApiConfigDraft {
     }
   }
 
-  ApiConfig toConfig(ApiConfig base) {
+  /// Everything the editor holds, written onto one preset.
+  ///
+  /// Used while the LLM and the embedding side run on the same preset; when
+  /// they are two different presets each half goes to its own through
+  /// [applyLlmTo] and [applyEmbeddingTo].
+  ApiConfig toConfig(ApiConfig base) => applyEmbeddingTo(applyLlmTo(base));
+
+  /// The LLM half of the editor — connection, sampling, reasoning, cache. The
+  /// preset's embedding fields are left exactly as they are.
+  ApiConfig applyLlmTo(ApiConfig base) {
     final normalized = normalizeValues(values);
     final parsedReasoningHistoryCount =
         int.tryParse(reasoningHistoryCount) ?? 0;
-    final parsedEmbeddingRequestsPerMinute = int.tryParse(
-      embeddingRequestsPerMinute,
-    );
     return base.copyWith(
       name: name.trim(),
       endpoint: endpoint.trim(),
@@ -174,13 +180,26 @@ class ApiConfigDraft {
       omitPresencePenalty: normalized.omitPresencePenalty,
       omitReasoning: normalized.omitReasoning,
       omitReasoningEffort: normalized.omitReasoningEffort,
-      embeddingEnabled: normalized.embeddingEnabled,
-      embeddingUseSame: normalized.embeddingUseSame,
       cacheControlTtl: normalized.cacheControlTtl,
       cacheBreakpointMode: normalized.cacheBreakpointMode,
       sessionIdMode: normalized.sessionIdMode,
       promptPostProcessing: normalized.promptPostProcessing,
       protocol: normalized.protocol,
+      extraRequestParameters: normalized.extraRequestParameters,
+    );
+  }
+
+  /// The embedding half of the editor, written onto whichever preset the
+  /// Embeddings tab is pointed at — which is not necessarily the preset the
+  /// chat side runs on.
+  ApiConfig applyEmbeddingTo(ApiConfig base) {
+    final normalized = normalizeValues(values);
+    final parsedEmbeddingRequestsPerMinute = int.tryParse(
+      embeddingRequestsPerMinute,
+    );
+    return base.copyWith(
+      embeddingEnabled: normalized.embeddingEnabled,
+      embeddingUseSame: normalized.embeddingUseSame,
       embeddingEndpoint: embeddingEndpoint.trim(),
       embeddingApiKey: embeddingApiKey.trim(),
       embeddingModel: embeddingModel.trim(),
@@ -191,7 +210,6 @@ class ApiConfigDraft {
               parsedEmbeddingRequestsPerMinute > 0
           ? parsedEmbeddingRequestsPerMinute
           : base.embeddingRequestsPerMinute,
-      extraRequestParameters: normalized.extraRequestParameters,
     );
   }
 }

--- a/lib/features/settings/api_list_provider.dart
+++ b/lib/features/settings/api_list_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/models/api_config.dart';
 import '../../core/llm/embedding_request_gate.dart';
@@ -7,13 +8,37 @@ import '../../core/state/db_provider.dart';
 import '../../core/state/shared_prefs_provider.dart';
 import '../../core/utils/sync_deletion_tracker.dart';
 
+/// SharedPreferences key holding the preset the embedding side runs on.
+const kActiveEmbeddingConfigIdKey = 'activeEmbeddingConfigId';
+
 final activeApiPresetIdProvider = StateProvider<String?>((ref) => null);
+
+/// The preset the embedding side runs on — picked on the API screen's
+/// Embeddings tab and stored apart from [activeApiPresetIdProvider].
+///
+/// Embeddings are a connection of their own: switching the chat preset must
+/// never drag the vector index onto another endpoint, because every stored
+/// vector is tied to the model that produced it. The single remaining link
+/// between the two selections is this preset's "Use LLM API" toggle, which
+/// `resolveEmbeddingConfig` reads to borrow the *active LLM* endpoint.
+final activeEmbeddingPresetIdProvider = StateProvider<String?>((ref) => null);
 
 final _activeIdInitializedProvider = Provider<bool>((ref) => false);
 
 final activeApiConfigProvider = Provider<ApiConfig?>((ref) {
   final list = ref.watch(apiListProvider).value;
   final id = ref.watch(activeApiPresetIdProvider);
+  if (list == null || list.isEmpty) return null;
+  if (id == null) return list.first;
+  return list.firstWhere((c) => c.id == id, orElse: () => list.first);
+});
+
+/// The preset every embedding request reads its settings from. Mirrors
+/// [activeApiConfigProvider], but follows [activeEmbeddingPresetIdProvider] so
+/// the two selections move independently.
+final activeEmbeddingConfigProvider = Provider<ApiConfig?>((ref) {
+  final list = ref.watch(apiListProvider).value;
+  final id = ref.watch(activeEmbeddingPresetIdProvider);
   if (list == null || list.isEmpty) return null;
   if (id == null) return list.first;
   return list.firstWhere((c) => c.id == id, orElse: () => list.first);
@@ -34,8 +59,35 @@ class ApiListNotifier extends AsyncNotifier<List<ApiConfig>> {
       if (savedId != null && configs.any((c) => c.id == savedId)) {
         ref.read(activeApiPresetIdProvider.notifier).state = savedId;
       }
+      await _restoreEmbeddingSelection(prefs, configs, savedId);
     }
     return configs;
+  }
+
+  /// Restores the embedding preset selection — and seeds it on the first run
+  /// after embeddings got a selection of their own.
+  ///
+  /// Embeddings used to simply follow the chat preset, so an upgrade pins them
+  /// to the preset they were already running on (the saved chat one, or the
+  /// first) rather than letting them keep following whatever the chat side is
+  /// switched to next. A stored id pointing at a deleted preset is re-seeded
+  /// the same way.
+  Future<void> _restoreEmbeddingSelection(
+    SharedPreferences prefs,
+    List<ApiConfig> configs,
+    String? savedChatId,
+  ) async {
+    if (configs.isEmpty) return;
+    final savedId = prefs.getString(kActiveEmbeddingConfigIdKey);
+    if (savedId != null && configs.any((c) => c.id == savedId)) {
+      ref.read(activeEmbeddingPresetIdProvider.notifier).state = savedId;
+      return;
+    }
+    final seed = savedChatId != null && configs.any((c) => c.id == savedChatId)
+        ? savedChatId
+        : configs.first.id;
+    ref.read(activeEmbeddingPresetIdProvider.notifier).state = seed;
+    await prefs.setString(kActiveEmbeddingConfigIdKey, seed);
   }
 
   Future<void> put(ApiConfig config) async {
@@ -43,8 +95,25 @@ class ApiListNotifier extends AsyncNotifier<List<ApiConfig>> {
     ref.invalidateSelf();
   }
 
+  /// Writes several presets in one go, reloading the list once at the end.
+  ///
+  /// The API screen edits two presets at a time (the LLM one and, when they
+  /// differ, the embedding one); saving them through [put] twice would reload
+  /// the list — and flash the screen's loading state — twice per keystroke.
+  Future<void> putAll(Iterable<ApiConfig> configs) async {
+    final repo = ref.read(apiConfigRepoProvider);
+    for (final config in configs) {
+      await repo.put(config);
+    }
+    ref.invalidateSelf();
+  }
+
   void setEmbeddingEnabled(String id, bool enabled) {
-    EmbeddingRequestGate.setEnabled(enabled);
+    // The gate is global, so only the preset the embedding side actually runs
+    // on may open or close it.
+    if (id == ref.read(activeEmbeddingConfigProvider)?.id) {
+      EmbeddingRequestGate.setEnabled(enabled);
+    }
     final configs = state.value;
     if (configs == null) return;
     state = AsyncData([

--- a/lib/features/settings/api_settings_screen.dart
+++ b/lib/features/settings/api_settings_screen.dart
@@ -108,6 +108,11 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
 
   String? _loadedPresetId;
 
+  /// The preset the *embedding* half of the editor is loaded from. It follows
+  /// the LLM one only until the user picks another on the Embeddings tab —
+  /// the two selections are independent from then on.
+  String? _loadedEmbeddingPresetId;
+
   /// Whether the presets sheet is on screen. A bulk delete can outlive it, and
   /// closing "the sheet" once it is gone would pop whatever took its place.
   bool _presetSheetOpen = false;
@@ -218,9 +223,21 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
     }
   }
 
+  void _persistActiveEmbeddingId(String? id) async {
+    final prefs = ref.read(sharedPreferencesProvider).value;
+    if (prefs == null) return;
+    if (id != null) {
+      await prefs.setString(kActiveEmbeddingConfigIdKey, id);
+    } else {
+      await prefs.remove(kActiveEmbeddingConfigIdKey);
+    }
+  }
+
   void _loadActivePreset() {
     final config = ref.read(activeApiConfigProvider);
     if (config != null) _loadFromConfig(config);
+    final embeddingConfig = ref.read(activeEmbeddingConfigProvider);
+    if (embeddingConfig != null) _loadEmbeddingFromConfig(embeddingConfig);
   }
 
   void _loadFromConfig(ApiConfig config) {
@@ -238,11 +255,6 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
     _contextSizeCtrl.text = draft.contextSize;
     _firstChunkTimeoutCtrl.text = draft.firstChunkTimeoutSeconds;
     _reasoningHistoryCountCtrl.text = draft.reasoningHistoryCount;
-    _embEndpointCtrl.text = draft.embeddingEndpoint;
-    _embApiKeyCtrl.text = draft.embeddingApiKey;
-    _embModelCtrl.text = draft.embeddingModel;
-    _embChunkTokensCtrl.text = draft.embeddingMaxChunkTokens;
-    _embRequestsPerMinuteCtrl.text = draft.embeddingRequestsPerMinute;
 
     setState(() {
       _temperature = values.temperature;
@@ -265,8 +277,6 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
       _omitPresencePenalty = values.omitPresencePenalty;
       _omitReasoning = values.omitReasoning;
       _omitReasoningEffort = values.omitReasoningEffort;
-      _embeddingEnabled = values.embeddingEnabled;
-      _embeddingUseSame = values.embeddingUseSame;
       _cacheControlTtl = values.cacheControlTtl;
       _cacheBreakpointMode = values.cacheBreakpointMode;
       _sessionIdMode = values.sessionIdMode;
@@ -274,7 +284,37 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
       _protocol = values.protocol;
       _extraRequestParameters = values.extraRequestParameters;
       _fetchedModels = [];
+      // With "Use LLM API" on, the embedding model list was fetched from this
+      // connection, so it goes with the preset it came from.
+      if (_embeddingUseSame) _embFetchedModels = [];
+    });
+
+    _loading = false;
+  }
+
+  /// Loads the embedding half of the editor from the preset the Embeddings tab
+  /// points at — [activeEmbeddingConfigProvider], which is not necessarily the
+  /// preset the LLM tab is on.
+  void _loadEmbeddingFromConfig(ApiConfig config) {
+    if (config.id == _loadedEmbeddingPresetId) return;
+    _loadedEmbeddingPresetId = config.id;
+    _loading = true;
+    final draft = ApiConfigDraft.fromConfig(config);
+
+    _embEndpointCtrl.text = draft.embeddingEndpoint;
+    _embApiKeyCtrl.text = draft.embeddingApiKey;
+    _embModelCtrl.text = draft.embeddingModel;
+    _embChunkTokensCtrl.text = draft.embeddingMaxChunkTokens;
+    _embRequestsPerMinuteCtrl.text = draft.embeddingRequestsPerMinute;
+
+    setState(() {
+      _embeddingEnabled = draft.values.embeddingEnabled;
+      _embeddingUseSame = draft.values.embeddingUseSame;
+      // Both the model list and the connection badge describe the preset that
+      // was open a moment ago.
       _embFetchedModels = [];
+      _embStatus = ApiConnectionStatus.idle;
+      _embError = '';
     });
 
     _loading = false;
@@ -327,7 +367,19 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
       embeddingMaxChunkTokens: _embChunkTokensCtrl.text,
       embeddingRequestsPerMinute: _embRequestsPerMinuteCtrl.text,
     );
-    await _ref.read(apiListProvider.notifier).put(draft.toConfig(config));
+    final notifier = _ref.read(apiListProvider.notifier);
+    final embeddingConfig = _ref.read(activeEmbeddingConfigProvider);
+    if (embeddingConfig == null || embeddingConfig.id == config.id) {
+      await notifier.put(draft.toConfig(config));
+      return;
+    }
+    // The two tabs are on two different presets, so each half is written to
+    // its own: saving from the LLM tab must never copy this editor's embedding
+    // fields onto the LLM preset, nor the other way round.
+    await notifier.putAll([
+      draft.applyLlmTo(config),
+      draft.applyEmbeddingTo(embeddingConfig),
+    ]);
   }
 
   bool get _supportsTemperature => true;
@@ -426,15 +478,23 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
   Widget build(BuildContext context) {
     final asyncList = ref.watch(apiListProvider);
     final activeConfig = ref.watch(activeApiConfigProvider);
+    final embeddingConfig = ref.watch(activeEmbeddingConfigProvider);
 
     if (activeConfig != null && activeConfig.id != _loadedPresetId) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _loadFromConfig(activeConfig);
       });
     }
+    if (embeddingConfig != null &&
+        embeddingConfig.id != _loadedEmbeddingPresetId) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _loadEmbeddingFromConfig(embeddingConfig);
+      });
+    }
 
     final list = asyncList.value ?? [];
     final activeName = _activeName(activeConfig, list);
+    final embeddingName = _activeName(embeddingConfig, list);
 
     return SheetView(
       startExpanded: widget.startExpanded,
@@ -464,7 +524,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
                   index: _tab,
                   child: switch (_tab) {
                     0 => _buildLlmTab(list, activeName),
-                    1 => _buildEmbeddingsTab(list, activeName),
+                    1 => _buildEmbeddingsTab(list, embeddingName),
                     _ => StudioSlotsTab(controller: _agentsScrollController),
                   },
                 ),
@@ -499,37 +559,52 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
     );
   }
 
-  Widget _buildTopControls(List<ApiConfig> list, String activeName) {
-    // Preset selector pill (tab-specific — slides with the body content).
-    // LLM and Embeddings each check their own connection from the badge beside
-    // the pill; the agents tab has no connection of its own to probe.
-    final pill = _buildPresetPill(context, list, activeName);
-    return switch (_tab) {
-      0 => ConnectionStatus(
+  /// The preset pill plus its connection badge, above each tab's settings.
+  ///
+  /// [forEmbedding] decides which selection the pill speaks for: the LLM tab
+  /// switches the chat connection, the Embeddings tab the one embeddings run
+  /// on. The flag is passed rather than read off `_tab` because both tab
+  /// bodies are alive during a slide, and each must keep showing its own.
+  Widget _buildTopControls(
+    List<ApiConfig> list,
+    String presetName, {
+    required bool forEmbedding,
+  }) {
+    final pill = _buildPresetPill(
+      context,
+      list,
+      presetName,
+      forEmbedding: forEmbedding,
+    );
+    if (!forEmbedding) {
+      return ConnectionStatus(
         status: _llmStatus,
         errorMessage: _llmError,
         onRetry: _testLlmConnection,
         child: pill,
-      ),
-      // Nothing to probe until the preset has embeddings switched on, so the
-      // badge appears with the rest of the embedding settings.
-      1 when _embeddingEnabled => ConnectionStatus(
-        status: _embStatus,
-        errorMessage: _embError,
-        onRetry: _testEmbConnection,
-        child: pill,
-      ),
-      _ => pill,
-    };
+      );
+    }
+    // Nothing to probe until the preset has embeddings switched on, so the
+    // badge appears with the rest of the embedding settings.
+    if (!_embeddingEnabled) return pill;
+    return ConnectionStatus(
+      status: _embStatus,
+      errorMessage: _embError,
+      onRetry: _testEmbConnection,
+      child: pill,
+    );
   }
 
   Widget _buildPresetPill(
     BuildContext context,
     List<ApiConfig> list,
-    String activeName,
-  ) {
+    String activeName, {
+    required bool forEmbedding,
+  }) {
     return GestureDetector(
-      onTap: list.isEmpty ? null : _showPresetSheet,
+      onTap: list.isEmpty
+          ? null
+          : () => _showPresetSheet(forEmbedding: forEmbedding),
       child: Container(
         height: 32,
         padding: const EdgeInsets.symmetric(horizontal: 12),
@@ -600,7 +675,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
         children: [
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
-            child: _buildTopControls(list, activeName),
+            child: _buildTopControls(list, activeName, forEmbedding: false),
           ),
           _buildConnectionGroup(context),
           _buildGenerationGroup(),
@@ -1033,7 +1108,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
 
   // ── Embeddings tab ────────────────────────────────────────────────────────────
 
-  Widget _buildEmbeddingsTab(List<ApiConfig> list, String activeName) {
+  Widget _buildEmbeddingsTab(List<ApiConfig> list, String embeddingName) {
     return Builder(
       builder: (context) => ListView(
         controller: _embScrollController,
@@ -1044,7 +1119,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
         children: [
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
-            child: _buildTopControls(list, activeName),
+            child: _buildTopControls(list, embeddingName, forEmbedding: true),
           ),
           MenuGroup(
             compact: true,
@@ -1057,7 +1132,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
                 value: _embeddingEnabled,
                 onChanged: (v) {
                   setState(() => _embeddingEnabled = v);
-                  final config = ref.read(activeApiConfigProvider);
+                  final config = ref.read(activeEmbeddingConfigProvider);
                   if (config != null) {
                     ref
                         .read(apiListProvider.notifier)
@@ -1258,11 +1333,17 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
   /// (`cardsBuilder`), so switching the sort mode, dragging a row, deleting a
   /// preset or selecting several updates the open sheet in place — it is never
   /// closed and reopened to show the change.
-  Future<void> _showPresetSheet() async {
+  ///
+  /// It lists the same presets either way; [forEmbedding] only decides which
+  /// selection a tap moves — the chat connection or the embedding one.
+  Future<void> _showPresetSheet({required bool forEmbedding}) async {
     _presetSheetOpen = true;
     await GlazeBottomSheet.show<void>(
       context,
-      title: 'settings_api_configs_title'.tr(),
+      // Same list, two roles — the title says which one a tap is choosing.
+      title: forEmbedding
+          ? 'settings_embedding_config_title'.tr()
+          : 'settings_api_configs_title'.tr(),
       headerAction: Consumer(
         builder: (context, ref, _) {
           final selection = ref.watch(apiPresetSelectionProvider);
@@ -1296,7 +1377,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
                 tooltip: 'settings_new_config_tooltip'.tr(),
                 onPressed: () {
                   Navigator.of(context, rootNavigator: true).pop();
-                  _createNewPreset();
+                  _createNewPreset(forEmbedding: forEmbedding);
                 },
               ),
             ],
@@ -1313,10 +1394,13 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
             sort.mode == ApiPresetSortMode.manual &&
             ref.watch(apiPresetReorderArmedProvider);
         // The active id falls back to the *repository's* first preset, the same
-        // one activeApiConfigProvider picks — sorting only reorders what is
-        // shown, so it must not move the highlight to another row.
+        // one activeApiConfigProvider (or its embedding twin) picks — sorting
+        // only reorders what is shown, so it must not move the highlight to
+        // another row.
         final activeId =
-            ref.watch(activeApiPresetIdProvider) ??
+            (forEmbedding
+                ? ref.watch(activeEmbeddingPresetIdProvider)
+                : ref.watch(activeApiPresetIdProvider)) ??
             (list.isNotEmpty ? list.first.id : null);
         final sorted = sortApiConfigs(list, sort);
         return BottomSheetCards(
@@ -1328,6 +1412,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
                 selection: selection,
                 reordering: reordering,
                 canDelete: list.length > 1,
+                forEmbedding: forEmbedding,
               ),
           ],
           onReorder: reordering
@@ -1380,6 +1465,7 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
     required ApiPresetSelectionState selection,
     required bool reordering,
     required bool canDelete,
+    required bool forEmbedding,
   }) {
     final isActive = config.id == activeId;
     final isSelected = selection.contains(config.id);
@@ -1448,6 +1534,15 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
         }
         Navigator.of(context, rootNavigator: true).pop();
         _saveTimer?.cancel();
+        if (forEmbedding) {
+          // Only the embedding side moves: the chat connection stays where it
+          // is, and so does everything the LLM tab holds.
+          ref.read(activeEmbeddingPresetIdProvider.notifier).state = config.id;
+          _persistActiveEmbeddingId(config.id);
+          _loadedEmbeddingPresetId = null;
+          _loadEmbeddingFromConfig(config);
+          return;
+        }
         ref.read(activeApiPresetIdProvider.notifier).state = config.id;
         _persistActiveId(config.id);
         _loadedPresetId = null;
@@ -1457,12 +1552,25 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
   }
 
   /// Moves the editor off a preset that was just deleted: clearing the active
-  /// id lets [activeApiConfigProvider] fall back to the first one left.
+  /// id lets [activeApiConfigProvider] — and [activeEmbeddingConfigProvider],
+  /// which can be sitting on a different preset — fall back to the first one
+  /// left.
   void _reloadAfterDelete(String? activeId, Set<String> removedIds) {
-    if (activeId == null || !removedIds.contains(activeId)) return;
-    ref.read(activeApiPresetIdProvider.notifier).state = null;
-    _persistActiveId(null);
-    _loadedPresetId = null;
+    var moved = false;
+    if (activeId != null && removedIds.contains(activeId)) {
+      ref.read(activeApiPresetIdProvider.notifier).state = null;
+      _persistActiveId(null);
+      _loadedPresetId = null;
+      moved = true;
+    }
+    final embeddingId = ref.read(activeEmbeddingPresetIdProvider);
+    if (embeddingId != null && removedIds.contains(embeddingId)) {
+      ref.read(activeEmbeddingPresetIdProvider.notifier).state = null;
+      _persistActiveEmbeddingId(null);
+      _loadedEmbeddingPresetId = null;
+      moved = true;
+    }
+    if (!moved) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _loadActivePreset();
     });
@@ -1567,7 +1675,10 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
     );
   }
 
-  Future<void> _createNewPreset() async {
+  /// Creates a preset and points the tab it was created from at it: a preset
+  /// added from the Embeddings tab becomes the embedding connection, leaving
+  /// the chat one alone.
+  Future<void> _createNewPreset({bool forEmbedding = false}) async {
     await GlazeBottomSheet.show<void>(
       context,
       title: 'settings_new_config_title'.tr(),
@@ -1583,10 +1694,18 @@ class _ApiSettingsScreenState extends ConsumerState<ApiSettingsScreen> {
             id: DateTime.now().millisecondsSinceEpoch.toString(),
             name: trimmed,
           );
-          ref.read(activeApiPresetIdProvider.notifier).state = newConfig.id;
-          _persistActiveId(newConfig.id);
-          _loadedPresetId = null;
-          _loadFromConfig(newConfig);
+          if (forEmbedding) {
+            ref.read(activeEmbeddingPresetIdProvider.notifier).state =
+                newConfig.id;
+            _persistActiveEmbeddingId(newConfig.id);
+            _loadedEmbeddingPresetId = null;
+            _loadEmbeddingFromConfig(newConfig);
+          } else {
+            ref.read(activeApiPresetIdProvider.notifier).state = newConfig.id;
+            _persistActiveId(newConfig.id);
+            _loadedPresetId = null;
+            _loadFromConfig(newConfig);
+          }
           await ref.read(apiListProvider.notifier).put(newConfig);
         },
       ),

--- a/test/api_config_draft_test.dart
+++ b/test/api_config_draft_test.dart
@@ -58,6 +58,75 @@ void main() {
     expect(mapped, config);
   });
 
+  test('each half of the editor is written to its own preset', () {
+    // The API screen can sit on two presets at once — the LLM tab on one, the
+    // Embeddings tab on another — so neither half may leak onto the other's
+    // preset when the editor saves.
+    const llm = ApiConfig(
+      id: 'llm',
+      name: 'LLM',
+      endpoint: 'https://llm.test',
+      apiKey: 'llm-key',
+      model: 'chat-model',
+      embeddingEnabled: false,
+      embeddingUseSame: true,
+      embeddingEndpoint: 'https://old-embeddings.test',
+      embeddingModel: 'old-embedding-model',
+    );
+    const embedding = ApiConfig(
+      id: 'embedding',
+      name: 'Embeddings',
+      endpoint: 'https://embedding-preset.test',
+      apiKey: 'embedding-preset-key',
+      model: 'embedding-preset-chat-model',
+    );
+    final source = ApiConfigDraft.fromConfig(llm);
+    final draft = ApiConfigDraft(
+      values: source.values.copyWith(
+        embeddingEnabled: true,
+        embeddingUseSame: false,
+      ),
+      name: 'Edited LLM',
+      endpoint: 'https://edited-llm.test',
+      apiKey: 'edited-llm-key',
+      model: 'edited-chat-model',
+      maxTokens: source.maxTokens,
+      contextSize: source.contextSize,
+      firstChunkTimeoutSeconds: source.firstChunkTimeoutSeconds,
+      reasoningHistoryCount: source.reasoningHistoryCount,
+      embeddingEndpoint: 'https://edited-embeddings.test',
+      embeddingApiKey: 'edited-embedding-key',
+      embeddingModel: 'edited-embedding-model',
+      embeddingMaxChunkTokens: '256',
+      embeddingRequestsPerMinute: '40',
+    );
+
+    final savedLlm = draft.applyLlmTo(llm);
+    final savedEmbedding = draft.applyEmbeddingTo(embedding);
+
+    // The LLM preset takes the connection fields and keeps its own embedding
+    // settings untouched.
+    expect(savedLlm.name, 'Edited LLM');
+    expect(savedLlm.endpoint, 'https://edited-llm.test');
+    expect(savedLlm.embeddingEnabled, isFalse);
+    expect(savedLlm.embeddingUseSame, isTrue);
+    expect(savedLlm.embeddingEndpoint, 'https://old-embeddings.test');
+    expect(savedLlm.embeddingModel, 'old-embedding-model');
+    // The embedding preset takes the embedding fields and keeps its own name
+    // and chat connection.
+    expect(savedEmbedding.name, 'Embeddings');
+    expect(savedEmbedding.endpoint, 'https://embedding-preset.test');
+    expect(savedEmbedding.apiKey, 'embedding-preset-key');
+    expect(savedEmbedding.model, 'embedding-preset-chat-model');
+    expect(savedEmbedding.embeddingEnabled, isTrue);
+    expect(savedEmbedding.embeddingUseSame, isFalse);
+    expect(savedEmbedding.embeddingEndpoint, 'https://edited-embeddings.test');
+    expect(savedEmbedding.embeddingApiKey, 'edited-embedding-key');
+    expect(savedEmbedding.embeddingModel, 'edited-embedding-model');
+    expect(savedEmbedding.embeddingMaxChunkTokens, 256);
+    expect(savedEmbedding.embeddingRequestsPerMinute, 40);
+  });
+
   test('trims text and preserves current numeric values on invalid input', () {
     const config = ApiConfig(
       id: 'api',

--- a/test/characterization/shared_prefs_keys_test.dart
+++ b/test/characterization/shared_prefs_keys_test.dart
@@ -246,6 +246,7 @@ void main() {
         'gz_force_mobile_layout',
         'addBlockAtTop',
         'activeApiConfigId',
+        'activeEmbeddingConfigId',
         'activePresetId',
         'activePersonaId',
         'globalVars',

--- a/test/embedding_config_provider_test.dart
+++ b/test/embedding_config_provider_test.dart
@@ -1,11 +1,15 @@
 import 'dart:io';
 
+import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
 import 'package:glaze_flutter/core/models/api_config.dart';
 import 'package:glaze_flutter/core/llm/embedding_request_gate.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
 import 'package:glaze_flutter/core/state/lorebook_embedding_provider.dart';
 import 'package:glaze_flutter/features/settings/api_list_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('resolveEmbeddingConfig', () {
@@ -45,12 +49,65 @@ void main() {
       expect(config.maxChunkTokens, 256);
       expect(config.requestsPerMinute, 40);
     });
+
+    test('borrows the active LLM preset while "use LLM API" is on', () {
+      const llm = ApiConfig(
+        id: 'llm',
+        endpoint: 'https://llm.example/v1',
+        apiKey: 'llm-key',
+        model: 'chat-model',
+      );
+      const embedding = ApiConfig(
+        id: 'embedding',
+        endpoint: 'https://other.example/v1',
+        apiKey: 'other-key',
+        model: 'other-chat-model',
+        embeddingEnabled: true,
+        embeddingUseSame: true,
+        embeddingModel: 'embedding-model',
+      );
+
+      final config = resolveEmbeddingConfig(embedding, llm);
+
+      // The toggle is the one link left between the two selections: the
+      // endpoint and key come from the LLM preset, everything else from the
+      // embedding one.
+      expect(config.endpoint, llm.endpoint);
+      expect(config.apiKey, llm.apiKey);
+      expect(config.model, 'embedding-model');
+    });
+
+    test(
+      'ignores the LLM preset once the endpoint is the embedding preset\'s own',
+      () {
+        const llm = ApiConfig(
+          id: 'llm',
+          endpoint: 'https://llm.example/v1',
+          apiKey: 'llm-key',
+          model: 'chat-model',
+        );
+        const embedding = ApiConfig(
+          id: 'embedding',
+          embeddingEnabled: true,
+          embeddingUseSame: false,
+          embeddingEndpoint: 'https://vectors.example/v1',
+          embeddingApiKey: 'vector-key',
+          embeddingModel: 'embedding-model',
+        );
+
+        final config = resolveEmbeddingConfig(embedding, llm);
+
+        expect(config.endpoint, 'https://vectors.example/v1');
+        expect(config.apiKey, 'vector-key');
+        expect(config.model, 'embedding-model');
+      },
+    );
   });
 
   group('vectorSearchAvailableProvider', () {
     bool available(ApiConfig? config) {
       final container = ProviderContainer(
-        overrides: [activeApiConfigProvider.overrideWithValue(config)],
+        overrides: [activeEmbeddingConfigProvider.overrideWithValue(config)],
       );
       addTearDown(container.dispose);
       return container.read(vectorSearchAvailableProvider);
@@ -88,7 +145,7 @@ void main() {
       );
     });
 
-    test('is true once embeddings are enabled on the chat preset', () {
+    test('is true once embeddings are enabled on the embedding preset', () {
       expect(
         available(
           const ApiConfig(
@@ -100,6 +157,28 @@ void main() {
         ),
         isTrue,
       );
+    });
+
+    test('follows the embedding preset, not the chat one', () {
+      // The chat preset having embeddings off must not hide the vector UI when
+      // the embedding side runs on a preset that has them on.
+      final container = ProviderContainer(
+        overrides: [
+          activeApiConfigProvider.overrideWithValue(
+            const ApiConfig(id: 'chat', endpoint: 'https://chat.example/v1'),
+          ),
+          activeEmbeddingConfigProvider.overrideWithValue(
+            const ApiConfig(
+              id: 'embedding',
+              endpoint: 'https://vectors.example/v1',
+              embeddingEnabled: true,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(vectorSearchAvailableProvider), isTrue);
     });
 
     test('gates every vector affordance in the UI', () {
@@ -121,6 +200,133 @@ void main() {
         );
       }
     });
+  });
+
+  group('the embedding preset selection', () {
+    Future<ProviderContainer> containerWith(
+      List<ApiConfig> configs, {
+      Map<String, Object> prefs = const {},
+    }) async {
+      SharedPreferences.setMockInitialValues(prefs);
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      final container = ProviderContainer(
+        overrides: [appDbProvider.overrideWithValue(db)],
+      );
+      addTearDown(container.dispose);
+      for (final config in configs) {
+        await container.read(apiConfigRepoProvider).put(config);
+      }
+      container.invalidate(apiListProvider);
+      await container.read(apiListProvider.future);
+      return container;
+    }
+
+    const chat = ApiConfig(
+      id: 'chat',
+      name: 'Chat',
+      endpoint: 'https://chat.example/v1',
+      apiKey: 'chat-key',
+      model: 'chat-model',
+    );
+    const otherChat = ApiConfig(
+      id: 'other-chat',
+      name: 'Other chat',
+      endpoint: 'https://other-chat.example/v1',
+      apiKey: 'other-chat-key',
+      model: 'other-chat-model',
+    );
+    const vectors = ApiConfig(
+      id: 'vectors',
+      name: 'Vectors',
+      embeddingEnabled: true,
+      embeddingUseSame: false,
+      embeddingEndpoint: 'https://vectors.example/v1',
+      embeddingApiKey: 'vector-key',
+      embeddingModel: 'embedding-model',
+    );
+
+    test(
+      'switching the chat preset leaves the embedding one where it is',
+      () async {
+        final container = await containerWith([chat, otherChat, vectors]);
+        container.read(activeEmbeddingPresetIdProvider.notifier).state =
+            vectors.id;
+        // The repo normalizes an endpoint on the way in, so the expectation is
+        // taken from the stored preset rather than from the literal above.
+        final stored = container.read(activeEmbeddingConfigProvider)!;
+        final before = container.read(embeddingConfigProvider);
+        expect(before.endpoint, stored.embeddingEndpoint);
+
+        container.read(activeApiPresetIdProvider.notifier).state = otherChat.id;
+
+        expect(container.read(activeApiConfigProvider)?.id, otherChat.id);
+        expect(container.read(activeEmbeddingConfigProvider)?.id, vectors.id);
+        final config = container.read(embeddingConfigProvider);
+        expect(config.endpoint, stored.embeddingEndpoint);
+        expect(config.apiKey, 'vector-key');
+        expect(config.model, 'embedding-model');
+      },
+    );
+
+    test(
+      '"use LLM API" follows the chat preset the user switches to',
+      () async {
+        const shared = ApiConfig(
+          id: 'shared',
+          name: 'Shared',
+          embeddingEnabled: true,
+          embeddingUseSame: true,
+          embeddingModel: 'embedding-model',
+        );
+        final container = await containerWith([chat, otherChat, shared]);
+        container.read(activeEmbeddingPresetIdProvider.notifier).state =
+            shared.id;
+        final storedChat = container.read(activeApiConfigProvider)!;
+        expect(
+          container.read(embeddingConfigProvider).endpoint,
+          storedChat.endpoint,
+        );
+
+        container.read(activeApiPresetIdProvider.notifier).state = otherChat.id;
+
+        final storedOther = container.read(activeApiConfigProvider)!;
+        final config = container.read(embeddingConfigProvider);
+        expect(config.endpoint, storedOther.endpoint);
+        expect(config.apiKey, otherChat.apiKey);
+        expect(config.model, 'embedding-model');
+      },
+    );
+
+    test(
+      'pins the embedding preset to the saved chat one on first run',
+      () async {
+        final container = await containerWith(
+          [chat, vectors],
+          prefs: {'activeApiConfigId': vectors.id},
+        );
+
+        expect(container.read(activeEmbeddingPresetIdProvider), vectors.id);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString(kActiveEmbeddingConfigIdKey), vectors.id);
+      },
+    );
+
+    test(
+      'restores a stored embedding preset that differs from the chat one',
+      () async {
+        final container = await containerWith(
+          [chat, otherChat, vectors],
+          prefs: {
+            'activeApiConfigId': otherChat.id,
+            kActiveEmbeddingConfigIdKey: vectors.id,
+          },
+        );
+
+        expect(container.read(activeApiConfigProvider)?.id, otherChat.id);
+        expect(container.read(activeEmbeddingConfigProvider)?.id, vectors.id);
+      },
+    );
   });
 
   group('EmbeddingRequestGate', () {


### PR DESCRIPTION
The Embeddings tab shared the LLM tab's preset selection, so switching the chat connection silently moved the embedding one with it — pointing the vector index at another model, or hiding vector search entirely when the new preset had **Embeddings → Vector search** off. The two are separate entities; the only thing that may tie them together is the **Use LLM API** toggle.

## Selection

- Add `activeEmbeddingPresetIdProvider` and `activeEmbeddingConfigProvider` beside the chat pair in `api_list_provider.dart`, persisted under the new SharedPreferences key `activeEmbeddingConfigId`.
- `ApiListNotifier.build` seeds that key once, from the saved chat preset (or the first preset), so an upgrade keeps embeddings running on the preset they were already on instead of following the chat side from then on. A stored id pointing at a deleted preset is re-seeded the same way.
- `ApiListNotifier.setEmbeddingEnabled` only opens or closes the global `EmbeddingRequestGate` for the preset the embedding side actually runs on.

## Resolution

- `resolveEmbeddingConfig(embeddingConfig, [llmConfig])` takes the model, chunk size and rate limit from the embedding preset, and borrows the endpoint and key from the LLM preset only while `embeddingUseSame` is on (or while the dedicated embedding endpoint is still blank).
- `embeddingConfigProvider` watches `activeApiConfigProvider` **only** in that borrowing case — with the toggle off, a chat-preset switch cannot even invalidate the embedding connection.
- `vectorSearchAvailableProvider` now reads the embedding preset, so the vector UI no longer appears and disappears with the chat selection.

## API screen

- The Embeddings tab gets its own preset pill, presets sheet (titled "Embedding connection"), connection badge and "new preset" target; `_loadEmbeddingFromConfig` loads its fields from that preset, and the sheet flag is passed explicitly rather than read off `_tab` so both tab bodies keep their own pill during a slide.
- `ApiConfigDraft` splits into `applyLlmTo` (connection / sampling / reasoning) and `applyEmbeddingTo` (embedding fields); `_save` sends each half to its own preset through the new `ApiListNotifier.putAll` (one list reload), and still uses the combined `toConfig` when both tabs sit on the same preset.
- Deleting a preset moves either selection off it independently.

## Elsewhere

- A JS backup import pins `activeEmbeddingConfigId` to the imported LLM preset, which is where `profile_resolver` folds the legacy embedding profile in.
- New strings `settings_embedding_config_title` in `en.json` / `ru.json`.
- Documented as **INV-PS2c** in `docs/INVARIANTS.md`, with INV-PS2b and `docs/ARCHITECTURE.md` updated to point at the embedding preset.

## Verification

- `flutter analyze` — clean (only the pre-existing infos/warnings on untouched files).
- `flutter test` — 3688 tests green, run against Flutter 3.44.9 (the CI version).
- New tests: the "Use LLM API" borrow and the toggle-off isolation in `resolveEmbeddingConfig`; `vectorSearchAvailableProvider` following the embedding preset; a DB-backed group proving a chat-preset switch leaves the embedding connection untouched, that the borrow does follow it, and that the seeding / restore paths pin the right preset; and `applyLlmTo` / `applyEmbeddingTo` not crossing halves in `api_config_draft_test.dart`.
- Not run: the app itself — no runtime or hot-reload check of the new Embeddings-tab pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLRwj7NjciU7XTjbcLiwNA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLRwj7NjciU7XTjbcLiwNA)_