### PR TITLE
feat(chat): mark where the prompt's history begins

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -679,6 +679,33 @@ export class Bridge {
     this._updateBatcher.enqueue(msg.id, () => this._executeUpdateMessage(msg));
   }
 
+  // Moves the CONTEXT LIMIT rule to the oldest message the next prompt still
+  // carries; '' retires it. Patches only the two rows involved instead of
+  // re-rendering the chat, and reaches them through `itemMap`, which retains
+  // every row element — so the rule is right whether or not the boundary is
+  // currently mounted. The renderer keeps the id as well, which is what makes a
+  // later full re-render draw the rule again without another call from Flutter.
+  setContextWindowStart(messageId) {
+    const next = messageId || null;
+    const previous = this.renderer.contextStartId || null;
+    this.renderer.setContextWindowStart(next);
+    if (previous === next) return;
+    if (previous) {
+      const el = this.virtualList.itemMap?.get(previous)?.el;
+      if (el) {
+        el.querySelector(':scope > .context-limit-marker')?.remove();
+        delete el.dataset.contextStart;
+      }
+    }
+    if (next) {
+      const el = this.virtualList.itemMap?.get(next)?.el;
+      if (el && !el.querySelector(':scope > .context-limit-marker')) {
+        el.dataset.contextStart = '1';
+        el.insertBefore(this.renderer.createContextLimitMarker(), el.firstChild);
+      }
+    }
+  }
+
   // Patch only memory badges when the async memory providers settle. This
   // deliberately avoids rebuilding message bodies/panels and works for both
   // mounted and virtualized rows because itemMap retains every row element.

--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -44,6 +44,16 @@ export class Renderer {
     this._lastTimestamps = { date: null, idx: -1 };
     this.selectionManager = null;
     this.allowMessageScripts = false;
+    // Id of the oldest message the next prompt still carries. Every render of
+    // that message draws the CONTEXT LIMIT rule above it; null draws none.
+    // Held here rather than on the message map so a re-render (a preset switch,
+    // a scrollback batch) keeps the rule without Flutter re-sending it.
+    this.contextStartId = null;
+  }
+
+  /** Sets which message opens the prompt window; '' or null clears the rule. */
+  setContextWindowStart(messageId) {
+    this.contextStartId = messageId || null;
   }
 
   /* ----- Public: render a message ----- */
@@ -133,6 +143,12 @@ if (messageData.isEditing) classes.push('editing');
     section.className = classes.join(' ');
     section.classList.add('msg-appear');
     section.addEventListener('animationend', () => section.classList.remove('msg-appear'), { once: true });
+
+    /* --- Context-window rule: the chat above it is out of the prompt --- */
+    if (id && id === this.contextStartId) {
+      section.dataset.contextStart = '1';
+      section.appendChild(this.createContextLimitMarker());
+    }
 
     /* --- Header --- */
     section.appendChild(this._createHeader(messageData));
@@ -1006,6 +1022,16 @@ if (messageData.isEditing) classes.push('editing');
     el.className = 'date-separator';
     el.dataset.dateSeparator = dateStr;
     el.innerHTML = `<div class="date-separator-line"></div><span class="date-separator-label">${this._formatDateDisplay(dateStr)}</span><div class="date-separator-line"></div>`;
+    return el;
+  }
+
+  /// The rule the first in-prompt message wears. Built like a date separator
+  /// so the two read as the same kind of divider, and public because the bridge
+  /// stamps it onto an already-rendered row when the boundary moves.
+  createContextLimitMarker() {
+    const el = document.createElement('div');
+    el.className = 'context-limit-marker';
+    el.innerHTML = `<div class="date-separator-line"></div><span class="date-separator-label">Context limit</span><div class="date-separator-line"></div>`;
     return el;
   }
 

