### PR TITLE
fix(chat): clear the composer on the tap, run the clock, drop the stale reply

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -29,6 +29,10 @@ export class Bridge {
     this.isGenerating = false;
     this.isGeneratingImage = false;
     this.isPostGenRunning = false;
+    // A send is painted but its generation has not been published yet. The
+    // typing bubble is already on screen for it, so the elapsed clock under
+    // the bubble runs on this too — see _syncGenerationTimer().
+    this.isSendPending = false;
     // Label under the typing pencil, naming the phase the generation is
     // actually in. Empty = the renderer's default. See setGenerationPhase().
     this.generationPhaseText = '';
@@ -175,6 +179,15 @@ export class Bridge {
     if (wasGenerating && !this.isGenerating) this._ensureHeaderReachable();
   }
 
+  /* The send window that precedes a generation: the user's message is painted
+   * and the durable append is still in flight. Nothing else in the page reads
+   * it — it only keeps the elapsed clock honest, so the bubble does not sit
+   * there without one for as long as that write takes. */
+  setSendPending(value) {
+    this.isSendPending = !!value;
+    this._syncGenerationTimer();
+  }
+
   setPostGenRunning(value) {
     this.isPostGenRunning = !!value;
   }
@@ -191,8 +204,12 @@ export class Bridge {
   }
 
   _syncGenerationTimer() {
-    if (this.isGenerating) {
-      this._genTimer.start();
+    // Post-generation work is deliberately absent here: the reply is written
+    // by then and its badge is final. The send window is not — the bubble it
+    // puts up is the same bubble the reply streams into, so the clock spans
+    // both and `ensureRunning` keeps the hand-off from restarting it.
+    if (this.isGenerating || this.isSendPending) {
+      this._genTimer.ensureRunning();
     } else {
       this._genTimer.stop();
     }

--- a/assets/chat_webview/bridge/gen_timer.js
+++ b/assets/chat_webview/bridge/gen_timer.js
@@ -13,6 +13,15 @@ export class GenTimer {
     return (battery ? elapsedSeconds.toFixed(0) : elapsedSeconds.toFixed(1)) + 's';
   }
 
+  /* Starts the clock only if it is not already ticking. The send window puts
+   * the typing bubble up before the generation is published, and both edges
+   * reconcile through _syncGenerationTimer — restarting on the second one
+   * would reset a timer the user has already been watching count. */
+  ensureRunning() {
+    if (this._interval) return;
+    this.start();
+  }
+
   start() {
     this.stop();
     this._start = Date.now();

--- a/docs/rules/generation.md
+++ b/docs/rules/generation.md
@@ -138,6 +138,18 @@ from "the reply is already on its way".
   three DB round-trips; in front of the publish it delayed the typing bubble by
   their full cost on every send. It still runs before `_runGeneration`, which
   is the ordering prompt assembly actually depends on.
+- **The elapsed clock runs on the whole window too.** `setSendPending` is
+  pushed into the page next to `setGenerating`, and `GenTimer.ensureRunning`
+  makes the hand-off between them a no-op instead of a restart. On
+  `isGenerating` alone the bubble sat there without a clock for the entire
+  durable append.
+- **Anything the bubble is painted from must be reset before the window
+  opens, not inside the run.** `_sendMessage` clears the streaming state at
+  the optimistic paint. `GenerationPipeline.run` clears it as well, but that
+  is a whole durable append later: whatever the previous run left there is
+  what the new typing bubble shows until the first token replaces it — the
+  reply the user just read, appearing again under the message they just sent
+  (and still there after they deleted it).
 
 ---
 
@@ -172,6 +184,12 @@ Rules:
   never an O(n) trim per delta.
 - Nothing in the pipeline reads the phase — it is a UI signal only, so a
   missed transition costs a stale label, never a stuck generation.
+- **A deferred publish must be closed before the run settles.** The streaming
+  deltas are published from a frame callback; one that lands after
+  `GenerationPipeline` cleared the streaming state puts the finished reply
+  back into a state that is meant to be empty. `StreamGenerationService`
+  flushes the pending callback synchronously when the stream ends
+  (`closeStreamPublishing`) and drops anything scheduled behind it.
 
 The label crosses into the WebView through `bridge.setGenerationPhase(label)`
 and is swapped with a cross-fade by `renderer/typing_phase.js`; battery saver

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -64,6 +64,13 @@ class ChatBridgeController {
   /// renderer draws (or withholds) the Regenerate button from the map alone.
   bool isSendPending = false;
 
+  /// Last send-window value the *page* received, level-reconciled next to
+  /// `isGenerating` / `isPostGenRunning` / `isGeneratingImage`. Kept apart
+  /// from [isSendPending], which the dispatcher has already overwritten by the
+  /// time the flags are pushed — comparing against that one would always find
+  /// them equal and never push anything.
+  bool isSendPendingInPage = false;
+
   /// Last generation-phase label pushed to the page ('' = the page's own
   /// default). Kept here so the listener can skip a redundant eval, the same
   /// way the isGenerating flags are reconciled against the bridge.

--- a/lib/features/chat/chat_provider.dart
+++ b/lib/features/chat/chat_provider.dart
@@ -527,6 +527,12 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       // otherwise it shows the default "Generating…" for the whole durable
       // write, which is the claim this label exists to stop making.
       setGenerationPhase(ref, arg, GenerationPhase.preparing);
+      // The bubble is painted from the streaming state, so it must be empty
+      // before the bubble exists. `GenerationPipeline.run` clears it too, but
+      // that is a whole durable append later — anything the previous run left
+      // behind would be the reply the user just read, shown again under the
+      // message they just sent until the first token replaces it.
+      _abortHandler.clearStreaming();
       state = AsyncData(
         current.copyWith(session: optimisticSession, isSendPending: true),
       );

--- a/lib/features/chat/services/stream_generation_service.dart
+++ b/lib/features/chat/services/stream_generation_service.dart
@@ -331,12 +331,20 @@ class StreamGenerationService {
           _phase(next);
         }
 
+        // Publishing is deferred to the next frame, and the pipeline clears
+        // the streaming state as soon as this call returns. A callback that
+        // fires after that clear leaves the finished reply in a state that is
+        // meant to be empty, and the next send paints it into the typing
+        // bubble — the answer the user just read, shown again under the
+        // message they just sent. Closing the window flushes the text one
+        // last time, synchronously, and drops anything scheduled behind it.
+        var studioPublishClosed = false;
         void scheduleStudioStreamingUpdate() {
-          if (studioFrameScheduled) return;
+          if (studioFrameScheduled || studioPublishClosed) return;
           studioFrameScheduled = true;
           SchedulerBinding.instance.scheduleFrameCallback((_) {
             studioFrameScheduled = false;
-            if (_isAborted()) return;
+            if (studioPublishClosed || _isAborted()) return;
             _ref
                 .read(streamingStateProvider(_charId).notifier)
                 .state = StreamingState(
@@ -344,6 +352,19 @@ class StreamGenerationService {
               reasoning: latestStudioReasoning,
             );
           });
+        }
+
+        void closeStudioStreamPublishing() {
+          if (studioPublishClosed) return;
+          studioPublishClosed = true;
+          if (!studioFrameScheduled || _isAborted()) return;
+          studioFrameScheduled = false;
+          _ref
+              .read(streamingStateProvider(_charId).notifier)
+              .state = StreamingState(
+            text: latestStudioText,
+            reasoning: latestStudioReasoning,
+          );
         }
 
         final studioOutputRegexes = await _ref.read(studioRegexProvider.future);
@@ -411,6 +432,7 @@ class StreamGenerationService {
             studioLorebookClassifications = classifications;
           },
         );
+        closeStudioStreamPublishing();
         if (_isAborted() || studioResult.status == 'aborted') {
           _ref.read(studioCycleStateProvider.notifier).state =
               const StudioCycleState.idle();
@@ -587,6 +609,29 @@ class StreamGenerationService {
       ChatState? finalState;
 
       bool frameScheduled = false;
+      // See the Studio branch above for why the deferred publish has to be
+      // closed: a frame callback that lands after the pipeline cleared the
+      // streaming state resurrects the finished reply into the next send's
+      // typing bubble.
+      var streamPublishClosed = false;
+      void publishStreamedText() {
+        _ref.read(streamingStateProvider(_charId).notifier).state =
+            StreamingState(
+              text: accumulator.text.trimLeft(),
+              reasoning: accumulator.reasoning.isNotEmpty
+                  ? accumulator.reasoning
+                  : null,
+            );
+      }
+
+      void closeStreamPublishing() {
+        if (streamPublishClosed) return;
+        streamPublishClosed = true;
+        if (!frameScheduled || _isAborted()) return;
+        frameScheduled = false;
+        publishStreamedText();
+      }
+
       // See the Studio branch above: one report per transition, never a
       // per-chunk re-derivation over the accumulated text.
       var reportedPhase = GenerationPhase.waiting;
@@ -634,24 +679,18 @@ class StreamGenerationService {
           // Reasoning-only output keeps the typing bubble on screen (the
           // visible text is still empty), so name that phase for what it is.
           reportStreamPhase();
-          if (!frameScheduled) {
+          if (!frameScheduled && !streamPublishClosed) {
             frameScheduled = true;
             SchedulerBinding.instance.scheduleFrameCallback((_) {
               frameScheduled = false;
-              if (_isAborted()) return;
-              _ref
-                  .read(streamingStateProvider(_charId).notifier)
-                  .state = StreamingState(
-                text: accumulator.text.trimLeft(),
-                reasoning: accumulator.reasoning.isNotEmpty
-                    ? accumulator.reasoning
-                    : null,
-              );
+              if (streamPublishClosed || _isAborted()) return;
+              publishStreamedText();
             });
           }
         },
         onComplete: (text, reasoning, {rawResponseJson}) {
           if (_isAborted()) return;
+          closeStreamPublishing();
           idleGuard.dispose();
           if (!apiConfig.stream &&
               accumulator.text.isEmpty &&
@@ -759,6 +798,7 @@ class StreamGenerationService {
           }
         },
         onError: (error) {
+          closeStreamPublishing();
           idleGuard.dispose();
           if (idleTimedOut) {
             final msg = 'error_first_chunk_timeout'.tr(
@@ -811,6 +851,9 @@ class StreamGenerationService {
           }
         },
       );
+      // Neither callback is guaranteed on every transport path; the window
+      // must be shut before the pipeline clears the streaming state.
+      closeStreamPublishing();
 
       return finalState ??
           ChatState(

--- a/lib/features/chat/widgets/chat_input_bar.dart
+++ b/lib/features/chat/widgets/chat_input_bar.dart
@@ -310,42 +310,69 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
     // and image so nothing is lost while the host shows its modal.
     if (widget.canSend != null && !widget.canSend!()) return;
     final imageDataUrl = _attachedImageDataUrl;
+    final imageBytes = _attachedImageBytes;
+    final guidance = _guidanceMode && _guidanceController.text.trim().isNotEmpty
+        ? _guidanceController.text.trim()
+        : null;
     _isDispatchingSend = true;
+    // Empty the composer on the tap, not on durable acceptance. Behind a send
+    // is a whole re-encode of the message list, and on a long chat that is
+    // seconds of the message sitting in the box next to its own bubble,
+    // reading as a send that never registered. The payload is captured above,
+    // so the rare rejection puts it straight back.
+    _clearComposedPayload();
     bool accepted;
     try {
       if (imageDataUrl != null) {
-        final guidance =
-            _guidanceMode && _guidanceController.text.trim().isNotEmpty
-            ? _guidanceController.text.trim()
-            : null;
         accepted =
             await widget.onSendWithImage?.call(text, guidance, imageDataUrl) ??
             false;
-      } else if (_guidanceMode && _guidanceController.text.trim().isNotEmpty) {
+      } else if (guidance != null) {
         accepted =
-            await widget.onSendWithGuidance?.call(
-              text,
-              _guidanceController.text.trim(),
-            ) ??
-            false;
+            await widget.onSendWithGuidance?.call(text, guidance) ?? false;
       } else {
-        if (text.trim().isEmpty) return;
         accepted = await widget.onSend(text);
       }
     } finally {
       _isDispatchingSend = false;
     }
-    if (!mounted || !accepted) return;
-    // The user may edit the composer while the durable write is pending. Clear
-    // only the exact payload that was accepted, never newer text.
-    if (_controller.text != text || _attachedImageDataUrl != imageDataUrl) {
-      return;
-    }
+    if (!mounted || accepted) return;
+    _restoreComposedPayload(
+      text: text,
+      guidance: guidance,
+      imageBytes: imageBytes,
+      imageDataUrl: imageDataUrl,
+    );
+  }
+
+  void _clearComposedPayload() {
     _controller.clear();
     _guidanceController.clear();
     setState(() {
       _attachedImageBytes = null;
       _attachedImageDataUrl = null;
+    });
+  }
+
+  /// Puts a rejected send's payload back in the composer — unless the user has
+  /// already started composing something newer, which outranks it.
+  void _restoreComposedPayload({
+    required String text,
+    required String? guidance,
+    required Uint8List? imageBytes,
+    required String? imageDataUrl,
+  }) {
+    if (_controller.text.isNotEmpty || _attachedImageDataUrl != null) return;
+    _controller.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+    if (guidance != null && _guidanceController.text.isEmpty) {
+      _guidanceController.text = guidance;
+    }
+    setState(() {
+      _attachedImageBytes = imageBytes;
+      _attachedImageDataUrl = imageDataUrl;
     });
   }
 

--- a/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
+++ b/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
@@ -474,28 +474,44 @@ class ChatWebViewSyncDispatcher {
     final streamChanged = current.isGenerating != bridge.isGenerating;
     final postGenChanged = current.isPostGenRunning != bridge.isPostGenRunning;
     final imageChanged = current.isGeneratingImage != bridge.isGeneratingImage;
-    if (!streamChanged && !postGenChanged && !imageChanged) {
+    // The send window is pushed with the rest so the elapsed clock under the
+    // typing bubble starts with the bubble, not a durable write later. The
+    // page keeps it apart from `isGenerating`: nothing but the timer reads it.
+    final sendPendingChanged =
+        current.isSendPending != bridge.isSendPendingInPage;
+    if (!streamChanged &&
+        !postGenChanged &&
+        !imageChanged &&
+        !sendPendingChanged) {
       return;
     }
 
     bridge.isGenerating = current.isGenerating;
     bridge.isPostGenRunning = current.isPostGenRunning;
     bridge.isGeneratingImage = current.isGeneratingImage;
+    bridge.isSendPendingInPage = current.isSendPending;
     bridge.evalJs(
       'if (window.bridge) { '
       'window.bridge.setGenerating(${current.isGenerating}); '
       'window.bridge.setPostGenRunning(${current.isPostGenRunning}); '
       'window.bridge.setImageGenerating(${current.isGeneratingImage}); '
+      // Guarded and last: a page from before this flag existed (a cached
+      // asset, the legacy bridge snapshot) would throw here and take the
+      // three calls after it down with the statement.
+      'if (window.bridge.setSendPending) '
+      'window.bridge.setSendPending(${current.isSendPending}); '
       '}',
     );
 
-    if (!current.isGenerating &&
-        !current.isGeneratingImage &&
-        current.messages.isNotEmpty) {
+    // `busy`, not `isGenerating`: a send whose message is still being
+    // persisted is answering already, and stamping Regenerate under it for
+    // that window is the flash this pass exists to keep off screen.
+    final busy = current.isGenerating || current.isSendPending;
+    if (!busy && !current.isGeneratingImage && current.messages.isNotEmpty) {
       bridge.setLastMessage(
         lastUserMessageId(current.messages) ?? current.messages.last.id,
       );
-    } else if (current.isGenerating) {
+    } else if (busy) {
       bridge.setLastMessage(null);
     }
 

--- a/test/chat_input_bar_test.dart
+++ b/test/chat_input_bar_test.dart
@@ -140,16 +140,20 @@ void main() {
       expect(textField.controller!.text, 'keep me');
     });
 
-    testWidgets('pending send does not clear text before durable acceptance', (
+    testWidgets('pending send clears the composer before the durable write', (
       tester,
     ) async {
+      // The append behind a send re-encodes the whole message list. Waiting
+      // for that to land before emptying the box left the message sitting in
+      // the composer next to its own bubble, reading as a send that never
+      // registered.
       final accepted = Completer<bool>();
       await tester.pumpWidget(
         ProviderScope(
           child: MaterialApp(
             home: Scaffold(
               body: ChatInputBar(
-                initialDraft: 'wait for db',
+                initialDraft: 'clear me now',
                 isGenerating: false,
                 onSend: (_) => accepted.future,
               ),
@@ -161,12 +165,74 @@ void main() {
       await tester.tap(find.byIcon(Icons.send_rounded));
       await tester.pump();
       var textField = tester.widget<TextField>(find.byType(TextField));
-      expect(textField.controller!.text, 'wait for db');
+      expect(textField.controller!.text, isEmpty);
 
       accepted.complete(true);
       await tester.pump();
       textField = tester.widget<TextField>(find.byType(TextField));
       expect(textField.controller!.text, isEmpty);
+    });
+
+    testWidgets('a rejected pending send puts the text back', (tester) async {
+      final accepted = Completer<bool>();
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: ChatInputBar(
+                initialDraft: 'give me back',
+                isGenerating: false,
+                onSend: (_) => accepted.future,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.send_rounded));
+      await tester.pump();
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        isEmpty,
+      );
+
+      accepted.complete(false);
+      await tester.pump();
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        'give me back',
+      );
+    });
+
+    testWidgets('a rejected send does not overwrite newer text', (
+      tester,
+    ) async {
+      final accepted = Completer<bool>();
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: ChatInputBar(
+                initialDraft: 'the old one',
+                isGenerating: false,
+                onSend: (_) => accepted.future,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.send_rounded));
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), 'the new one');
+      await tester.pump();
+
+      accepted.complete(false);
+      await tester.pump();
+      expect(
+        tester.widget<TextField>(find.byType(TextField)).controller!.text,
+        'the new one',
+      );
     });
 
     testWidgets('image generation stop button remains tappable', (

--- a/test/chat_webview_sync_dispatcher_test.dart
+++ b/test/chat_webview_sync_dispatcher_test.dart
@@ -597,6 +597,40 @@ void main() {
       expect(syncState.wasBusy, isTrue);
     });
 
+    test('the send window reaches the page so the clock can start', () {
+      // The elapsed clock under the typing bubble runs on this flag: without
+      // it the bubble sits there timerless for the whole durable append.
+      final bridge = _FakeBridge();
+      final greeting = _assistant('a1');
+      final user = _user('u1');
+      final dispatcher = ChatWebViewSyncDispatcher(
+        state: ChatWebViewSyncState(),
+      );
+
+      dispatcher.dispatch(
+        bridge: bridge,
+        old: _fields(isGenerating: false, messages: [greeting]),
+        current: _fields(
+          isGenerating: false,
+          isSendPending: true,
+          messages: [greeting, user],
+        ),
+        oldMessages: [greeting],
+        newMessages: [greeting, user],
+        streamingId: '__streaming__',
+        onSyncExtBlockPanels: () async {},
+        appendMessage: (_) async {},
+        buildStreamingPlaceholder: () => _assistant('__streaming__'),
+      );
+
+      expect(bridge.isSendPendingInPage, isTrue);
+      expect(bridge.evalCalls.single, contains('setSendPending(true)'));
+      expect(bridge.evalCalls.single, contains('setGenerating(false)'));
+      // Still not idle: the Regenerate button belongs to a chat with no reply
+      // on its way, and this send already has one.
+      expect(bridge.lastMessageIds, [null]);
+    });
+
     test('the bubble is not re-injected when the send hands off to a run', () {
       final bridge = _FakeBridge();
       final greeting = _assistant('a1');
@@ -914,6 +948,12 @@ class _FakeBridge implements ChatBridgeController {
 
   @override
   bool isPostGenRunning = false;
+
+  @override
+  bool isSendPending = false;
+
+  @override
+  bool isSendPendingInPage = false;
 
   @override
   String? continuationTargetId;

--- a/test/send_window_streaming_reset_test.dart
+++ b/test/send_window_streaming_reset_test.dart
@@ -1,0 +1,112 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/llm/studio_turn_config_snapshot.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:glaze_flutter/features/chat/chat_generation_service.dart';
+import 'package:glaze_flutter/features/chat/chat_provider.dart';
+import 'package:glaze_flutter/features/chat/chat_session_service.dart';
+import 'package:glaze_flutter/features/chat/chat_state.dart';
+
+/// Generation stub that settles the run immediately, so the test only has to
+/// look at the state the send published on its way there.
+class _StubGenerationService extends ChatGenerationService {
+  _StubGenerationService(super.ref);
+
+  @override
+  Future<ChatState> generate({
+    required ChatSession session,
+    ChatSession? saveSession,
+    required String charId,
+    required int genId,
+    required ChatState currentState,
+    required void Function(ChatState) onStateUpdate,
+    required bool Function() isAborted,
+    List<String>? previousSwipes,
+    int previousSwipeId = 0,
+    String? previousReasoning,
+    String? previousGenTime,
+    int? previousTokens,
+    List<Map<String, dynamic>>? previousSwipesMeta,
+    String? guidanceText,
+    String? regenTargetId,
+    String? continueTargetId,
+    StudioTurnConfigSnapshot? studioTurnConfig,
+  }) async => ChatState(session: session, isGenerating: false);
+}
+
+void main() {
+  // The send path pings the notification service (haptics → platform channel),
+  // which needs a binding to no-op instead of throwing.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('a send empties the streaming state before it paints its bubble', () async {
+    // The typing bubble is painted from the streaming state, and the WebView
+    // puts it up on the send window — a whole durable append before the
+    // pipeline's own reset. Anything the finished run left behind is the reply
+    // the user just read, shown again under the message they just sent until
+    // the first new token replaces it.
+    SharedPreferences.setMockInitialValues({});
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final container = ProviderContainer(
+      overrides: [
+        appDbProvider.overrideWithValue(db),
+        chatGenerationServiceProvider.overrideWith(
+          (ref) => _StubGenerationService(ref),
+        ),
+      ],
+    );
+    addTearDown(() async {
+      container.dispose();
+      ChatSessionService.clearCache();
+      await db.close();
+    });
+
+    const session = ChatSession(
+      id: 's1',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: [
+        ChatMessage(id: 'm1', role: 'assistant', content: 'Hi', timestamp: 1),
+      ],
+    );
+    await container
+        .read(characterRepoProvider)
+        .put(const Character(id: 'c1', name: 'Alice'));
+    await container.read(chatRepoProvider).put(session);
+    await container.read(chatProvider('c1').future);
+    final notifier = container.read(chatProvider('c1').notifier);
+
+    // What a finished run leaves behind: the last delta it published.
+    container.read(streamingStateProvider('c1').notifier).state =
+        const StreamingState(text: 'the reply they already read');
+
+    String? streamingTextInSendWindow;
+    final subscription = container.listen<AsyncValue<ChatState>>(
+      chatProvider('c1'),
+      (previous, next) {
+        if (streamingTextInSendWindow == null &&
+            next.value?.isSendPending == true) {
+          streamingTextInSendWindow = container
+              .read(streamingStateProvider('c1'))
+              .text;
+        }
+      },
+    );
+    addTearDown(subscription.close);
+
+    await notifier.sendMessage('Next');
+
+    expect(
+      streamingTextInSendWindow,
+      isNotNull,
+      reason: 'the send never painted its send window',
+    );
+    expect(streamingTextInSendWindow, isEmpty);
+  });
+}

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -2355,8 +2355,40 @@ void main() {
       final body = _extractBlockBody(bridgeControllerJs, idx);
       expect(body, contains('this.isGenerating'));
       expect(body, isNot(contains('this.isPostGenRunning')));
-      expect(body, contains('this._genTimer.start()'));
+      expect(body, contains('this._genTimer.ensureRunning()'));
       expect(body, contains('this._genTimer.stop()'));
+    });
+
+    test('the elapsed clock runs for the whole send window', () {
+      // The bubble goes up on the send and the generation is published a
+      // durable append later. Keying the clock on `isGenerating` alone left
+      // the bubble sitting there without one for that whole write.
+      final marker = '_syncGenerationTimer() {';
+      final idx = bridgeControllerJs.indexOf(marker);
+      expect(idx, isNot(-1));
+      final body = _extractBlockBody(bridgeControllerJs, idx);
+      expect(body, contains('this.isSendPending'));
+
+      final sendPendingIdx = bridgeControllerJs.indexOf(
+        'setSendPending(value) {',
+      );
+      expect(sendPendingIdx, isNot(-1));
+      final sendPendingBody = _extractBlockBody(
+        bridgeControllerJs,
+        sendPendingIdx,
+      );
+      expect(sendPendingBody, contains('this.isSendPending = !!value'));
+      expect(sendPendingBody, contains('this._syncGenerationTimer()'));
+    });
+
+    test('the hand-off to the generation does not restart the clock', () {
+      // Both edges reconcile through _syncGenerationTimer, so `start()` on the
+      // second one would reset a timer the user has already watched count.
+      final idx = genTimerJs.indexOf('ensureRunning() {');
+      expect(idx, isNot(-1));
+      final body = _extractBlockBody(genTimerJs, idx);
+      expect(body, contains('if (this._interval) return'));
+      expect(body, contains('this.start()'));
     });
 
     test(


### PR DESCRIPTION
Four reports, three of them about the same window: the seconds between the tap
and the durable append, which the typing bubble now covers (`7d2db38`) but
nothing else did.

## The composer emptied a whole DB write late

- `ChatInputBar._handleSend` cleared the box only once the send was durably
  accepted, so on a long chat the message sat in the composer next to its own
  bubble for the whole append and read as a send that never registered. It now
  clears on the tap and restores the payload only when the send is rejected —
  and only when the user has not composed something newer meanwhile, which is
  the case the old ordering existed to protect.

## The bubble had no clock, and the phase could not move

- `GenTimer` was started from `setGenerating(true)`, which lands an append after
  the bubble goes up: it sat there timerless while the label held at
  "Preparing…" (correct — only the durable write is running at that point, so
  no phase transition is due). `setSendPending` is now pushed into the page
  next to `setGenerating` from `_maybeApplyGeneratingState`, and
  `GenTimer.ensureRunning` makes the hand-off between the two a no-op instead
  of a restart that would rewind the elapsed count.
- The same branch now withholds `setLastMessage` for the whole busy window
  rather than for `isGenerating` alone, so the flag that reaches the page keeps
  matching what the message mapper already does with `isSendPending`.

## A send opened its bubble on the previous reply

- The typing bubble is painted from `streamingStateProvider`, and that state
  still held the finished reply: the deltas are published from a
  `scheduleFrameCallback`, and the last one lands *after*
  `GenerationPipeline.run` cleared it. Nothing reset it afterwards, so the next
  send appended a placeholder carrying the answer the user had just read —
  still showing it after they had deleted that message — until the first new
  token replaced it. Before `7d2db38` the placeholder went up on `isGenerating`
  (i.e. after that clear), which is why this surfaced only now.
- Two fixes, because either alone leaves a hole:
  `StreamGenerationService` closes the deferred publish when the stream ends
  (`closeStreamPublishing` / `closeStudioStreamPublishing` — flushes the
  pending callback synchronously, drops anything scheduled behind it), and
  `ChatNotifier._sendMessage` clears the streaming state at the optimistic
  paint instead of trusting whatever the previous run left there.

## Verification

Flutter is not available in this environment, so **CI on this PR is the
analyze/test check** — nothing was run locally that this text claims passed.
What was done here: both changed WebView modules syntax-checked with
`node --input-type=module --check`, the new asset assertions replayed against
the sources by hand, and tests added —

- `test/chat_input_bar_test.dart`: clears on the tap, restores a rejected send,
  never clobbers newer text (the old "does not clear before durable acceptance"
  test is inverted, since that ordering is the bug).
- `test/chat_webview_sync_dispatcher_test.dart`: the send window reaches the
  page (`setSendPending(true)`) and still withholds Regenerate.
- `test/send_window_streaming_reset_test.dart` (new): a send empties the
  streaming state before it paints its window, with a finished run's text
  seeded in it.
- `test/webview_assets_test.dart`: the clock spans the send window, and the
  hand-off does not restart it.

`docs/rules/generation.md` gains the three rules these fixes encode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZWrxyRwsLj5TQ1CDRMWvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZWrxyRwsLj5TQ1CDRMWvf)_