### PR TITLE
fix(chat): build the WebView settings once per surface, not per rebuild

### DIFF
--- a/lib/features/chat/widgets/chat_webview_preload.dart
+++ b/lib/features/chat/widgets/chat_webview_preload.dart
@@ -17,6 +17,10 @@ class ChatWebViewPreloader extends StatefulWidget {
 class _ChatWebViewPreloaderState extends State<ChatWebViewPreloader> {
   bool _preloaded = false;
 
+  /// Same reasoning as the chat surface: allocate the settings once instead
+  /// of on every rebuild of the preloader.
+  late final InAppWebViewSettings _webViewSettings = chatWebViewInAppSettings();
+
   @override
   Widget build(BuildContext context) {
     // Skip webview preloading on Windows and Linux (no InAppWebView
@@ -41,7 +45,7 @@ class _ChatWebViewPreloaderState extends State<ChatWebViewPreloader> {
                   keepAlive: chatWebViewKeepAlive,
                   initialFile: chatWebViewInitialFile(),
                   initialUrlRequest: chatWebViewInitialUrlRequest(),
-                  initialSettings: chatWebViewInAppSettings(),
+                  initialSettings: _webViewSettings,
                   onLoadStop: (_, _) {
                     if (mounted) setState(() => _preloaded = true);
                   },

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -95,6 +95,12 @@ class ChatWebViewSurface extends ConsumerStatefulWidget {
 class _ChatWebViewSurfaceState extends ConsumerState<ChatWebViewSurface> {
   bool _mountNativeView = !Platform.isWindows;
 
+  /// Built once per surface. [InAppWebViewSettings] is only read when the
+  /// platform view is first created, but every rebuild used to allocate a
+  /// fresh one — along with the WebViewAssetLoader/AssetsPathHandler it
+  /// carries, which register with the plugin and are never released.
+  late final InAppWebViewSettings _webViewSettings = chatWebViewInAppSettings();
+
   @override
   void initState() {
     super.initState();
@@ -247,7 +253,7 @@ class _ChatWebViewSurfaceState extends ConsumerState<ChatWebViewSurface> {
                       keepAlive: chatWebViewKeepAliveForPlatform(),
                       initialFile: chatWebViewInitialFile(),
                       initialUrlRequest: chatWebViewInitialUrlRequest(),
-                      initialSettings: chatWebViewInAppSettings(),
+                      initialSettings: _webViewSettings,
                       onWebViewCreated: _onWebViewCreated,
                       onLoadStop: _onLoadStop,
                       shouldOverrideUrlLoading: (controller, request) async {


### PR DESCRIPTION
`initialSettings:` called `chatWebViewInAppSettings()` from inside `build()`, so every rebuild of the chat surface allocated a fresh `InAppWebViewSettings` together with the `WebViewAssetLoader` and `AssetsPathHandler` it carries. Those are platform-interface objects — constructing one registers it with the plugin, and only the instance handed to the platform view at creation time is ever used, so every later allocation was registered and then dropped without being released.

## Changes

- `chat_webview_surface.dart`: hold the settings in a `late final` field built once per surface instead of calling `chatWebViewInAppSettings()` on every build.
- `chat_webview_preload.dart`: same pattern in the preloader, which rebuilt its settings on every build until the preload finished.

## Verification

Profile build on a Pixel 8 Pro emulator (Android 16, x86_64) with a seeded 600-message chat, driven over adb; heap sampled through the Dart VM service with `getAllocationProfile(gc: true)`.

- Before, per 10 chat open/close cycles: `AssetsPathHandler` +192, +195, +190 (`MethodChannel`, `_Channel`, `_ChannelCallbackRecord`, `ListQueue` track it one-for-one) — linear over 30 cycles and unchanged across five consecutive forced GCs, so the objects are retained rather than uncollected.
- After: +10, +10, +10 over the same 30 cycles. Dart heap growth over 10 cycles drops from ~150-410 KB to ~8 KB.
- `flutter analyze` — 9 issues, all info/warning, identical to the `nightly` baseline and none in the touched files.
- `flutter test` — 3812 pass. The 4 failures (`agent_ops_localization_contract_test.dart`, three clipboard cases in `chat_input_bar_test.dart`) reproduce on unpatched `nightly` and are local-only: the contract test needs the `easy_localization:generate` step CI runs, and the clipboard cases pass in CI on ubuntu.

One settings object per surface mount is still never released; that disposal belongs to the plugin side and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)