### PR TITLE
fix(chat): stop the chat rendering nothing until it is re-entered

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ When editing files matching a pattern below, READ the corresponding rule file FI
 | Drift reads/writes, repositories | `docs/rules/database.md` |
 | Architecture details, full flow | `docs/ARCHITECTURE.md` |
 | Formal invariants with code references | `docs/INVARIANTS.md` |
-| Message rendering — `assets/chat_webview/formatter/`, `renderer/` | `docs/rules/message-rendering.md` + `docs/INVARIANTS.md` (INV-MR1–8) |
+| Message rendering — `assets/chat_webview/formatter/`, `renderer/`, `useVirtualScroll.js` | `docs/rules/message-rendering.md` + `docs/INVARIANTS.md` (INV-MR1–8) |
 | Custom `==...==` markdown markers | `docs/markdown-markers.md` |
 | Windows/build failures, dependency overrides | `docs/BUILD_NOTES.md` |
 | Class/file organization, decomposition | `docs/CODE_STYLE.md` |

--- a/assets/chat_webview/useVirtualScroll.js
+++ b/assets/chat_webview/useVirtualScroll.js
@@ -335,6 +335,7 @@ class UseVirtualScroll {
             this.items[i].el.dataset.index = i;
         }
         this.cache.shiftKeys(1);
+        this._shiftVisibleIndices(1, 0);
         this.cache.setHeight(0, this._estimateHeight(el));
         this._onItemsChanged('prepend');
     }
@@ -378,6 +379,14 @@ class UseVirtualScroll {
         }
         
         this.cache.shiftKeys(-1, deletedIndex + 1);
+        // The observer reports an index, not an id, so a set left holding the
+        // pre-delete numbering makes every later updateWindow() read somebody
+        // else's row as visible. Shift it exactly the way the height cache is
+        // shifted, and drop the row that is gone: no entry will ever arrive to
+        // retire it, because its element was unobserved above.
+        this.visibleIndices.delete(deletedIndex);
+        this.realVisibleIndices.delete(deletedIndex);
+        this._shiftVisibleIndices(-1, deletedIndex + 1);
         
         if (deletedIndex < this.renderStart) {
             this.renderStart = Math.max(0, this.renderStart - 1);
@@ -385,8 +394,33 @@ class UseVirtualScroll {
         } else if (deletedIndex < this.renderEnd) {
             this.renderEnd = Math.max(0, this.renderEnd - 1);
         }
+        this._clampWindow();
         
         this._onItemsChanged('remove');
+    }
+
+    /* Renumbers the observer-fed index sets after the item list shifts, the
+     * same way VirtualScrollHeightCache.shiftKeys renumbers cached heights. */
+    _shiftVisibleIndices(amount, startIndex) {
+        for (const set of [this.visibleIndices, this.realVisibleIndices]) {
+            if (set.size === 0) continue;
+            const shifted = [];
+            for (const idx of set) {
+                if (idx < startIndex) shifted.push(idx);
+                else if (idx + amount >= 0) shifted.push(idx + amount);
+            }
+            set.clear();
+            for (const idx of shifted) set.add(idx);
+        }
+    }
+
+    /* Keeps the render window inside the list. A window that has collapsed
+     * (or run past the end) renders nothing, and renderDOM has no way to tell
+     * that apart from a deliberately empty list. */
+    _clampWindow() {
+        const count = this.items.length;
+        this.renderEnd = Math.max(0, Math.min(this.renderEnd, count));
+        this.renderStart = Math.max(0, Math.min(this.renderStart, this.renderEnd));
     }
 
     // Lightweight "follow the bottom while streaming" — ported from Vue
@@ -607,9 +641,19 @@ class UseVirtualScroll {
             this.renderStart += 1;
             this.renderEnd += 1;
         }
+        this._clampWindow();
         
         this.updateSpacers();
         this.renderDOM();
