### PR TITLE
fix(chat): export hidden messages the way SillyTavern marks them

### DIFF
--- a/lib/core/services/chat_import_export.dart
+++ b/lib/core/services/chat_import_export.dart
@@ -36,7 +36,6 @@ Future<FileExportResult> exportChatAsJsonl({
   lines.add(jsonEncode(metadata));
 
   for (final msg in session.messages) {
-    if (msg.isHidden) continue;
     final isUser = msg.role == 'user';
     // A user message names the persona it was actually sent as; [userName] is
     // only the fallback for the ones that carry none (chats written before
@@ -48,10 +47,18 @@ Future<FileExportResult> exportChatAsJsonl({
               : messagePersona)
         : character.name;
 
+    // SillyTavern (and every reader built on its format, Tavo included) has
+    // no hidden flag of its own: `/hide` just sets `is_system` on the message
+    // and the prompt builder drops every `is_system` line. So `is_system` is
+    // where our [ChatMessage.isHidden] has to land, alongside the messages
+    // that are genuinely system-role. Exporting hidden messages at all is the
+    // point — they used to be skipped outright, which lost them silently.
+    final isSystem = msg.isHidden || msg.role == 'system';
+
     final stMsg = <String, dynamic>{
       'name': name,
       'is_user': isUser,
-      'is_system': msg.role == 'system',
+      'is_system': isSystem,
       'send_date': _formatSTDate(
         DateTime.fromMillisecondsSinceEpoch(msg.timestamp ?? 0),
       ),
@@ -66,6 +73,14 @@ Future<FileExportResult> exportChatAsJsonl({
     }
     if (msg.id.isNotEmpty) {
       stMsg['extra']!['glazeMessageId'] = msg.id;
+    }
+    // `is_system` flattens two distinct Glaze states (hidden, and system-role)
+    // into one flag, so a Glaze -> Glaze round trip needs both spelled out to
+    // come back unchanged. Foreign files carry neither and fall back to the
+    // SillyTavern reading of `is_system` on import.
+    if (isSystem) {
+      stMsg['extra']!['glazeHidden'] = msg.isHidden;
+      stMsg['extra']!['glazeRole'] = msg.role;
     }
 
     if (msg.swipes.isNotEmpty && msg.swipes.length > 1) {
@@ -138,14 +153,34 @@ ChatMessage? convertStMessage(Map<String, dynamic> obj, int index) {
     final text = (obj['mes'] as String?) ?? '';
     final sendDate = obj['send_date'] as String?;
 
+    final extra = obj['extra'];
+    final extraMap = extra is Map<String, dynamic>
+        ? extra
+        : const <String, dynamic>{};
+    // Written by our own export when `is_system` had to carry two states at
+    // once. Present only on Glaze-written files, and authoritative there.
+    final glazeRole = extraMap['glazeRole'] as String?;
+    final glazeHidden = extraMap['glazeHidden'];
+
     String role;
-    if (isSystem) {
-      role = 'system';
+    if (glazeRole != null && glazeRole.isNotEmpty) {
+      role = glazeRole;
     } else if (isUser) {
+      // `is_user` outranks `is_system`: SillyTavern leaves `is_user` alone when
+      // it hides a message, so both flags together is a hidden user message,
+      // never a system one (its own system lines are always `is_user: false`).
       role = 'user';
+    } else if (isSystem) {
+      role = 'system';
     } else {
       role = 'assistant';
     }
+
+    // In the SillyTavern format `is_system` means "kept out of the prompt" —
+    // that is exactly [ChatMessage.isHidden], not our system role, which we do
+    // send. So a foreign `is_system` line imports as hidden; without this an
+    // ST/Tavo hidden message came back visible *and* went to the model.
+    final isHidden = glazeHidden is bool ? glazeHidden : isSystem;
 
     if (text.trim().isEmpty) return null;
 
@@ -157,15 +192,11 @@ ChatMessage? convertStMessage(Map<String, dynamic> obj, int index) {
         : <String>[];
     final swipeId = _parseInt(obj['swipe_id']) ?? 0;
 
-    String? reasoning;
-    final extra = obj['extra'];
-    if (extra is Map<String, dynamic>) {
-      reasoning = extra['reasoning'] as String?;
-    }
+    final reasoning = extraMap['reasoning'] as String?;
 
     return ChatMessage(
       id:
-          (extra is Map ? extra['glazeMessageId'] as String? : null) ??
+          extraMap['glazeMessageId'] as String? ??
           'imp_${DateTime.now().millisecondsSinceEpoch}_$index',
       role: role,
       content: text,
@@ -173,6 +204,7 @@ ChatMessage? convertStMessage(Map<String, dynamic> obj, int index) {
       swipes: swipes,
       swipeId: swipeId,
       reasoning: reasoning,
+      isHidden: isHidden,
     );
   } catch (_) {
     return null;

--- a/test/chat_hidden_message_export_test.dart
+++ b/test/chat_hidden_message_export_test.dart
@@ -1,0 +1,165 @@
+// Hidden messages survive a chat export and come back hidden.
+//
+// The JSONL export used to skip every hidden message outright, so a chat
+// exported from Glaze reached SillyTavern/Tavo with those messages missing
+// entirely — nothing to "see", hidden or otherwise. SillyTavern has no hidden
+// flag of its own: `/hide` sets `is_system` on the message and the prompt
+// builder drops every `is_system` line, so that flag is where `isHidden` has
+// to land. `extra.glazeHidden` / `extra.glazeRole` keep a Glaze -> Glaze round
+// trip lossless, since `is_system` alone cannot say which of the two states it
+// stands for.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/models/character.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/core/services/chat_import_export.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('glaze_hidden_export_test');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+  });
+
+  Future<List<Map<String, dynamic>>> exportMessages(
+    List<ChatMessage> messages,
+  ) async {
+    final result = await exportChatAsJsonl(
+      session: ChatSession(
+        id: 's1',
+        characterId: 'c1',
+        sessionIndex: 0,
+        messages: messages,
+      ),
+      character: const Character(id: 'c1', name: 'Alice'),
+      outputDir: tempDir.path,
+      userName: 'User',
+    );
+    final lines = await File(result.filePath).readAsLines();
+    return lines
+        .skip(1)
+        .map((l) => jsonDecode(l) as Map<String, dynamic>)
+        .toList();
+  }
+
+  /// Exports [messages] and imports the file back, as a user round-tripping a
+  /// chat through the export.
+  Future<List<ChatMessage>> roundTrip(List<ChatMessage> messages) async {
+    final exported = await exportMessages(messages);
+    final content = exported.map(jsonEncode).join('\n');
+    return importChatFromJsonlString(content).messages;
+  }
+
+  const conversation = [
+    ChatMessage(id: 'u1', role: 'user', content: 'visible ask'),
+    ChatMessage(
+      id: 'a1',
+      role: 'assistant',
+      content: 'hidden reply',
+      isHidden: true,
+    ),
+    ChatMessage(
+      id: 'u2',
+      role: 'user',
+      content: 'hidden ask',
+      isHidden: true,
+    ),
+    ChatMessage(id: 's1', role: 'system', content: 'a system note'),
+    ChatMessage(id: 'a2', role: 'assistant', content: 'visible reply'),
+  ];
+
+  test('a hidden message is exported instead of being dropped', () async {
+    final exported = await exportMessages(conversation);
+
+    expect(exported.length, conversation.length);
+    expect(
+      exported.map((m) => m['mes']),
+      ['visible ask', 'hidden reply', 'hidden ask', 'a system note',
+        'visible reply'],
+    );
+  });
+
+  test('a hidden message is marked the way SillyTavern marks one', () async {
+    final exported = await exportMessages(conversation);
+
+    // `is_system` is the marker, on the hidden assistant message...
+    expect(exported[1]['is_system'], isTrue);
+    expect(exported[1]['is_user'], isFalse);
+    // ...and on the hidden user one, which keeps `is_user` as SillyTavern does.
+    expect(exported[2]['is_system'], isTrue);
+    expect(exported[2]['is_user'], isTrue);
+
+    // A visible message carries neither.
+    expect(exported[0]['is_system'], isFalse);
+    expect(exported[4]['is_system'], isFalse);
+  });
+
+  test('the round trip keeps hidden state and role', () async {
+    final imported = await roundTrip(conversation);
+
+    expect(imported.length, conversation.length);
+    for (var i = 0; i < conversation.length; i++) {
+      expect(imported[i].content, conversation[i].content, reason: 'content $i');
+      expect(imported[i].role, conversation[i].role, reason: 'role $i');
+      expect(
+        imported[i].isHidden,
+        conversation[i].isHidden,
+        reason: 'isHidden $i',
+      );
+    }
+  });
+
+  test('a system-role message does not come back hidden', () async {
+    final imported = await roundTrip(conversation);
+
+    final systemMessage = imported.firstWhere((m) => m.role == 'system');
+    expect(systemMessage.content, 'a system note');
+    expect(systemMessage.isHidden, isFalse);
+  });
+
+  test('a foreign is_system line imports as hidden', () async {
+    // A SillyTavern/Tavo file: `is_system` and nothing else. `is_system` there
+    // means "kept out of the prompt", which is our isHidden — importing it as
+    // a plain system-role message sent it to the model.
+    final content = [
+      jsonEncode({'user_name': 'User', 'chat_metadata': <String, dynamic>{}}),
+      jsonEncode({
+        'name': 'Alice',
+        'is_user': false,
+        'is_system': true,
+        'mes': 'hidden by /hide',
+      }),
+      jsonEncode({
+        'name': 'User',
+        'is_user': true,
+        'is_system': true,
+        'mes': 'hidden user turn',
+      }),
+      jsonEncode({
+        'name': 'Alice',
+        'is_user': false,
+        'is_system': false,
+        'mes': 'visible',
+      }),
+    ].join('\n');
+
+    final imported = importChatFromJsonlString(content).messages;
+
+    expect(imported.length, 3);
+    expect(imported[0].isHidden, isTrue);
+    expect(imported[0].role, 'system');
+    // `is_user` outranks `is_system` — this is a hidden user turn, not a
+    // system message.
+    expect(imported[1].isHidden, isTrue);
+    expect(imported[1].role, 'user');
+    expect(imported[2].isHidden, isFalse);
+    expect(imported[2].role, 'assistant');
+  });
+}


### PR DESCRIPTION
A chat exported from Glaze reached SillyTavern/Tavo with its hidden messages missing entirely: `exportChatAsJsonl` skipped every message with `isHidden` set (`if (msg.isHidden) continue;`), so there was no flag for a reader to miss — the lines simply were not in the file. The import side never read a hidden flag either, and mapped `is_system` straight onto our system role, which `HistoryAssembler.assemble` does send to the model (it filters on `isHidden` / `isTyping`, never on role).

SillyTavern has no hidden flag of its own: `hideChatMessageRange` (`public/scripts/chats.js`) sets `message.is_system = hide` and nothing else, and the prompt builder drops every `is_system` line (`coreChat = chat.filter(x => !x.is_system ...)`). So its `is_system` carries exactly our `isHidden` semantics, not our system role.

## Changes

- Export hidden messages instead of dropping them, marked as `is_system: true` — the same flag SillyTavern's `/hide` sets, so an importer built on that format sees them (`exportChatAsJsonl`, `lib/core/services/chat_import_export.dart`)
- Write `extra.glazeHidden` / `extra.glazeRole` next to the existing `extra.glazeMessageId` whenever `is_system` is set, since that one flag cannot say which of the two Glaze states (hidden, or system-role) it stands for; a Glaze → Glaze round trip is lossless again, and foreign files that carry neither fall back to the SillyTavern reading
- Import a foreign `is_system` line as `isHidden` rather than as a system-role message that goes into the prompt (`convertStMessage`) — this also covers the ST and Tavo backup importers, which both parse chats through the same function
- Let `is_user` outrank `is_system` when deriving the role: SillyTavern leaves `is_user` alone when hiding, so both flags together is a hidden user message, and its own system lines are always `is_user: false`. Previously such a message came back as a system-role message
- Read `extra` once into a typed local instead of re-testing it per field

## Verification

- New `test/chat_hidden_message_export_test.dart`: hidden messages are exported rather than dropped, marked as `is_system` (with `is_user` preserved on a hidden user turn), a round trip preserves hidden state and role across hidden-user / hidden-assistant / genuine-system-role / visible messages, and a foreign SillyTavern `is_system` line imports as hidden
- `flutter analyze --no-fatal-infos --no-fatal-warnings` — no errors (9 pre-existing infos/warnings, none in the touched files)
- `flutter test` — full suite green, 3875 tests, on Flutter 3.44.9 (the version CI pins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMygzTz9a6ow5sDHibhbFu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMygzTz9a6ow5sDHibhbFu)_