### PR TITLE
fix(chat): stop the page bringing the typing bubble back on its own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,16 @@ jobs:
         # generator, not build_runner, and is gitignored like the rest of the
         # generated code. Without this step the localization contract test has
         # no file to check the translation keys against.
+        #
+        # `-s en.json` is not optional. In `keys` format the generator reads
+        # `files.first` from a bare `Directory.list()` (easy_localization
+        # 3.0.8, bin/generate.dart), which is filesystem order — with the
+        # glossary files sitting next to the locales in that folder, the run
+        # picked one of them often enough to fail the contract test at random
+        # on unrelated PRs. Naming the source file makes the step deterministic.
         run: >-
           dart run easy_localization:generate
-          -S assets/translations -f keys -o locale_keys.g.dart
+          -S assets/translations -s en.json -f keys -o locale_keys.g.dart
 
       - name: Analyze
         run: flutter analyze --no-fatal-infos --no-fatal-warnings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ interactive.** Use only one-shot commands such as:
 - `flutter analyze`
 - `flutter test`
 - `dart run build_runner build --delete-conflicting-outputs`
-- `dart run easy_localization:generate -S assets/translations -f keys -o locale_keys.g.dart`
+- `dart run easy_localization:generate -S assets/translations -s en.json -f keys -o locale_keys.g.dart`
 
 Fall back to `& "$env:FLUTTER_ROOT\bin\flutter.bat"` if `flutter` is not on
 `PATH`. If runtime or hot-reload verification is required, ask the user to run

