### PR TITLE
feat(chat): let the drawer's edit mode retarget the empty composer's send button

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -391,7 +391,7 @@
   "composer_action_attach": "Attach image",
   "composer_action_fullscreen": "Fullscreen editor",
   "composer_action_guidance": "Guidance",
-  "composer_empty_action_hint": "Drop an action here to change what the send button does while the message box is empty",
+  "composer_empty_action_hint": "Drop a card from the Actions tab here to change what the send button does while the message box is empty",
   "composer_empty_action_reset": "Restore the default action (impersonate)",
   "btn_reset": "Reset",
   "stat_messages": "Messages",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -391,6 +391,8 @@
   "composer_action_attach": "Attach image",
   "composer_action_fullscreen": "Fullscreen editor",
   "composer_action_guidance": "Guidance",
+  "composer_empty_action_hint": "Drop an action here to change what the send button does while the message box is empty",
+  "composer_empty_action_reset": "Restore the default action (impersonate)",
   "btn_reset": "Reset",
   "stat_messages": "Messages",
   "stat_gen_time": "Generation Time",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -285,6 +285,8 @@
   "composer_action_attach": "Прикрепить изображение",
   "composer_action_fullscreen": "Полноэкранный редактор",
   "composer_action_guidance": "Направление",
+  "composer_empty_action_hint": "Перетащите сюда действие, чтобы изменить кнопку отправки при пустом поле ввода",
+  "composer_empty_action_reset": "Вернуть действие по умолчанию (имперсонация)",
   "btn_reset": "Сбросить",
   "action_new_session": "Новая сессия",
   "action_rename": "Переименовать",

--- a/assets/translations/ru.json
+++ b/assets/translations/ru.json
@@ -285,7 +285,7 @@
   "composer_action_attach": "Прикрепить изображение",
   "composer_action_fullscreen": "Полноэкранный редактор",
   "composer_action_guidance": "Направление",
-  "composer_empty_action_hint": "Перетащите сюда действие, чтобы изменить кнопку отправки при пустом поле ввода",
+  "composer_empty_action_hint": "Перетащите сюда карточку из вкладки «Действия», чтобы изменить кнопку отправки при пустом поле ввода",
   "composer_empty_action_reset": "Вернуть действие по умолчанию (имперсонация)",
   "btn_reset": "Сбросить",
   "action_new_session": "Новая сессия",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -278,6 +278,7 @@ lib/
 │   ├── chat/
 │   │   ├── chat_provider.dart        # ChatNotifier: state owner; delegates to controllers + pipeline
 │   │   ├── composer_pins_provider.dart # What sits in the row under the composer (actions/replies/tools)
+│   │   ├── composer_empty_action_provider.dart # What the send button runs while the composer is empty (default: impersonate)
 │   │   ├── quick_replies_provider.dart # The Actions tab's user-written replies
 │   │   ├── chat_state.dart           # ChatState + StreamingState value objects
 │   │   ├── editing_message_provider.dart # Tracks which message is being edited

--- a/lib/features/chat/composer_empty_action_provider.dart
+++ b/lib/features/chat/composer_empty_action_provider.dart
@@ -8,13 +8,14 @@ import 'composer_pins_provider.dart';
 /// With nothing typed the button has never sent anything — it impersonated the
 /// user. That is one guess out of a dozen at what the only button the thumb
 /// already rests on should do, so the slot is the user's to assign: in the
-/// drawer's edit mode any card or pinned button dragged onto the send button
-/// lands here, and the button takes that item's glyph and tap whenever the
-/// composer is empty. Null is the built-in impersonation.
+/// drawer's edit mode a card dragged onto the send button lands here, and the
+/// button takes that card's glyph and tap whenever the composer is empty. Null
+/// is the built-in impersonation.
 ///
-/// Unlike [composerPinsProvider] this is an override of one button's idle
-/// state rather than a home of its own, so whatever is assigned keeps the place
-/// it already had: a tool dropped here still has its card in the Tools tab.
+/// Only the Actions tab can fill it — see [isAssignable]. Unlike
+/// [composerPinsProvider] this is an override of one button's idle state rather
+/// than a home of its own, so whatever is assigned keeps the place it already
+/// had: a quick reply assigned here still has its card in the Actions grid.
 /// Filtering it out would hide it behind a slot that is itself invisible the
 /// moment the composer has text in it.
 ///
