### PR TITLE
fix(studio): keep prompt_builder.dart out of the Studio assembly files

### DIFF
--- a/lib/core/llm/studio_message_builder.dart
+++ b/lib/core/llm/studio_message_builder.dart
@@ -113,9 +113,10 @@ class StudioMessageBuilder {
 
     // Blocks flagged `appendToLastMessage` are merged into the last user-role
     // history message instead of being emitted on their own (mirrors the
-    // classic non-Studio pipeline — see `applyAppendToLastMessage` in
-    // `prompt_builder.dart`). Their macros are expanded once here so the merged
-    // copy is identical to what a plain instruction block would have emitted.
+    // classic non-Studio pipeline — see `applyAppendToLastMessage` in the
+    // ordinary prompt builder). Their macros are expanded once here so the
+    // merged copy is identical to what a plain instruction block would have
+    // emitted.
     final appendableEntries = <({String name, String content})>[];
     for (final block in blocks) {
       if (block.type != StudioBlockType.instruction) continue;
@@ -558,9 +559,10 @@ class StudioMessageBuilder {
 
   /// Appends the expanded contents of preset blocks flagged
   /// `appendToLastMessage` to the last user-role history message, mirroring the
-  /// classic `applyAppendToLastMessage` in `prompt_builder.dart`. Studio history
-  /// messages are not flagged `isHistory`, so the last user turn is located by
-  /// `role` alone. No-op when there are no appendable entries or no user turn.
+  /// classic `applyAppendToLastMessage` in the ordinary prompt builder. Studio
+  /// history messages are not flagged `isHistory`, so the last user turn is
+  /// located by `role` alone. No-op when there are no appendable entries or no
+  /// user turn.
   List<PromptMessage> _applyAppendToLastMessage(
     List<PromptMessage> history,
     List<({String name, String content})> appendableEntries,


### PR DESCRIPTION
`prompt_build_architecture_test.dart` › "Studio request assembly excludes ordinary prompt artifacts" fails on `nightly` (824e4ef), so CI is red on every PR opened against it — including #386, whose diff does not touch `lib/core/llm/` at all.

The test forbids the literal string `prompt_builder.dart` in the six Studio request-assembly files, so the ordinary prompt path cannot creep back into them. `lib/core/llm/studio_message_builder.dart` names it in two comments added by #385 (lines 115 and 559). There is no import and no `PromptPayload` / `PromptResult` use — it is the wording alone that trips the contract.

## Changes

- reword the two `appendToLastMessage` comments in `StudioMessageBuilder` to point at "the ordinary prompt builder" instead of naming `prompt_builder.dart`, and rewrap the affected lines

The test itself is left exactly as strict as it was, and no behaviour changes: the diff is two comments.

## Verification

- Reproduced the failure first on the base commit 824e4ef (`flutter test test/prompt_build_architecture_test.dart` → `+3 -1`), then confirmed the same file passes with the change (`+4`).
- `flutter test test/studio_typed_message_builder_test.dart` — 16/16, so the `appendToLastMessage` path the comments describe is still covered.
- `flutter analyze --no-fatal-infos --no-fatal-warnings lib/core/llm/studio_message_builder.dart` — no issues.
- `dart format` was deliberately **not** run on the file: it rewrites it wholesale on the base commit too, so running it here would bury a two-comment fix under an unrelated reformat. CI has no formatting step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137NTHNxY3UPZ4iwrnyW1jU

---
_Generated by [Claude Code](https://claude.ai/code/session_0137NTHNxY3UPZ4iwrnyW1jU)_