+        // Adding or dropping a row moves every spacer under a scroll position
+        // that did not move with it. A delete out of a long chat can push the
+        // mounted rows clean off the viewport, and nothing scrolls afterwards
+        // to notice — so check here rather than waiting for a scroll event.
+        // Not on a prepend: `prependMessages` grows the head one row at a time
+        // and only restores the reading position once the whole page is in, so
+        // mid-loop the viewport is *meant* to be off the band. The scroll it
+        // then applies runs this check anyway.
+        if (type !== 'prepend') this._recoverIfViewportIsBlank();
         
         if (this._scrollToBottomPending) {
             this._scrollToBottomPending = false;
@@ -677,8 +721,96 @@ class UseVirtualScroll {
         }
     }
 
+    /* The scroll-space band the mounted rows occupy, in the same units the
+     * spacers are written in — both come from the height cache, so the two
+     * always agree even while the cache is still catching up with reality. */
+    _renderedBand() {
+        const top = this.paddingTop;
+        return {
+            top,
+            bottom: top + this.cache.getRenderedContentHeight(this.renderStart, this.renderEnd),
+        };
+    }
+
+    /* True when every mounted row lies entirely above or below the viewport:
+     * the chat shows nothing, and the IntersectionObserver cannot say so
+     * because nothing is close enough to the viewport to report on. */
+    _viewportOutsideRenderedBand() {
+        if (this.items.length === 0) return false;
+        if (this.renderEnd <= this.renderStart) return true;
+        const { top, bottom } = this._renderedBand();
+        const viewTop = this.container.scrollTop;
+        const viewBottom = viewTop + this.container.clientHeight;
+        return bottom <= viewTop || top >= viewBottom;
+    }
+
+    /* The window the current scroll position asks for. Derived from the height
+     * cache alone, so it needs neither an observer entry nor a mounted row —
+     * which is what makes it the recovery for a window that has drifted away
+     * from the viewport. */
+    _windowForScrollTop(scrollTop) {
+        const count = this.items.length;
+        const clientHeight = this.container.clientHeight || 800;
+        const targetRow = this.cache.findRowAtScrollTop(scrollTop);
+        const targetIndex = targetRow >= 0
+            ? targetRow * this.columns
+            : Math.max(0, count - 1);
+
+        let newStart = Math.max(0, targetIndex - this.getBuffer());
+        const sums = this.cache.ensure();
+        let hSum = 0;
+        let r = Math.floor(targetIndex / this.columns);
+        while (hSum < clientHeight + 1000 && r * this.columns < count) {
+            hSum += sums[r + 1] - sums[r];
+            r++;
+        }
+        let newEnd = Math.min(count, r * this.columns + this.getBuffer());
+
+        if (this.columns > 1) {
+            newStart = Math.floor(newStart / this.columns) * this.columns;
+            newEnd = Math.ceil(newEnd / this.columns) * this.columns;
+            newEnd = Math.min(count, newEnd);
+        }
+        if (newEnd <= newStart) newEnd = Math.min(count, newStart + 1);
+        return { start: newStart, end: newEnd };
+    }
+
+    /* Rebuilds the window around the scroll position. Moves the window only —
+     * never scrollTop — so a scrollToBottom or smartScroll already in flight
+     * still lands where it meant to. */
+    _recenterOnScrollPosition() {
+        if (this.items.length === 0) return false;
+        const { start, end } = this._windowForScrollTop(this.container.scrollTop);
+        if (start === this.renderStart && end === this.renderEnd) return false;
+        this.renderStart = start;
+        this.renderEnd = end;
+        this.visibleIndices.clear();
+        this.realVisibleIndices.clear();
+        this.updateSpacers();
+        this.renderDOM();
+        return true;
+    }
+
+    /* The single safety net for a blank chat: every path that can move the
+     * rows away from the viewport without a scroll event ends here. */
+    _recoverIfViewportIsBlank() {
+        if (!this.mounted) return false;
+        if (!this._viewportOutsideRenderedBand()) return false;
+        return this._recenterOnScrollPosition();
+    }
+
     updateWindow() {
-        if (this.visibleIndices.size === 0) return;
+        if (this.visibleIndices.size === 0) {
+            // Nothing intersects. Either the list is simply idle, or the window
+            // has drifted off the viewport — and in that second case no
+            // observer entry is ever coming to say so: everything mounted sits
+            // further away than the observer's margin, so it reports nothing
+            // and there is no visible index left to grow the window from.
+            // Returning here is what left the chat permanently blank until the
+            // user opened another chat and came back (a fresh setMessages).
+            this._recoverIfViewportIsBlank();
+            return;
+        }
         const indices = Array.from(this.visibleIndices).sort((a, b) => a - b);
         const minVis = indices[0];
         const maxVis = indices[indices.length - 1];
@@ -757,6 +889,12 @@ class UseVirtualScroll {
                 }
                 if (!changed) return;
                 this.updateSpacers();
+                // A late height correction (images, fonts, badges) rewrites the
+                // spacers under a scroll position that stays put. In a long
+                // chat that can shift the mounted rows out of the viewport with
+                // no scroll event to follow, which is the second way a chat
+                // went blank on its own.
+                this._recoverIfViewportIsBlank();
                 if (wasPinned) {
                     requestAnimationFrame(() => {
                         if (this.mounted && this._pinnedToBottom) this.smartScroll();
@@ -800,6 +938,12 @@ class UseVirtualScroll {
             this._pinnedToBottom = true;
         }
 
+        // Before the programmatic-scroll gate: a chat whose rows have drifted
+        // off the viewport shows nothing, and our own scrolls (the opening jump
+        // to the bottom, the streaming follow) are exactly when that happens.
+        // The recovery moves the window only, so it cannot fight them.
+        this._recoverIfViewportIsBlank();
+
         if (this.isProgrammaticScrolling) return;
         this.isScrolling = true;
         clearTimeout(this.scrollTimeout);
@@ -812,41 +956,14 @@ class UseVirtualScroll {
             
             const scrollTop = this.container.scrollTop;
             const clientHeight = this.container.clientHeight;
-            const renderedTop = this.paddingTop;
-            const renderedHeight = this.cache.getRenderedContentHeight(this.renderStart, this.renderEnd);
-            const renderedBottom = renderedTop + renderedHeight;
+            const { top: renderedTop, bottom: renderedBottom } = this._renderedBand();
+            // A jump this far outside the mounted rows is cheaper to serve by
+            // rebuilding the window than by letting the observer walk to it.
             const scrollBuffer = 2000;
-            
-            if (scrollTop < renderedTop - scrollBuffer || scrollTop + clientHeight > renderedBottom + scrollBuffer) {
-                const count = this.items.length;
-                const targetRow = this.cache.findRowAtScrollTop(scrollTop);
-                const targetIndex = targetRow >= 0 ? targetRow * this.columns : Math.max(0, count - 1);
-                
-                let newStart = Math.max(0, targetIndex - this.getBuffer());
-                const sums = this.cache.ensure();
-                let hSum = 0;
-                let r = Math.floor(targetIndex / this.columns);
-                while (hSum < clientHeight + 1000 && r * this.columns < count) {
-                    hSum += sums[r + 1] - sums[r];
-                    r++;
-                }
-                let newEnd = Math.min(count, r * this.columns + this.getBuffer());
-                
-                if (this.columns > 1) {
-                    newStart = Math.floor(newStart / this.columns) * this.columns;
-                    newEnd = Math.ceil(newEnd / this.columns) * this.columns;
-                    newEnd = Math.min(count, newEnd);
-                }
-                
-                if (newStart !== this.renderStart || newEnd !== this.renderEnd) {
-                    this.renderStart = newStart;
-                    this.renderEnd = newEnd;
-                    this.visibleIndices.clear();
-                    this.realVisibleIndices.clear();
-                    this.updateSpacers();
-                    this.renderDOM();
-                }
-            }
+            const farAway = scrollTop < renderedTop - scrollBuffer ||
+                scrollTop + clientHeight > renderedBottom + scrollBuffer;
+
+            if (farAway) this._recenterOnScrollPosition();
         });
     }
 

--- a/docs/rules/message-rendering.md
+++ b/docs/rules/message-rendering.md
@@ -1,9 +1,10 @@
 # Message Rendering Rules
 
-Rules for `assets/chat_webview/formatter/` and `assets/chat_webview/renderer/` —
-everything that turns a message body into what the reader sees.
+Rules for `assets/chat_webview/formatter/`, `assets/chat_webview/renderer/` and
+the virtualised list they render into (`assets/chat_webview/useVirtualScroll.js`)
+— everything that turns a message body into what the reader sees.
 
-Read this before changing either directory. The behaviour it describes is
+Read this before changing any of them. The behaviour it describes is
 covered by `test/webview_js` (a real browser renders the card corpus); the
 shape of the modules is covered by `test/webview_assets_test.dart`.
 
@@ -125,6 +126,41 @@ whole card, taking its `<style>` with it; the same scan reached inside a `<pre>`
 the block pass never formats, so the run it held was never restored and the
 leak sweep deleted it. Do not move it back in front of the parse: there is now
 no markdown pass anywhere that reads a string containing live HTML.
+
+---
+
+## The render window is never allowed to leave the viewport
+
+The list is virtualised (`useVirtualScroll.js`): only a window of rows is
+mounted, and an `IntersectionObserver` grows that window as rows come into
+view. The observer is a *local* mechanism — it can only report on rows that
+are already mounted and within its `1000px` margin. So the one state it cannot
+recover from is the window drifting entirely off the viewport: nothing is near
+enough to report, `visibleIndices` empties, and there is no visible index left
+to grow the window from. The chat renders nothing, and no amount of scrolling
+brings it back — only a fresh `setMessages`, which is why the symptom was
+"open another chat and come back".
+
+Three things move the rows out from under a scroll position that does not move
+with them: a delete or an append rewrites the spacers, a late height correction
+(images, fonts, badges) rewrites them again from the `ResizeObserver`, and a
+fast scroll can outrun the observer entirely.
+
+So every one of those paths ends at `_recoverIfViewportIsBlank()`, and the
+recovery it runs (`_recenterOnScrollPosition`) is derived from the scroll
+position and the height cache alone — it needs neither an observer entry nor a
+mounted row. It moves the window and never `scrollTop`, so a `scrollToBottom`
+or a streaming `smartScroll` already in flight still lands where it meant to.
+
+Two rules follow, and `specs/virtual_window.spec.js` holds them:
+
+* **no early return may leave the list with nothing rendered.** `updateWindow`
+  returning on an empty `visibleIndices` is exactly the bug above.
+* **anything that renumbers `items` renumbers the observer's index sets too.**
+  The observer reports an index, not an id. `remove` and `prepend` shift
+  `visibleIndices` / `realVisibleIndices` the same way they shift the height
+  cache; a set left on the old numbering points the next `updateWindow` at
+  somebody else's row, and past the end of the list once enough rows go.
 
 ---
 

--- a/lib/features/chat/bridge/bridge_message_commands.dart
+++ b/lib/features/chat/bridge/bridge_message_commands.dart
@@ -57,7 +57,11 @@ class MessageBridgeCommands {
     // the image-resolve pass above so the synthetic (text-less) entry is not
     // fed through resolveImgResults.
     final origin = _host.chatOrigin;
-    if (visibleStartIndex == 0 && origin != null) {
+    // Nothing left to head: an emptied chat gets no origin marker, the same
+    // rule the page applies when the last message under one is deleted
+    // (`_pruneOrphanSeparators` retires `__date_origin` once no real message
+    // remains).
+    if (visibleStartIndex == 0 && origin != null && mapped.isNotEmpty) {
       mapped.insert(0, {...origin, '__separator': true});
     }
     final json = jsonEncode(mapped);

--- a/lib/features/chat/widgets/chat_message_sync.dart
+++ b/lib/features/chat/widgets/chat_message_sync.dart
@@ -11,7 +11,7 @@ import '../bridge/chat_bridge_controller.dart';
 /// contract is preserved exactly:
 ///   * No-op when a session switch is in progress (defer to caller).
 ///   * First load (old empty) → `setMessages`.
-///   * Cleared (new empty) → `clearAll`.
+///   * Cleared (new empty) → `clearAll` + an empty `setMessages`.
 ///   * Head prepend → `prependMessages` for the prefix.
 ///   * Tail append → `appendMessages`.
 ///   * Any pure removal — head truncation, tail truncation, mid-chat
@@ -69,6 +69,11 @@ class ChatMessageSync {
     if (newIds.isEmpty) {
       onDomReset?.call();
       await bridge.clearAll();
+      // `clearAll` raises the page's loading screen for the `setMessages` that
+      // follows it on every other reset path. Deleting the last message has no
+      // such call, so the spinner sat over the emptied chat — a chat that
+      // renders nothing until it is re-entered — until this one arrived.
+      await bridge.setMessages(const [], visibleStartIndex: visibleStartIndex);
       return;
     }
 

--- a/test/chat_message_sync_removal_test.dart
+++ b/test/chat_message_sync_removal_test.dart
@@ -107,6 +107,26 @@ void main() {
       ]);
     });
 
+    test('emptying the chat re-renders instead of only clearing', () async {
+      final bridge = _RecordingBridge();
+
+      // `clearAll` raises the page's loading screen for the `setMessages` that
+      // follows it everywhere else. Without one here the spinner stayed up over
+      // the emptied chat and nothing rendered until the session was re-entered.
+      await const ChatMessageSync().sync(
+        bridge: bridge,
+        oldMsgs: [_msg('a1', 'assistant')],
+        newMsgs: const [],
+        visibleStartIndex: 0,
+        busy: false,
+        sessionSwitching: false,
+      );
+
+      expect(bridge.clearAllCalls, 1);
+      expect(bridge.setMessagesCalls, [<String>[]]);
+      expect(bridge.removedIds, isEmpty);
+    });
+
     test('an unrelated shorter list falls back to a full re-render', () async {
       final bridge = _RecordingBridge();
 

--- a/test/webview_js/README.md
+++ b/test/webview_js/README.md
@@ -33,6 +33,7 @@ imports the assets by their real paths, and ES modules do not load over
 | `specs/interaction.spec.js` | clicks, `:target`, links, scripts-off behaviour |
 | `specs/streaming.spec.js` | every prefix of a card body renders as a card |
 | `specs/document_contract.spec.js` | what a card may rely on inside the shadow root (INV-MR1…MR8) |
+| `specs/virtual_window.spec.js` | the render window of the virtualised list — the chat must never go blank |
 
 ## The rule
 

--- a/test/webview_js/specs/virtual_window.spec.js
+++ b/test/webview_js/specs/virtual_window.spec.js
@@ -1,0 +1,191 @@
+// The render window of the virtualised message list.
+//
+// Every case here is one chat that went blank and stayed blank — the bug the
+// user hit as "the chat stops rendering; I have to open another chat and come
+// back". Coming back worked because it is a fresh `setMessages`, which rebuilds
+// the window from scratch; nothing short of that recovered.
+//
+// The failure is always the same shape: the rows that are mounted end up
+// entirely above or below the viewport. The IntersectionObserver cannot report
+// on them (they are further away than its 1000px margin), so `visibleIndices`
+// empties, `updateWindow` has nothing to grow the window from, and the list
+// sits there rendering nothing. These drive the real page in a real browser
+// because the failure is a geometry one — a source-level assertion cannot see
+// it.
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/assets/chat_webview/index.html';
+
+async function boot(page) {
+  await page.setViewportSize({ width: 400, height: 700 });
+  await page.goto(PAGE);
+  await page.waitForFunction(() => !!window.bridge);
+  await page.evaluate(() => {
+    window.__M = (id, role, text) => ({
+      id,
+      role,
+      text,
+      timestamp: 1767225600000,
+      isUser: role === 'user',
+      isAssistant: role !== 'user',
+      isSystem: false,
+      displayName: role === 'user' ? 'You' : 'Alice',
+      isError: false,
+      isHidden: false,
+      isGenerating: false,
+      isPostGenRunning: false,
+    });
+    // Bodies of uneven length, so the height cache carries real estimates
+    // rather than one uniform row height.
+    window.__slice = (from, to) =>
+      JSON.stringify(
+        Array.from({ length: to - from }, (_, k) => {
+          const i = from + k;
+          return window.__M(
+            'm' + i,
+            i % 2 ? 'user' : 'assistant',
+            `Message ${i}. ` + 'lorem ipsum dolor sit amet '.repeat(3 + (i % 7)),
+          );
+        }),
+      );
+  });
+}
+
+/** How many message rows the reader can actually see. */
+const onScreenCount = (page) =>
+  page.evaluate(() => {
+    const container = window.bridge.virtualList.container;
+    const view = container.getBoundingClientRect();
+    return [...document.querySelectorAll('#chat-container .message-section')].filter(
+      (el) => {
+        const r = el.getBoundingClientRect();
+        return r.height > 0 && r.bottom > view.top && r.top < view.bottom;
+      },
+    ).length;
+  });
+
+async function openChat(page, from, to) {
+  await page.evaluate(([f, t]) => window.bridge.setMessages(window.__slice(f, t)), [from, to]);
+  await page.waitForTimeout(600);
+}
+
+test('a jump that lands between the observer margin and the scroll buffer still renders', async ({
+  page,
+}) => {
+  await boot(page);
+  await openChat(page, 0, 60);
+  expect(await onScreenCount(page)).toBeGreaterThan(0);
+
+  // The dead zone: far enough from the mounted rows that nothing intersects
+  // (the observer's margin is 1000px), close enough that the scroll handler's
+  // 2000px "big jump" recovery does not fire either.
+  await page.evaluate(() => {
+    window.bridge.virtualList.container.scrollTop = 1200;
+  });
+  await page.waitForTimeout(400);
+
+  expect(await onScreenCount(page)).toBeGreaterThan(0);
+});
+
+test('a chat left blank does not stay blank once the reader scrolls', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 0, 60);
+
+  await page.evaluate(() => {
+    window.bridge.virtualList.container.scrollTop = 1200;
+  });
+  await page.waitForTimeout(300);
+  // Small nudges — the size of a finger settling, not a fling.
+  for (const delta of [40, -40, 60]) {
+    await page.evaluate((d) => {
+      window.bridge.virtualList.container.scrollTop += d;
+    }, delta);
+    await page.waitForTimeout(200);
+  }
+
+  expect(await onScreenCount(page)).toBeGreaterThan(0);
+});
+
+test('deleting a message does not blank the chat', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 0, 60);
+  await page.evaluate(() => {
+    window.bridge.virtualList.container.scrollTop = 1200;
+  });
+  await page.waitForTimeout(400);
+
+  await page.evaluate(() => window.bridge.removeMessage('m10'));
+  await page.waitForTimeout(600);
+
+  expect(await onScreenCount(page)).toBeGreaterThan(0);
+});
+
+test('an append while the reader is scrolled up does not blank the chat', async ({
+  page,
+}) => {
+  await boot(page);
+  await openChat(page, 0, 60);
+  await page.evaluate(() => {
+    window.bridge.virtualList.container.scrollTop = 1200;
+  });
+  await page.waitForTimeout(400);
+
+  await page.evaluate(() => window.bridge.appendMessages(window.__slice(60, 62)));
+  await page.waitForTimeout(600);
+
+  expect(await onScreenCount(page)).toBeGreaterThan(0);
+});
+
+test('a fling straight to the top of a long chat renders the top', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 0, 120);
+
+  await page.evaluate(() => {
+    window.bridge.virtualList.container.scrollTop = 0;
+  });
+  await page.waitForTimeout(500);
+
+  expect(await onScreenCount(page)).toBeGreaterThan(0);
+  expect(await page.evaluate(() => window.bridge.virtualList.renderStart)).toBe(0);
+});
+
+test('deleting keeps the observer index sets in step with the list', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 0, 40);
+  await page.waitForTimeout(300);
+
+  // Every index the observer reported is an index into `items`. A delete
+  // renumbers `items`, so a set left un-shifted points the next updateWindow()
+  // at somebody else's row — and past the end of the list once enough rows go.
+  await page.evaluate(() => {
+    for (let i = 30; i < 40; i++) window.bridge.removeMessage('m' + i);
+  });
+  await page.waitForTimeout(1200);
+
+  const { count, maxVisible } = await page.evaluate(() => {
+    const vl = window.bridge.virtualList;
+    return {
+      count: vl.items.length,
+      maxVisible: vl.visibleIndices.size ? Math.max(...vl.visibleIndices) : -1,
+    };
+  });
+  expect(maxVisible).toBeLessThan(count);
+  expect(await onScreenCount(page)).toBeGreaterThan(0);
+});
+
+test('emptying the chat does not leave the loading screen up', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 0, 3);
+  expect(await page.evaluate(() => !!document.getElementById('loading-screen'))).toBe(false);
+
+  // What deleting the last message sends: clearAll raises the loading screen
+  // for the re-render that follows it, and the re-render is an empty batch.
+  await page.evaluate(() => {
+    window.bridge.clearAll();
+    window.bridge.setMessages('[]');
+  });
+  await page.waitForTimeout(500);
+
+  expect(await page.evaluate(() => !!document.getElementById('loading-screen'))).toBe(false);
+  expect(await onScreenCount(page)).toBe(0);
+});