@@ -24,17 +25,33 @@ import 'composer_pins_provider.dart';
 class ComposerEmptyActionNotifier extends AsyncNotifier<ComposerPin?> {
   static const storageKey = 'composer_empty_action_v1';
 
+  /// Whether [pin] may take the empty composer's button.
+  ///
+  /// Actions only — the tab's quick replies and the composer's own actions.
+  /// A Tools card opens a sheet *about* the chat, which is not what a thumb
+  /// resting on the send button is reaching for; the row below is where those
+  /// belong. Enforced here rather than only at the drop, so a stored id
+  /// cannot outlive the rule.
+  static bool isAssignable(ComposerPin pin) =>
+      pin.kind != ComposerPinKind.tool;
+
   @override
   Future<ComposerPin?> build() async {
     final prefs = await ref.read(sharedPreferencesProvider.future);
     final saved = prefs.getString(storageKey);
-    // An id this build cannot parse falls back to impersonation rather than to
-    // a dead button, on the same terms a stale pin is dropped from the row.
-    return saved == null ? null : ComposerPin.decode(saved);
+    if (saved == null) return null;
+    // An id this build cannot parse — or no longer allows — falls back to
+    // impersonation rather than to a dead button, on the same terms a stale
+    // pin is dropped from the row.
+    final pin = ComposerPin.decode(saved);
+    return pin != null && isAssignable(pin) ? pin : null;
   }
 
-  /// Assigns [pin] to the empty composer, replacing whatever was there.
+  /// Assigns [pin] to the empty composer, replacing whatever was there. A pin
+  /// [isAssignable] refuses is ignored; the UI declines the drop, and this is
+  /// the backstop.
   Future<void> assign(ComposerPin pin) async {
+    if (!isAssignable(pin)) return;
     state = AsyncData(pin);
     final prefs = await ref.read(sharedPreferencesProvider.future);
     await prefs.setString(storageKey, pin.encode());

--- a/lib/features/chat/composer_empty_action_provider.dart
+++ b/lib/features/chat/composer_empty_action_provider.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/state/shared_prefs_provider.dart';
+import 'composer_pins_provider.dart';
+
+/// What the send button does while the composer is empty.
+///
+/// With nothing typed the button has never sent anything — it impersonated the
+/// user. That is one guess out of a dozen at what the only button the thumb
+/// already rests on should do, so the slot is the user's to assign: in the
+/// drawer's edit mode any card or pinned button dragged onto the send button
+/// lands here, and the button takes that item's glyph and tap whenever the
+/// composer is empty. Null is the built-in impersonation.
+///
+/// Unlike [composerPinsProvider] this is an override of one button's idle
+/// state rather than a home of its own, so whatever is assigned keeps the place
+/// it already had: a tool dropped here still has its card in the Tools tab.
+/// Filtering it out would hide it behind a slot that is itself invisible the
+/// moment the composer has text in it.
+///
+/// A single encoded [ComposerPin], stored under its own key rather than folded
+/// into the pins list: it is one slot, and a list would have to carry a
+/// position that means nothing here.
+class ComposerEmptyActionNotifier extends AsyncNotifier<ComposerPin?> {
+  static const storageKey = 'composer_empty_action_v1';
+
+  @override
+  Future<ComposerPin?> build() async {
+    final prefs = await ref.read(sharedPreferencesProvider.future);
+    final saved = prefs.getString(storageKey);
+    // An id this build cannot parse falls back to impersonation rather than to
+    // a dead button, on the same terms a stale pin is dropped from the row.
+    return saved == null ? null : ComposerPin.decode(saved);
+  }
+
+  /// Assigns [pin] to the empty composer, replacing whatever was there.
+  Future<void> assign(ComposerPin pin) async {
+    state = AsyncData(pin);
+    final prefs = await ref.read(sharedPreferencesProvider.future);
+    await prefs.setString(storageKey, pin.encode());
+  }
+
+  /// Gives the button its impersonation back.
+  Future<void> reset() async {
+    state = const AsyncData(null);
+    final prefs = await ref.read(sharedPreferencesProvider.future);
+    await prefs.remove(storageKey);
+  }
+}
+
+final composerEmptyActionProvider =
+    AsyncNotifierProvider<ComposerEmptyActionNotifier, ComposerPin?>(
+      ComposerEmptyActionNotifier.new,
+    );

--- a/lib/features/chat/widgets/chat_input_bar.dart
+++ b/lib/features/chat/widgets/chat_input_bar.dart
@@ -16,6 +16,7 @@ import '../../../shared/widgets/fullscreen_editor.dart';
 import '../../../shared/widgets/glass_surface.dart';
 import '../chat_provider.dart'
     show ImpersonationState, chatProvider, impersonationStateProvider;
+import '../composer_empty_action_provider.dart';
 import '../composer_pins_provider.dart';
 import '../quick_replies_provider.dart';
 import '../services/drawer_item_launcher.dart';
@@ -451,13 +452,8 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
   /// open, each button can be dragged along the row and carries a down-arrow
   /// that drops it back into its tab. The other direction has no badge — a card
   /// dragged out of a drawer grid and dropped here is what puts it up.
-  Widget _buildActionRow() {
+  Widget _buildActionRow(bool editing) {
     final pins = ref.watch(composerPinsProvider).value ?? kDefaultComposerPins;
-    // Gated on the drawer being open as well as on edit mode: with the drawer
-    // shut there is nowhere for a demoted button to land, and no pencil on
-    // screen to explain the arrows.
-    final editing =
-        widget.isDrawerOpen && ref.watch(chatDrawerEditingProvider);
 
     final buttons = <Widget>[];
     for (var index = 0; index < pins.length; index++) {
@@ -576,6 +572,117 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
         child: content,
       ),
     );
+  }
+
+  /// The send button — and, while the composer is empty, the one slot in the
+  /// composer the drawer's pencil can retarget.
+  ///
+  /// With text in the box the button sends, mid-generation it stops, and edit
+  /// mode leaves both of those alone: neither is a preference. Empty, it has
+  /// always guessed — it impersonated the user — so that state is the one the
+  /// user gets to assign. Whatever [composerEmptyActionProvider] holds lends
+  /// the button its glyph and its tap; a card or a pinned button dropped on it
+  /// in edit mode is what puts it there, and the undo badge hands the
+  /// impersonation back.
+  ///
+  /// Only the empty state goes dead in edit mode, for the reason the row's
+  /// buttons all do: a tap that both retargets and fires would be a trap.
+  /// Sending and stopping stay live, since neither is what the drop is aimed
+  /// at.
+  Widget _buildSendButton({
+    required bool isGenerating,
+    required bool hasContent,
+    required bool editing,
+  }) {
+    final emptyPin = ref.watch(composerEmptyActionProvider).value;
+    // Null once the thing it points at is gone — a deleted quick reply, a tool
+    // with no chat to open against. The button falls back to impersonation
+    // rather than wearing a glyph that does nothing.
+    final emptyAction = emptyPin == null ? null : _resolvePin(emptyPin);
+
+    final button = _SendBtn(
+      icon: isGenerating
+          ? Icons.stop_rounded
+          : hasContent
+          ? (_guidanceMode && _controller.text.trim().isEmpty
+                ? Icons.check_rounded
+                : Icons.send_rounded)
+          : (emptyAction?.icon ?? Icons.account_circle_rounded),
+      batterySaver: widget.batterySaver,
+      onTap: editing && !isGenerating && !hasContent
+          ? null
+          : () {
+              if (isGenerating) {
+                widget.onStop?.call();
+              } else if (widget.isEditingMessage) {
+                return;
+              } else if (hasContent) {
+                _handleSend();
+              } else if (emptyAction?.onTap != null) {
+                emptyAction!.onTap!();
+              } else {
+                final guidance =
+                    _guidanceMode &&
+                        _guidanceController.text.trim().isNotEmpty
+                    ? _guidanceController.text.trim()
+                    : null;
+                widget.onImpersonate?.call(guidance);
+              }
+            },
+    );
+    if (!editing) return button;
+
+    final content = Stack(
+      clipBehavior: Clip.none,
+      children: [
+        button,
+        // Reset, not the row's demote arrow: an assignment here never took the
+        // card out of its tab, so there is nothing to send back — only a
+        // default to restore.
+        if (emptyPin != null)
+          Positioned(
+            top: -6,
+            right: -6,
+            child: MagicCardBadge(
+              icon: Icons.undo,
+              color: context.cs.primary,
+              tooltip: 'composer_empty_action_reset'.tr(),
+              size: 18,
+              onTap: _resetEmptyAction,
+            ),
+          ),
+      ],
+    );
+
+    return Tooltip(
+      // The slot is invisible the moment anything is typed, so the hint is the
+      // only thing that says a drop lands here at all.
+      message: 'composer_empty_action_hint'.tr(),
+      preferBelow: false,
+      child: DragTarget<ComposerPin>(
+        onWillAcceptWithDetails: (details) => details.data != emptyPin,
+        onAcceptWithDetails: (details) => _assignEmptyAction(details.data),
+        // Scale rather than a ring: a border would grow the 40px circle and
+        // shove the row it shares a baseline with.
+        builder: (context, candidate, _) => AnimatedScale(
+          duration: const Duration(milliseconds: 120),
+          scale: candidate.isEmpty ? 1.0 : 1.15,
+          child: content,
+        ),
+      ),
+    );
+  }
+
+  /// Points the empty composer's button at [pin]. The pin keeps its place in
+  /// the drawer or the row — see [composerEmptyActionProvider].
+  void _assignEmptyAction(ComposerPin pin) {
+    Haptics.mediumImpact();
+    unawaited(ref.read(composerEmptyActionProvider.notifier).assign(pin));
+  }
+
+  void _resetEmptyAction() {
+    Haptics.mediumImpact();
+    unawaited(ref.read(composerEmptyActionProvider.notifier).reset());
   }
 
   void _unpin(ComposerPin pin) {
@@ -835,6 +942,10 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
         widget.isGenerating ||
         widget.isGeneratingImage ||
         widget.isPostGenRunning;
+    // Gated on the drawer being open as well as on edit mode: with the drawer
+    // shut there is nowhere for a demoted button to land, nothing on screen to
+    // drag into the send button, and no pencil to explain the badges.
+    final editing = widget.isDrawerOpen && ref.watch(chatDrawerEditingProvider);
 
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
@@ -979,33 +1090,12 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
               children: [
                 // Expanded, so a row long enough to overflow scrolls instead of
                 // shoving the send button off the screen.
-                Expanded(child: _buildActionRow()),
+                Expanded(child: _buildActionRow(editing)),
                 const SizedBox(width: 8),
-                _SendBtn(
-                  icon: isGenerating
-                      ? Icons.stop_rounded
-                      : hasContent
-                      ? (_guidanceMode && _controller.text.trim().isEmpty
-                            ? Icons.check_rounded
-                            : Icons.send_rounded)
-                      : Icons.account_circle_rounded,
-                  batterySaver: widget.batterySaver,
-                  onTap: () {
-                    if (isGenerating) {
-                      widget.onStop?.call();
-                    } else if (widget.isEditingMessage) {
-                      return;
-                    } else if (hasContent) {
-                      _handleSend();
-                    } else {
-                      final guidance =
-                          _guidanceMode &&
-                              _guidanceController.text.trim().isNotEmpty
-                          ? _guidanceController.text.trim()
-                          : null;
-                      widget.onImpersonate?.call(guidance);
-                    }
-                  },
+                _buildSendButton(
+                  isGenerating: isGenerating,
+                  hasContent: hasContent,
+                  editing: editing,
                 ),
               ],
             ),

--- a/lib/features/chat/widgets/chat_input_bar.dart
+++ b/lib/features/chat/widgets/chat_input_bar.dart
@@ -581,9 +581,10 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
   /// mode leaves both of those alone: neither is a preference. Empty, it has
   /// always guessed — it impersonated the user — so that state is the one the
   /// user gets to assign. Whatever [composerEmptyActionProvider] holds lends
-  /// the button its glyph and its tap; a card or a pinned button dropped on it
-  /// in edit mode is what puts it there, and the undo badge hands the
-  /// impersonation back.
+  /// the button its glyph and its tap; an Actions card dropped on it in edit
+  /// mode is what puts it there, and the undo badge hands the impersonation
+  /// back. Tools are turned away at the drop — see
+  /// [ComposerEmptyActionNotifier.isAssignable].
   ///
   /// Only the empty state goes dead in edit mode, for the reason the row's
   /// buttons all do: a tap that both retargets and fires would be a trap.
@@ -595,8 +596,8 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
     required bool editing,
   }) {
     final emptyPin = ref.watch(composerEmptyActionProvider).value;
-    // Null once the thing it points at is gone — a deleted quick reply, a tool
-    // with no chat to open against. The button falls back to impersonation
+    // Null once the thing it points at is gone — a quick reply since deleted,
+    // the drawer button on desktop. The button falls back to impersonation
     // rather than wearing a glyph that does nothing.
     final emptyAction = emptyPin == null ? null : _resolvePin(emptyPin);
 
@@ -660,7 +661,12 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
       message: 'composer_empty_action_hint'.tr(),
       preferBelow: false,
       child: DragTarget<ComposerPin>(
-        onWillAcceptWithDetails: (details) => details.data != emptyPin,
+        // Actions only, so a Tools card dragged across the button is refused
+        // rather than silently swallowed: the drag keeps looking for the row
+        // below, which is where a tool belongs.
+        onWillAcceptWithDetails: (details) =>
+            details.data != emptyPin &&
+            ComposerEmptyActionNotifier.isAssignable(details.data),
         onAcceptWithDetails: (details) => _assignEmptyAction(details.data),
         // Scale rather than a ring: a border would grow the 40px circle and
         // shove the row it shares a baseline with.

--- a/test/chat_input_bar_test.dart
+++ b/test/chat_input_bar_test.dart
@@ -305,6 +305,81 @@ void main() {
       expect(impersonateCalls, 1);
     });
 
+    testWidgets('the empty slot takes an Actions drop and refuses a tool', (
+      tester,
+    ) async {
+      // Stands in for the drawer's grids, which drag this very payload type.
+      Widget handle(String label, ComposerPin pin) => Draggable<ComposerPin>(
+        key: ValueKey(label),
+        data: pin,
+        feedback: const SizedBox(width: 20, height: 20),
+        // Painted, not a bare SizedBox: an empty box does not hit-test, so the
+        // gesture would never reach the [Draggable] and the drag would never
+        // start — a green test proving nothing.
+        child: const ColoredBox(
+          color: Color(0xFF00FF00),
+          child: SizedBox(width: 20, height: 20),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  handle('tool', ComposerPin.tool('char-card')),
+                  handle('reply', ComposerPin.action(ComposerAction.guidance)),
+                  ChatInputBar(
+                    isGenerating: false,
+                    isDrawerOpen: true,
+                    onMagicDrawer: () {},
+                    onSend: (_) async => true,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ChatInputBar)),
+      );
+      container.read(chatDrawerEditingProvider.notifier).state = true;
+      await tester.pumpAndSettle();
+
+      Future<void> dragOntoSendButton(String label) async {
+        final target = tester.getCenter(
+          find.byIcon(Icons.account_circle_rounded),
+        );
+        final origin = tester.getCenter(find.byKey(ValueKey(label)));
+        final gesture = await tester.startGesture(origin);
+        // Past the drag slop first, so the [Draggable] is actually up before
+        // the pointer reaches the button.
+        await gesture.moveTo(origin + const Offset(0, 24));
+        await tester.pump();
+        await gesture.moveTo(target);
+        await tester.pump();
+        await gesture.up();
+        await tester.pumpAndSettle();
+      }
+
+      // A Tools card opens a sheet about the chat — not what a thumb resting
+      // on the send button is reaching for.
+      await dragOntoSendButton('tool');
+      expect(container.read(composerEmptyActionProvider).value, isNull);
+      expect(find.byIcon(Icons.account_circle_rounded), findsOneWidget);
+
+      await dragOntoSendButton('reply');
+      expect(
+        container.read(composerEmptyActionProvider).value,
+        ComposerPin.action(ComposerAction.guidance),
+      );
+      expect(find.byIcon(Icons.account_circle_rounded), findsNothing);
+    });
+
     testWidgets('edit mode kills the empty tap but not send or stop', (
       tester,
     ) async {

--- a/test/chat_input_bar_test.dart
+++ b/test/chat_input_bar_test.dart
@@ -3,6 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/chat/composer_empty_action_provider.dart';
+import 'package:glaze_flutter/features/chat/composer_pins_provider.dart';
+import 'package:glaze_flutter/features/chat/state/chat_drawer_editing_provider.dart';
 import 'package:glaze_flutter/features/chat/widgets/chat_input_bar.dart';
 import 'package:glaze_flutter/features/chat/widgets/input_bar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -25,12 +28,16 @@ void main() {
       void Function(String? guidance)? onImpersonate,
       VoidCallback? onStop,
       bool acceptSend = true,
+      bool isDrawerOpen = false,
+      VoidCallback? onMagicDrawer,
     }) {
       sentMessages = [];
       return ProviderScope(
         child: MaterialApp(
           home: Scaffold(
             body: ChatInputBar(
+              isDrawerOpen: isDrawerOpen,
+              onMagicDrawer: onMagicDrawer,
               onSend: (text) async {
                 sentMessages.add(text);
                 return acceptSend;
@@ -233,6 +240,104 @@ void main() {
         tester.widget<TextField>(find.byType(TextField)).controller!.text,
         'the new one',
       );
+    });
+
+    testWidgets('the empty composer impersonates when nothing is assigned', (
+      tester,
+    ) async {
+      var impersonateCalls = 0;
+      await tester.pumpWidget(
+        buildChatInputBar(onImpersonate: (_) => impersonateCalls++),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.account_circle_rounded), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.account_circle_rounded));
+
+      expect(impersonateCalls, 1);
+    });
+
+    testWidgets('an assigned action takes over the empty composer', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({
+        ComposerEmptyActionNotifier.storageKey: 'action:guidance',
+      });
+      var impersonateCalls = 0;
+      await tester.pumpWidget(
+        buildChatInputBar(onImpersonate: (_) => impersonateCalls++),
+      );
+      await tester.pumpAndSettle();
+
+      // The assignment lends the button its glyph, so the state is readable
+      // without tapping it.
+      expect(find.byIcon(Icons.account_circle_rounded), findsNothing);
+      final sendButton = find.ancestor(
+        of: find.byIcon(ComposerAction.guidance.icon),
+        matching: find.byType(InkWell),
+      );
+      expect(sendButton, findsOneWidget);
+
+      await tester.tap(sendButton);
+      await tester.pumpAndSettle();
+
+      expect(impersonateCalls, 0);
+      // Guidance mode opened: the steering field is the composer's second box.
+      expect(find.byType(TextField), findsNWidgets(2));
+    });
+
+    testWidgets('a stored action this build cannot resolve impersonates', (
+      tester,
+    ) async {
+      // A quick reply that has since been deleted resolves to nothing. The
+      // button falls back rather than going dead.
+      SharedPreferences.setMockInitialValues({
+        ComposerEmptyActionNotifier.storageKey: 'reply:qr-gone',
+      });
+      var impersonateCalls = 0;
+      await tester.pumpWidget(
+        buildChatInputBar(onImpersonate: (_) => impersonateCalls++),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.account_circle_rounded));
+
+      expect(impersonateCalls, 1);
+    });
+
+    testWidgets('edit mode kills the empty tap but not send or stop', (
+      tester,
+    ) async {
+      var impersonateCalls = 0;
+      var stopCalls = 0;
+      await tester.pumpWidget(
+        buildChatInputBar(
+          isDrawerOpen: true,
+          onMagicDrawer: () {},
+          onImpersonate: (_) => impersonateCalls++,
+          onStop: () => stopCalls++,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ChatInputBar)),
+      );
+      container.read(chatDrawerEditingProvider.notifier).state = true;
+      await tester.pumpAndSettle();
+
+      // A tap that both retargets the slot and fires it would be a trap.
+      await tester.tap(find.byIcon(Icons.account_circle_rounded));
+      await tester.pump();
+      expect(impersonateCalls, 0);
+
+      // Sending is not what the drop is aimed at, so it stays live.
+      await tester.enterText(find.byType(TextField).first, 'still sends');
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.send_rounded));
+      await tester.pumpAndSettle();
+      expect(sentMessages, ['still sends']);
+      expect(stopCalls, 0);
     });
 
     testWidgets('image generation stop button remains tappable', (

--- a/test/composer_empty_action_test.dart
+++ b/test/composer_empty_action_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/chat/composer_empty_action_provider.dart';
+import 'package:glaze_flutter/features/chat/composer_pins_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  ProviderContainer makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  Future<ComposerPin?> load(ProviderContainer container) =>
+      container.read(composerEmptyActionProvider.future);
+
+  group('composer empty action', () {
+    test('defaults to nothing, which is the built-in impersonation', () async {
+      SharedPreferences.setMockInitialValues({});
+      expect(await load(makeContainer()), isNull);
+    });
+
+    test('reads a stored assignment of every kind', () async {
+      for (final pin in [
+        ComposerPin.action(ComposerAction.guidance),
+        ComposerPin.reply('qr-1'),
+        ComposerPin.tool('char-card'),
+      ]) {
+        SharedPreferences.setMockInitialValues({
+          ComposerEmptyActionNotifier.storageKey: pin.encode(),
+        });
+        expect(await load(makeContainer()), pin);
+      }
+    });
+
+    test('falls back to impersonation on an id it cannot parse', () async {
+      SharedPreferences.setMockInitialValues({
+        ComposerEmptyActionNotifier.storageKey: 'widget:gone',
+      });
+      expect(await load(makeContainer()), isNull);
+    });
+
+    test('assign persists the pin and replaces what was there', () async {
+      SharedPreferences.setMockInitialValues({});
+      final container = makeContainer();
+      await load(container);
+      final notifier = container.read(composerEmptyActionProvider.notifier);
+
+      await notifier.assign(ComposerPin.tool('regex'));
+      await notifier.assign(ComposerPin.reply('qr-2'));
+
+      expect(container.read(composerEmptyActionProvider).value,
+          ComposerPin.reply('qr-2'));
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getString(ComposerEmptyActionNotifier.storageKey),
+        'reply:qr-2',
+      );
+    });
+
+    test('reset clears both the state and the stored key', () async {
+      SharedPreferences.setMockInitialValues({
+        ComposerEmptyActionNotifier.storageKey: 'action:attach',
+      });
+      final container = makeContainer();
+      await load(container);
+      await container.read(composerEmptyActionProvider.notifier).reset();
+
+      expect(container.read(composerEmptyActionProvider).value, isNull);
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getString(ComposerEmptyActionNotifier.storageKey),
+        isNull,
+      );
+    });
+
+    test('an assignment does not touch the composer row', () async {
+      // The slot retargets a button that is already on screen rather than
+      // rehoming a card, so the pins list — and the drawer grids that filter
+      // on it — must not move.
+      SharedPreferences.setMockInitialValues({});
+      final container = makeContainer();
+      final before = await container.read(composerPinsProvider.future);
+      await load(container);
+      await container
+          .read(composerEmptyActionProvider.notifier)
+          .assign(ComposerPin.tool('regex'));
+
+      expect(container.read(composerPinsProvider).value, before);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getStringList(ComposerPinsNotifier.storageKey), isNull);
+    });
+  });
+}