--- a/assets/chat_webview/styles.css
+++ b/assets/chat_webview/styles.css
@@ -1675,6 +1675,28 @@
 }
 
 /* ============================================================
+ * Context-limit rule
+ * Drawn inside the oldest message the next prompt still carries: the
+ * chat above it is history the model no longer sees. Amber matches the
+ * cutoff notice in the tokenizer sheet, which counts the same messages.
+ * ============================================================ */
+.context-limit-marker {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 10px;
+  user-select: none;
+}
+.context-limit-marker .date-separator-line {
+  background: rgba(224, 160, 48, 0.35);
+}
+.context-limit-marker .date-separator-label {
+  color: #e0a030;
+  opacity: 0.85;
+  font-weight: 600;
+}
+
+/* ============================================================
  * Background layer
  * Flutter paints the theme surface color (and a fallback background)
  * behind the transparent WebView. When a bg image is set, a duplicate

--- a/lib/core/llm/context_calculator.dart
+++ b/lib/core/llm/context_calculator.dart
@@ -331,6 +331,21 @@ class TokenBreakdown {
         .toSet(),
   );
 
+  /// Oldest message the prompt still carries — where the history the model
+  /// sees begins. Null when the trim kept nothing, or when the kept messages
+  /// carry no source id (a Studio-built window, a synthetic block).
+  ///
+  /// Read from [trimmedHistory] rather than from [historyAnchorId]: the anchor
+  /// exists only under [HistoryTrimMode.stepped], and the chat marks the same
+  /// boundary whichever mode produced it.
+  String? get windowStartMessageId {
+    for (final message in trimmedHistory) {
+      final id = message.sourceMessageId;
+      if (id != null && id.isNotEmpty) return id;
+    }
+    return null;
+  }
+
   int get lorebookTotal =>
       (sourceTokens['lorebook'] ?? 0) +
       (macroTokens['lorebooks'] ?? 0) +

--- a/lib/features/chat/bridge/bridge_message_commands.dart
+++ b/lib/features/chat/bridge/bridge_message_commands.dart
@@ -21,6 +21,17 @@ class MessageBridgeCommands {
     return _host.callJs('setGenerationPhase', label);
   }
 
+  /// Marks where the prompt's history begins: the page draws a CONTEXT LIMIT
+  /// rule inside [messageId] and retires the one it drew before. Everything
+  /// above that rule is chat the model no longer sees.
+  ///
+  /// A null id (sent as an empty string) clears the rule — which is what a
+  /// chat that fits its window whole, and a chat with no calculated prompt yet,
+  /// both look like.
+  Future<void> setContextWindowStart(String? messageId) {
+    return _host.callJs('setContextWindowStart', messageId ?? '');
+  }
+
   Future<void> setMessages(
     List<ChatMessage> messages, {
     int visibleStartIndex = 0,

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -706,6 +706,8 @@ class ChatBridgeController {
       messages.updateMessageContent(id, text, isUser);
   Future<void> removeMessage(String id) => messages.removeMessage(id);
   Future<void> setLastMessage(String? id) => messages.setLastMessage(id);
+  Future<void> setContextWindowStart(String? id) =>
+      messages.setContextWindowStart(id);
   Future<void> clearAll({bool keepPlaceholder = true}) =>
       messages.clearAll(keepPlaceholder: keepPlaceholder);
   Future<void> scrollToBottom({bool smooth = false}) =>

--- a/lib/features/chat/services/magic_drawer_stats_service.dart
+++ b/lib/features/chat/services/magic_drawer_stats_service.dart
@@ -7,6 +7,7 @@ import '../../../core/llm/context_calculator.dart';
 import '../../../core/llm/lorebook_activation.dart';
 import '../../../core/llm/prompt_isolate.dart';
 import '../providers/prompt_build_providers.dart';
+import '../../../core/models/api_config.dart';
 import '../../../core/models/lorebook.dart';
 import '../../../core/models/persona.dart';
 import '../../../core/models/preset.dart';
@@ -256,6 +257,11 @@ class MagicDrawerStatsService {
         maxTokens: chatApi.maxTokens,
         authorsNote: session.authorsNote?.content ?? '',
         summary: base.summaryContent ?? '',
+        // The trim mode and its knobs decide where the history starts just as
+        // much as the window size does, so a breakdown taken under one mode
+        // must not be handed back under another — the drawer's numbers and the
+        // chat's context rule both come off this cache.
+        trimSignature: chatApi.contextBudgetSignature,
       );
 
       final cached = TokenBreakdownCache.get(hash);
@@ -303,6 +309,11 @@ class MagicDrawerStatsService {
           totalTokens: breakdown.totalTokens + lastVectorTokens,
           cutoffIndex: breakdown.cutoffIndex,
           trimmedHistory: breakdown.trimmedHistory,
+          // Carried, not dropped: the anchor is what the next stepped trim
+          // reuses, and the visible ids are what the chat's context rule and
+          // the memory refilter read off this breakdown.
+          historyAnchorId: breakdown.historyAnchorId,
+          visibleMessageIds: breakdown.visibleMessageIds,
           lorebookReserveTokens: breakdown.lorebookReserveTokens,
           memoryTokens: breakdown.memoryTokens,
           vectorLoreTokens: lastVectorTokens,

--- a/lib/features/chat/state/context_window_marker.dart
+++ b/lib/features/chat/state/context_window_marker.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../chat_provider.dart';
+import 'cached_token_breakdown.dart';
+
+/// Id of the oldest message the next prompt still carries — the message the
+/// chat draws its CONTEXT LIMIT rule above.
+///
+/// Read from the breakdown the last prompt build left behind, so it answers for
+/// the trim that actually ran. Both modes land here: sliding reports the cut it
+/// recomputed this turn, stepped the window its anchor holds open. Null while
+/// nothing was cut (the whole chat is in the prompt, so there is no boundary to
+/// draw) and null while no breakdown exists — a rule guessed from nothing is
+/// worse than no rule.
+final contextWindowStartProvider = Provider.autoDispose
+    .family<String?, String>((ref, charId) {
+      final breakdown = ref.watch(cachedTokenBreakdownProvider(charId));
+      // A session switch keeps the character's cached breakdown, whose boundary
+      // belongs to the session that was open when it was built. Watching the id
+      // re-runs this, and the membership check below drops a boundary the open
+      // chat has no message for.
+      ref.watch(chatProvider(charId).select((s) => s.value?.session?.id));
+      if (breakdown == null || breakdown.cutoffIndex <= 0) return null;
+      final id = breakdown.windowStartMessageId;
+      if (id == null) return null;
+      final messages = ref.read(chatProvider(charId)).value?.messages;
+      if (messages == null) return null;
+      return messages.any((message) => message.id == id) ? id : null;
+    });

--- a/lib/features/chat/widgets/chat_webview_build_listeners.dart
+++ b/lib/features/chat/widgets/chat_webview_build_listeners.dart
@@ -19,6 +19,7 @@ import '../chat_provider.dart';
 import '../chat_state.dart';
 import '../editing_message_provider.dart';
 import '../services/continuation_message_merger.dart';
+import '../state/context_window_marker.dart';
 import '../state/generation_phase_provider.dart';
 import 'chat_message_sync.dart';
 import 'chat_streaming_bridge_sync.dart';
@@ -81,6 +82,7 @@ class ChatWebViewBuildListeners {
     _listenPersonaRoster();
     _listenEditingMessage();
     _listenGenerationPhase();
+    _listenContextWindowStart();
     _listenStreaming();
     _listenInfoBlocks();
     _listenExtSettingsAndPresets();
@@ -196,6 +198,20 @@ class ChatWebViewBuildListeners {
   /// tracks the work the app is actually doing (assembling the prompt,
   /// retrieving memory, waiting on the model) instead of claiming the reply
   /// is being written from the moment the bubble appears.
+  /// Keeps the CONTEXT LIMIT rule on the message the prompt actually starts
+  /// at. The boundary moves whenever a prompt is built — a turn, the inspector
+  /// preview, the drawer's recount — and is cleared with the breakdown itself
+  /// (a delete, a changed connection): pushing the null through is what retires
+  /// a rule the trim no longer draws.
+  void _listenContextWindowStart() {
+    ref.listen<String?>(contextWindowStartProvider(charId), (prev, next) {
+      final b = bridge;
+      if (b == null || !ready()) return;
+      if (prev == next) return;
+      unawaited(b.setContextWindowStart(next));
+    });
+  }
+
   void _listenGenerationPhase() {
     ref.listen<GenerationPhase>(generationPhaseProvider(charId), (prev, next) {
       final b = bridge;

--- a/lib/features/chat/widgets/chat_webview_initializer.dart
+++ b/lib/features/chat/widgets/chat_webview_initializer.dart
@@ -12,6 +12,7 @@ import '../../personas/persona_list_provider.dart';
 import '../bridge/chat_bridge_controller.dart';
 import '../bridge/chat_overlay_blur_region.dart';
 import '../chat_provider.dart';
+import '../state/context_window_marker.dart';
 import '../state/generation_phase_provider.dart';
 
 /// Snapshot of the [ChatWebViewWidget] fields needed by
@@ -214,6 +215,14 @@ class ChatWebViewInitializer {
           .map((e) => {'messageIds': e.messageIds})
           .toList(),
       patchMessages: false,
+    );
+    // The WebView is kept alive across chats, so the renderer still holds the
+    // previous chat's context boundary and would draw its rule on whichever
+    // message happens to share that id. Push this chat's boundary — usually
+    // null — before the first paint, the same reason the search state above is
+    // pushed early.
+    await bridge.setContextWindowStart(
+      ref.read(contextWindowStartProvider(input.charId)),
     );
     // Seed the phase before rendering an active typing node. The renderer uses
     // this value while constructing the node, not only on later transitions.

--- a/test/context_window_marker_test.dart
+++ b/test/context_window_marker_test.dart
@@ -1,0 +1,214 @@
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/llm/context_calculator.dart';
+import 'package:glaze_flutter/core/llm/history_assembler.dart';
+import 'package:glaze_flutter/core/llm/history_trim.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:glaze_flutter/features/chat/chat_provider.dart';
+import 'package:glaze_flutter/features/chat/chat_session_service.dart';
+import 'package:glaze_flutter/features/chat/state/cached_token_breakdown.dart';
+import 'package:glaze_flutter/features/chat/state/context_window_marker.dart';
+
+/// History of [count] messages, each roughly the same size, ids `m0..mN`.
+List<PromptMessage> _history(int count) => [
+  for (var i = 0; i < count; i++)
+    PromptMessage(
+      role: i.isEven ? 'user' : 'assistant',
+      content: 'message $i ${'filler ' * 20}',
+      sourceMessageId: 'm$i',
+      isHistory: true,
+    ),
+];
+
+TokenBreakdown _run(
+  List<PromptMessage> history, {
+  required String mode,
+  String? anchorId,
+  int contextSize = 4000,
+}) => ContextCalculator(
+  contextSize: contextSize,
+  maxTokens: 1000,
+  historyTrimMode: mode,
+  historyAnchorId: anchorId,
+).calculate(staticBlocks: const [], historyMessages: history);
+
+/// A chat of [count] messages with the same ids the history above carries, so
+/// a breakdown taken over that history points at messages this session has.
+Future<ProviderContainer> _openChat(int count) async {
+  final db = AppDatabase.forTesting(NativeDatabase.memory());
+  final container = ProviderContainer(
+    overrides: [appDbProvider.overrideWithValue(db)],
+  );
+  addTearDown(() async {
+    container.dispose();
+    ChatSessionService.clearCache();
+    await db.close();
+  });
+  await container
+      .read(characterRepoProvider)
+      .put(const Character(id: 'c1', name: 'Test', currentSessionIndex: 0));
+  await container
+      .read(chatRepoProvider)
+      .put(
+        ChatSession(
+          id: 'c1_0',
+          characterId: 'c1',
+          sessionIndex: 0,
+          messages: [
+            for (var i = 0; i < count; i++)
+              ChatMessage(
+                id: 'm$i',
+                role: i.isEven ? 'user' : 'assistant',
+                content: 'message $i',
+                timestamp: i,
+              ),
+          ],
+        ),
+      );
+  await container.read(chatProvider('c1').future);
+  return container;
+}
+
+/// What the chat would draw the rule at, given [breakdown] as the last
+/// calculated prompt.
+String? _marker(ProviderContainer container, TokenBreakdown breakdown) {
+  container.read(cachedTokenBreakdownProvider('c1').notifier).state = breakdown;
+  return container.read(contextWindowStartProvider('c1'));
+}
+
+/// The boundary the chat draws its CONTEXT LIMIT rule at: the oldest message
+/// the prompt still carries. It is read off the breakdown rather than
+/// re-derived, so it has to be right under either trim mode.
+void main() {
+  group('windowStartMessageId', () {
+    test('sliding marks the oldest message that survived the cut', () {
+      final result = _run(_history(80), mode: HistoryTrimMode.sliding);
+
+      expect(result.cutoffIndex, greaterThan(0));
+      expect(result.windowStartMessageId, 'm${result.cutoffIndex}');
+      expect(
+        result.windowStartMessageId,
+        result.trimmedHistory.first.sourceMessageId,
+      );
+    });
+
+    test('stepped marks the anchor it holds the window open on', () {
+      final result = _run(_history(80), mode: HistoryTrimMode.stepped);
+
+      expect(result.cutoffIndex, greaterThan(0));
+      expect(result.windowStartMessageId, result.historyAnchorId);
+    });
+
+    test('stepped holds the boundary still while the anchor does', () {
+      final first = _run(_history(80), mode: HistoryTrimMode.stepped);
+      final anchor = first.windowStartMessageId!;
+
+      final later = _run(
+        _history(84),
+        mode: HistoryTrimMode.stepped,
+        anchorId: anchor,
+      );
+
+      expect(
+        later.windowStartMessageId,
+        anchor,
+        reason: 'the rule may not creep down the chat between steps',
+      );
+    });
+
+    test('sliding moves the boundary as the chat grows', () {
+      final first = _run(_history(80), mode: HistoryTrimMode.sliding);
+      final later = _run(_history(90), mode: HistoryTrimMode.sliding);
+
+      expect(later.cutoffIndex, greaterThan(first.cutoffIndex));
+      expect(
+        later.windowStartMessageId,
+        isNot(first.windowStartMessageId),
+        reason: 'a sliding cut starts at a different message every turn',
+      );
+    });
+
+    test('a chat that fits whole reports a boundary but no cut', () {
+      final result = _run(
+        _history(5),
+        mode: HistoryTrimMode.sliding,
+        contextSize: 40000,
+      );
+
+      expect(result.cutoffIndex, 0);
+      expect(
+        result.windowStartMessageId,
+        'm0',
+        reason:
+            'the window starts at the first message; it is the zero cutoff, '
+            'not a null id, that tells the chat there is no rule to draw',
+      );
+    });
+
+    test('an empty window has no boundary', () {
+      final result = _run(
+        _history(40),
+        mode: HistoryTrimMode.sliding,
+        // maxTokens (1000) eats the whole window, so nothing fits.
+        contextSize: 1000,
+      );
+
+      expect(result.trimmedHistory, isEmpty);
+      expect(result.windowStartMessageId, isNull);
+    });
+  });
+
+  // The rule has to appear under either trim mode — the modes cut differently,
+  // and the marker is the only place in the chat that says where the prompt
+  // begins.
+  group('contextWindowStartProvider', () {
+    test('draws the rule at the sliding cut', () async {
+      final container = await _openChat(80);
+      final breakdown = _run(_history(80), mode: HistoryTrimMode.sliding);
+
+      expect(breakdown.cutoffIndex, greaterThan(0));
+      expect(_marker(container, breakdown), 'm${breakdown.cutoffIndex}');
+    });
+
+    test('draws the rule at the stepped anchor', () async {
+      final container = await _openChat(80);
+      final breakdown = _run(_history(80), mode: HistoryTrimMode.stepped);
+
+      expect(breakdown.cutoffIndex, greaterThan(0));
+      expect(breakdown.historyAnchorId, isNotNull);
+      expect(_marker(container, breakdown), breakdown.historyAnchorId);
+    });
+
+    test('a chat that fits whole gets no rule', () async {
+      final container = await _openChat(5);
+      final breakdown = _run(
+        _history(5),
+        mode: HistoryTrimMode.stepped,
+        contextSize: 40000,
+      );
+
+      expect(breakdown.cutoffIndex, 0);
+      expect(_marker(container, breakdown), isNull);
+    });
+
+    test('a boundary this chat has no message for is dropped', () async {
+      // What a session switch leaves behind: the character's cached breakdown
+      // still describes the chat that was open when it was built.
+      final container = await _openChat(20);
+      final breakdown = _run(_history(80), mode: HistoryTrimMode.stepped);
+
+      expect(breakdown.windowStartMessageId, isNotNull);
+      expect(_marker(container, breakdown), isNull);
+    });
+
+    test('no calculated prompt yet means no rule', () async {
+      final container = await _openChat(80);
+
+      expect(container.read(contextWindowStartProvider('c1')), isNull);
+    });
+  });
+}

--- a/test/webview_js/specs/context_limit.spec.js
+++ b/test/webview_js/specs/context_limit.spec.js
@@ -1,0 +1,117 @@
+// The CONTEXT LIMIT rule marks where the prompt's history begins: the chat
+// above it is history the model no longer sees.
+//
+// Flutter pushes one message id (the oldest message the last prompt build kept)
+// and the page draws the rule inside that message. The failures these protect
+// against are a rule that multiplies as the boundary moves, one that survives
+// the chat it was drawn for, and one that a re-render silently drops.
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/assets/chat_webview/index.html';
+
+async function boot(page) {
+  await page.goto(PAGE);
+  await page.waitForFunction(() => !!window.bridge);
+  await page.evaluate(() => {
+    window.__M = (id, role, text) =>
+      JSON.stringify({
+        id,
+        role,
+        text,
+        timestamp: 1767225600000,
+        isUser: role === 'user',
+        isAssistant: role !== 'user',
+        isSystem: false,
+        displayName: role === 'user' ? 'You' : 'Alice',
+        isError: false,
+        isHidden: false,
+        isGenerating: false,
+        isPostGenRunning: false,
+      });
+  });
+}
+
+/// Renders `m1..m4`, alternating roles, as one full batch.
+async function render(page) {
+  await page.evaluate(() => {
+    const ids = ['m1', 'm2', 'm3', 'm4'];
+    window.bridge.setMessages(
+      JSON.stringify(
+        ids.map((id, i) =>
+          JSON.parse(window.__M(id, i % 2 === 0 ? 'user' : 'assistant', id)),
+        ),
+      ),
+    );
+  });
+}
+
+/// Ids of the messages currently wearing the rule — a list, because the bug
+/// worth catching is two of them at once.
+const marked = (page) =>
+  page.evaluate(() =>
+    [...document.querySelectorAll('.context-limit-marker')].map(
+      (el) => el.closest('.message-section')?.dataset.messageId ?? null,
+    ),
+  );
+
+test('the rule is drawn inside the message the prompt starts at', async ({
+  page,
+}) => {
+  await boot(page);
+  await render(page);
+  await page.evaluate(() => window.bridge.setContextWindowStart('m2'));
+
+  expect(await marked(page)).toEqual(['m2']);
+  // First child, so it reads as a rule above the message rather than a badge
+  // somewhere inside it.
+  expect(
+    await page.evaluate(
+      () =>
+        document.querySelector('.message-section[data-message-id="m2"]')
+          .firstElementChild.className,
+    ),
+  ).toBe('context-limit-marker');
+});
+
+test('moving the boundary leaves exactly one rule behind', async ({ page }) => {
+  await boot(page);
+  await render(page);
+  await page.evaluate(() => window.bridge.setContextWindowStart('m2'));
+  await page.evaluate(() => window.bridge.setContextWindowStart('m3'));
+
+  expect(await marked(page)).toEqual(['m3']);
+});
+
+test('an empty boundary retires the rule', async ({ page }) => {
+  await boot(page);
+  await render(page);
+  await page.evaluate(() => window.bridge.setContextWindowStart('m2'));
+  await page.evaluate(() => window.bridge.setContextWindowStart(''));
+
+  expect(await marked(page)).toEqual([]);
+});
+
+test('a re-render redraws the rule without another push', async ({ page }) => {
+  await boot(page);
+  await render(page);
+  await page.evaluate(() => window.bridge.setContextWindowStart('m3'));
+
+  // What a preset switch does: the same messages, rendered again.
+  await render(page);
+
+  expect(await marked(page)).toEqual(['m3']);
+});
+
+test('a boundary this chat has no message for draws nothing', async ({
+  page,
+}) => {
+  await boot(page);
+  await render(page);
+  await page.evaluate(() => window.bridge.setContextWindowStart('gone'));
+
+  expect(await marked(page)).toEqual([]);
+
+  // And the next real boundary still lands.
+  await page.evaluate(() => window.bridge.setContextWindowStart('m4'));
+  expect(await marked(page)).toEqual(['m4']);
+});


### PR DESCRIPTION
The chat gave no sign of where the context window starts: the tokenizer sheet counted the messages that did not fit, three taps away, and the chat itself rendered a cut message and a carried one identically. This draws the boundary where it is read — a CONTEXT LIMIT rule inside the oldest message the next prompt still carries.

## The marker

- Add `TokenBreakdown.windowStartMessageId` — the oldest message the trim kept. Read from `trimmedHistory` rather than from `historyAnchorId`, which only `HistoryTrimMode.stepped` fills in, so the same boundary comes out of either trim mode.
- Add `contextWindowStartProvider` (`lib/features/chat/state/context_window_marker.dart`): the id the chat marks, or null when the chat fits whole (`cutoffIndex == 0`), when no prompt has been calculated yet, or when the cached breakdown belongs to a session that is no longer open.
- Push it over the bridge as `MessageBridgeCommands.setContextWindowStart`. The page patches only the two rows involved, reaching them through `itemMap`, so the rule lands whether or not the boundary is currently mounted — and the renderer keeps the id, so a full re-render (a preset switch, a scrollback batch) draws it again without another call from Flutter.
- Draw the rule as the first child of the in-prompt message's section: same shape as a date separator, amber like the cutoff notice in the tokenizer sheet that counts the same messages.
- Seed it from `ChatWebViewInitializer` before the first paint. The WebView is kept alive across chats, so the renderer would otherwise carry the previous chat's boundary into this one — the same reason the search state is pushed early.

## Keeping the numbers honest

- Key the drawer's `TokenBreakdownCache` on the connection's `contextBudgetSignature`, as `tokenizer_sheet.dart` already does. Without it a breakdown taken under one trim mode could be served after a switch to the other, and both the drawer's numbers and the new rule come off that cache.
- Carry `historyAnchorId` and `visibleMessageIds` through `MagicDrawerStatsService`'s vector-lore rebuild of a breakdown instead of dropping them.

## Verification

- `test/context_window_marker_test.dart` (11 cases): `windowStartMessageId` under both trim modes — the sliding cut moves every turn, the stepped boundary holds still while its anchor does — plus the provider end to end against a real in-memory chat, asserting the rule appears in **both** modes and is withheld for a chat that fits, a stale cross-session breakdown, and a chat with no calculated prompt.
- `test/webview_js/specs/context_limit.spec.js` (5 cases): the rule renders inside the right message as its first child, moving the boundary leaves exactly one, an empty id retires it, a re-render redraws it without another push, and an id this chat has no message for draws nothing.
- `flutter analyze`: no errors (9 pre-existing warnings/infos on the base branch). `npx playwright test`: 86 passed. `flutter test`: 3851 passing; the 3 failures in `test/chat_input_bar_test.dart` (clipboard attachment thumbnails) also fail on `nightly` unchanged and are unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
