### PR TITLE
fix(chat): stop branching a rewrite-free chat from forking the card

### DIFF
--- a/docs/rules/database.md
+++ b/docs/rules/database.md
@@ -493,7 +493,25 @@ tracked via `SyncDeletionTracker.record('tracker_snapshot', sessionId)`.
 
 `ChatSessionService.branchSession` creates the branch, copies DB state,
 reconstructs live tracker rows, and updates the character's current session in
-one Drift transaction. Session baseline and
+one Drift transaction.
+
+The branch gets a **card of its own only when the session's card can already
+differ from the character it points at** — `ChatSessionBranchRepo`
+`requiresCardForkInTransaction`: a canon checkpoint past the root (a Card
+Rewriter apply or a rollback), a session lorebook overlay, or a source card
+that is itself a session-owned variant (`variantOrder != 0`), which a rewrite
+would edit in place and so must not be shared by two sessions. Then the branch
+forks the card at the latest surviving checkpoint, roots its own canon
+timeline, and lands on `${newCharacterId}_0`.
+
+With no rewrite behind it the branch keeps the source card and is a plain extra
+session on that character (`${charId}_$nextIndex`, the character's current
+session index moved onto it), with no character row, no revision row and no
+canon checkpoint: the first rewrite in either session forks the root card by
+itself (`ManualRewriteApplyRepo._forkSessionCharacter`). Branching a chat that
+never ran the Card Rewriter must not leave a variant behind.
+
+Session baseline and
 Studio configuration are copied as settings. Provenance-backed state is copied
 only when its complete source range is retained: tracker snapshots, character
 knowledge facts, reconciliation checkpoints, cleanup journals (copied with the

--- a/lib/core/db/repositories/chat_session_branch_repo.dart
+++ b/lib/core/db/repositories/chat_session_branch_repo.dart
@@ -36,6 +36,33 @@ class ChatSessionBranchRepo {
   final SessionCanonCheckpointRepo _checkpointRepo;
   final SessionLorebookEmbeddingJobRepo _embeddingJobRepo;
 
+  /// Whether a branch of [sourceSessionId] needs its own card variant.
+  ///
+  /// It does once the session's card can differ from the source character:
+  /// a rewrite has already been applied here (a checkpoint past the root, or
+  /// a session lorebook overlay), or the card is a session-owned variant that
+  /// the next rewrite would edit in place — a variant shared by two sessions
+  /// would let one branch rewrite the other's card.
+  ///
+  /// Otherwise the branch is just another session on the same card: the first
+  /// rewrite in either session forks the root card on its own
+  /// (`ManualRewriteApplyRepo._forkSessionCharacter`), so forking here only
+  /// buries the character list under variants no rewrite ever touched.
+  Future<bool> requiresCardForkInTransaction({
+    required Character sourceCharacter,
+    required String sourceSessionId,
+  }) async {
+    if (sourceCharacter.variantOrder != 0) return true;
+    final checkpoints = await _checkpointRepo.getForSession(sourceSessionId);
+    if (checkpoints.any((checkpoint) => checkpoint.sequence > 0)) return true;
+    final overlay =
+        await (db.select(db.sessionLorebookEvolutionRows)
+              ..where((row) => row.chatSessionId.equals(sourceSessionId))
+              ..limit(1))
+            .getSingleOrNull();
+    return overlay != null;
+  }
+
   Future<ChatSessionBranchResult> createInTransaction({
     required Character sourceCharacter,
     required ChatSession sourceSession,

--- a/lib/features/chat/chat_session_service.dart
+++ b/lib/features/chat/chat_session_service.dart
@@ -244,6 +244,40 @@ class ChatSessionService {
     });
   }
 
+  /// Inserts a branch that keeps the source card: a plain extra session on
+  /// that character, carrying the retained slice instead of a fresh greeting.
+  ///
+  /// Runs inside [branchSession]'s transaction, so it claims the index the
+  /// same way [_insertNewSession] does — insert-if-absent, stepping forward
+  /// while the id is taken — and moves the character's current session onto
+  /// the branch the user is about to be sent to.
+  Future<ChatSession> _insertBranchSession({
+    required Character character,
+    required ChatSession source,
+    required List<ChatMessage> retainedMessages,
+    required Map<String, String> sessionVars,
+  }) async {
+    final repo = _ref.read(chatRepoProvider);
+    final charRepo = _ref.read(characterRepoProvider);
+    var index = await _nextSessionIndex(character.id);
+    while (true) {
+      final session = ChatSession(
+        id: '${character.id}_$index',
+        characterId: character.id,
+        sessionIndex: index,
+        messages: retainedMessages,
+        sessionVars: sessionVars,
+        authorsNote: source.authorsNote,
+        updatedAt: currentTimestampSeconds(),
+      );
+      if (await repo.insertIfAbsent(session)) {
+        await charRepo.setCurrentSessionIndex(character.id, index);
+        return session;
+      }
+      index++;
+    }
+  }
+
   Future<ChatSession> branchSession(
     String charId,
     ChatSession current,
@@ -272,21 +306,39 @@ class ChatSessionService {
       if (character == null) {
         throw StateError('Character ${durableSource.characterId} not found');
       }
-      final branchResult = await _ref
-          .read(chatSessionBranchRepoProvider)
-          .createInTransaction(
-            sourceCharacter: character,
-            sourceSession: durableSource,
-            retainedMessages: durableSource.messages.sublist(
-              0,
-              durableIndex + 1,
-            ),
-            sessionVars: {
-              ...current.sessionVars,
-              'branchedAt': DateTime.now().millisecondsSinceEpoch.toString(),
-            },
+      final retainedMessages = durableSource.messages.sublist(
+        0,
+        durableIndex + 1,
+      );
+      final sessionVars = {
+        ...current.sessionVars,
+        'branchedAt': DateTime.now().millisecondsSinceEpoch.toString(),
+      };
+      // A branch only needs a card of its own once the Card Rewriter can have
+      // moved this session's card away from the character it points at. With
+      // no rewrite behind it the branch is a plain extra session on the same
+      // card, and the first rewrite in either session forks the card itself.
+      final branchRepo = _ref.read(chatSessionBranchRepoProvider);
+      final forksCard = await branchRepo.requiresCardForkInTransaction(
+        sourceCharacter: character,
+        sourceSessionId: durableSource.id,
+      );
+      final branchResult = forksCard
+          ? await branchRepo.createInTransaction(
+              sourceCharacter: character,
+              sourceSession: durableSource,
+              retainedMessages: retainedMessages,
+              sessionVars: sessionVars,
+            )
+          : null;
+      final branch =
+          branchResult?.session ??
+          await _insertBranchSession(
+            character: character,
+            source: durableSource,
+            retainedMessages: retainedMessages,
+            sessionVars: sessionVars,
           );
-      final branch = branchResult.session;
       final messageIds = branch.messages.map((message) => message.id).toSet();
       await _ref
           .read(characterSessionBaselineRepoProvider)
@@ -294,8 +346,10 @@ class ChatSessionService {
             fromSessionId: current.id,
             toSessionId: branch.id,
             characterId: branch.characterId,
-            baselineCardJson: branchResult.rootSnapshotJson,
-            baselineHash: branchResult.rootRevisionHash,
+            // Null keeps the source session's own baseline evidence, which is
+            // exactly the card an unforked branch inherits.
+            baselineCardJson: branchResult?.rootSnapshotJson,
+            baselineHash: branchResult?.rootRevisionHash,
           );
       await _ref
           .read(memoryBookRepoProvider)
@@ -332,18 +386,21 @@ class ChatSessionService {
             toSessionId: branch.id,
             messageIds: messageIds,
           );
-      final root = await _ref
-          .read(sessionCanonCheckpointRepoProvider)
-          .getLatest(branch.id);
-      await _ref
-          .read(chatSessionBranchRepoProvider)
-          .copyCanonTransitionsInTransaction(
-            sourceSessionId: current.id,
-            branchSessionId: branch.id,
-            branchCharacterId: branch.characterId,
-            branchRevisionHash: root!.characterRevisionHash,
-            sourceCheckpointSequence: branchResult.sourceCheckpointSequence,
-          );
+      // Only a forked branch has a canon timeline to inherit: an unforked one
+      // branches a session that never applied a rewrite, so there is neither a
+      // root checkpoint nor a transition to copy.
+      if (branchResult != null) {
+        final root = await _ref
+            .read(sessionCanonCheckpointRepoProvider)
+            .getLatest(branch.id);
+        await branchRepo.copyCanonTransitionsInTransaction(
+          sourceSessionId: current.id,
+          branchSessionId: branch.id,
+          branchCharacterId: branch.characterId,
+          branchRevisionHash: root!.characterRevisionHash,
+          sourceCheckpointSequence: branchResult.sourceCheckpointSequence,
+        );
+      }
       await _ref
           .read(ledgerReconciliationCheckpointRepoProvider)
           .copyForSessionBranch(

--- a/lib/features/chat/widgets/message_actions.dart
+++ b/lib/features/chat/widgets/message_actions.dart
@@ -101,7 +101,11 @@ void showMessageContextMenu({
                 .read(chatProvider(charId).notifier)
                 .branchSession(messageIndex);
             if (branch != null && context.mounted) {
-              context.go('/chat/${branch.characterId}?session=0');
+              // A branch that kept the source card lands on that character's
+              // next session index, not on 0.
+              context.go(
+                '/chat/${branch.characterId}?session=${branch.sessionIndex}',
+              );
             }
           },
         ),

--- a/test/chat_session_branch_transaction_test.dart
+++ b/test/chat_session_branch_transaction_test.dart
@@ -308,9 +308,27 @@ void main() {
           .read(_serviceProvider)
           .branchSession('c1', current, 1);
 
-      expect(branch.id, '${branch.characterId}_0');
-      expect(branch.characterId, isNot('c1'));
-      expect(branch.sessionIndex, 0);
+      // No rewrite ran in the source session, so the branch keeps its card
+      // and is just the character's next session.
+      expect(branch.characterId, 'c1');
+      expect(branch.id, 'c1_2');
+      expect(branch.sessionIndex, 2);
+      expect(
+        await container.read(characterRepoProvider).getAll(),
+        hasLength(1),
+      );
+      expect(
+        await container
+            .read(characterRevisionRepoProvider)
+            .getForCharacter('c1'),
+        isEmpty,
+      );
+      expect(
+        await container
+            .read(sessionCanonCheckpointRepoProvider)
+            .getForSession(branch.id),
+        isEmpty,
+      );
       expect(branch.messages.map((message) => message.id), ['m0', 'm1']);
       expect(
         (await container.read(chatRepoProvider).getById(branch.id))?.id,
@@ -319,7 +337,7 @@ void main() {
       expect(
         (await container.read(characterRepoProvider).getById('c1'))!
             .currentSessionIndex,
-        0,
+        2,
       );
       expect(
         (await container.read(chatRepoProvider).getById('c1_1'))!
@@ -332,14 +350,9 @@ void main() {
       final baseline = await container
           .read(characterSessionBaselineRepoProvider)
           .getBySessionId(branch.id);
-      final branchRoot =
-          (await container
-                  .read(characterRevisionRepoProvider)
-                  .getForCharacter(branch.characterId))
-              .single;
-      expect(baseline?.baselineHash, branchRoot.revisionHash);
-      expect(baseline?.baselineCardJson, branchRoot.snapshotJson);
-      expect(baseline?.characterId, branch.characterId);
+      expect(baseline?.baselineHash, 'baseline-hash');
+      expect(baseline?.baselineCardJson, '{"name":"baseline"}');
+      expect(baseline?.characterId, 'c1');
       expect(
         baseline?.cardUpdatePolicy,
         CharacterCardUpdatePolicy.pinnedBaseline,
@@ -506,6 +519,89 @@ void main() {
     )..where((row) => row.sessionId.equals('c1_0'))).get();
     expect(sourceManifests, hasLength(4));
     expect(await manifests.getVariationAcceptances('c1_0'), hasLength(2));
+  });
+
+  test('branch forks the card for a session-owned variant', () async {
+    await container
+        .read(characterRepoProvider)
+        .put(
+          const Character(
+            id: 'c1',
+            name: 'Character',
+            currentSessionIndex: 0,
+            variantGroupId: 'group',
+            variantName: 'Session 1',
+            variantOrder: 1,
+          ),
+        );
+    final current = ChatSession(
+      id: 'c1_0',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: [_message('m0'), _message('m1')],
+    );
+    await container.read(chatRepoProvider).put(current);
+
+    final branch = await container
+        .read(_serviceProvider)
+        .branchSession('c1', current, 0);
+
+    // The variant is the source session's own card: a shared one would let a
+    // rewrite in the branch edit the card the source session is still using.
+    expect(branch.characterId, isNot('c1'));
+    expect(branch.id, '${branch.characterId}_0');
+    final forked = await container
+        .read(characterRepoProvider)
+        .getById(branch.characterId);
+    expect(forked?.variantGroupId, 'group');
+    expect(forked?.variantOrder, 2);
+    expect(
+      (await container
+              .read(sessionCanonCheckpointRepoProvider)
+              .getForSession(branch.id))
+          .single
+          .sequence,
+      0,
+    );
+  });
+
+  test('branch forks the card for an evolved lorebook entry', () async {
+    final current = ChatSession(
+      id: 'c1_0',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: [_message('m0'), _message('m1')],
+    );
+    await container.read(chatRepoProvider).put(current);
+    await db
+        .into(db.sessionLorebookEvolutionRows)
+        .insert(
+          SessionLorebookEvolutionRowsCompanion.insert(
+            chatSessionId: current.id,
+            lorebookId: 'book',
+            entryId: 'entry',
+            baseContent: 'base',
+            baseContentHash: CardCanonicalizer.scalarSha256('base'),
+            content: 'evolved',
+            contentHash: CardCanonicalizer.scalarSha256('evolved'),
+            createdAt: 1,
+            updatedAt: 2,
+          ),
+        );
+
+    final branch = await container
+        .read(_serviceProvider)
+        .branchSession('c1', current, 0);
+
+    expect(branch.characterId, isNot('c1'));
+    final overlay = await container
+        .read(sessionLorebookEvolutionRepoProvider)
+        .getByTarget(
+          sessionId: branch.id,
+          lorebookId: 'book',
+          entryId: 'entry',
+        );
+    expect(overlay?.content, 'evolved');
   });
 
   test('branch roots card and lore at latest surviving checkpoint', () async {


### PR DESCRIPTION
Branching a chat always forked a character variant, so a chat that never ran the Card Rewriter — Studio off, no rewrite ever applied — left a `Branch from X` card behind on every branch and buried the character list under variants nothing had ever edited.

The fork is not needed there: `ManualRewriteApplyRepo._forkSessionCharacter` already forks a root card (`variantOrder == 0`) lazily, on the first rewrite that would edit it, and rebinds that session to the fork. Forking up front only mattered for a session whose card can already differ from the character it points at.

## Changes

- `ChatSessionBranchRepo.requiresCardForkInTransaction` decides whether a branch needs its own card: a canon checkpoint past the root (a rewrite apply or a rollback), a session lorebook overlay, or a source card that is itself a session-owned variant (`variantOrder != 0`) — a variant is edited in place by a rewrite, so two sessions must never share one.
- `ChatSessionService.branchSession` takes the forked path only when that returns true; the forked branch is unchanged (card rooted at the latest surviving checkpoint, own canon root, `${newCharacterId}_0`).
- `ChatSessionService._insertBranchSession` handles the other case: the branch is a plain extra session on the same character — `${charId}_$nextIndex` with the retained slice, `branchedAt`, and the author's note, claiming its index the way `_insertNewSession` does and moving the character's current session onto it. No character row, no revision row, no canon checkpoint.
- An unforked branch keeps the source session's own baseline evidence (`CharacterSessionBaselineRepo.copyForSessionBranch` with a null card/hash), and canon transitions are inherited only by a forked branch, which is the only one with a timeline to inherit.
- The Branch action in `message_actions.dart` opens `?session=${branch.sessionIndex}` instead of a hardcoded `?session=0`, which would otherwise land on the wrong chat.
- `docs/rules/database.md` § Session branch policy documents the fork rule.

The Studio enabled flag deliberately does not enter the condition: with Studio on but no rewrite applied, the card has still not diverged, and the first rewrite forks it on its own.

## Verification

Flutter 3.44.9 installed in the agent container, `dart run build_runner build` and the easy_localization generator run as CI does.

- `flutter analyze --no-fatal-infos --no-fatal-warnings` — no issues on the changed files; the tree's 9 pre-existing infos/warnings are untouched.
- `flutter test test/chat_session_branch_transaction_test.dart` — 6/6. The existing "durable, current, provenance-filtered, and isolated" case now asserts the no-fork outcome (branch on `c1`, no second character row, no revision row, no checkpoint, source baseline kept), and two cases were added for the fork that must stay: a session-owned variant (new card in the same group, `variantOrder` 2, own canon root) and an evolved lorebook entry. The checkpoint-timeline case is unchanged and still forks.
- Full `flutter test` — green. The first run of this PR was red on `prompt_build_architecture_test.dart` › "Studio request assembly excludes ordinary prompt artifacts", which was failing on the base commit too and is fixed by #387; this branch has since been rebased onto `nightly` carrying that fix, and all three checks pass on the current head.
- The WebView render suite was not run locally — no assets in `assets/chat_webview/` are involved — and it is green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137NTHNxY3UPZ4iwrnyW1jU