--- a/test/composer_empty_action_test.dart
+++ b/test/composer_empty_action_test.dart
@@ -20,17 +20,63 @@ void main() {
       expect(await load(makeContainer()), isNull);
     });
 
-    test('reads a stored assignment of every kind', () async {
+    test('reads a stored assignment of either Actions kind', () async {
       for (final pin in [
         ComposerPin.action(ComposerAction.guidance),
         ComposerPin.reply('qr-1'),
-        ComposerPin.tool('char-card'),
       ]) {
         SharedPreferences.setMockInitialValues({
           ComposerEmptyActionNotifier.storageKey: pin.encode(),
         });
         expect(await load(makeContainer()), pin);
       }
+    });
+
+    test('the Actions tab fills the slot; Tools do not', () {
+      expect(
+        ComposerEmptyActionNotifier.isAssignable(
+          ComposerPin.action(ComposerAction.guidance),
+        ),
+        isTrue,
+      );
+      expect(
+        ComposerEmptyActionNotifier.isAssignable(ComposerPin.reply('qr-1')),
+        isTrue,
+      );
+      // A Tools card opens a sheet about the chat, which is not what the
+      // send button is for. The row below is where those belong.
+      expect(
+        ComposerEmptyActionNotifier.isAssignable(ComposerPin.tool('char-card')),
+        isFalse,
+      );
+    });
+
+    test('drops a stored tool, which the rule no longer allows', () async {
+      SharedPreferences.setMockInitialValues({
+        ComposerEmptyActionNotifier.storageKey: 'tool:char-card',
+      });
+      expect(await load(makeContainer()), isNull);
+    });
+
+    test('assign refuses a tool and leaves the slot as it was', () async {
+      SharedPreferences.setMockInitialValues({
+        ComposerEmptyActionNotifier.storageKey: 'action:attach',
+      });
+      final container = makeContainer();
+      await load(container);
+      await container
+          .read(composerEmptyActionProvider.notifier)
+          .assign(ComposerPin.tool('regex'));
+
+      expect(
+        container.read(composerEmptyActionProvider).value,
+        ComposerPin.action(ComposerAction.attach),
+      );
+      final prefs = await SharedPreferences.getInstance();
+      expect(
+        prefs.getString(ComposerEmptyActionNotifier.storageKey),
+        'action:attach',
+      );
     });
 
     test('falls back to impersonation on an id it cannot parse', () async {
@@ -46,7 +92,7 @@ void main() {
       await load(container);
       final notifier = container.read(composerEmptyActionProvider.notifier);
 
-      await notifier.assign(ComposerPin.tool('regex'));
+      await notifier.assign(ComposerPin.action(ComposerAction.guidance));
       await notifier.assign(ComposerPin.reply('qr-2'));
 
       expect(container.read(composerEmptyActionProvider).value,
@@ -76,7 +122,7 @@ void main() {
 
     test('an assignment does not touch the composer row', () async {
       // The slot retargets a button that is already on screen rather than
-      // rehoming a card, so the pins list — and the drawer grids that filter
+      // rehoming a card, so the pins list — and the Actions grid that filters
       // on it — must not move.
       SharedPreferences.setMockInitialValues({});
       final container = makeContainer();
@@ -84,7 +130,7 @@ void main() {
       await load(container);
       await container
           .read(composerEmptyActionProvider.notifier)
-          .assign(ComposerPin.tool('regex'));
+          .assign(ComposerPin.reply('qr-1'));
 
       expect(container.read(composerPinsProvider).value, before);
       final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
With text in the box the send button sends, and mid-generation it stops. Empty, it has always guessed one thing — it impersonated the user. That guess is now the user's to change, from the pencil that already edits the row beside it.

## Changes

- Add `composerEmptyActionProvider` (`lib/features/chat/composer_empty_action_provider.dart`): one persisted `ComposerPin` under `composer_empty_action_v1`, `null` meaning the built-in impersonation.
- `_ChatInputBarState._buildSendButton` replaces the inline `_SendBtn`: while the composer is empty the button takes its glyph and its tap from the assigned pin, falling back to impersonation.
- In the drawer's edit mode (`chatDrawerEditingProvider` **and** the drawer open) the send button is a `DragTarget<ComposerPin>`, so an Actions card dropped on it takes over the empty state. The drop scales the button rather than ringing it — a border would grow the 40px circle and shove the row it shares a baseline with.
- An undo `MagicCardBadge` on the button hands the impersonation back.
- **Actions only.** `ComposerEmptyActionNotifier.isAssignable` turns tool pins away: a Tools card opens a sheet *about* the chat, which is not what a thumb resting on the send button is reaching for, and the pinned row below is where those belong. The drop target refuses them, so a tool dragged across the button keeps looking for the row instead of being silently swallowed. Enforced on read and on `assign` too, so a stored id cannot outlive the rule.
- Only the empty state's tap goes dead while editing, for the reason the row's buttons' do — a tap that both retargets and fires would be a trap. Sending and stopping stay live, since neither is what the drop is aimed at.
- Add `composer_empty_action_hint` / `composer_empty_action_reset` to `en.json` and `ru.json`, and the new provider to the `docs/ARCHITECTURE.md` tree.

### Why an assignment does not move the card

Unlike a pin, this retargets a button that is already on screen rather than rehoming a card, so the Actions grid does not filter on it: the slot is itself invisible the moment the composer has text in it, and a card vanishing into an invisible slot would be worse than a duplicate. A stored pin this build cannot resolve (a quick reply since deleted, the drawer button on desktop) falls back to impersonation rather than to a dead glyph.

## Verification

- `flutter analyze` — no errors; nothing reported in the touched files.
- `flutter test` — 3759 pass, on Flutter 3.47.2 with `build_runner` and `easy_localization:generate` run first.
- New `test/composer_empty_action_test.dart` (10 tests): the default, both Actions kinds round-tripping, the `isAssignable` rule, a stored tool being dropped, `assign` refusing a tool without disturbing the current slot, reset, and an assignment leaving `composerPinsProvider` untouched.
- New `ChatInputBar` widget tests: the default impersonation, an assignment taking over, an unresolvable assignment falling back, the edit-mode tap gating (and that send still works), and a drag test that drops both a tool and an action on the button and asserts only the action lands.

One note on that drag test — its first version passed while proving nothing: the drag handle was a bare `SizedBox`, which does not hit-test, so the gesture never reached the `Draggable` and no drop ever occurred. The "tool is refused" assertion was green with the button entirely broken. The handle is painted now, and both halves of the test exercise the real path.

Rebased onto `nightly` at 99b5952 (#381); no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnenE6BPQ21oWALjvqT5wd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnenE6BPQ21oWALjvqT5wd)_