### PR DESCRIPTION
The virtualised message list could end up with its whole render window off the
viewport, with no way back. `IntersectionObserver` only reports on rows that are
mounted and within its `rootMargin: 1000px`, so once the mounted rows drift
further away than that, `visibleIndices` empties, `UseVirtualScroll.updateWindow`
returns on its first line, and the chat renders nothing. The only recovery was a
fresh `setMessages` — which is why the chat came back after opening another one
and returning to it.

Three paths reach that state:

- a delete or an append rewrites the spacers under a scroll position that does
  not move with them;
- a late height correction (images, fonts, badges) does the same from the
  `ResizeObserver`;
- a scroll lands between the observer's `1000px` margin and the `2000px` "big
  jump" threshold in `_onContainerScroll`, where neither mechanism fires — and
  that threshold was skipped entirely while one of our own programmatic scrolls
  was in flight, which is exactly the window a chat opens in.

## Render window (`assets/chat_webview/useVirtualScroll.js`)

- Add `_recoverIfViewportIsBlank()`: when every mounted row lies outside the
  viewport, `_recenterOnScrollPosition()` rebuilds the window from the scroll
  position and the height cache — it needs neither an observer entry nor a
  mounted row. It moves the window only, never `scrollTop`, so a `scrollToBottom`
  or a streaming `smartScroll` already in flight still lands where it meant to.
