### PR TITLE
fix(sync): reconcile Ledger after pulled deletions

### DIFF
--- a/lib/core/db/repositories/session_canon_rollback_repo.dart
+++ b/lib/core/db/repositories/session_canon_rollback_repo.dart
@@ -87,50 +87,76 @@ class SessionCanonRollbackRepo {
       throw StateError('Rollback session character does not exist.');
     }
     final targetCharacter = await _loadCharacterSnapshot(target);
-    final restored = targetCharacter.copyWith(
-      id: current.id,
-      name: current.name,
-      displayName: current.displayName,
-      avatarPath: current.avatarPath,
-      color: current.color,
-      updatedAt: current.updatedAt,
-      createdAt: current.createdAt,
-      gallery: current.gallery,
-      currentSessionIndex: current.currentSessionIndex,
-      fav: current.fav,
-      characterVersion: current.characterVersion,
-      picksHash: current.picksHash,
-      tokenCount: current.tokenCount,
-      variantGroupId: current.variantGroupId,
-      variantName: current.variantName,
-      variantOrder: current.variantOrder,
-      hidden: current.hidden,
-    );
+    var rollbackCharacterId = current.id;
+    var rollbackRevision = 0;
+    var rollbackHash = '';
+    final targetLive = target.characterId == current.id
+        ? null
+        : await CharacterRepo(db).getById(target.characterId);
+    final canRebindToTarget =
+        targetLive != null &&
+        CardCanonicalizer.sha256(targetLive) == target.characterRevisionHash;
 
