### PR TITLE
fix(ledger): feed recent game-clock history to prevent timeskip re-application

### DIFF
--- a/lib/core/llm/ledger/ledger_canon_authority.dart
+++ b/lib/core/llm/ledger/ledger_canon_authority.dart
@@ -137,6 +137,39 @@ class LedgerCanonAuthority {
     ...context.manualControls,
   ];
 
+  /// Recent committed game-clock trajectory (oldest→newest), capped at [limit]
+  /// entries. Each entry is `DD.MM.YYYY · day N · HH:MM`. Fed into the ledger
+  /// prompt so the model sees that a prior timeskip already happened and where
+  /// the clock currently stands — preventing a timeskip from being re-applied
+  /// or time from being over-advanced on later turns.
+  Future<List<String>> loadRecentGameClock(
+    String sessionId, {
+    int limit = 5,
+  }) async {
+    final snaps = await snapshotRepo.getBySessionId(sessionId);
+    final committed = snaps.where((s) => s.committed).toList().reversed;
+    final out = <String>[];
+    for (final s in committed) {
+      String? date;
+      String? day;
+      String? time;
+      for (final t in s.trackers) {
+        if (t.name == 'world:date') {
+          date = t.value;
+        } else if (t.name == 'world:day') {
+          day = t.value;
+        } else if (t.name == 'world:time') {
+          time = t.value;
+        }
+      }
+      if (date != null && time != null) {
+        out.add('$date · day ${day ?? '?'} · $time');
+      }
+      if (out.length >= limit) break;
+    }
+    return out;
+  }
+
   Future<Character> _loadSourceCharacter(String sessionId) async {
     final session = await chatRepo.getById(sessionId);
     if (session == null) {

--- a/lib/core/llm/ledger/ledger_prompt_factory.dart
+++ b/lib/core/llm/ledger/ledger_prompt_factory.dart
@@ -23,6 +23,7 @@ class LedgerPromptFactory {
     Character? character,
     Map<String, String> entityAliases = const {},
     StudioLedgerEngine engine = StudioLedgerEngine.currentReconciled,
+    List<String> gameClockHistory = const [],
   }) {
     if (engine == StudioLedgerEngine.legacyTurnOnly) {
       return _promptBuilder.buildLegacyTurnOnly(
@@ -31,6 +32,7 @@ class LedgerPromptFactory {
         currentTrackers: currentTrackers,
         recentMemoryEntries: recentMemoryEntries,
         focalUserName: macroCtx?.userName ?? '',
+        gameClockHistory: gameClockHistory,
       );
     }
     final hasActiveLedgerBlocks = ledgerBlocks.any(
@@ -49,6 +51,7 @@ class LedgerPromptFactory {
         character: character,
         entityAliases: entityAliases,
         focalUserName: macroCtx?.userName ?? '',
+        gameClockHistory: gameClockHistory,
       );
     }
 
@@ -69,7 +72,7 @@ $cardSection$entitySection<current_state>
 $trackerBlock
 </current_state>
 
-<existing_keys>
+${_clockBlock(gameClockHistory)}<existing_keys>
 $keyCatalog
 </existing_keys>
 
@@ -138,7 +141,14 @@ Game clock (world:time, world:date, world:day):
 - The game clock only moves FORWARD. Never rewind time; flashbacks and memories
   stay in prose without touching world:time. When time passes midnight, advance
   world:day (day 0 is the first day of the story) and world:date.
-- Do not invent time skips that the narrative does not support.''';
+- Do not invent time skips that the narrative does not support.
+- A timeskip already applied in a prior turn is consummated: it advances the
+  clock once and the new world:date/day stand from then on. Do not re-apply the
+  same timeskip on a later turn, and do not advance the clock for time the
+  narrative does not actually spend. Unless the user explicitly requests a NEW
+  timeskip, advance only by the hours/minutes the narrated events require.
+  Treat the <clock_history> block as the authoritative recent trajectory — its
+  newest line is where the clock currently stands.''';
 
     return const StudioAuxPromptAssembler().assemble(
       blocks: ledgerBlocks,
@@ -163,4 +173,7 @@ Game clock (world:time, world:date, world:day):
         })
         .join('\n');
   }
+
+  String _clockBlock(List<String> gameClockHistory) =>
+      StudioLedgerPrompt.buildGameClockHistoryBlock(gameClockHistory);
 }

