### PR TITLE
fix(regex): let a script tick both display-only and prompt-only

### DIFF
--- a/lib/core/llm/regex_service.dart
+++ b/lib/core/llm/regex_service.dart
@@ -49,8 +49,22 @@ String applyRegexes(
         continue;
       }
     }
-    if (script.promptOnly && !isPrompt) continue;
-    if (script.markdownOnly && !isMarkdown) continue;
+    // ST semantics: "Only Format Display" (markdownOnly) and "Only Format
+    // Prompt" (promptOnly) are two independent opt-ins, not one exclusive
+    // switch — `getRegexedString` ORs the two clauses. A script that ticks
+    // both therefore runs in the display pass *and* in the prompt pass.
+    // Requiring both at once made such a script dead everywhere, because no
+    // caller passes `isMarkdown` and `isPrompt` together.
+    //
+    // The storage pass (run-on-edit) passes neither flag, and still skips
+    // both kinds: a display- or prompt-scoped rewrite must never be baked
+    // into the stored message.
+    if (script.promptOnly || script.markdownOnly) {
+      final wantsThisPass =
+          (script.promptOnly && isPrompt) ||
+          (script.markdownOnly && isMarkdown);
+      if (!wantsThisPass) continue;
+    }
 
     final sEphemerality = script.ephemerality;
     if (!ignoreEphemerality &&

--- a/lib/core/state/active_regex_provider.dart
+++ b/lib/core/state/active_regex_provider.dart
@@ -26,5 +26,13 @@ final activeRegexesProvider = FutureProvider<List<PresetRegex>>((ref) async {
 
 final displayRegexesProvider = FutureProvider<List<PresetRegex>>((ref) async {
   final all = await ref.watch(activeRegexesProvider.future);
-  return all.where((r) => r.ephemerality.contains(1) && !r.promptOnly).toList();
+  // "Only Format Prompt" keeps a script out of the display pass — unless it
+  // also ticks "Only Format Display", which opts it into both passes (ST ORs
+  // the two flags; see [applyRegexes]).
+  return all
+      .where(
+        (r) =>
+            r.ephemerality.contains(1) && (!r.promptOnly || r.markdownOnly),
+      )
+      .toList();
 });

--- a/test/regex_service_test.dart
+++ b/test/regex_service_test.dart
@@ -129,6 +129,61 @@ void main() {
       expect(prompt, equals('aYb'));
     });
 
+    test(
+      'markdownOnly + promptOnly runs in both passes, never on stored text',
+      () {
+        // The pair a user imports to swap spaces for U+2007 on the way out and
+        // back on the way in: the "return" half ticks both "Only Format
+        // Display" and "Only Format Prompt". ST ORs the two flags, so it must
+        // fire in the display pass and in the prompt pass alike.
+        final script = PresetRegex.fromJson({
+          'id': 'both-only',
+          'name': 'Return Normal Spaces',
+          'regex': '/\u2007/g',
+          'replacement': ' ',
+          'markdownOnly': true,
+          'promptOnly': true,
+          'placement': [1, 2],
+          'ephemerality': [1, 2],
+        });
+
+        const input = 'a\u2007b';
+
+        expect(
+          applyRegexes(input, 2, 2, [script], ctx(), isPrompt: true),
+          equals('a b'),
+        );
+        expect(
+          applyRegexes(input, 2, 1, [script], ctx(), isMarkdown: true),
+          equals('a b'),
+        );
+        // Storage pass (run-on-edit): neither flag is set, so the rewrite must
+        // not be baked into the message.
+        expect(applyRegexes(input, 2, 1, [script], ctx()), equals(input));
+      },
+    );
+
+    test('promptOnly script rewrites spaces to figure spaces in the prompt', () {
+      final script = PresetRegex.fromJson({
+        'id': 'figure-spaces',
+        'name': 'Use Figure Spaces',
+        'regex': '/ /g',
+        'replacement': '\u2007',
+        'promptOnly': true,
+        'placement': [1, 2],
+        'ephemerality': [1, 2],
+      });
+
+      expect(
+        applyRegexes('a b', 2, 2, [script], ctx(), isPrompt: true),
+        equals('a\u2007b'),
+      );
+      expect(
+        applyRegexes('a b', 2, 1, [script], ctx(), isMarkdown: true),
+        equals('a b'),
+      );
+    });
+
     test('World Info placement 5 applies to lorebook blocks', () {
       final script = PresetRegex.fromJson({
         'id': 'wi-only',


### PR DESCRIPTION
SillyTavern treats "Only Format Display" (`markdownOnly`) and "Only Format Prompt" (`promptOnly`) as two independent opt-ins and ORs them — `getRegexedString` in `public/scripts/extensions/regex/engine.js`:

```js
(script.markdownOnly && isMarkdown) ||
(script.promptOnly && isPrompt) ||
(!script.markdownOnly && !script.promptOnly && !isMarkdown && !isPrompt)
```

Glaze required both at once (`&&`-of-negatives), and no caller ever passes `isMarkdown` and `isPrompt` together — `ChatMessageMapper.toMap` passes only `isMarkdown: true`, `applyPromptRegexes` only `isPrompt: true`. A script with both flags was therefore dead in every pass. An imported pair such as "Use Figure Spaces" / "Return Normal Spaces" swapped spaces for U+2007 in the outgoing prompt but never swapped them back for display.

## Changes

- `applyRegexes` (`lib/core/llm/regex_service.dart`) now runs a script when *either* opt-in matches the current pass, mirroring ST. The storage pass (run-on-edit, neither flag set) still skips both kinds, so a display rewrite is never baked into the stored message.
- `displayRegexesProvider` (`lib/core/state/active_regex_provider.dart`) stops dropping a `promptOnly` script that also ticks `markdownOnly` — that second gate kept such a script out of the display list even with the engine fixed.

## Verification

- Added `test/regex_service_test.dart` cases: a `markdownOnly + promptOnly` script fires in the display pass and in the prompt pass but not in the storage pass, and the `promptOnly` half of the pair rewrites spaces only in the prompt.
- Flag semantics checked against the SillyTavern sources (`engine.js` `getRegexedString`, plus the `isMarkdown: true` / `isPrompt: true` call sites in `public/script.js`).
- `flutter analyze` and `flutter test` were **not** run — no Flutter SDK in the agent environment; relying on CI for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeAHpjepbusNwo4X5DQDsp

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeAHpjepbusNwo4X5DQDsp)_