-    final latestRevision =
-        await (db.select(db.characterRevisionRows)
-              ..where((row) => row.characterId.equals(current.id))
-              ..orderBy([(row) => OrderingTerm.desc(row.revision)])
-              ..limit(1))
-            .getSingleOrNull();
-    if (latestRevision == null) {
-      throw StateError('Rollback character lineage does not exist.');
+    if (canRebindToTarget) {
+      final changed =
+          await (db.update(db.chatSessions)..where(
+                (row) =>
+                    row.sessionId.equals(sessionId) &
+                    row.characterId.equals(current.id),
+              ))
+              .write(
+                ChatSessionsCompanion(characterId: Value(target.characterId)),
+              );
+      if (changed != 1) throw StateError('Rollback session owner is stale.');
+      rollbackCharacterId = target.characterId;
+      rollbackRevision = target.characterRevision;
+      rollbackHash = target.characterRevisionHash;
+    } else {
+      final restored = targetCharacter.copyWith(
+        id: current.id,
+        name: current.name,
+        displayName: current.displayName,
+        avatarPath: current.avatarPath,
+        color: current.color,
+        updatedAt: current.updatedAt,
+        createdAt: current.createdAt,
+        gallery: current.gallery,
+        currentSessionIndex: current.currentSessionIndex,
+        fav: current.fav,
+        characterVersion: current.characterVersion,
+        picksHash: current.picksHash,
+        tokenCount: current.tokenCount,
+        variantGroupId: current.variantGroupId,
+        variantName: current.variantName,
+        variantOrder: current.variantOrder,
+        hidden: current.hidden,
+      );
+
+      final latestRevision =
+          await (db.select(db.characterRevisionRows)
+                ..where((row) => row.characterId.equals(current.id))
+                ..orderBy([(row) => OrderingTerm.desc(row.revision)])
+                ..limit(1))
+              .getSingleOrNull();
+      if (latestRevision == null) {
+        throw StateError('Rollback character lineage does not exist.');
+      }
+      rollbackRevision = latestRevision.revision + 1;
+      rollbackHash = CardCanonicalizer.sha256(restored);
+      await _restoreCharacterCas(current, restored);
+      await db
+          .into(db.characterRevisionRows)
+          .insert(
+            CharacterRevisionRowsCompanion.insert(
+              characterId: current.id,
+              revision: rollbackRevision,
+              revisionHash: rollbackHash,
+              parentRevisionHash: Value(latestRevision.revisionHash),
+              snapshotJson: jsonEncode(restored.toJson()),
+              createdAt: Value(currentTimestampSeconds()),
+            ),
+          );
     }
-    final newRevision = latestRevision.revision + 1;
-    final newHash = CardCanonicalizer.sha256(restored);
-    await _restoreCharacterCas(current, restored);
-    await db
-        .into(db.characterRevisionRows)
-        .insert(
-          CharacterRevisionRowsCompanion.insert(
-            characterId: current.id,
-            revision: newRevision,
-            revisionHash: newHash,
-            parentRevisionHash: Value(latestRevision.revisionHash),
-            snapshotJson: jsonEncode(restored.toJson()),
-            createdAt: Value(currentTimestampSeconds()),
-          ),
-        );
 
     final rollbackAnchor = target.sequence == 0
         ? SessionCanonCheckpointAnchor(
@@ -147,9 +173,9 @@ class SessionCanonRollbackRepo {
     final rollback = await _checkpoints.appendInTransaction(
       sessionId: sessionId,
       expectedParentCheckpointId: latest.id,
-      characterId: current.id,
-      characterRevision: newRevision,
-      characterRevisionHash: newHash,
+      characterId: rollbackCharacterId,
+      characterRevision: rollbackRevision,
+      characterRevisionHash: rollbackHash,
       rewriteJobId: rollbackId,
       anchor: rollbackAnchor,
     );

--- a/lib/core/db/repositories/sync_session_consistency_repo.dart
+++ b/lib/core/db/repositories/sync_session_consistency_repo.dart
@@ -1,0 +1,87 @@
+import '../../models/tracker.dart';
+import '../app_db.dart';
+import 'chat_repo.dart';
+import 'session_canon_checkpoint_repo.dart';
+import 'session_canon_rollback_repo.dart';
+import 'tracker_repo.dart';
+import 'tracker_snapshot_repo.dart';
+
+/// Restores derived session state after cloud entities have finished applying.
+class SyncSessionConsistencyRepo {
+  const SyncSessionConsistencyRepo(this.db);
+
+  final AppDatabase db;
+
+  Future<void> reconcile(Set<String> sessionIds) async {
+    for (final sessionId in sessionIds) {
+      await db.transaction(() => _reconcileSession(sessionId));
+    }
+  }
+
+  Future<void> _reconcileSession(String sessionId) async {
+    final chat = await ChatRepo(db).getById(sessionId);
+    if (chat == null) return;
+
+    await SessionCanonRollbackRepo(db).reconcileInTransaction(
+      sessionId: sessionId,
+      survivingMessages: chat.messages,
+    );
+    final canonHash = (await SessionCanonCheckpointRepo(
+      db,
+    ).getLatest(sessionId))?.characterRevisionHash;
+
+    final snapshots = TrackerSnapshotRepo(db);
+    final all = await snapshots.getBySessionId(sessionId);
+    final activeAnchors = {
+      for (final message in chat.messages)
+        (message.id, message.swipeId, message.agentSwipeId),
+    };
+    for (final snapshot in all) {
+      final basisHashes = snapshot.trackers
+          .map((tracker) => tracker.basisRevisionHash)
+          .where((hash) => hash.isNotEmpty)
+          .toSet();
+      final matchesCanon =
+          canonHash == null ||
+          canonHash.isEmpty ||
+          basisHashes.isEmpty ||
+          (basisHashes.length == 1 && basisHashes.single == canonHash);
+      if (!matchesCanon ||
+          !activeAnchors.contains((
+            snapshot.messageId,
+            snapshot.swipeId,
+            snapshot.agentSwipeId,
+          ))) {
+        await snapshots.deleteAnchor(
+          sessionId: sessionId,
+          messageId: snapshot.messageId,
+          swipeId: snapshot.swipeId,
+          agentSwipeId: snapshot.agentSwipeId,
+        );
+      }
+    }
+
+    List<Tracker> committedBase = const [];
+    for (final message in chat.messages.reversed) {
+      final snapshot = await snapshots.getByAnchor(
+        sessionId: sessionId,
+        messageId: message.id,
+        swipeId: message.swipeId,
+        agentSwipeId: message.agentSwipeId,
+      );
+      if (snapshot?.committed == true) {
+        committedBase = snapshot!.trackers;
+        break;
+      }
+    }
+
+    final trackers = TrackerRepo(db);
+    if (committedBase.isEmpty) {
+      committedBase = await trackers.getInitialGameTimeSeed(sessionId);
+      if (committedBase.isEmpty) {
+        committedBase = await trackers.getCompleteGameTime(sessionId);
+      }
+    }
+    await trackers.replaceLedgerState(sessionId, committedBase);
+  }
+}

--- a/lib/core/db/repositories/tracker_repo.dart
+++ b/lib/core/db/repositories/tracker_repo.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 
 import '../../models/tracker.dart';
@@ -6,6 +8,8 @@ import '../app_db.dart';
 import 'reconciliation_state_codec.dart';
 
 class TrackerRepo {
+  static const initialGameTimeSeedName = '__game_time_initial_seed_v1';
+
   final AppDatabase db;
 
   const TrackerRepo(this.db);
@@ -62,6 +66,41 @@ class TrackerRepo {
   /// session has no snapshot yet, so this narrowly scoped bootstrap is the
   /// only live model-owned state allowed into that initial committed base.
   Future<List<Tracker>> getInitialGameTimeSeed(String sessionId) async {
+    final stored = await get(sessionId, initialGameTimeSeedName);
+    if (stored != null &&
+        stored.scope == 'system' &&
+        stored.provenance == 'game_time_seed') {
+      try {
+        final value = jsonDecode(stored.value);
+        if (value is Map<String, dynamic>) {
+          final time = value['time'];
+          final date = value['date'];
+          final day = value['day'];
+          if (time is String &&
+              time.trim().isNotEmpty &&
+              date is String &&
+              date.trim().isNotEmpty &&
+              day is String &&
+              day.trim().isNotEmpty) {
+            return {'world:time': time, 'world:date': date, 'world:day': day}
+                .entries
+                .map(
+                  (entry) => Tracker(
+                    sessionId: sessionId,
+                    name: entry.key,
+                    value: entry.value,
+                    scope: 'ledger',
+                    provenance: 'game_time_seed',
+                    updatedAt: stored.updatedAt,
+                  ),
+                )
+                .toList(growable: false);
+          }
+        }
+      } on FormatException {
+        // Fall through to the legacy provenance-only representation.
+      }
+    }
     return _getCompleteGameTime(
       sessionId,
       (tracker) => tracker.provenance == 'game_time_seed',
@@ -107,6 +146,15 @@ class TrackerRepo {
           final current = await get(sessionId, name);
           if (current?.value != expectedValues[name]) return false;
         }
+      }
+      if (await get(sessionId, initialGameTimeSeedName) == null) {
+        await upsertValue(
+          sessionId,
+          initialGameTimeSeedName,
+          jsonEncode({'time': time, 'date': date, 'day': day}),
+          scope: 'system',
+          provenance: 'game_time_seed',
+        );
       }
       for (final entry in {
         'world:time': time,

--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/llm/game_time.dart';
 import '../../core/llm/tokenizer.dart';
 import '../../core/models/chat_message.dart';
 import '../../core/models/tracker.dart';
@@ -265,29 +264,14 @@ class ChatMessageService {
         messageIds: invalidatedMessageIds,
       );
       await checkpointRepo.deleteForMessages(session.id, invalidatedMessageIds);
-      // Rolling back before the first committed snapshot wipes all
-      // model-owned Ledger rows — including the game clock. Preserve the
-      // current complete tuple as a bootstrap seed so the next generation
-      // (e.g. regenerating after deleting the assistant reply) still stamps
-      // the opening clock and the next Ledger run sees a valid baseline.
+      // Rolling back before the first committed snapshot restores the original
+      // clock seed. Legacy sessions without one retain a complete live clock as
+      // a best-effort baseline, but must not promote it to an initial seed.
       var committedBase = fallbackSnapshot?.trackers ?? const <Tracker>[];
       if (fallbackSnapshot == null) {
-        final liveLedger = await trackerRepo.getBySessionAndScope(
-          session.id,
-          'ledger',
-        );
-        final clock = GameTimeState.fromTrackers(liveLedger);
-        final time = clock.time;
-        final date = clock.date;
-        final day = clock.day;
-        if (time != null && date != null && day != null) {
-          await trackerRepo.seedInitialGameTime(
-            sessionId: session.id,
-            time: time,
-            date: date,
-            day: '$day',
-          );
-          committedBase = await trackerRepo.getInitialGameTimeSeed(session.id);
+        committedBase = await trackerRepo.getInitialGameTimeSeed(session.id);
+        if (committedBase.isEmpty) {
+          committedBase = await trackerRepo.getCompleteGameTime(session.id);
         }
       }
       await trackerRepo.replaceLedgerState(session.id, committedBase);
@@ -315,8 +299,9 @@ class ChatMessageService {
       debugPrint('[ChatMessageService] failed to clear message index: $e');
     }
 
-    ChatSessionService.updateCache(updated);
-    return updated;
+    final durable = await chatRepo.getById(session.id) ?? updated;
+    ChatSessionService.updateCache(durable);
+    return durable;
   }
 
   ChatSession toggleMessageHidden(ChatSession session, int index) {

--- a/lib/features/cloud_sync/services/sync_engine.dart
+++ b/lib/features/cloud_sync/services/sync_engine.dart
@@ -65,6 +65,7 @@ class SyncEngine {
   final SessionDeletionStore _sessionDeletionStore;
   final CharacterDeletionStore _characterDeletionStore;
   final Future<void> Function(LorebookActivations) _saveLorebookActivations;
+  final Future<void> Function(Set<String>)? _reconcilePulledSessions;
   final SyncQueue _queue = SyncQueue();
   late final SyncBinaryAssetSyncer _binarySyncer;
   bool _includeApiKeys = false;
@@ -98,6 +99,7 @@ class SyncEngine {
     this._saveLorebookActivations, [
     this._reconciliationStateStore,
     this._sessionLorebookOverlayStore,
+    this._reconcilePulledSessions,
   ]) {
     _binarySyncer = SyncBinaryAssetSyncer(
       _adapter,
@@ -577,8 +579,24 @@ class SyncEngine {
     // Both dependent aggregates validate against chats/base lorebooks. Apply
     // primary entities first, current lore projections second, and immutable
     // reconciliation provenance last.
+    final primaryErrors = await applyEntries(primaryEntries);
+    if (primaryErrors.isNotEmpty) {
+      throw SyncQueueAggregateError(primaryErrors);
+    }
+    final touchedSessionIds = primaryEntries
+        .where(
+          (entry) =>
+              entry.type == 'chat' ||
+              entry.type == 'tracker_snapshot' ||
+              entry.type == 'tracker_value',
+        )
+        .map((entry) => entry.id)
+        .toSet();
+    if (touchedSessionIds.isNotEmpty) {
+      await _reconcilePulledSessions?.call(touchedSessionIds);
+    }
+
     final taskErrors = <Object>[
-      ...await applyEntries(primaryEntries),
       ...await applyEntries(overlayEntries),
       ...await applyEntries(reconciliationEntries),
     ];
@@ -923,11 +941,9 @@ class SyncEngine {
           return SyncSerialization.infoBlocksPayload(blocks);
         case 'tracker_snapshot':
           final snaps = await _trackerSnapshotStore.getBySessionId(id);
-          if (snaps.isEmpty) return null;
           return {'__trackerSnapshots': true, 'items': snaps};
         case 'tracker_value':
           final trackers = await _trackerValueStore.getBySessionId(id);
-          if (trackers.isEmpty) return null;
           return {'__trackerValues': true, 'items': trackers};
         case 'studio_config':
           final config = await _studioConfigStore.getById(id);
@@ -1063,7 +1079,10 @@ class SyncEngine {
           break;
       }
     } catch (_) {
-      if (type == 'reconciliation_state' ||
+      if (type == 'chat' ||
+          type == 'tracker_snapshot' ||
+          type == 'tracker_value' ||
+          type == 'reconciliation_state' ||
           type == 'session_lorebook_overlays') {
         rethrow;
       }

--- a/lib/features/cloud_sync/services/sync_manifest.dart
+++ b/lib/features/cloud_sync/services/sync_manifest.dart
@@ -227,11 +227,13 @@ class SyncManifestBuilder implements SyncManifestProvider {
       );
     }
 
-    final trackerSnapshotSessionIds = await _trackerSnapshotStore
-        .getAllSessionIds();
+    final chatSessionIds = sessions.map((session) => session.sessionId).toSet();
+    final trackerSnapshotSessionIds = {
+      ...chatSessionIds,
+      ...await _trackerSnapshotStore.getAllSessionIds(),
+    };
     for (final sessionId in trackerSnapshotSessionIds) {
       final snapshots = await _trackerSnapshotStore.getBySessionId(sessionId);
-      if (snapshots.isEmpty) continue;
       final payload = {'__trackerSnapshots': true, 'items': snapshots};
       final hash = SyncSerialization.computeSyncHash(payload);
       final key = entryKey('tracker_snapshot', sessionId);
@@ -253,10 +255,12 @@ class SyncManifestBuilder implements SyncManifestProvider {
       );
     }
 
-    final trackerValueSessionIds = await _trackerValueStore.getAllSessionIds();
+    final trackerValueSessionIds = {
+      ...chatSessionIds,
+      ...await _trackerValueStore.getAllSessionIds(),
+    };
     for (final sessionId in trackerValueSessionIds) {
       final trackers = await _trackerValueStore.getBySessionId(sessionId);
-      if (trackers.isEmpty) continue;
       final payload = {'__trackerValues': true, 'items': trackers};
       final hash = SyncSerialization.computeSyncHash(payload);
       final key = entryKey('tracker_value', sessionId);

--- a/lib/features/cloud_sync/services/sync_service.dart
+++ b/lib/features/cloud_sync/services/sync_service.dart
@@ -46,6 +46,7 @@ class SyncService {
   final SessionDeletionStore _sessionDeletionStore;
   final CharacterDeletionStore _characterDeletionStore;
   final Future<void> Function(LorebookActivations) _saveLorebookActivations;
+  final Future<void> Function(Set<String>)? _reconcilePulledSessions;
 
   SyncProvider _provider = SyncProvider.dropbox;
   SyncStatus _status = SyncStatus.idle;
@@ -119,9 +120,11 @@ class SyncService {
     required SessionDeletionStore sessionDeletionStore,
     required CharacterDeletionStore characterDeletionStore,
     required Future<void> Function(LorebookActivations) saveLorebookActivations,
+    Future<void> Function(Set<String>)? reconcilePulledSessions,
   }) : _sessionDeletionStore = sessionDeletionStore,
        _characterDeletionStore = characterDeletionStore,
-       _saveLorebookActivations = saveLorebookActivations;
+       _saveLorebookActivations = saveLorebookActivations,
+       _reconcilePulledSessions = reconcilePulledSessions;
 
   CloudAdapter get _adapter {
     switch (_provider) {
@@ -186,6 +189,7 @@ class SyncService {
     _saveLorebookActivations,
     _reconciliationStateStore,
     _sessionLorebookOverlayStore,
+    _reconcilePulledSessions,
   );
 
   Future<void> init() async {

--- a/lib/features/cloud_sync/sync_provider.dart
+++ b/lib/features/cloud_sync/sync_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 
 import '../../../core/state/db_provider.dart';
+import '../../../core/db/repositories/sync_session_consistency_repo.dart';
 import '../../../core/state/character_folder_provider.dart'
     show characterFolderRepoProvider;
 import '../../../core/state/lorebook_provider.dart'
@@ -59,6 +60,9 @@ final syncServiceProvider = FutureProvider<SyncService>((ref) async {
     sessionDeletionStore: ref.watch(sessionDeletionRepoProvider),
     characterDeletionStore: ref.watch(characterDeletionRepoProvider),
     saveLorebookActivations: saveLorebookActivations,
+    reconcilePulledSessions: SyncSessionConsistencyRepo(
+      ref.watch(appDbProvider),
+    ).reconcile,
   );
   await service.init();
 

--- a/test/chat_bulk_delete_test.dart
+++ b/test/chat_bulk_delete_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:glaze_flutter/core/db/app_db.dart';
 import 'package:glaze_flutter/core/db/repositories/ledger_reconciliation_checkpoint_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/tracker_repo.dart';
 import 'package:glaze_flutter/core/models/chat_message.dart';
 import 'package:glaze_flutter/core/models/character_knowledge_fact.dart';
 import 'package:glaze_flutter/core/models/knowledge_cleanup.dart';
@@ -15,7 +16,7 @@ final _messageServiceProvider = Provider(ChatMessageService.new);
 
 void main() {
   test(
-    'deleting the last assistant message preserves the game clock as a seed',
+    'deleting generated messages restores the original game-time seed',
     () async {
       final db = AppDatabase.forTesting(NativeDatabase.memory());
       final container = ProviderContainer(
@@ -31,39 +32,49 @@ void main() {
         characterId: 'c1',
         sessionIndex: 0,
         messages: const [
-          ChatMessage(id: 'u1', role: 'user', content: 'hi', timestamp: 1),
+          ChatMessage(
+            id: 'g1',
+            role: 'assistant',
+            content: 'hello',
+            timestamp: 1,
+          ),
+          ChatMessage(id: 'u1', role: 'user', content: 'hi', timestamp: 2),
           ChatMessage(
             id: 'a1',
             role: 'assistant',
             content: 'reply',
-            timestamp: 2,
+            timestamp: 3,
+          ),
+          ChatMessage(id: 'u2', role: 'user', content: 'next', timestamp: 4),
+          ChatMessage(
+            id: 'a2',
+            role: 'assistant',
+            content: 'later',
+            timestamp: 5,
           ),
         ],
       );
       await container.read(chatRepoProvider).put(session);
-      // A complete clock tuple from a previous Ledger run — no committed
-      // tracker snapshot exists yet.
       final trackerRepo = container.read(trackerRepoProvider);
-      for (final entry in {
-        'world:time': '14:15',
-        'world:date': '01.01.2027',
-        'world:day': '2',
-      }.entries) {
-        await trackerRepo.upsertValue(
-          's1',
-          entry.key,
-          entry.value,
-          scope: 'ledger',
-          provenance: 'studio_ledger',
-        );
-      }
+      await trackerRepo.seedInitialGameTime(
+        sessionId: 's1',
+        time: '08:00',
+        date: '21.04.2026',
+      );
+      await trackerRepo.upsertValue(
+        's1',
+        'world:time',
+        '08:27',
+        scope: 'ledger',
+        provenance: 'studio_ledger',
+      );
 
       await container.read(_messageServiceProvider).deleteMessages(session, {
-        1,
+        2,
+        3,
+        4,
       });
 
-      // The rollback-to-empty path must keep a complete bootstrap tuple so a
-      // following regeneration still stamps the opening clock.
       final seed = await trackerRepo.getInitialGameTimeSeed('s1');
       expect(seed.map((t) => t.name).toSet(), {
         'world:time',
@@ -71,11 +82,62 @@ void main() {
         'world:day',
       });
       final byName = {for (final t in seed) t.name: t.value};
-      expect(byName['world:time'], '14:15');
-      expect(byName['world:date'], '01.01.2027');
-      expect(byName['world:day'], '2');
+      expect(byName['world:time'], '08:00');
+      expect(byName['world:date'], '21.04.2026');
+      expect(byName['world:day'], '0');
+      expect((await trackerRepo.get('s1', 'world:time'))?.value, '08:00');
+      expect(
+        (await container.read(chatRepoProvider).getById('s1'))?.messages.map(
+          (message) => message.id,
+        ),
+        ['g1', 'u1'],
+      );
     },
   );
+
+  test('legacy rollback keeps live clock without inventing a seed', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+    final session = ChatSession(
+      id: 's1',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: const [
+        ChatMessage(id: 'u1', role: 'user', content: 'hi'),
+        ChatMessage(id: 'a1', role: 'assistant', content: 'reply'),
+      ],
+    );
+    await container.read(chatRepoProvider).put(session);
+    final trackerRepo = container.read(trackerRepoProvider);
+    for (final entry in {
+      'world:time': '08:27',
+      'world:date': '21.04.2026',
+      'world:day': '0',
+    }.entries) {
+      await trackerRepo.upsertValue(
+        's1',
+        entry.key,
+        entry.value,
+        scope: 'ledger',
+        provenance: 'studio_ledger',
+      );
+    }
+
+    await container.read(_messageServiceProvider).deleteMessages(session, {1});
+
+    expect((await trackerRepo.get('s1', 'world:time'))?.value, '08:27');
+    expect(await trackerRepo.getInitialGameTimeSeed('s1'), isEmpty);
+    expect(
+      await trackerRepo.get('s1', TrackerRepo.initialGameTimeSeedName),
+      isNull,
+    );
+  });
 
   test(
     'bulk delete persists final state and clears raw-message index',

--- a/test/session_canon_delete_rollback_test.dart
+++ b/test/session_canon_delete_rollback_test.dart
@@ -428,6 +428,85 @@ void main() {
       4,
     );
   });
+
+  test('deleting a rewrite anchor rebinds an automatic fork', () async {
+    final original = Character(
+      id: 'original',
+      name: 'Original',
+      description: 'before rewrite',
+    );
+    final fork = Character(
+      id: 'fork',
+      name: 'Original',
+      description: 'after rewrite',
+      variantGroupId: 'original',
+      variantOrder: 1,
+    );
+    await container.read(characterRepoProvider).put(original);
+    await container.read(characterRepoProvider).put(fork);
+    await revision(original, 12, '');
+    await revision(fork, 1, '');
+    await revision(fork, 2, CardCanonicalizer.sha256(fork));
+    final session = const ChatSession(
+      id: 's1',
+      characterId: 'fork',
+      sessionIndex: 0,
+      messages: [
+        ChatMessage(id: 'm0', role: 'user', content: 'before'),
+        ChatMessage(id: 'anchor', role: 'assistant', content: 'rewrite'),
+      ],
+    );
+    await container.read(chatRepoProvider).put(session);
+    final checkpoints = container.read(sessionCanonCheckpointRepoProvider);
+    final root = await checkpoints.appendRootInTransaction(
+      sessionId: session.id,
+      characterId: original.id,
+      characterRevision: 12,
+      characterRevisionHash: CardCanonicalizer.sha256(original),
+    );
+    await checkpoints.appendInTransaction(
+      sessionId: session.id,
+      expectedParentCheckpointId: root.id,
+      characterId: fork.id,
+      characterRevision: 2,
+      characterRevisionHash: CardCanonicalizer.sha256(fork),
+      rewriteJobId: 'job-fork',
+      anchor: const SessionCanonCheckpointAnchor(
+        messageId: 'anchor',
+        swipeId: 0,
+        agentSwipeId: 0,
+      ),
+    );
+
+    final result = await container.read(_serviceProvider).deleteMessages(
+      session,
+      {1},
+    );
+
+    expect(result.characterId, original.id);
+    expect(
+      (await container.read(chatRepoProvider).getById(session.id))?.characterId,
+      original.id,
+    );
+    final timeline = await checkpoints.getForSession(session.id);
+    expect(timeline.last.characterId, original.id);
+    expect(timeline.last.characterRevision, 12);
+    expect(
+      timeline.last.characterRevisionHash,
+      CardCanonicalizer.sha256(original),
+    );
+    expect(
+      await container
+          .read(characterRevisionRepoProvider)
+          .getForCharacter(original.id),
+      hasLength(1),
+    );
+    expect(
+      (await container.read(characterRepoProvider).getById(fork.id))
+          ?.description,
+      'after rewrite',
+    );
+  });
 }
 
 Character _card(String description) => Character(

--- a/test/sync_lifecycle_test.dart
+++ b/test/sync_lifecycle_test.dart
@@ -670,6 +670,7 @@ class SyncWorld {
   SyncWorld({
     FakeReconciliationStateStore? reconciliationStateStore,
     FakeSessionLorebookOverlayStore? sessionLorebookOverlayStore,
+    Future<void> Function(Set<String>)? reconcilePulledSessions,
   }) {
     characters = FakeCharacterStore();
     chats = FakeChatStore();
@@ -688,6 +689,7 @@ class SyncWorld {
     characterDeletions = FakeCharacterDeletionStore(characters);
     reconciliationStates = reconciliationStateStore;
     sessionLorebookOverlays = sessionLorebookOverlayStore;
+    _reconcilePulledSessions = reconcilePulledSessions;
     manifestProvider = InMemoryManifestProvider(
       characterRepo: characters,
       chatRepo: chats,
@@ -703,6 +705,8 @@ class SyncWorld {
       reconciliationStateStore: reconciliationStates,
     );
   }
+
+  Future<void> Function(Set<String>)? _reconcilePulledSessions;
 
   SyncEngine get engine => SyncEngine(
     cloud,
@@ -733,6 +737,7 @@ class SyncWorld {
     (_) async {},
     reconciliationStates,
     sessionLorebookOverlays,
+    _reconcilePulledSessions,
   );
 }
 
@@ -791,6 +796,7 @@ SyncEngine _realStoreEngine({
     FakeCharacterDeletionStore(characters),
     (_) async {},
     reconciliationStore,
+    null,
   );
 }
 
@@ -915,6 +921,57 @@ void main() {
 
     expect(world.chats.data[sessionId], cloudChat);
     expect(reconciliationStates.data[sessionId], statePayload);
+  });
+
+  test('pull reconciles touched sessions after primary entities', () async {
+    final seen = <Set<String>>[];
+    late final SyncWorld world;
+    world = SyncWorld(
+      reconcilePulledSessions: (ids) async {
+        seen.add(Set.of(ids));
+        if (!world.chats.data.containsKey('session')) {
+          throw StateError('Reconciliation ran before chat apply');
+        }
+      },
+    );
+    const chat = ChatSession(
+      id: 'session',
+      characterId: 'character',
+      sessionIndex: 0,
+      updatedAt: 2000,
+    );
+    final entry = SyncManifestEntry(
+      type: 'chat',
+      id: chat.id,
+      path: cloudPath('chat', chat.id),
+      updatedAt: chat.updatedAt,
+      hash: SyncSerialization.computeChatMetadataHash(
+        const SessionMetadata(
+          sessionId: 'session',
+          characterId: 'character',
+          sessionIndex: 0,
+          updatedAt: 2000,
+          messageCount: 0,
+          lastMessageContent: '',
+          lastMessageTimestamp: 0,
+        ),
+      ),
+    );
+    final manifest = SyncManifest(
+      deviceId: 'cloud',
+      createdAt: 1,
+      entries: {entry.key: entry},
+    );
+    world.cloud.files[entry.path] = jsonEncode(chat.toJson());
+    world.cloud.files[cloudPath('manifest', 'manifest')] = jsonEncode(
+      manifest.toJson(),
+    );
+
+    await world.engine.pullEntities(onProgress: (_) {}, onConflict: (_) {});
+
+    expect(seen, [
+      {'session'},
+    ]);
   });
 
   test('pull applies chat before session lorebook overlays', () async {

--- a/test/sync_session_consistency_repo_test.dart
+++ b/test/sync_session_consistency_repo_test.dart
@@ -1,0 +1,186 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/character_revision_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/chat_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/session_canon_checkpoint_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/sync_session_consistency_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/tracker_repo.dart';
+import 'package:glaze_flutter/core/db/repositories/tracker_snapshot_repo.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/models/tracker.dart';
+import 'package:glaze_flutter/core/services/card_rewriter/card_rewriter_contracts.dart';
+
+void main() {
+  test(
+    'post-pull reconciliation removes orphan snapshots and restores Ledger',
+    () async {
+      final db = AppDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      const sessionId = 'session';
+      const chat = ChatSession(
+        id: sessionId,
+        characterId: 'character',
+        sessionIndex: 0,
+        messages: [
+          ChatMessage(id: 'm0', role: 'user', content: 'before'),
+          ChatMessage(id: 'm1', role: 'assistant', content: 'accepted'),
+        ],
+      );
+      await ChatRepo(db).put(chat);
+      final snapshots = TrackerSnapshotRepo(db);
+      Tracker location(String messageId, String value) => Tracker(
+        sessionId: sessionId,
+        name: 'scene.location',
+        value: value,
+        scope: 'ledger',
+        provenance: messageId,
+      );
+      await snapshots.upsertTrackers(
+        sessionId: sessionId,
+        messageId: 'm1',
+        swipeId: 0,
+        agentSwipeId: 0,
+        trackers: [location('m1', 'accepted')],
+        committed: true,
+      );
+      await snapshots.upsertTrackers(
+        sessionId: sessionId,
+        messageId: 'deleted',
+        swipeId: 0,
+        agentSwipeId: 0,
+        trackers: [location('deleted', 'stale')],
+        committed: true,
+      );
+      final trackers = TrackerRepo(db);
+      await trackers.upsert(location('deleted', 'stale'));
+
+      await SyncSessionConsistencyRepo(db).reconcile({sessionId});
+
+      expect(
+        (await snapshots.getBySessionId(sessionId)).map((s) => s.messageId),
+        ['m1'],
+      );
+      expect(
+        (await trackers.get(sessionId, 'scene.location'))?.value,
+        'accepted',
+      );
+    },
+  );
+
+  test('rejects live snapshots from canon that was rolled back', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    const sessionId = 'session';
+    const original = Character(
+      id: 'original',
+      name: 'Card',
+      description: 'old',
+    );
+    const fork = Character(id: 'fork', name: 'Card', description: 'new');
+    await db
+        .into(db.characters)
+        .insert(
+          CharactersCompanion.insert(
+            charId: 'original',
+            name: 'Card',
+            description: Value('old'),
+          ),
+        );
+    await db
+        .into(db.characters)
+        .insert(
+          CharactersCompanion.insert(
+            charId: 'fork',
+            name: 'Card',
+            description: Value('new'),
+          ),
+        );
+    final revisions = CharacterRevisionRepo(db);
+    Future<void> addRevision(Character card) => revisions.insert(
+      CharacterRevisionRecord(
+        characterId: card.id,
+        revision: 1,
+        revisionHash: CardCanonicalizer.sha256(card),
+        parentRevisionHash: '',
+        snapshotJson: jsonEncode(card.toJson()),
+        createdAt: 1,
+      ),
+    );
+    await addRevision(original);
+    await addRevision(fork);
+    const chat = ChatSession(
+      id: sessionId,
+      characterId: 'fork',
+      sessionIndex: 0,
+      messages: [
+        ChatMessage(id: 'old', role: 'assistant', content: 'old base'),
+        ChatMessage(id: 'new', role: 'assistant', content: 'new turn'),
+      ],
+    );
+    await ChatRepo(db).put(chat);
+    final checkpoints = SessionCanonCheckpointRepo(db);
+    final root = await checkpoints.appendRootInTransaction(
+      sessionId: sessionId,
+      characterId: original.id,
+      characterRevision: 1,
+      characterRevisionHash: CardCanonicalizer.sha256(original),
+    );
+    await checkpoints.appendInTransaction(
+      sessionId: sessionId,
+      expectedParentCheckpointId: root.id,
+      characterId: fork.id,
+      characterRevision: 1,
+      characterRevisionHash: CardCanonicalizer.sha256(fork),
+      rewriteJobId: 'rewrite',
+      anchor: const SessionCanonCheckpointAnchor(
+        messageId: 'deleted-anchor',
+        swipeId: 0,
+        agentSwipeId: 0,
+      ),
+    );
+    final snapshots = TrackerSnapshotRepo(db);
+    Tracker clock(String messageId, String value, String hash) => Tracker(
+      sessionId: sessionId,
+      name: 'world:time',
+      value: value,
+      scope: 'ledger',
+      provenance: messageId,
+      basisRevisionNumber: 1,
+      basisRevisionHash: hash,
+    );
+    await snapshots.upsertTrackers(
+      sessionId: sessionId,
+      messageId: 'old',
+      swipeId: 0,
+      agentSwipeId: 0,
+      trackers: [clock('old', '20:50', CardCanonicalizer.sha256(original))],
+      committed: true,
+    );
+    await snapshots.upsertTrackers(
+      sessionId: sessionId,
+      messageId: 'new',
+      swipeId: 0,
+      agentSwipeId: 0,
+      trackers: [clock('new', '23:48', CardCanonicalizer.sha256(fork))],
+      committed: true,
+    );
+
+    await SyncSessionConsistencyRepo(db).reconcile({sessionId});
+
+    expect((await ChatRepo(db).getById(sessionId))?.characterId, original.id);
+    expect(
+      (await snapshots.getBySessionId(sessionId)).map((s) => s.messageId),
+      ['old'],
+    );
+    expect(
+      (await TrackerRepo(db).get(sessionId, 'world:time'))?.value,
+      '20:50',
+    );
+  });
+}

--- a/test/tracker_repo_test.dart
+++ b/test/tracker_repo_test.dart
@@ -154,6 +154,113 @@ void main() {
     });
   });
 
+  group('TrackerRepo initial game-time seed', () {
+    test('keeps immutable seed after live clock advances', () async {
+      await repo.seedInitialGameTime(
+        sessionId: 's1',
+        time: '08:00',
+        date: '21.04.2026',
+      );
+      await repo.upsertValue(
+        's1',
+        'world:time',
+        '08:27',
+        scope: 'ledger',
+        provenance: 'studio_ledger',
+      );
+
+      final live = {
+        for (final t in await repo.getCompleteGameTime('s1')) t.name: t.value,
+      };
+      final seed = {
+        for (final t in await repo.getInitialGameTimeSeed('s1'))
+          t.name: t.value,
+      };
+      expect(live['world:time'], '08:27');
+      expect(seed, {
+        'world:time': '08:00',
+        'world:date': '21.04.2026',
+        'world:day': '0',
+      });
+    });
+
+    test('repeated seeding cannot overwrite stored initial seed', () async {
+      await repo.seedInitialGameTime(
+        sessionId: 's1',
+        time: '08:00',
+        date: '21.04.2026',
+      );
+      await repo.seedInitialGameTime(
+        sessionId: 's1',
+        time: '08:27',
+        date: '22.04.2026',
+        day: '1',
+      );
+
+      final seed = {
+        for (final t in await repo.getInitialGameTimeSeed('s1'))
+          t.name: t.value,
+      };
+      expect(seed, {
+        'world:time': '08:00',
+        'world:date': '21.04.2026',
+        'world:day': '0',
+      });
+    });
+
+    test('reads legacy provenance-only seed', () async {
+      for (final entry in {
+        'world:time': '09:00',
+        'world:date': '01.05.2026',
+        'world:day': '2',
+      }.entries) {
+        await repo.upsertValue(
+          's1',
+          entry.key,
+          entry.value,
+          scope: 'ledger',
+          provenance: 'game_time_seed',
+        );
+      }
+
+      final seed = {
+        for (final t in await repo.getInitialGameTimeSeed('s1'))
+          t.name: t.value,
+      };
+      expect(seed['world:time'], '09:00');
+      expect(await repo.get('s1', TrackerRepo.initialGameTimeSeedName), isNull);
+    });
+
+    test('replaceLedgerState preserves immutable seed metadata', () async {
+      await repo.seedInitialGameTime(
+        sessionId: 's1',
+        time: '08:00',
+        date: '21.04.2026',
+      );
+
+      await repo.replaceLedgerState('s1', [
+        _tracker(
+          sessionId: 's1',
+          name: 'world:time',
+          value: '08:27',
+          scope: 'ledger',
+          provenance: 'studio_ledger',
+        ),
+      ]);
+
+      expect(
+        (await repo.getInitialGameTimeSeed(
+          's1',
+        )).firstWhere((t) => t.name == 'world:time').value,
+        '08:00',
+      );
+      expect(
+        await repo.get('s1', TrackerRepo.initialGameTimeSeedName),
+        isNotNull,
+      );
+    });
+  });
+
   group('TrackerRepo.delete', () {
     test('removes a single tracker', () async {
       await repo.upsert(_tracker(sessionId: 's1', name: 'a', value: '1'));


### PR DESCRIPTION
## Changes
- preserve an immutable initial game-time seed so deleting generated messages can restore the original clock
- reconcile pulled chat, tracker snapshots, live Ledger state, and canon checkpoints after primary sync entities settle
- restore the original character binding when deletion crosses an automatic Card Rewriter fork
- sync explicit empty tracker aggregates to prevent stale cloud state from returning
- surface primary chat and tracker apply failures instead of finalizing inconsistent pulls

## Verification
- `flutter test test/tracker_repo_test.dart test/chat_bulk_delete_test.dart test/session_canon_delete_rollback_test.dart test/sync_session_consistency_repo_test.dart test/sync_lifecycle_test.dart test/ext_blocks_sync_test.dart` (109 tests passed)
- targeted `dart analyze` on changed production and test files
- `git diff --check upstream/nightly...HEAD`