--- a/lib/core/llm/ledger/ledger_turn_runner.dart
+++ b/lib/core/llm/ledger/ledger_turn_runner.dart
@@ -185,6 +185,9 @@ class LedgerTurnRunner {
       }
 
       // ── 3. Build prompt ─────────────────────────────────────────────────
+      final gameClockHistory = await _canonAuthority.loadRecentGameClock(
+        request.sessionId,
+      );
       final rawPrompt = _promptFactory.buildLedgerPrompt(
         finalAssistantText: request.finalAssistantText,
         recentHistoryText: request.recentHistoryText,
@@ -195,6 +198,7 @@ class LedgerTurnRunner {
         character: canon.source,
         entityAliases: entityAliases,
         engine: request.engine,
+        gameClockHistory: gameClockHistory,
       );
       final prompt = request.macroCtx == null
           ? rawPrompt

--- a/lib/core/llm/studio_ledger_prompt.dart
+++ b/lib/core/llm/studio_ledger_prompt.dart
@@ -52,6 +52,7 @@ class StudioLedgerPrompt {
     Character? character,
     Map<String, String> entityAliases = const {},
     String focalUserName = '',
+    List<String> gameClockHistory = const [],
   }) {
     final trackerBlock = buildCurrentStateBlock(
       currentTrackers,
@@ -61,6 +62,7 @@ class StudioLedgerPrompt {
     final memoryBlock = _buildMemoryBlock(recentMemoryEntries);
     final cardBlock = buildCharacterCardSection(character);
     final entityBlock = buildEntityAliasSection(entityAliases);
+    final clockBlock = buildGameClockHistoryBlock(gameClockHistory);
 
     return '''$_systemPrompt
 
@@ -69,7 +71,7 @@ $cardBlock
 $trackerBlock
 </current_state>
 
-<existing_keys>
+$clockBlock<existing_keys>
 $keyCatalog
 </existing_keys>
 
@@ -142,6 +144,7 @@ knowledgeFacts rules:
     required List<Tracker> currentTrackers,
     required List<MemoryEntry> recentMemoryEntries,
     String focalUserName = '',
+    List<String> gameClockHistory = const [],
   }) {
     final trackerBlock = buildCurrentStateBlock(
       currentTrackers,
@@ -149,13 +152,14 @@ knowledgeFacts rules:
     );
     final keyCatalog = buildExistingKeyCatalog(currentTrackers);
     final memoryBlock = _buildMemoryBlock(recentMemoryEntries);
+    final clockBlock = buildGameClockHistoryBlock(gameClockHistory);
     return '''$_legacyTurnOnlySystemPrompt
 
 <current_state>
 $trackerBlock
 </current_state>
 
-<existing_keys>
+$clockBlock<existing_keys>
 $keyCatalog
 </existing_keys>
 
@@ -322,6 +326,15 @@ knowledgeFacts rules:
     return '<existing_fact_entities>\n$lines\n</existing_fact_entities>\n\n';
   }
 
+  /// Compact `<clock_history>` section listing the recent game-clock
+  /// trajectory (oldest→newest). Lets the ledger see that a timeskip already
+  /// happened and where the clock currently stands, so it does not re-apply a
+  /// previous skip or over-advance time. Empty entries yield an empty block.
+  static String buildGameClockHistoryBlock(List<String> entries) {
+    if (entries.isEmpty) return '';
+    return '<clock_history>\n${entries.join('\n')}\n</clock_history>\n\n';
+  }
+
   static const String _systemPrompt =
       '''You are Studio Ledger, an internal continuity and state extractor.
 You do not write story prose.
@@ -397,7 +410,14 @@ Rules:
   world:day (day 0 = first story day) and world:date.
   For an ordinary continuous turn with no explicit duration, advance the clock
   by 1–5 minutes. Use an explicitly narrated duration instead when available.
-  Do not invent time skips the narrative does not support.''';
+  Do not invent time skips the narrative does not support.
+  A timeskip already applied in a prior turn is consummated: it advances the
+  clock once and the new world:date/day stand from then on. Do not re-apply the
+  same timeskip on a later turn, and do not advance the clock for time the
+  narrative does not actually spend. Unless the user explicitly requests a NEW
+  timeskip, advance only by the hours/minutes the narrated events require.
+  Treat <clock_history> as the authoritative recent trajectory — its newest
+  line is where the clock currently stands.''';
 
   static const String _legacyTurnOnlySystemPrompt =
       '''You are Studio Ledger, an internal continuity and state extractor.

--- a/test/studio_ledger_test.dart
+++ b/test/studio_ledger_test.dart
@@ -229,6 +229,46 @@ void main() {
       expect(prompt, isNot(contains('rename_entity')));
       expect(prompt, isNot(contains('accepted assistant prose as evidence')));
     });
+
+    test('clock history block renders ordered entries and is omitted when empty', () {
+      final withEntries = const StudioLedgerPrompt().build(
+        finalAssistantText: 'Lucy closes the door.',
+        recentHistoryText: '',
+        currentTrackers: const [],
+        recentMemoryEntries: const [],
+        gameClockHistory: const [
+          '14.09.0755 · day 0 · 12:11',
+          '28.09.0755 · day 14 · 12:11',
+        ],
+      );
+      expect(withEntries, contains('<clock_history>'));
+      expect(withEntries, contains('14.09.0755 · day 0 · 12:11'));
+      expect(withEntries, contains('28.09.0755 · day 14 · 12:11'));
+      expect(withEntries, contains('A timeskip already applied in a prior turn is consummated'));
+      expect(withEntries, contains('Treat <clock_history> as the authoritative recent trajectory'));
+
+      final withoutEntries = const StudioLedgerPrompt().build(
+        finalAssistantText: 'Lucy closes the door.',
+        recentHistoryText: '',
+        currentTrackers: const [],
+        recentMemoryEntries: const [],
+      );
+      expect(withoutEntries, isNot(contains('</clock_history>')));
+      expect(withoutEntries, isNot(contains('14.09.0755 · day 0 · 12:11')));
+    });
+
+    test('buildGameClockHistoryBlock is empty for no entries', () {
+      expect(
+        StudioLedgerPrompt.buildGameClockHistoryBlock(const []),
+        isEmpty,
+      );
+      expect(
+        StudioLedgerPrompt.buildGameClockHistoryBlock([
+          '29.09.0755 · day 15 · 08:00',
+        ]),
+        contains('29.09.0755 · day 15 · 08:00'),
+      );
+    });
   });
 
   group('Ledger reconciliation', () {


### PR DESCRIPTION
## Problem

The ledger model re-applied a two-week timeskip a second time (day 14 -> 28) on the next turn: it re-derived the skip from the narration (a 'two-week arson campaign') without seeing where the world clock actually stood, so the clock over-advanced.

## Fix

Feed the last N committed world clock snapshots into the ledger prompt and strengthen the game-clock rules so a timeskip, once applied, is not re-applied.

- \LedgerCanonAuthority.loadRecentGameClock(sessionId)\ — latest N committed \world:date/day/time\ snapshots, oldest -> newest.
- \StudioLedgerPrompt\ — inject \<clock_history>\ after \<current_state>\; add 'consummated / do not re-apply' rule text.
- \LedgerPromptFactory\ — forward \gameClockHistory\ to both build paths.
- \LedgerTurnRunner\ — load the recent clock before building the prompt.

## Verification

- \lutter test test/studio_ledger_test.dart\: 64 passed.
- \dart analyze\: no issues.
- \git diff --check\: clean.