### PR TITLE
fix(catalog): import the card definition into description, not personality

### DIFF
--- a/lib/features/catalog/services/chub_provider.dart
+++ b/lib/features/catalog/services/chub_provider.dart
@@ -152,8 +152,11 @@ CharacterData _convertToGlaze(Map<String, dynamic> node) {
 
   return CharacterData(
     name: (def['name'] ?? node['name'] ?? 'Unknown') as String,
-    description: '',
-    personality: (def['personality'] ?? '') as String,
+    // Chub's `personality` IS the card body, `tavern_personality` is the V2
+    // personality field, and `description` is the storefront tagline (kept in
+    // creatorNotes below).
+    description: (def['personality'] ?? '') as String,
+    personality: (def['tavern_personality'] ?? '') as String,
     scenario: (def['scenario'] ?? '') as String,
     firstMes: (def['first_message'] ?? '') as String,
     mesExample: (def['example_dialogs'] ?? '') as String,

--- a/lib/features/catalog/services/datacat_provider.dart
+++ b/lib/features/catalog/services/datacat_provider.dart
@@ -280,9 +280,11 @@ String _stripDatacatMarkers(String text) {
 /// SillyTavern-CharacterLibrary reference. For JanitorAI-source rows the real
 /// definition is in `personality` and the website blurb (often HTML) is in
 /// `description`; Saucepan rows overload `description` / recovery variants. We
-/// keep the definition in [CharacterData.personality] and the blurb in
-/// [CharacterData.creatorNotes] — consistent with the JanitorAI provider, so the
-/// blurb never lands in the prompt body.
+/// keep the definition in [CharacterData.description] and the blurb in
+/// [CharacterData.creatorNotes] — the same placement `buildV2FromDatacat` uses
+/// (definition into `data.description`, `data.personality` left empty), so
+/// `{{description}}` resolves to the prompt body and the blurb never lands in
+/// it.
 CharacterData _datacatCharacterData(Map<String, dynamic> char) {
   String s(dynamic v) => v == null ? '' : v.toString();
   String pick(List<String> xs) =>
@@ -331,8 +333,8 @@ CharacterData _datacatCharacterData(Map<String, dynamic> char) {
 
   return CharacterData(
     name: name.isEmpty ? 'Unknown' : name,
-    description: '',
-    personality: definition,
+    description: definition,
+    personality: '',
     scenario: scenario,
     firstMes: firstMes,
     mesExample:

--- a/lib/features/catalog/services/janitor_provider.dart
+++ b/lib/features/catalog/services/janitor_provider.dart
@@ -443,13 +443,13 @@ DownloadedCharacter _convertToGlaze(Map<String, dynamic> m) {
   return DownloadedCharacter(
     charData: CharacterData(
       name: (m['name'] ?? m['chat_name'] ?? 'Unknown') as String,
-      description: '',
       // Only take the real definition field. A CLOSED card hides `personality`,
-      // so falling back to `description` here would dump the public bio/blurb
-      // (often HTML) into the prompt. The bio is already surfaced via
-      // creatorNotes below; leaving personality empty correctly signals that the
-      // definition is unavailable without local extraction.
-      personality: (m['personality'] ?? '') as String,
+      // so falling back to the row's `description` here would dump the public
+      // bio/blurb (often HTML) into the prompt. The bio is already surfaced via
+      // creatorNotes below; leaving the definition empty correctly signals that
+      // it is unavailable without local extraction.
+      description: (m['personality'] ?? '') as String,
+      personality: '',
       scenario: (m['scenario'] ?? '') as String,
       firstMes: (m['first_message'] ?? m['first_mes'] ?? '') as String,
       mesExample:

--- a/lib/features/catalog/services/janny_provider.dart
+++ b/lib/features/catalog/services/janny_provider.dart
@@ -245,8 +245,10 @@ Future<DownloadedCharacter> jannyFetchCharacter(String characterId, String? slug
   return DownloadedCharacter(
     charData: CharacterData(
       name: (character['name'] ?? 'Unnamed') as String,
-      description: '',
-      personality: (character['personality'] ?? '') as String,
+      // Janny keeps the definition in `personality` and the blurb in
+      // `description`; the definition goes to the prompt body field.
+      description: (character['personality'] ?? '') as String,
+      personality: '',
       scenario: (character['scenario'] ?? '') as String,
       firstMes: (character['firstMessage'] ?? '') as String,
       mesExample: (character['exampleDialogs'] ?? '') as String,

--- a/lib/features/catalog/widgets/catalog_detail_launcher.dart
+++ b/lib/features/catalog/widgets/catalog_detail_launcher.dart
@@ -235,7 +235,7 @@ class _CatalogDetailLauncherState
         },
       );
       final data = res.charData;
-      if (data == null || data.personality.trim().isEmpty) return null;
+      if (data == null || data.description.trim().isEmpty) return null;
       return _datacatResult = DownloadedCharacter(
         charData: data,
         avatarUrl: res.avatarUrl,
@@ -251,20 +251,20 @@ class _CatalogDetailLauncherState
   Character _toCharacter(DownloadedCharacter d) {
     final data = d.charData;
     // A closed JanitorAI definition hides the real prompt (it isn't in the
-    // public card, only in the blurb which we keep out of personality). Show a
-    // hint in the preview's prompt slot instead of a blank field. Display-only:
-    // _doImport imports `downloaded` (empty personality), not this preview
-    // object, so the hint text is never written to the library.
+    // public card, only in the blurb which we keep out of the description).
+    // Show a hint in the preview's prompt slot instead of a blank field.
+    // Display-only: _doImport imports `downloaded` (empty description), not
+    // this preview object, so the hint text is never written to the library.
     final janitorClosed =
         widget.provider == CatalogProvider.janitor && !_definitionPublic;
-    final personality = janitorClosed && data.personality.trim().isEmpty
+    final description = janitorClosed && data.description.trim().isEmpty
         ? 'catalog_janitor_closed_prompt'.tr()
-        : data.personality;
+        : data.description;
     return Character(
       id: 'preview:${widget.item.id}',
       name: data.name.isEmpty ? widget.item.name : data.name,
-      description: data.description,
-      personality: personality,
+      description: description,
+      personality: data.personality,
       scenario: data.scenario,
       firstMes: data.firstMes,
       mesExample: data.mesExample,


### PR DESCRIPTION
Every catalog provider that reads a site API wrote the character definition into `CharacterData.personality` and left `description` empty, while the local extractors (`janitor_extractor.dart`, `saucepan_extractor.dart`) and the PNG/JSON importer (`character_importer.dart`) put it into `description`. A preset that only references `{{description}}` — the field SillyTavern fills from `data.description`, and what most imported presets use — therefore built a prompt with no character definition at all.

This aligns the API providers with the local paths, with SillyTavern's `getCharacterCardFields()`, and with `buildV2FromDatacat` in the SillyTavern-CharacterLibrary reference (definition into `data.description`, `data.personality` left empty).

## Changes

- `datacat_provider.dart` — `_datacatCharacterData` returns the resolved definition as `description` and leaves `personality` empty; doc comment updated to describe the new placement. The definition-picking logic (Saucepan branch, recovery variants, `chara_card_v2_json` fallback) is unchanged.
- `janitor_provider.dart` — `_convertToGlaze` maps the row's `personality` (the real definition) to `description`. Still no fallback to the row's `description`: that is the public HTML blurb and stays in `creatorNotes`, so a closed card imports with an empty definition rather than a bio in the prompt body.
- `chub_provider.dart` — `_convertToGlaze` maps `definition.personality` to `description`, and additionally maps `definition.tavern_personality` to `personality`, which is the actual V2 personality field and was previously dropped.
- `janny_provider.dart` — `jannyFetchCharacter` maps `personality` to `description`.
- `catalog_detail_launcher.dart` — the preview follows: the "does the DataCat copy carry the prompt?" check in `_datacatCard` and the closed-JanitorAI-card placeholder in `_toCharacter` now read `description`.

## Notes

- Characters imported before this change still hold the definition in `personality`; no migration is included.

## Verification

- `flutter analyze lib/features/catalog` — no new issues (the two `unused_element` warnings in `janitor_lorebook_capture_sheet.dart` are pre-existing and in an untouched file).
- `flutter test test/janitor_field_diff_test.dart test/catalog_provider_switch_race_test.dart test/janitor_separate_test.dart test/janitor_public_lorebook_test.dart` — 49 passing. There are no unit tests covering the provider field maps.
- Not run: the full `flutter test` suite and the WebView render suite — left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