- Run it from `updateWindow` (instead of returning on an empty visible set), from
  `_onItemsChanged`, from the `ResizeObserver`, and from `_onContainerScroll`
  ahead of its `isProgrammaticScrolling` gate. Skipped on a `prepend`, where
  `Bridge.prependMessages` deliberately restores the reading position only after
  the whole page is in.
- Shift `visibleIndices` / `realVisibleIndices` on `remove` and `prepend` the way
  `VirtualScrollHeightCache.shiftKeys` shifts cached heights. The observer
  reports an index, not an id, so a set left on the old numbering pointed the
  next `updateWindow` at somebody else's row — and past the end of the list once
  enough rows went.
- Clamp the render window to the list on every mutation (`_clampWindow`).
- Extract `_windowForScrollTop` / `_renderedBand` out of `_onContainerScroll`, so
  the scroll handler and the recovery compute the window the same way.

## Emptying a chat

- Deleting the last message left the page's loading screen up for good:
  `Bridge.clearAll` raises it for the `setMessages` that follows it on every
  other reset path, and this path had none. `ChatMessageSync.sync` now follows
  the `clearAll` with an empty `setMessages`.
- `MessageBridgeCommands.setMessages` no longer prepends the session origin
  ("Created on" / "Branched on") marker to an empty batch — the same rule the
  page already applies in `_pruneOrphanSeparators`, which retires
  `__date_origin` once no real message remains.

## Docs

- `docs/rules/message-rendering.md` gains a section on the render window, and now
  covers `useVirtualScroll.js` alongside `formatter/` and `renderer/` (CLAUDE.md
  context table updated to match), so the next refactor does not reintroduce the
  early return.

## Verification

- `test/webview_js` — 69 passing (Playwright, real Chromium, real page).
  Six new cases in `specs/virtual_window.spec.js` reproduce the blank-chat states
  end to end; **five of them fail without this change** (verified by stashing the
  asset diff and re-running).
- `test/chat_message_sync_removal_test.dart` gains a case for the emptied-chat
  re-render.
- `flutter analyze` and `flutter test` were **not** run — no Flutter SDK in the
  agent environment. The three Dart edits are small and were reviewed by reading;
  CI is the first execution of them.
- Not verified on a device: the fix is a change in geometry recovery, so a run on
  the Android nightly build is worth doing before promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Qq6E2nKKtK2ogjdYB48yP

---
_Generated by [Claude Code](https://claude.ai/code/session_015Qq6E2nKKtK2ogjdYB48yP)_