### PR TITLE
fix(chat): share one WebView asset loader instead of one per mount

### DIFF
--- a/lib/features/chat/bridge/chat_webview_settings.dart
+++ b/lib/features/chat/bridge/chat_webview_settings.dart
@@ -52,12 +52,20 @@ String? chatWebViewAndroidAssetUrl() {
 }
 
 /// Android [WebViewAssetLoader] for bundled chat assets, or `null` elsewhere.
+/// One loader for the whole app. The chat WebView is kept alive and reused
+/// ([chatWebViewKeepAliveForPlatform]), and the plugin only parses
+/// `initialSettings` when it actually builds a new native WebView — a
+/// keep-alive reuse skips `FlutterWebView` entirely. A per-mount handler would
+/// therefore register a MethodChannel that the native side never calls, and
+/// nothing disposes it.
+WebViewAssetLoader? _sharedChatAssetLoader;
+
 WebViewAssetLoader? chatWebViewAssetLoader() {
   if (!chatWebViewUsesAndroidAssetLoader()) return null;
   // Bundled chat assets only. Local Glaze files are served by the loopback
   // HTTP server started in [initChatWebViewEnvironment] — not
   // [InternalStoragePathHandler], which crashes on 6.1.5 (#1980 / #2451).
-  return WebViewAssetLoader(
+  return _sharedChatAssetLoader ??= WebViewAssetLoader(
     pathHandlers: [AssetsPathHandler(path: '/assets/')],
   );
 }


### PR DESCRIPTION
Follow-up to #390, which cut the per-rebuild allocation but left one leaked `AssetsPathHandler` per chat surface mount.

`chatWebViewAssetLoader()` built a fresh `WebViewAssetLoader` on every call. Each `AssetsPathHandler` registers a `MethodChannel` under a unique name in its `_init` and installs a method call handler on the binary messenger; nothing disposes it, and the binding's handler map holds it for the process lifetime.

On Android the chat WebView is kept alive and reused. `FlutterWebViewFactory.create` returns the cached `FlutterWebView` for a known `keepAliveId` and only constructs a new one — the only place `initialSettings` is parsed — when there is no cached instance. Every mount after the first therefore handed the native side settings it never reads, while the handler they carried stayed registered on the Dart side.

Disposing per mount would be the wrong shape: whichever mount created the native WebView owns the live handler, and in practice that is the preloader, not the surface. Sharing one loader sidesteps the ownership question entirely — the native side only ever uses one, and `handle()` is stateless.

## Changes

- `chat_webview_settings.dart`: `chatWebViewAssetLoader()` returns a lazily created shared `WebViewAssetLoader` instead of a new one per call.

## Verification

Profile build on a Pixel 8 Pro emulator (Android 16, x86_64) with a seeded 600-message chat, driven over adb; heap sampled through the Dart VM service with `getAllocationProfile(gc: true)`.

- `AssetsPathHandler` across 30 chat open/close cycles: `1 → 1 → 1 → 1` (+0, +0, +0). `MethodChannel` flat at 23. For comparison: +190 per 10 cycles before #390, +10 after it.
- Dart heap over the same 30 cycles: 88,342,144 → 88,342,272 → 88,341,920 bytes — flat.
- Cold start into the chat renders correctly: styles, italics, quote colouring, avatars, Context card. No asset-loading or console errors in logcat, so the shared handler serves `appassets.androidplatform.net` as before.
- `flutter analyze` — 9 issues, all info/warning, identical to the `nightly` baseline, 0 errors.
- `flutter test` — 3812 pass, including `chat_webview_keep_alive_test.dart` and `chat_webview_security_test.dart`, which cover these settings helpers. The same 4 failures as on unpatched `nightly` remain and are local-only (the contract test needs CI's `easy_localization:generate` step; the clipboard cases pass in CI on ubuntu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)