--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -39,6 +39,13 @@ export class Bridge {
     // Placeholder element lifted out by clearAll, waiting for the setMessages
     // that follows it. See _keepingPlaceholderLast().
     this._parkedPlaceholder = null;
+    // Whether Flutter still believes a typing placeholder is on screen. The
+    // page may carry that node across a re-render of the same list, but it
+    // must never bring one back on its own: `updateMessage` is rAF-batched, so
+    // a delta issued before the placeholder was taken away can execute after
+    // it, and the re-create branch in _executeUpdateMessage would then put the
+    // finished reply back on screen as a second copy of itself.
+    this._placeholderActive = false;
     // Scroll-hide header state. Lifted out of the _setupScrollListener closure
     // so the rest of the controller can reach it: _ensureHeaderReachable()
     // un-hides the header when the list shrinks out of scroll range, and
@@ -571,6 +578,11 @@ export class Bridge {
     const carriedPlaceholder =
       this._detachStreamingPlaceholder() || this._parkedPlaceholder || null;
     this._parkedPlaceholder = null;
+    // Carrying one across says it is still live. Not carrying one says
+    // nothing: the node may simply have been lost, which is the case the
+    // re-create branch in _executeUpdateMessage exists for. Only removeMessage
+    // and a chat-replacing clearAll retire the placeholder.
+    if (carriedPlaceholder) this._placeholderActive = true;
     this._suppressLoadMore = true;
     // When re-rendering in place (e.g. a preset switch changes display regexes),
     // remember the current reading position so the batch replace below doesn't
@@ -618,6 +630,7 @@ export class Bridge {
     // The placeholder is itself appended through here — pinning it behind
     // itself would evict and re-add the node for nothing.
     if (msg.id === STREAMING_ID) {
+      this._placeholderActive = true;
       this._renderAndAppend(msg);
     } else {
       this._keepingPlaceholderLast(() => this._renderAndAppend(msg));
@@ -679,11 +692,13 @@ export class Bridge {
   _executeUpdateMessage(msg) {
     const section = document.querySelector(`[data-message-id="${msg.id}"]`);
     if (!section) {
-      // Last line of defence for the virtual placeholder: Flutter only sends
-      // updates for it while it believes one is on screen, so if the node is
-      // gone the list lost it somewhere. Re-create it instead of dropping the
-      // reply on the floor.
-      if (msg.id === STREAMING_ID) {
+      // Last line of defence for the virtual placeholder: while Flutter still
+      // believes one is on screen, a node the list lost has to be re-created
+      // or the reply streams into nothing. Once the placeholder has been taken
+      // away — or a full re-render landed without it — a late delta must not
+      // bring it back: that is the finished reply, shown a second time under
+      // itself, and it outlives the run that produced it.
+      if (msg.id === STREAMING_ID && this._placeholderActive) {
         this._renderAndAppend(msg);
         this.virtualList.scrollToBottom();
       }
@@ -873,6 +888,10 @@ export class Bridge {
 
   removeMessage(messageId) {
     this.flush();
+    // The node lingers for its exit animation, but Flutter has stopped
+    // believing in it right here — anything that arrives for it from now on is
+    // a leftover of the run that just ended.
+    if (messageId === STREAMING_ID) this._placeholderActive = false;
     if (this._panelHost) {
       for (const [panelId, panel] of [...this._panelHost._panels.entries()]) {
         if (panel.messageId === messageId) this._panelHost.close(panelId);
@@ -934,14 +953,20 @@ export class Bridge {
     for (const id of orphanIds) this.virtualList.remove(id);
   }
 
-  clearAll() {
+  /* [keepPlaceholder] is false when the chat itself is being replaced. The
+   * typing bubble belongs to the chat being left: carrying it into the next
+   * one shows a reply on its way in a session where nothing is running, and it
+   * then rides along on every following re-render. */
+  clearAll(keepPlaceholder = true) {
     this.flush();
     this._showLoadingScreen();
     this._panelHost?.closeAll();
     // Park the placeholder rather than dropping it: every clearAll on the
     // message-sync path is immediately followed by setMessages, which puts it
     // back at the tail. Without this the reply streams into a removed node.
-    this._parkedPlaceholder = this._detachStreamingPlaceholder();
+    const parked = this._detachStreamingPlaceholder();
+    this._parkedPlaceholder = keepPlaceholder ? parked : null;
+    if (!keepPlaceholder) this._placeholderActive = false;
     this.virtualList.clear();
   }
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -23,10 +23,17 @@ and recreated in CI.
 ```powershell
 flutter pub get
 dart run build_runner build --delete-conflicting-outputs
-dart run easy_localization:generate -S assets/translations -f keys -o locale_keys.g.dart
+dart run easy_localization:generate -S assets/translations -s en.json -f keys -o locale_keys.g.dart
 flutter analyze --no-fatal-infos --no-fatal-warnings
 flutter test --reporter expanded
 ```
+
+`-s en.json` is required, not decorative: in `keys` format the generator reads
+`files.first` from a bare `Directory.list()` of the source folder
+(easy_localization 3.0.8, `bin/generate.dart`), which is filesystem order. The
+glossary files live in that folder too, so without naming the source file the
+run sometimes generates `LocaleKeys` from `glossary_en.json` — one key — and
+the localization contract test fails on a diff that never touched translations.
 
 Build every affected target platform that is available in the verification
 environment. Glaze targets Windows, Android, iOS, macOS, and Linux; web is not

--- a/docs/REFACTORING_FOLLOW_UPS.md
+++ b/docs/REFACTORING_FOLLOW_UPS.md
@@ -144,7 +144,7 @@ Every extraction stage must:
 - run focused characterization tests for the changed ownership boundary;
 - run `dart run build_runner build --delete-conflicting-outputs` after generated
   model or Drift structural changes;
-- run `dart run easy_localization:generate -S assets/translations -f keys -o locale_keys.g.dart`
+- run `dart run easy_localization:generate -S assets/translations -s en.json -f keys -o locale_keys.g.dart`
   when localization keys or their generated contract can be affected;
 - pass the CI analyzer command:
   `flutter analyze --no-fatal-infos --no-fatal-warnings`;

--- a/docs/rules/generation.md
+++ b/docs/rules/generation.md
@@ -125,6 +125,24 @@ from "the reply is already on its way".
   (`_keepingPlaceholderLast`) and carries it across a full re-render
   (`clearAll` parks it, `setMessages` puts it back). An update for a
   placeholder whose node is gone re-creates it rather than dropping the reply.
+- **…and the page must never bring one back on its own.** The same constant id
+  makes every late delta look like the live one. `updateMessage` is rAF-batched
+  and the streaming pushes share the message-mutation queue, while the falling
+  edge removes the placeholder *synchronously* — so a delta issued before the
+  run settled routinely executes after it. The page therefore tracks whether
+  Flutter still believes a placeholder is on screen (`_placeholderActive`,
+  cleared by `removeMessage` and by a re-render that carries none) and
+  re-creates only while it does; `pushStreamingMessageOwned` appends only while
+  the send/generation window is open (`ChatWebViewSyncState.wasBusy`). Without
+  both, the finished reply stands a second time under itself in a bubble
+  nothing removes again — it outlives leaving and re-opening the chat, because
+  no persisted message corresponds to it.
+- **A session switch replaces the chat, so it drops the bubble instead of
+  parking it** (`clearAll(keepPlaceholder: false)`). Carried over, it claims a
+  reply is on its way in a chat where nothing is running, and it then rides
+  along on every following re-render. The same-session re-sync keeps the
+  default, because its `clearAll` is always followed by `setMessages` of the
+  list the placeholder belongs to.
 - **Treat it as busy wherever `isGenerating` gates a UI affordance.** It is why
   `ChatMessageSync.sync` takes `busy` rather than `isGenerating`: the
   optimistic bubble is a tail append, and stamping the Regenerate button there

--- a/lib/features/chat/bridge/bridge_message_commands.dart
+++ b/lib/features/chat/bridge/bridge_message_commands.dart
@@ -215,9 +215,15 @@ class MessageBridgeCommands {
     }
   }
 
-  Future<void> clearAll() {
+  /// Wipes the message list.
+  ///
+  /// [keepPlaceholder] is false when the *chat* is being replaced rather than
+  /// re-rendered: the page parks the typing bubble across a `clearAll` +
+  /// `setMessages` pair, and a session switch must not hand it to the chat
+  /// being opened — nothing is generating there.
+  Future<void> clearAll({bool keepPlaceholder = true}) {
     _host.clearCachedTriggeredRegexes();
-    return _host.evalJs('window.bridge?.clearAll()');
+    return _host.evalJs('window.bridge?.clearAll($keepPlaceholder)');
   }
 
   Future<void> scrollToBottom({bool smooth = false}) {

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -676,7 +676,8 @@ class ChatBridgeController {
       messages.updateMessageContent(id, text, isUser);
   Future<void> removeMessage(String id) => messages.removeMessage(id);
   Future<void> setLastMessage(String? id) => messages.setLastMessage(id);
-  Future<void> clearAll() => messages.clearAll();
+  Future<void> clearAll({bool keepPlaceholder = true}) =>
+      messages.clearAll(keepPlaceholder: keepPlaceholder);
   Future<void> scrollToBottom({bool smooth = false}) =>
       messages.scrollToBottom(smooth: smooth);
   Future<void> requestScrollToBottomOnAppend() =>

--- a/lib/features/chat/widgets/chat_streaming_bridge_sync.dart
+++ b/lib/features/chat/widgets/chat_streaming_bridge_sync.dart
@@ -90,8 +90,17 @@ Future<void> pushStreamingMessageOwned({
       if (!ownsStream()) return;
       if (syncState.streamingSent) {
         await bridge.updateMessage(message);
-      } else {
+      } else if (syncState.wasBusy) {
+        // The first delta of a run whose placeholder append is still in
+        // flight puts the bubble up itself. Only while a reply is actually on
+        // its way, though: this runs on the shared mutation queue, so a delta
+        // that was still crossing the channel when the run settled lands
+        // *after* the falling edge removed the placeholder — and appending it
+        // there stands the finished reply a second time under itself, in a
+        // bubble nothing will ever take away again.
         await bridge.appendMessage(message);
+      } else {
+        return;
       }
       if (ownsStream()) syncState.streamingSent = true;
     } catch (_) {

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -821,7 +821,14 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
         if (!ownsSwitch()) return;
       }
 
-      await _bridgeOp(bridge.clearAll(), label: 'clearAll');
+      // The chat itself is being replaced, so the page must drop the typing
+      // bubble instead of parking it for the setMessages below: it belongs to
+      // the session being left, and carried over it shows a reply on its way
+      // in a chat where nothing is running.
+      await _bridgeOp(
+        bridge.clearAll(keepPlaceholder: false),
+        label: 'clearAll',
+      );
       if (!ownsSwitch()) return;
       _resetStreamingPresentationState();
       await _bridgeOp(

--- a/test/characterization/bridge_selection_edit_swipe_test.dart
+++ b/test/characterization/bridge_selection_edit_swipe_test.dart
@@ -598,7 +598,7 @@ void main() {
     });
 
     test('flush() called before clearAll', () {
-      final idx = bridgeJs.indexOf('clearAll()');
+      final idx = bridgeJs.indexOf('clearAll(keepPlaceholder = true)');
       final methodBody = bridgeJs.substring(idx, idx + 100);
       expect(methodBody, contains('this.flush()'));
     });

--- a/test/chat_delete_plan_test.dart
+++ b/test/chat_delete_plan_test.dart
@@ -99,7 +99,15 @@ void main() {
     final plan = service.planDeleteMessages(session, {1, 3})!;
     final committed = await service.commitDeleteMessages(session, plan);
 
-    expect(identical(committed, plan.session), isTrue);
+    // `commitDeleteMessages` ends in a re-read of the row it just wrote
+    // (#376), so what comes back is the durable session rather than the
+    // planned instance. The contract this guards is that the two carry the
+    // same list — the optimistic paint is exactly what got persisted.
+    expect(committed.id, plan.session.id);
+    expect(
+      committed.messages.map((m) => m.id),
+      plan.session.messages.map((m) => m.id),
+    );
     final persisted = await container.read(chatRepoProvider).getById('s1');
     expect(persisted?.messages.map((m) => m.id), ['m0', 'm2', 'm4']);
     expect(persisted?.deletedMessageCount, 2);

--- a/test/chat_message_sync_removal_test.dart
+++ b/test/chat_message_sync_removal_test.dart
@@ -140,7 +140,7 @@ class _RecordingBridge implements ChatBridgeController {
   }
 
   @override
-  Future<void> clearAll() async {
+  Future<void> clearAll({bool keepPlaceholder = true}) async {
     clearAllCalls++;
   }
 

--- a/test/chat_webview_sync_dispatcher_test.dart
+++ b/test/chat_webview_sync_dispatcher_test.dart
@@ -415,6 +415,30 @@ void main() {
       expect(bridge.searchCalls, [('foo', 2, false)]);
     });
 
+    test('a delta that settles after the run does not re-append the bubble', () async {
+      // The shared mutation queue can hold a delta that was still crossing the
+      // channel when the run settled: the falling edge removes the placeholder
+      // synchronously, so this lands after it. Appending there stood the
+      // finished reply a second time under itself, in a bubble nothing takes
+      // away again — it survived leaving and re-opening the chat.
+      final bridge = _FakeBridge();
+      final syncState = ChatWebViewSyncState()
+        ..wasBusy = false
+        ..streamingSent = false;
+
+      await pushStreamingMessageOwned(
+        bridge: bridge,
+        message: _assistant('__streaming__'),
+        syncState: syncState,
+        epoch: syncState.streamEpoch,
+        isCurrent: () => true,
+      );
+
+      expect(bridge.appendedMessages, isEmpty);
+      expect(bridge.updatedMessages, isEmpty);
+      expect(syncState.streamingSent, isFalse);
+    });
+
     test('session switch invalidates a delayed streaming delta', () async {
       final bridge = _FakeBridge();
       final delayedAppend = Completer<void>();

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -1489,7 +1489,7 @@ void main() {
     });
 
     test('clearAll() also closes all panels', () {
-      final marker = 'clearAll() {';
+      final marker = 'clearAll(keepPlaceholder = true) {';
       final idx = bridgeControllerJs.indexOf(marker);
       expect(idx, isNot(-1));
       final body = _extractBlockBody(bridgeControllerJs, idx);
@@ -2579,11 +2579,15 @@ void main() {
       // clearAll + setMessages used to drop it while Flutter still believed
       // it was on screen — every following delta then updated nothing and the
       // reply streamed into a removed node.
-      final clearIdx = bridgeControllerJs.indexOf('clearAll() {');
+      final clearIdx = bridgeControllerJs.indexOf(
+        'clearAll(keepPlaceholder = true) {',
+      );
       expect(clearIdx, isNot(-1));
+      final clearBody = _extractBlockBody(bridgeControllerJs, clearIdx);
+      expect(clearBody, contains('this._detachStreamingPlaceholder()'));
       expect(
-        _extractBlockBody(bridgeControllerJs, clearIdx),
-        contains('_parkedPlaceholder = this._detachStreamingPlaceholder()'),
+        clearBody,
+        contains('this._parkedPlaceholder = keepPlaceholder ? parked : null'),
       );
 
       final setIdx = bridgeControllerJs.indexOf(
@@ -2595,13 +2599,53 @@ void main() {
       expect(setBody, contains('_reattachStreamingPlaceholder(carriedPlaceholder)'));
     });
 
-    test('an update for a lost placeholder re-creates it', () {
+    test('replacing the chat drops the placeholder instead of parking it', () {
+      // The bubble belongs to the session being left. Carried into the chat
+      // being opened it claims a reply is on its way there, and it then rides
+      // along on every following re-render.
+      final clearIdx = bridgeControllerJs.indexOf(
+        'clearAll(keepPlaceholder = true) {',
+      );
+      expect(clearIdx, isNot(-1));
+      final clearBody = _extractBlockBody(bridgeControllerJs, clearIdx);
+      expect(
+        clearBody,
+        contains('if (!keepPlaceholder) this._placeholderActive = false'),
+      );
+    });
+
+    test('an update for a lost placeholder re-creates it, but only while '
+        'one is wanted', () {
       final idx = bridgeControllerJs.indexOf('_executeUpdateMessage(msg) {');
       expect(idx, isNot(-1));
       final body = _extractBlockBody(bridgeControllerJs, idx);
       final guard = body.substring(0, body.indexOf('const animate'));
       expect(guard, contains('msg.id === STREAMING_ID'));
       expect(guard, contains('_renderAndAppend(msg)'));
+      // `updateMessage` is rAF-batched, so a delta issued before the
+      // placeholder was taken away can execute after it. Re-creating one then
+      // puts the finished reply back on screen as a second copy of itself,
+      // and it outlives the run that produced it.
+      expect(guard, contains('this._placeholderActive'));
+
+      final removeIdx = bridgeControllerJs.indexOf('removeMessage(messageId) {');
+      expect(removeIdx, isNot(-1));
+      expect(
+        _extractBlockBody(bridgeControllerJs, removeIdx),
+        contains('if (messageId === STREAMING_ID) this._placeholderActive = false'),
+      );
+
+      final setIdx = bridgeControllerJs.indexOf(
+        'setMessages(messagesJson, preserveScroll = false) {',
+      );
+      expect(
+        _extractBlockBody(bridgeControllerJs, setIdx),
+        contains('if (carriedPlaceholder) this._placeholderActive = true'),
+        reason:
+            'a re-render that carries one says it is live; one that does not '
+            'says nothing — the node may simply have been lost, which is what '
+            'the re-create branch is for',
+      );
     });
   });
 

--- a/test/webview_js/specs/placeholder_lifecycle.spec.js
+++ b/test/webview_js/specs/placeholder_lifecycle.spec.js
@@ -1,0 +1,195 @@
+// The typing placeholder is a virtual message: Flutter owns one constant id
+// for it and the page draws it. Every bug in this file is the page keeping
+// that bubble alive after Flutter has stopped believing in it — the reply,
+// shown a second time under itself, in a chat that may not even be generating.
+//
+// These drive the real bridge in a real browser, because the failure is an
+// ordering one: `updateMessage` is rAF-batched, so a delta issued before the
+// placeholder was taken away executes after it.
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/assets/chat_webview/index.html';
+const STREAMING_ID = '__streaming__';
+
+async function boot(page) {
+  await page.goto(PAGE);
+  await page.waitForFunction(() => !!window.bridge);
+  await page.evaluate(() => {
+    window.__M = (id, role, text, extra = {}) =>
+      JSON.stringify({
+        id,
+        role,
+        text,
+        timestamp: 1767225600000,
+        isUser: role === 'user',
+        isAssistant: role !== 'user',
+        isSystem: false,
+        displayName: role === 'user' ? 'You' : 'Alice',
+        isError: false,
+        isHidden: false,
+        isGenerating: false,
+        isPostGenRunning: false,
+        ...extra,
+      });
+  });
+}
+
+/// Ids of every message section the browser actually laid out, in order.
+const renderedIds = (page) =>
+  page.evaluate(() =>
+    [...document.querySelectorAll('.message-section')]
+      .filter((el) => el.offsetHeight > 0)
+      .map((el) => el.dataset.messageId),
+  );
+
+/// A chat with a greeting, the user's message and a reply streaming into the
+/// placeholder — the state every case below starts from.
+async function generating(page) {
+  await page.evaluate(() => {
+    window.bridge.setMessages(
+      JSON.stringify([JSON.parse(window.__M('a1', 'assistant', 'greeting'))]),
+    );
+    window.bridge.appendMessages(
+      JSON.stringify([JSON.parse(window.__M('u1', 'user', 'hi'))]),
+    );
+    window.bridge.appendMessage(
+      window.__M('__streaming__', 'assistant', 'the reply', { isTyping: true }),
+    );
+  });
+  await page.waitForTimeout(60);
+}
+
+test('a delta that lands after the placeholder was taken away is dropped', async ({
+  page,
+}) => {
+  await boot(page);
+  await generating(page);
+
+  // The run settles: the dispatcher removes the placeholder and the durable
+  // reply is appended in its place.
+  await page.evaluate(() => {
+    window.bridge.removeMessage('__streaming__');
+    window.bridge.appendMessages(
+      JSON.stringify([JSON.parse(window.__M('a2', 'assistant', 'the reply'))]),
+    );
+  });
+  await page.waitForTimeout(500);
+
+  // A last delta for that run arrives afterwards. Re-creating the bubble here
+  // is what showed the finished reply twice — and the copy survived, because
+  // nothing removes a placeholder Flutter no longer knows about.
+  await page.evaluate(() => {
+    window.bridge.updateMessage(
+      window.__M('__streaming__', 'assistant', 'the reply', { isTyping: true }),
+    );
+  });
+  await page.waitForTimeout(300);
+
+  expect(await renderedIds(page)).toEqual(['a1', 'u1', 'a2']);
+});
+
+test('a delta batched across the removal does not resurrect the bubble', async ({
+  page,
+}) => {
+  await boot(page);
+  await generating(page);
+
+  // Same turn, tighter: the update is issued in the same tick as the removal,
+  // so the batcher runs it while the exit animation is still on screen.
+  await page.evaluate(() => {
+    window.bridge.removeMessage('__streaming__');
+    window.bridge.appendMessages(
+      JSON.stringify([JSON.parse(window.__M('a2', 'assistant', 'the reply'))]),
+    );
+    window.bridge.updateMessage(
+      window.__M('__streaming__', 'assistant', 'the reply', { isTyping: true }),
+    );
+  });
+  await page.waitForTimeout(900);
+
+  expect(await renderedIds(page)).toEqual(['a1', 'u1', 'a2']);
+});
+
+test('opening another chat does not carry the typing bubble into it', async ({
+  page,
+}) => {
+  await boot(page);
+  await generating(page);
+
+  // Session switch: clearAll(false) + setMessages. The park-and-restore that
+  // carries the placeholder across a re-render must not apply here.
+  await page.evaluate(async () => {
+    await window.bridge.clearAll(false);
+    await window.bridge.setMessages(
+      JSON.stringify([JSON.parse(window.__M('b1', 'assistant', 'other chat'))]),
+    );
+  });
+  await page.waitForTimeout(200);
+
+  expect(await renderedIds(page)).toEqual(['b1']);
+
+  // And a delta still in flight for the chat that was left cannot put it back.
+  await page.evaluate(() => {
+    window.bridge.updateMessage(
+      window.__M('__streaming__', 'assistant', 'the reply', { isTyping: true }),
+    );
+  });
+  await page.waitForTimeout(300);
+  expect(await renderedIds(page)).toEqual(['b1']);
+});
+
+test('a re-render of the same chat still carries the typing bubble', async ({
+  page,
+}) => {
+  await boot(page);
+  await generating(page);
+
+  // The message-sync path: clearAll immediately followed by setMessages of the
+  // same session. Dropping the placeholder here would leave every following
+  // delta updating a node that is gone.
+  await page.evaluate(async () => {
+    await window.bridge.clearAll();
+    await window.bridge.setMessages(
+      JSON.stringify([
+        JSON.parse(window.__M('a1', 'assistant', 'greeting')),
+        JSON.parse(window.__M('u1', 'user', 'hi')),
+      ]),
+    );
+  });
+  await page.waitForTimeout(200);
+
+  expect(await renderedIds(page)).toEqual(['a1', 'u1', STREAMING_ID]);
+
+  // And it is still the live bubble: the next delta reaches it.
+  await page.evaluate(() => {
+    window.bridge.updateMessage(
+      window.__M('__streaming__', 'assistant', 'more text', { isTyping: true }),
+    );
+  });
+  await page.waitForTimeout(200);
+  const text = await page.evaluate(
+    () =>
+      document.querySelector('[data-message-id="__streaming__"]').dataset
+        .rawText,
+  );
+  expect(text).toBe('more text');
+});
+
+test('a placeholder the list lost mid-run is still re-created', async ({
+  page,
+}) => {
+  await boot(page);
+  await generating(page);
+
+  // The case the re-create branch exists for: the node is gone while the run
+  // is still on. Dropping the delta here would stream the reply into nothing.
+  await page.evaluate(() => {
+    window.bridge.virtualList.remove('__streaming__');
+    window.bridge.updateMessage(
+      window.__M('__streaming__', 'assistant', 'the reply', { isTyping: true }),
+    );
+  });
+  await page.waitForTimeout(200);
+
+  expect(await renderedIds(page)).toEqual(['a1', 'u1', STREAMING_ID]);
+});


### PR DESCRIPTION
Two reports — the reply shown twice after a send, and a typing bubble that
appears when a chat is opened — are the same defect from two directions: the
page keeps the virtual placeholder alive after Flutter has stopped believing in
it.

Both are reproduced in a real browser against the real bridge:
`test/webview_js/specs/placeholder_lifecycle.spec.js` fails on `nightly` and
passes on this branch.

## A late delta re-created the bubble

- `_executeUpdateMessage` re-creates a placeholder whose node is gone, on the
  assumption that "Flutter only sends updates for it while it believes one is
  on screen". That assumption does not hold: `updateMessage` is rAF-batched and
  the streaming pushes share the message-mutation queue, while the falling edge
  calls `removeMessage` **synchronously** — so a delta issued before the run
  settled routinely executes after it.
- What came back was the finished reply, standing a second time under itself in
  a bubble nothing takes away again. Since no persisted message corresponds to
  it, it read as a "ghost" — and it survived leaving and re-opening the chat,
  because the next `setMessages` carried it across.
- The page now tracks whether a placeholder is wanted at all
  (`_placeholderActive`, retired by `removeMessage` and by a chat-replacing
  `clearAll`) and re-creates only while it is. A node the list genuinely lost
  mid-run is still re-created — that is what the branch exists for, and it has
  its own test.

## The same delta could re-append it

- `pushStreamingMessageOwned` appends when no placeholder is up. That is right
  while the reply is on its way (the first delta can beat the dispatcher's own
  append) and a resurrection once the run has ended. It now appends only inside
  the busy window (`ChatWebViewSyncState.wasBusy`), which is exactly "Flutter
  believes a reply is on its way".

## Opening a chat carried the previous chat's bubble into it

- `clearAll` parks the placeholder for the `setMessages` that follows it, which
  is right for a re-render of the same list and wrong for a session switch: the
  bubble then claimed a reply was on its way in a chat where nothing was
  running, and rode along on every following re-render.
- `clearAll` takes `keepPlaceholder` (default `true`, so the message-sync path
  is unchanged) and `_applySessionSwitch` passes `false`.

## Verification

Flutter is not available in this environment, so **CI on this PR is the
analyze/test check** — nothing was run locally that this text claims passed.
What was run here: the WebView render suite, `62 passed`, including five new
cases —

- a delta that lands after the placeholder was taken away is dropped;
- a delta batched across the removal does not resurrect it;
- opening another chat does not carry the bubble into it;
- a re-render of the same chat still carries it, and the next delta reaches it;
- a placeholder the list lost mid-run is still re-created.

Dart side: a dispatcher test for the append guard, plus the asset and
characterization assertions updated to the new `clearAll` signature and the new
re-create guard. `docs/rules/generation.md` gains the three rules this encodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZWrxyRwsLj5TQ1CDRMWvf

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZWrxyRwsLj5TQ1CDRMWvf)_