### PR TITLE
feat(studio): appendToLastMessage + decode replacement escapes

### DIFF
--- a/lib/core/llm/regex_service.dart
+++ b/lib/core/llm/regex_service.dart
@@ -97,7 +97,7 @@ String _applySingleScript(
   var processed = text;
 
   var pattern = script.regex;
-  final replacement = script.replacement;
+  final replacement = _decodeReplacementEscapes(script.replacement);
   final macroCtx = _macroContextFor(ctx);
 
   // ST's `filterString`: every trim string is macro-substituted, and the
@@ -291,4 +291,83 @@ _parseRegexPattern(String raw) {
 
 String _escapeRegex(String s) {
   return RegExp.escape(s);
+}
+
+/// Decodes escape sequences in a "Replace With" template before it is applied,
+/// mirroring SillyTavern's behavior for the replacement field.
+///
+/// - `\uXXXX` and `\u{XXXX}` → the corresponding code point.
+/// - `\n`, `\t`, `\r`, `\\` → newline / tab / carriage return / backslash.
+/// - `\0`..`\9` are left untouched so `_resolveReplacement` can treat them as
+///   capture-group backreferences.
+String _decodeReplacementEscapes(String input) {
+  if (input.isEmpty || !input.contains('\\')) return input;
+
+  final out = StringBuffer();
+  var i = 0;
+  while (i < input.length) {
+    final c = input[i];
+    if (c != '\\' || i == input.length - 1) {
+      out.write(c);
+      i++;
+      continue;
+    }
+
+    final next = input[i + 1];
+
+    if (next == 'u') {
+      var consumed = false;
+      if (i + 2 < input.length && input[i + 2] == '{') {
+        final close = input.indexOf('}', i + 3);
+        if (close != -1) {
+          final code = int.tryParse(input.substring(i + 3, close), radix: 16);
+          if (code != null && code > 0 && code <= 0x10FFFF) {
+            out.write(String.fromCharCodes([code]));
+            i = close + 1;
+            consumed = true;
+          }
+        }
+      } else if (i + 5 < input.length) {
+        final hex = input.substring(i + 2, i + 6);
+        if (RegExp(r'^[0-9a-fA-F]{4}$').hasMatch(hex)) {
+          final code = int.tryParse(hex, radix: 16);
+          if (code != null && code > 0) {
+            out.write(String.fromCharCodes([code]));
+            i += 6;
+            consumed = true;
+          }
+        }
+      }
+      if (consumed) continue;
+      out.write(c);
+      i++;
+      continue;
+    }
+
+    // Digit following a backslash is a capture-group reference, not an escape.
+    if (RegExp(r'[0-9]').hasMatch(next)) {
+      out.write(c);
+      i++;
+      continue;
+    }
+
+    switch (next) {
+      case 'n':
+        out.write('\n');
+        i += 2;
+      case 't':
+        out.write('\t');
+        i += 2;
+      case 'r':
+        out.write('\r');
+        i += 2;
+      case '\\':
+        out.write(r'\');
+        i += 2;
+      default:
+        out.write(c);
+        i++;
+    }
+  }
+  return out.toString();
 }

--- a/lib/core/llm/studio_message_builder.dart
+++ b/lib/core/llm/studio_message_builder.dart
@@ -111,26 +111,56 @@ class StudioMessageBuilder {
         ? context.continueInstruction
         : null;
 
+    // Blocks flagged `appendToLastMessage` are merged into the last user-role
+    // history message instead of being emitted on their own (mirrors the
+    // classic non-Studio pipeline — see `applyAppendToLastMessage` in
+    // `prompt_builder.dart`). Their macros are expanded once here so the merged
+    // copy is identical to what a plain instruction block would have emitted.
+    final appendableEntries = <({String name, String content})>[];
+    for (final block in blocks) {
+      if (block.type != StudioBlockType.instruction) continue;
+      if (!block.appendToLastMessage) continue;
+      final content = _blockExpander
+          .expandStudioBlockContent(
+            block.content,
+            context: context,
+            priorBriefs: priorBriefs,
+            preset: studioPreset,
+          )
+          .trim();
+      if (content.isEmpty) continue;
+      _recordLorebookMacroClassifications(
+        block.content,
+        emittedLorebookClassifications,
+      );
+      appendableEntries.add((name: block.id, content: content));
+    }
+
     // Emits one chat-history block: depth-anchored blocks interleaved in, the
     // continue instruction (when set) pinned directly after the last chat
     // message, and per-message reasoning attached on the final writer's run.
     List<Map<String, dynamic>> emitHistory(List<PromptMessage> history) {
+      final mergedHistory = _applyAppendToLastMessage(history, appendableEntries);
       if (isFinalResponse &&
           (reasoningHistoryCount == -1 || reasoningHistoryCount > 0)) {
         return _historyWithReasoning(
-          history,
+          mergedHistory,
           reasoningHistoryCount,
           depthMessages: depthMessages,
           continueInstruction: continueInstruction,
         );
       }
       return insertContinueInstruction(
-        interleaveDepthWithHistory(history, depthMessages),
+        interleaveDepthWithHistory(mergedHistory, depthMessages),
         continueInstruction,
       ).map((m) => m.toApiMap()).toList();
     }
 
     for (final block in blocks) {
+      // appendToLastMessage blocks are already merged into the last user
+      // history message (see appendableEntries above) — do not emit them again
+      // as their own message.
+      if (block.appendToLastMessage) continue;
       // Type-based resolution takes precedence over mode/id. The codec sets
       // `type` and `contextSlot` correctly for every preset, but block ids vary
       // (final_chat_history, loom_chat_history, etc.) so id matching alone is
@@ -525,6 +555,43 @@ class StudioMessageBuilder {
     'runtime_dynamic' => StudioContextSlot.runtimeDynamic,
     _ => null,
   };
+
+  /// Appends the expanded contents of preset blocks flagged
+  /// `appendToLastMessage` to the last user-role history message, mirroring the
+  /// classic `applyAppendToLastMessage` in `prompt_builder.dart`. Studio history
+  /// messages are not flagged `isHistory`, so the last user turn is located by
+  /// `role` alone. No-op when there are no appendable entries or no user turn.
+  List<PromptMessage> _applyAppendToLastMessage(
+    List<PromptMessage> history,
+    List<({String name, String content})> appendableEntries,
+  ) {
+    if (appendableEntries.isEmpty || history.isEmpty) return history;
+
+    final lastUserIdx = history.lastIndexWhere((m) => m.role == 'user');
+    if (lastUserIdx < 0) return history;
+
+    final joined = appendableEntries
+        .map((b) => b.content.trim())
+        .where((s) => s.isNotEmpty)
+        .join('\n\n');
+    if (joined.isEmpty) return history;
+
+    final blockNames = appendableEntries
+        .map((b) => b.name.isNotEmpty ? b.name : 'block')
+        .join(', ');
+    final original = history[lastUserIdx];
+    final updated = <PromptMessage>[...history];
+    updated[lastUserIdx] = PromptMessage(
+      role: original.role,
+      content: '${original.content}\n\n$joined',
+      isHistory: original.isHistory,
+      blockName: '${original.blockName ?? 'Last user'} + $blockNames',
+      sourceMessageId: original.sourceMessageId,
+      reasoningContent: original.reasoningContent,
+      imagePath: original.imagePath,
+    );
+    return updated;
+  }
 
   List<Map<String, dynamic>> _historyWithReasoning(
     List<PromptMessage> history,

--- a/lib/core/models/studio_config.dart
+++ b/lib/core/models/studio_config.dart
@@ -90,6 +90,17 @@ abstract class StudioPresetBlock with _$StudioPresetBlock {
     /// blocks themselves.
     @Default('relative') String insertionMode,
     int? depth,
+
+    /// When true, this block's content (after macro expansion) is appended to
+    /// the last user-role message in the chat history at prompt-assembly time,
+    /// mirroring the classic (non-Studio) `PresetBlock.appendToLastMessage`
+    /// (see `preset.dart` and `applyAppendToLastMessage` in
+    /// `prompt_builder.dart`). The block's own [role] is ignored in this mode —
+    /// content is always merged into the last user message, and the block is
+    /// NOT additionally emitted as its own message. If no user message exists
+    /// in history, the block is silently dropped. Only meaningful for
+    /// `type: instruction` blocks; ignored on `history`/`context` blocks.
+    @Default(false) bool appendToLastMessage,
   }) = _StudioPresetBlock;
 
   factory StudioPresetBlock.fromJson(Map<String, dynamic> json) =>

--- a/lib/core/models/studio_preset_codec.dart
+++ b/lib/core/models/studio_preset_codec.dart
@@ -400,6 +400,7 @@ abstract final class StudioPresetCodec {
     groupBoundary: _string(json['groupBoundary'], 'none'),
     insertionMode: _string(json['insertionMode'], 'relative'),
     depth: json['depth'] is num ? (json['depth'] as num).toInt() : null,
+    appendToLastMessage: json['appendToLastMessage'] == true,
   );
 
   static String? _resolveLegacyTarget(String id, String title) {

--- a/lib/features/studio/widgets/studio_block_editor_inline.dart
+++ b/lib/features/studio/widgets/studio_block_editor_inline.dart
@@ -128,6 +128,16 @@ class StudioBlockEditorInline extends StatelessWidget {
         showIf: (item) =>
             item['mode'] == 'direct' && item['insertionMode'] == 'depth',
       ),
+      // Append-to-last-user-message: merge this block's (macro-expanded)
+      // content into the last user-role history message instead of emitting it
+      // as its own message — mirrors the classic preset's `appendToLastMessage`
+      // toggle. Only meaningful for instruction blocks.
+      GenericEditorField(
+        key: 'appendToLastMessage',
+        label: 'label_append_last_user'.tr(),
+        type: 'switch',
+        showIf: (item) => item['type'] == 'instruction',
+      ),
     ];
     if (headerPrompt) {
       fields

--- a/test/studio_typed_message_builder_test.dart
+++ b/test/studio_typed_message_builder_test.dart
@@ -440,4 +440,77 @@ void main() {
       'Second',
     ]);
   });
+
+  test('appendToLastMessage merges expanded content into the last user turn', () {
+    final messages = builder.buildAgentMessages(
+      agent: const StudioAgent(id: 'final'),
+      context: context,
+      config: config,
+      studioPreset: const StudioPreset(
+        id: 'studio',
+        blocks: [
+          StudioPresetBlock(
+            id: 'chat_history',
+            type: StudioBlockType.history,
+            mode: 'direct',
+            injectionPoint: 'final',
+            order: 1,
+          ),
+          StudioPresetBlock(
+            id: 'memory',
+            appendToLastMessage: true,
+            content: '<memory>{{char}}</memory>',
+            injectionPoint: 'final',
+            order: 2,
+          ),
+        ],
+      ),
+      priorBriefs: const [],
+      isFinalResponse: true,
+    );
+
+    expect(messages.map((message) => message['role']), ['user', 'assistant']);
+    expect(messages.first['content'], 'First\n\n<memory>Lucy</memory>');
+  });
+
+  test('appendToLastMessage is silently dropped when history has no user turn',
+      () {
+        final messages = builder.buildAgentMessages(
+          agent: const StudioAgent(id: 'final'),
+          context: const StudioContext(
+            slots: {},
+            history: [
+              PromptMessage(role: 'assistant', content: 'Only assistant'),
+            ],
+            sessionVars: {},
+            globalVars: {},
+            macroContext: MacroContext(charName: 'Lucy', charId: 'char', sessionId: 's'),
+            diagnostics: StudioContextDiagnostics(),
+          ),
+          config: config,
+          studioPreset: const StudioPreset(
+            id: 'studio',
+            blocks: [
+              StudioPresetBlock(
+                id: 'chat_history',
+                type: StudioBlockType.history,
+                mode: 'direct',
+                injectionPoint: 'final',
+              ),
+              StudioPresetBlock(
+                id: 'memory',
+                appendToLastMessage: true,
+                content: '<memory>Lucy</memory>',
+                injectionPoint: 'final',
+              ),
+            ],
+          ),
+          priorBriefs: const [],
+          isFinalResponse: true,
+        );
+
+        expect(messages.map((message) => message['content']), [
+          'Only assistant',
+        ]);
+      });
 }


### PR DESCRIPTION
## Studio: append-to-last-user-message

The classic (non-Studio) `PresetBlock.appendToLastMessage` lets a block's macro-expanded content be merged into the last user turn instead of being emitted as its own message. This ports that to Studio presets:

- Add `appendToLastMessage` to `StudioPresetBlock`.
- Read/write it through the preset codec (`_block` in `StudioPresetCodec`).
- In `StudioMessageBuilder`, collect instruction blocks flagged `appendToLastMessage`, skip them as standalone messages, and merge their expanded content into the last user-role history message in `emitHistory` (mirrors the classic `applyAppendToLastMessage`).
- Expose a `switch` field ("Append to last user message") in the inline Studio block editor, shown for instruction blocks.

## Regex: decode `\u`/`\n` escapes in Replace With

The `Replace With` replacement string was applied literally: `\uXXXX` and `\n` typed as text were not decoded (unlike SillyTavern). Add `_decodeReplacementEscapes` in `RegexService._applySingleScript` to decode `\uXXXX`, `\u{XXXX}`, `\n`, `\t`, `\r`, `\\`, while leaving `\0`-`\9` intact so `_resolveReplacement` still treats them as capture-group backreferences.

## Verification

- `dart run build_runner build` after the freezed/json model change.
- `dart analyze` clean.
- `flutter test` green for `studio_preset_codec_test.dart`, `append_to_last_message_test.dart`, `studio_typed_message_builder_test.dart` (33 tests).
- Not run: `test/webview_js` render suite (no Node/Playwright in this session) - left to CI.
