### PR TITLE
fix(chat): land on the message the search and the arrows point at

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -62,6 +62,7 @@ export class Bridge {
     this._selectionManager = new SelectionManager(
       (name, args) => this._sendToFlutter(name, args),
       () => this._orderedMessageIds(),
+      () => this._allMessageSections(),
     );
     this._editController = new EditController((name, args) => this._sendToFlutter(name, args));
     this._interaction = new InteractionDispatch(this);
@@ -1652,6 +1653,18 @@ export class Bridge {
   selectMessagesAbove() { this._selectionManager.selectAbove(); }
 
   selectMessagesBelow() { this._selectionManager.selectBelow(); }
+
+  /* Every message element the chat holds, mounted or not. `items` keeps the
+   * (possibly detached) element of each message, and the list re-mounts that
+   * same element instead of re-rendering it — so anything that has to reach the
+   * whole chat has to come through here rather than through the document. */
+  _allMessageSections() {
+    const list = this.virtualList;
+    if (Array.isArray(list?.items)) {
+      return list.items.map(item => item.el).filter(Boolean);
+    }
+    return Array.from(document.querySelectorAll('.message-section'));
+  }
 
   // Ordered list of real message ids (top → bottom), excluding date separators.
   // Range selection needs the full order even for messages currently outside

--- a/assets/chat_webview/bridge/selection_manager.js
+++ b/assets/chat_webview/bridge/selection_manager.js
@@ -3,11 +3,21 @@
 import { appBody } from '../renderer/message_document.js';
 
 export class SelectionManager {
-  constructor(sendToFlutter, getOrderedIds) {
+  constructor(sendToFlutter, getOrderedIds, getSections) {
     this._sendToFlutter = sendToFlutter;
     // Returns all real message ids in display order (top → bottom). Injected so
     // range selection can reach messages outside the virtual-scroll window.
     this._getOrderedIds = typeof getOrderedIds === 'function' ? getOrderedIds : () => [];
+    // Returns every message element, mounted or not — for the same reason.
+    // Selecting a run of messages picks ids the render window does not hold,
+    // and the list re-mounts the element it already built rather than
+    // re-rendering it, so a class written only to what is in the document now
+    // is a class those messages never get: the reader scrolls back to a
+    // message the toolbar counts as selected and sees it unselected, in a chat
+    // that does not look like it is in selection mode at all.
+    this._getSections = typeof getSections === 'function'
+      ? getSections
+      : () => Array.from(document.querySelectorAll('.message-section'));
     this._selectionMode = false;
     this._selectedIds = new Set();
     // Last message the user tapped. The "select everything above / below"
@@ -29,7 +39,7 @@ export class SelectionManager {
       this._selectedIds.clear();
       this._lastTappedId = null;
     }
-    document.querySelectorAll('.message-section').forEach(msgEl => {
+    this._sections().forEach(msgEl => {
       msgEl.classList.toggle('selection-mode', this._selectionMode);
       msgEl.classList.toggle('selected', this._selectedIds.has(msgEl.dataset.messageId));
     });
@@ -93,10 +103,19 @@ export class SelectionManager {
 
   selectBelow() { this._selectSide(true); }
 
-  // Sync the `selected` class for sections currently in the DOM. Sections that
-  // scroll into view later pick it up via applyClassesToSection().
+  // Every message element the chat has, not only the ones the virtual list
+  // currently mounts. A section built before this ran picks the classes up
+  // through applyClassesToSection(); one already built and merely unmounted
+  // never renders again, so it has to be written to here.
+  _sections() {
+    return this._getSections().filter(
+      el => el && el.classList && el.classList.contains('message-section'),
+    );
+  }
+
+  // Sync the `selected` class across the whole chat.
   _applySelectionClasses() {
-    document.querySelectorAll('.message-section').forEach(msgEl => {
+    this._sections().forEach(msgEl => {
       msgEl.classList.toggle('selected', this._selectedIds.has(msgEl.dataset.messageId));
     });
   }

--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -41,6 +41,10 @@ export class Renderer {
     this.searchQuery = null;
     this.activeSearchIndex = -1;
     this.searchMatches = [];
+    // How many highlights the last full pass numbered. The arrow keys only
+    // move which one is active, and that is only safe to do in place while the
+    // highlights still in the DOM are the ones that pass counted.
+    this.searchTotal = 0;
     this._lastTimestamps = { date: null, idx: -1 };
     this.selectionManager = null;
     this.allowMessageScripts = false;
@@ -1113,6 +1117,19 @@ if (messageData.isEditing) classes.push('editing');
       this.searchQuery = query;
       this.activeSearchIndex = -1;
       this.searchMatches = [];
+      this.searchTotal = 0;
+      return;
+    }
+
+    // Walking the hits with the prev/next arrows changes exactly one thing
+    // about the page: which highlight is the active one. The full pass below
+    // re-formats and re-writes the shadow body of *every message in the chat*
+    // to arrive at that — hundreds of milliseconds on a long chat, once per
+    // press, while the presses arrive faster than the passes finish. That is
+    // what made the arrows feel dead and the list feel unable to reach the
+    // hit. Move the class instead, and let the scroll be the only work.
+    if (query && query === this.searchQuery && !_retried &&
+        this._moveActiveMatch(activeIndex, scroll)) {
       return;
     }
 
@@ -1128,8 +1145,6 @@ if (messageData.isEditing) classes.push('editing');
       ? window.bridge.virtualList.items.map(it => it.el)
       : document.querySelectorAll('.message-section');
 
-    let activeMessageId = null;
-
     items.forEach(section => {
       if (!section) return;
       const isUser = section.classList.contains('user');
@@ -1139,7 +1154,6 @@ if (messageData.isEditing) classes.push('editing');
           const root = host.shadowRoot.querySelector('.glaze-message');
           if (root) {
             const formatted = this.formatter.format(rawText, isUser, isReasoning);
-            const prevMatchIndex = globalState.matchIndex;
             const highlighted = this._applySearchHighlight(formatted, globalState);
             // Same policy as a normal render (see writeShadowContent), so a
             // search pass renders the message exactly like the pass before it:
@@ -1159,10 +1173,6 @@ if (messageData.isEditing) classes.push('editing');
             // The rewrite dropped the CSS report with the rest of the body;
             // put it back so searching does not hide a broken stylesheet.
             if (!window.bridge?.isGenerating) reportCssErrors(root);
-            
-            if (activeIndex >= prevMatchIndex && activeIndex < globalState.matchIndex) {
-              activeMessageId = section.dataset.messageId || section.dataset.vlId;
-            }
           }
         }
       };
@@ -1179,6 +1189,7 @@ if (messageData.isEditing) classes.push('editing');
     });
 
     const total = globalState.matchIndex;
+    this.searchTotal = total;
 
     // Flutter counts matches over the raw message text while this pass counts
     // them over the formatted HTML, so the two can drift apart (markdown
@@ -1191,15 +1202,132 @@ if (messageData.isEditing) classes.push('editing');
 
     if (!scroll) return;
 
-    if (activeMessageId && window.bridge) {
-      // The match may live in a message the virtual list has not mounted:
-      // scrollToMessage renders the window around it first, so only then can
-      // the highlight itself be brought into view.
-      window.bridge.scrollToMessage(activeMessageId);
-      setTimeout(() => this._scrollToActiveMatch(), 250);
-    } else {
-      this._scrollToActiveMatch();
+    // Same reveal the arrows use — this pass just rebuilt the highlights, so
+    // the nodes it numbered are the ones in the page right now.
+    if (this.activeSearchIndex >= 0 && this._moveActiveMatch(this.activeSearchIndex, true)) {
+      return;
     }
+    // The numbering found nothing to reveal at that index. A highlight may
+    // still be marked active in the page from an earlier pass; take that.
+    this._scrollToActiveMatch();
+  }
+
+  /* The sections the highlight numbering runs over: every message, not only
+   * the ones the virtual list currently mounts. `items` keeps the (possibly
+   * detached) element of each message, and a detached element keeps its shadow
+   * root — so a match in an unmounted message is still countable and still
+   * findable. */
+  _searchSections() {
+    return (window.bridge && window.bridge.virtualList)
+      ? window.bridge.virtualList.items.map(it => it.el)
+      : Array.from(document.querySelectorAll('.message-section'));
+  }
+
+  /* The highlight nodes in the numbering the last pass gave them: message
+   * order, reasoning before body, document order within each. Re-collected on
+   * demand rather than cached — a message re-render (an edit, a swipe, a
+   * scrollback batch) replaces the nodes, and a handful of querySelectorAll
+   * calls over shadow roots is nothing next to re-formatting the chat. */
+  _collectSearchHighlights() {
+    const found = [];
+    for (const section of this._searchSections()) {
+      if (!section) continue;
+      const hosts = [
+        section.querySelector('.msg-reasoning-inner .message-content'),
+        section.querySelector('.msg-body .message-content'),
+      ];
+      for (const host of hosts) {
+        const root = host && host.shadowRoot &&
+          host.shadowRoot.querySelector('.glaze-message');
+        if (!root) continue;
+        for (const node of root.querySelectorAll('.search-highlight-text')) {
+          found.push({ node, section });
+        }
+      }
+    }
+    return found;
+  }
+
+  /* Moves the active highlight without re-rendering anything. Returns false
+   * when the highlights in the DOM are not the set the last pass numbered —
+   * a message was re-rendered with a different number of hits, say — which is
+   * the caller's cue to run the full pass instead of moving a class onto the
+   * wrong word. */
+  _moveActiveMatch(activeIndex, scroll) {
+    if (activeIndex < 0) return false;
+    const found = this._collectSearchHighlights();
+    if (found.length === 0 || found.length !== this.searchTotal) return false;
+
+    // Flutter numbers matches over the raw text and can overshoot what the
+    // formatted HTML holds; clamp rather than leaving the arrow dead.
+    const index = Math.min(activeIndex, found.length - 1);
+    this.activeSearchIndex = index;
+    found.forEach((m, i) => m.node.classList.toggle('active-search-match', i === index));
+    if (scroll) this._revealMatch(found[index]);
+    return true;
+  }
+
+  /* Brings one hit into view — through the virtual list, in one move.
+   *
+   * The match may live in a message the list has not mounted at all, so the row
+   * has to be rendered before anything about it can be measured; and its height
+   * is not final until images and fonts have landed, so where the hit sits
+   * inside it keeps moving for a few hundred milliseconds after that. Handing
+   * the node itself to the jump lets every correction pass aim at the word
+   * rather than at the middle of the message — and keeps the list the only
+   * thing writing scrollTop, which is what a second, independent scroll used to
+   * fight. */
+  _revealMatch(match) {
+    if (!match || !match.node) return;
+    const vl = window.bridge && window.bridge.virtualList;
+    const section = match.section;
+    const id = section && (section.dataset.messageId || section.dataset.vlId);
+    const known = vl && id && typeof vl.scrollToMessage === 'function' &&
+      (typeof vl.hasMessage !== 'function' || vl.hasMessage(id));
+    if (!known) {
+      this._alignHighlight(match.node);
+      return;
+    }
+    vl.scrollToMessage(id, false, { fineTarget: match.node });
+  }
+
+  /* Centres the highlight itself, measured live against the scroll container.
+   *
+   * Not `scrollIntoView`: the node sits in a shadow root inside a virtualised
+   * row, and its smooth animation runs against the list's own scrolling — the
+   * two used to fight, which is how a hit ended up landing anywhere but on the
+   * match. A measured delta on the container is a single, final move. */
+  _alignHighlight(node) {
+    const vl = window.bridge && window.bridge.virtualList;
+    const container = (vl && vl.container) || document.getElementById('chat-container');
+    if (!container || !node || !node.isConnected) return;
+    const apply = () => {
+      const rect = node.getBoundingClientRect();
+      // No box to aim at (a hit inside a collapsed reasoning block, say): the
+      // row is already centred, which is as close as this gets.
+      if (rect.height === 0) return;
+      const cRect = container.getBoundingClientRect();
+      const delta = (rect.top - cRect.top) - (cRect.height / 2) + (rect.height / 2);
+      if (Math.abs(delta) < 2) return;
+      container.scrollTop = Math.max(0, container.scrollTop + delta);
+    };
+    // Claim the scroll for the duration: the list must read these as its own
+    // moves, not as the reader scrolling away. Never while a jump of the list's
+    // own is in flight, though — that one owns the flag, and handing it back
+    // early would let the rest of its corrections read as the reader scrolling.
+    const claimed = !!vl && !vl._settleActive;
+    if (claimed) vl.isProgrammaticScrolling = true;
+    apply();
+    clearTimeout(this._matchAlignTimer);
+    // One late correction — the row's own height can still be settling
+    // (images, fonts) after the list reports it landed.
+    this._matchAlignTimer = setTimeout(() => {
+      apply();
+      if (claimed) {
+        vl.isProgrammaticScrolling = false;
+        vl._lastScrollTop = container.scrollTop;
+      }
+    }, 120);
   }
 
   _scrollToActiveMatch() {
@@ -1208,7 +1336,7 @@ if (messageData.isEditing) classes.push('editing');
       if (!host.shadowRoot) continue;
       const active = host.shadowRoot.querySelector('.search-highlight-text.active-search-match');
       if (!active) continue;
-      active.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      this._revealMatch({ node: active, section: host.closest('.message-section') });
       return;
     }
   }

--- a/assets/chat_webview/useVirtualScroll.js
+++ b/assets/chat_webview/useVirtualScroll.js
@@ -205,15 +205,32 @@ class UseVirtualScroll {
         this._scrollToBottomPending = false;
         this._pendingScrollToId = null;
 
+        // A jump to a row (search navigation, "jump to source message") is not
+        // one scroll but a settle: the target is mounted, landed on by
+        // measurement, and re-measured while its real height arrives. The token
+        // identifies the jump in flight so a newer one — or the reader taking
+        // over — retires it instead of two of them fighting over scrollTop.
+        this._settleToken = 0;
+        this._settleActive = false;
+        this._settleTimer = null;
+        this._fineTarget = null;
+
         this.initObservers();
         
         this._onContainerScroll = this._onContainerScroll.bind(this);
         this.container.addEventListener('scroll', this._onContainerScroll, { passive: true });
+        // The reader always wins over a jump that is still settling: a wheel
+        // notch or a finger on the glass retires it on the spot, rather than
+        // having the next correction pass drag the view back.
+        this._onUserScrollIntent = () => this._cancelSettle();
+        this.container.addEventListener('wheel', this._onUserScrollIntent, { passive: true });
+        this.container.addEventListener('touchstart', this._onUserScrollIntent, { passive: true });
     }
 
     // --- API parity with VirtualList ---
 
     clear() {
+        this._cancelSettle();
         this._clearDOM();
         this.items = [];
         this.itemMap.clear();
@@ -273,6 +290,7 @@ class UseVirtualScroll {
     // no longer exists) so callers can fall back to the default position.
     restoreAnchor(anchor) {
         if (!anchor) return false;
+        this._cancelSettle();
         const item = this.itemMap.get(anchor.id);
         if (!item) return false;
         const container = this.container;
@@ -448,6 +466,7 @@ class UseVirtualScroll {
         const count = this.items.length;
         if (count === 0) return Promise.resolve();
 
+        this._cancelSettle();
         this._pinnedToBottom = true;
         let effectiveBehavior = behavior;
         if (this.container.scrollHeight - this.container.scrollTop - this.container.clientHeight > 3000) {
@@ -498,19 +517,28 @@ class UseVirtualScroll {
     }
 
     scrollToTop() {
+        this._cancelSettle();
         this.isProgrammaticScrolling = true;
         this.container.scrollTop = 0;
         setTimeout(() => { this.isProgrammaticScrolling = false; }, 150);
     }
 
-    scrollToMessage(id, highlight = false) {
+    /* Resolves true once the row has been landed on and has stopped moving,
+     * false when the jump was retired (a newer one, or the reader taking
+     * over). Callers that need to aim at something *inside* the row — the
+     * active search match — must wait for that: until the row's real height is
+     * in, every offset inside it is a guess. */
+    scrollToMessage(id, highlight = false, options = {}) {
         const item = this.itemMap.get(id);
-        if (!item) return;
-        this.scrollToIndex(item.index, 'smooth');
+        if (!item) return Promise.resolve(false);
+        const landed = this.scrollToIndex(item.index, options.behavior || 'smooth', options.fineTarget || null);
         // Mirror Vue: briefly flash the message the user navigated to (e.g.
-        // from a tapped "new message" notification). Wait for scrollToIndex to
-        // (re)render the row so the element exists before flashing it.
-        if (highlight) setTimeout(() => this.flashMessage(id), 400);
+        // from a tapped "new message" notification). After the settle, not on a
+        // fixed timer — the row exists from the first pass, but flashing it
+        // while it is still being corrected into place draws the eye to a
+        // rectangle that is about to move.
+        if (highlight) landed.then((ok) => { if (ok) this.flashMessage(id); });
+        return landed;
     }
 
     flashMessage(id) {
@@ -524,42 +552,157 @@ class UseVirtualScroll {
         setTimeout(() => el.classList.remove('message-flash-highlight'), 2000);
     }
 
-    scrollToIndex(index, behavior = 'auto') {
+    /* A jump lands by *measuring* the target, never by computing an offset out
+     * of the height cache.
+     *
+     * A row that has never been mounted has no measured height: everything the
+     * cache holds for it is `estimateHeight` or the crude guess in
+     * `_estimateHeight`. An offset summed out of those is wrong by whatever the
+     * guesses were wrong by — hundreds of pixels per row in a chat of long
+     * messages — so the old jump landed near the target at best, and off the
+     * viewport entirely at worst, which then looked like the list refusing to
+     * go there at all.
+     *
+     * So: mount the window around the target, land on it by reading its real
+     * rect, then keep re-reading it while the real heights arrive. The
+     * corrections are what make the landing survive the two things that move
+     * the rows out from under it — the observers replacing estimates with
+     * measurements (which rewrites the top spacer under a scroll position that
+     * does not move with it) and late reflow from images, fonts and badges.
+     *
+     * Returns a promise resolving true once the row is still, false if the jump
+     * was retired. */
+    scrollToIndex(index, behavior = 'auto', fineTarget = null) {
         const count = this.items.length;
-        if (count === 0) return;
+        if (count === 0) return Promise.resolve(false);
         index = Math.max(0, Math.min(index, count - 1));
-        
-        this.isProgrammaticScrolling = true;
-        
-        if (index >= this.renderStart && index < this.renderEnd) {
-            const item = this.items[index];
-            if (item && item.el) {
-                const cRect = this.container.getBoundingClientRect();
-                const elRect = item.el.getBoundingClientRect();
-                const targetTop = this.container.scrollTop + (elRect.top - cRect.top) - (cRect.height / 2) + (elRect.height / 2);
-                this.container.scrollTo({ top: Math.max(0, targetTop), behavior });
-            }
-            setTimeout(() => { this.isProgrammaticScrolling = false; }, behavior === 'smooth' ? 300 : 50);
-            return;
+
+        // Jumping off the end detaches the streaming follow: otherwise the next
+        // chunk's smartScroll pins the list back to the bottom and the row the
+        // reader asked for is gone again.
+        this._pinnedToBottom = index >= count - 1;
+
+        this._cancelSettle();
+        this._fineTarget = fineTarget;
+        const mounted = this._isMounted(index);
+        if (!mounted) this._mountAround(index);
+
+        // Animate only a move the reader can actually follow. Over rows that
+        // are being mounted by this very call there is nothing on screen to
+        // animate through, and the animation would still be in flight while the
+        // corrections below move its destination.
+        const animated = mounted && behavior === 'smooth';
+        this._alignToIndex(index, animated ? 'smooth' : 'auto');
+        return this._settleOn(index, animated);
+    }
+
+    _isMounted(index) {
+        const item = this.items[index];
+        return !!item && item.el && item.el.parentNode === this.container;
+    }
+
+    /* Mounts a window centred on `index` so the row has a rect to measure. */
+    _mountAround(index) {
+        const count = this.items.length;
+        this.renderStart = Math.max(0, index - this.getBuffer());
+        this.renderEnd = Math.min(count, index + this.getBuffer() + 1);
+        if (this.columns > 1) {
+            this.renderStart = Math.floor(this.renderStart / this.columns) * this.columns;
+            this.renderEnd = Math.min(count, Math.ceil(this.renderEnd / this.columns) * this.columns);
         }
-        
-        let newStart = Math.max(0, index - this.getBuffer());
-        let newEnd = Math.min(count, index + this.getBuffer() + 1);
-        this.renderStart = newStart;
-        this.renderEnd = newEnd;
+        this._clampWindow();
         this.visibleIndices.clear();
         this.realVisibleIndices.clear();
         this.cache.invalidate();
         this.updateSpacers();
         this.renderDOM();
-        
-        setTimeout(() => {
-            let targetTop = this.paddingTop + this.cache.computeTargetTop(this.renderStart, index, this.columns);
-            const itemH = this.cache.getHeight(index);
-            targetTop = targetTop - (this.container.clientHeight / 2) + (itemH / 2);
-            this.container.scrollTo({ top: Math.max(0, targetTop), behavior });
-            setTimeout(() => { this.isProgrammaticScrolling = false; }, behavior === 'smooth' ? 300 : 50);
-        }, 50);
+    }
+
+    /* Centres the row on the viewport from its live rect. Relative to the
+     * current scrollTop, not an absolute offset: a delta stays correct however
+     * far the spacers have drifted from what the cache thought they were.
+     *
+     * A `fineTarget` (the active search hit, which lives in the row's shadow
+     * root) is aimed at instead of the row: centring the row only gets the
+     * reader to the right message, and in a long message the word they are
+     * looking for is pages away from its middle. It is aimed at *here*, inside
+     * the settle, rather than by a second scroll afterwards — two things
+     * writing scrollTop over the same landing is what made a hit end up
+     * anywhere but on the match. */
+    _alignToIndex(index, behavior = 'auto') {
+        const item = this.items[index];
+        if (!item || !item.el) return false;
+        // A correction pass can find the row unmounted — a height correction
+        // may have rebuilt the window under it. Put it back rather than
+        // scrolling to where it used to be.
+        if (item.el.parentNode !== this.container) this._mountAround(index);
+
+        const cRect = this.container.getBoundingClientRect();
+        const fine = this._fineTarget;
+        let elRect = item.el.getBoundingClientRect();
+        if (fine && fine.isConnected) {
+            const fineRect = fine.getBoundingClientRect();
+            // A hit with no box — inside a collapsed reasoning block, say —
+            // leaves the row itself as the closest thing to aim at.
+            if (fineRect.height > 0) elRect = fineRect;
+        }
+        if (elRect.height === 0) return false;
+        const delta = (elRect.top - cRect.top) - (cRect.height / 2) + (elRect.height / 2);
+        if (Math.abs(delta) < 1) return true;
+        const top = Math.max(0, this.container.scrollTop + delta);
+        if (behavior === 'smooth') this.container.scrollTo({ top, behavior: 'smooth' });
+        else this.container.scrollTop = top;
+        return true;
+    }
+
+    /* Re-measures the target over the window in which its height settles, and
+     * only then hands the list back to the observers.
+     *
+     * `afterAnimation` waits out a smooth scroll before correcting anything:
+     * a correction is an assignment to scrollTop, and an assignment cancels the
+     * browser's animation. The corrections are spread over the same window the
+     * rest of the list uses for late height changes, so the last one runs after
+     * the ResizeObserver has had its say about images and fonts. */
+    _settleOn(index, afterAnimation = false) {
+        const token = ++this._settleToken;
+        this._settleActive = true;
+        this.isProgrammaticScrolling = true;
+        const delays = afterAnimation ? [420, 540, 760] : [0, 60, 160, 320, 600];
+        return new Promise((resolve) => {
+            let i = 0;
+            const step = () => {
+                if (!this.mounted || token !== this._settleToken) { resolve(false); return; }
+                this._alignToIndex(index, 'auto');
+                if (++i < delays.length) {
+                    this._settleTimer = setTimeout(step, delays[i] - delays[i - 1]);
+                    return;
+                }
+                this._settleActive = false;
+                this._fineTarget = null;
+                this.isProgrammaticScrolling = false;
+                // The pin tracker must not read the settle's own landing as the
+                // reader scrolling away on the next event.
+                this._lastScrollTop = this.container.scrollTop;
+                this.updateWindow();
+                this._recoverIfViewportIsBlank();
+                resolve(true);
+            };
+            if (delays[0] > 0) this._settleTimer = setTimeout(step, delays[0]);
+            else requestAnimationFrame(step);
+        });
+    }
+
+    /* Retires the jump in flight. Called by every other scroll entry point and
+     * by the reader's first wheel notch or touch, so two scrolls never fight
+     * over scrollTop. */
+    _cancelSettle() {
+        this._fineTarget = null;
+        if (!this._settleActive) return;
+        this._settleToken++;
+        this._settleActive = false;
+        clearTimeout(this._settleTimer);
+        this._settleTimer = null;
+        this.isProgrammaticScrolling = false;
     }
 
     getMessageCount() { return this.items.length; }
@@ -668,6 +811,7 @@ class UseVirtualScroll {
     }
 
     refresh({ startAtBottom = true } = {}) {
+        this._cancelSettle();
         this.cache.clear();
         this.visibleIndices.clear();
         this.realVisibleIndices.clear();
@@ -795,6 +939,15 @@ class UseVirtualScroll {
      * rows away from the viewport without a scroll event ends here. */
     _recoverIfViewportIsBlank() {
         if (!this.mounted) return false;
+        // A jump that is still settling is its own, stronger recovery: it
+        // re-mounts the window around the target and re-measures it on every
+        // pass, so it cannot leave the list rendering nothing (`_settleOn` runs
+        // this check itself the moment it hands the list back). Recentring
+        // underneath it, on the other hand, unmounts the row being landed on —
+        // and it would do exactly that, because it reads a scroll position the
+        // height cache has not caught up with yet and maps it to some other
+        // row entirely.
+        if (this._settleActive) return false;
         if (!this._viewportOutsideRenderedBand()) return false;
         return this._recenterOnScrollPosition();
     }
@@ -969,9 +1122,12 @@ class UseVirtualScroll {
 
     destroy() {
         this.mounted = false;
+        this._cancelSettle();
         if (this.observer) this.observer.disconnect();
         if (this.realObserver) this.realObserver.disconnect();
         if (this.resizeObserver) this.resizeObserver.disconnect();
         this.container.removeEventListener('scroll', this._onContainerScroll);
+        this.container.removeEventListener('wheel', this._onUserScrollIntent);
+        this.container.removeEventListener('touchstart', this._onUserScrollIntent);
     }
 }

--- a/docs/rules/message-rendering.md
+++ b/docs/rules/message-rendering.md
@@ -164,6 +164,81 @@ Two rules follow, and `specs/virtual_window.spec.js` holds them:
 
 ---
 
+## A jump lands by measuring the target, never by summing the cache
+
+Everything the height cache holds for a row that has never been mounted is a
+guess — `estimateHeight`, or the coarse bands in `_estimateHeight`. So a jump
+(`scrollToIndex`) mounts a window around the target first, then reads the row's
+real rect and scrolls by the *delta* to centre it. A delta stays correct however
+far the spacers have drifted from what the cache thought they were; an absolute
+offset summed out of the cache is wrong by whatever the guesses were wrong by,
+which in a chat of long messages is screens, not pixels.
+
+Landing once is not enough either. Two things move the rows out from under a
+landing with no scroll event to follow: the observers replacing estimates with
+measurements (which rewrites the top spacer under a scroll position that does
+not move with it) and late reflow from images, fonts and badges. So a jump is a
+**settle**, not a scroll — `_settleOn` re-measures and re-corrects across the
+same window the rest of the list uses for late height changes, and only then
+hands the list back to `updateWindow`.
+
+Three rules follow, and `specs/search_navigation.spec.js` holds them:
+
+* **one thing writes `scrollTop` per landing.** A caller that needs to aim at
+  something *inside* the row — the active search hit, which lives in the row's
+  shadow root — hands that node to the jump as `fineTarget` and lets every
+  correction pass aim at it. A second scroll of its own afterwards (what
+  `scrollIntoView` on the highlight used to be) races the corrections, and the
+  hit ends up anywhere but in view.
+* **the reader outranks a settle.** A wheel notch or a touch retires it, as does
+  any other scroll entry point (`scrollToBottom`, `scrollToTop`, `refresh`,
+  `restoreAnchor`), so two of them are never in flight at once.
+* **`_recoverIfViewportIsBlank` stands down while a settle runs.** It is the
+  weaker recovery of the two: it maps a scroll position through a cache that has
+  not caught up yet, which unmounts the row being landed on. The settle re-mounts
+  its target on every pass and runs the blank check itself the moment it
+  finishes, so the invariant above still holds.
+
+---
+
+## State that has to reach the whole chat is written to `items`, not the document
+
+`document.querySelectorAll('.message-section')` is the twenty-odd rows the list
+has mounted, not the chat. And the list re-mounts the element it built once
+rather than re-rendering it, so a row that was outside the window when the
+write happened never gets a second chance at it.
+
+Anything whose truth spans the whole chat therefore goes through
+`virtualList.items` — `Bridge._allMessageSections()` for elements,
+`Bridge._orderedMessageIds()` for ids. Selection is the case that taught this:
+"select everything above" already walked the item order, so the toolbar counted
+messages the reader then scrolled back to and found unselected, in a chat that
+did not look like it was in selection mode at all
+(`specs/selection_window.spec.js`).
+
+Class writes that only ever concern one section — `applyClassesToSection` at
+render time, the editing section, the flash highlight — stay where they are.
+
+---
+
+## Walking the search hits moves a class, not the chat
+
+`setSearch` re-formats and rewrites the shadow body of **every message in the
+chat**. That is the right thing when the query changes; it is the wrong thing
+for the prev/next arrows, which change one thing only — which highlight is
+active. Doing the full pass per press costs hundreds of milliseconds on a long
+chat, and the presses arrive faster than the passes finish, which is what made
+the arrows look dead.
+
+So an active-index-only change takes `_moveActiveMatch`: re-collect the
+highlight nodes in the numbering the last pass gave them (message order,
+reasoning before body), move the `active-search-match` class, reveal. The count
+check is what keeps it honest — when the highlights in the page are not the set
+the last pass numbered, the full pass runs instead of a class landing on the
+wrong word.
+
+---
+
 ## A user message wears the persona it was sent as, not the active one
 
 Every user message stores the persona it was sent under — `personaId` and

--- a/lib/features/chat/widgets/chat_webview_initializer.dart
+++ b/lib/features/chat/widgets/chat_webview_initializer.dart
@@ -203,6 +203,10 @@ class ChatWebViewInitializer {
       activeIndex: (input.searchQuery?.isNotEmpty ?? false)
           ? input.searchCurrentIndex
           : -1,
+      // Numbering only: there is nothing to scroll to yet, and the highlights
+      // still in the page belong to the chat being replaced — revealing one of
+      // those would jump to a match in a message this chat does not have.
+      scroll: false,
     );
     // Memory membership is mapper input, not a post-render decoration. Seed it
     // before mapping so the first layout already includes MEM/PENDING/DRAFT
@@ -245,14 +249,18 @@ class ChatWebViewInitializer {
     if (input.blurRegions.isNotEmpty) {
       await bridge.setOverlayBlurRegions(input.blurRegions);
     }
+    await bridge.setSelectionMode(input.isSelectionMode);
+    await bridge.scrollToBottom();
+    // After the opening jump to the bottom, not before it: revealing the active
+    // match is a scroll of its own, and the two land in the order they are
+    // issued. Opening a chat whose search is still open should leave the reader
+    // on the match, not at the end of the chat.
     if (input.searchQuery != null && input.searchQuery!.isNotEmpty) {
       await bridge.setSearch(
         query: input.searchQuery!,
         activeIndex: input.searchCurrentIndex,
       );
     }
-    await bridge.setSelectionMode(input.isSelectionMode);
-    await bridge.scrollToBottom();
     unawaited(
       bridge.evalJs(
         'if (window.bridge) { '

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -192,6 +192,55 @@ void main() {
       );
     });
 
+    test('a jump measures the row instead of summing the height cache', () {
+      final body = _extractBlockBody(
+        virtualScrollJs,
+        virtualScrollJs.indexOf('_alignToIndex(index, behavior'),
+      );
+      expect(body, contains('getBoundingClientRect()'));
+      expect(
+        body,
+        contains('this.container.scrollTop + delta'),
+        reason:
+            'The landing is a delta on the live rect. An absolute offset summed '
+            'out of the height cache is wrong by however wrong the estimates '
+            'for the never-mounted rows were — screens, in a chat of long '
+            'messages.',
+      );
+      expect(
+        virtualScrollJs,
+        isNot(contains('this.cache.computeTargetTop(this.renderStart, index')),
+      );
+    });
+
+    test('a settling jump owns the scroll position alone', () {
+      final recovery = _extractBlockBody(
+        virtualScrollJs,
+        virtualScrollJs.indexOf('_recoverIfViewportIsBlank() {'),
+      );
+      // The weaker of the two recoveries stands down: it maps a scroll position
+      // through a cache that has not caught up yet, which unmounts the row
+      // being landed on. The settle re-mounts its target on every pass and runs
+      // the blank check itself when it finishes.
+      expect(recovery, contains('if (this._settleActive) return false;'));
+      final settle = _extractBlockBody(
+        virtualScrollJs,
+        virtualScrollJs.indexOf('_settleOn(index, afterAnimation = false)'),
+      );
+      expect(settle, contains('this._recoverIfViewportIsBlank()'));
+      // Everything else that scrolls retires the jump first, and so does the
+      // reader's first wheel notch or touch.
+      expect(
+        virtualScrollJs,
+        contains("addEventListener('wheel', this._onUserScrollIntent"),
+      );
+      final bottom = _extractBlockBody(
+        virtualScrollJs,
+        virtualScrollJs.indexOf("scrollToBottom(behavior = 'auto')"),
+      );
+      expect(bottom, contains('this._cancelSettle()'));
+    });
+
     test('scroll-to-bottom resolves after its correction pass', () {
       final body = _extractBlockBody(
         virtualScrollJs,
@@ -324,6 +373,43 @@ void main() {
       expect(
         bridgeControllerJs,
         contains('setSearch(query, activeIndex, scroll = true)'),
+      );
+    });
+
+    test('walking the search hits moves a class, not the chat', () {
+      final searchBlock = _extractBlockBody(
+        rendererMessageJs,
+        rendererMessageJs.indexOf('setSearch(query, activeIndex = -1'),
+      );
+      // The prev/next arrows change one thing — which highlight is active. The
+      // full pass re-formats and rewrites the shadow body of every message in
+      // the chat to arrive at that, which on a long chat takes longer than the
+      // gap between two presses.
+      expect(
+        searchBlock,
+        contains('this._moveActiveMatch(activeIndex, scroll)'),
+      );
+      final move = _extractBlockBody(
+        rendererMessageJs,
+        rendererMessageJs.indexOf('_moveActiveMatch(activeIndex, scroll) {'),
+      );
+      expect(move, isNot(contains('this.formatter.format')));
+      // …but only while the highlights in the page are the set the last pass
+      // numbered; otherwise the class lands on the wrong word.
+      expect(move, contains('found.length !== this.searchTotal'));
+    });
+
+    test('the active hit is revealed through the virtual list', () {
+      // One thing writes scrollTop per landing: the node is handed to the jump
+      // so its correction passes aim at the hit, instead of a second scroll of
+      // our own racing them.
+      expect(rendererMessageJs, contains('fineTarget: match.node'));
+      expect(
+        rendererMessageJs,
+        isNot(contains('.scrollIntoView(')),
+        reason:
+            'scrollIntoView on the highlight animates against the scrolling '
+            'of the list itself, and the hit lands anywhere but in view.',
       );
     });
 
@@ -2533,6 +2619,35 @@ void main() {
         contains('get selectionMode()'),
         reason: 'SelectionManager must expose selectionMode as public getter',
       );
+    });
+
+    test('selection classes reach messages outside the render window', () {
+      // Selection is held by id and covers the whole chat, but what the reader
+      // sees was written to the document — which in a virtualised list is the
+      // rows mounted right now. The list re-mounts the element it already
+      // built rather than re-rendering it, so a row outside the window at the
+      // time of the click never learned it had been selected.
+      final apply = _extractBlockBody(
+        selectionManagerJs,
+        selectionManagerJs.indexOf('_applySelectionClasses() {'),
+      );
+      expect(apply, contains('this._sections()'));
+      expect(
+        apply,
+        isNot(contains("document.querySelectorAll('.message-section')")),
+      );
+      final mode = _extractBlockBody(
+        selectionManagerJs,
+        selectionManagerJs.indexOf('setSelectionMode(enabled) {'),
+      );
+      expect(mode, contains('this._sections()'));
+      expect(
+        mode,
+        isNot(contains("document.querySelectorAll('.message-section')")),
+      );
+      // The whole-chat element list comes from the virtual list's items, the
+      // same place range selection reads its id order from.
+      expect(bridgeControllerJs, contains('_allMessageSections()'));
     });
 
     test('bridge.js does not access _selectionMode directly', () {

--- a/test/webview_js/README.md
+++ b/test/webview_js/README.md
@@ -34,6 +34,8 @@ imports the assets by their real paths, and ES modules do not load over
 | `specs/streaming.spec.js` | every prefix of a card body renders as a card |
 | `specs/document_contract.spec.js` | what a card may rely on inside the shadow root (INV-MR1…MR8) |
 | `specs/virtual_window.spec.js` | the render window of the virtualised list — the chat must never go blank |
+| `specs/search_navigation.spec.js` | walking the search hits — every arrow press lands on its own match |
+| `specs/selection_window.spec.js` | selecting messages the render window does not hold |
 
 ## The rule
 

--- a/test/webview_js/specs/search_navigation.spec.js
+++ b/test/webview_js/specs/search_navigation.spec.js
@@ -1,0 +1,268 @@
+// Walking the search hits with the prev/next arrows, in a virtualised list.
+//
+// The bug this holds down was reported as "the up/down buttons and the search
+// don't let you get to the message" — the arrows moved the counter but the
+// reader stayed where they were, or landed a screen away from the hit, or on a
+// blank stretch of chat.
+//
+// It is a geometry failure, which is why these drive the real page. A hit in a
+// message the list has not mounted has no measurable height: everything the
+// height cache holds for it is an estimate, and the old jump computed its
+// landing by summing those estimates. In a chat of uneven messages that is
+// wrong by hundreds of pixels a row. Then the observers replaced the estimates
+// with measurements, the top spacer was rewritten under a scroll position that
+// did not move with it, and whatever the jump had reached slid away again.
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/assets/chat_webview/index.html';
+
+// Messages of very uneven length, and only some of them carry the needle. The
+// unevenness is the point: it is what makes an estimated height wrong.
+async function boot(page) {
+  await page.setViewportSize({ width: 420, height: 720 });
+  await page.goto(PAGE);
+  await page.waitForFunction(() => !!window.bridge);
+  await page.evaluate(() => {
+    window.__chat = (count) =>
+      JSON.stringify(
+        Array.from({ length: count }, (_, i) => {
+          const long = 'lorem ipsum dolor sit amet consectetur '.repeat(2 + (i % 9) * 4);
+          // Every seventh message holds one needle, in the middle of its body.
+          const body = i % 7 === 3
+            ? `${long} needle-${i} ${long}`
+            : `Message ${i}. ${long}`;
+          return {
+            id: 'm' + i,
+            role: i % 2 ? 'user' : 'assistant',
+            text: body,
+            timestamp: 1767225600000,
+            isUser: i % 2 === 1,
+            isAssistant: i % 2 === 0,
+            isSystem: false,
+            displayName: i % 2 ? 'You' : 'Alice',
+            isError: false,
+            isHidden: false,
+            isGenerating: false,
+            isPostGenRunning: false,
+          };
+        }),
+      );
+  });
+}
+
+async function openChat(page, count) {
+  await page.evaluate((n) => window.bridge.setMessages(window.__chat(n)), count);
+  await page.waitForTimeout(600);
+}
+
+/** Where the active hit sits relative to the viewport, or null if nowhere. */
+const activeMatchBox = (page) =>
+  page.evaluate(() => {
+    const container = window.bridge.virtualList.container;
+    const view = container.getBoundingClientRect();
+    for (const host of document.querySelectorAll('.message-content')) {
+      if (!host.shadowRoot) continue;
+      const active = host.shadowRoot.querySelector(
+        '.search-highlight-text.active-search-match',
+      );
+      if (!active) continue;
+      const r = active.getBoundingClientRect();
+      if (r.height === 0) continue;
+      const section = host.closest('.message-section');
+      return {
+        top: r.top - view.top,
+        bottom: r.bottom - view.top,
+        viewHeight: view.height,
+        text: active.textContent,
+        messageId: section && (section.dataset.messageId || section.dataset.vlId),
+      };
+    }
+    return null;
+  });
+
+/** How many message rows the reader can actually see. */
+const onScreenCount = (page) =>
+  page.evaluate(() => {
+    const container = window.bridge.virtualList.container;
+    const view = container.getBoundingClientRect();
+    return [...document.querySelectorAll('#chat-container .message-section')].filter(
+      (el) => {
+        const r = el.getBoundingClientRect();
+        return r.height > 0 && r.bottom > view.top && r.top < view.bottom;
+      },
+    ).length;
+  });
+
+const search = async (page, index) => {
+  await page.evaluate((i) => window.bridge.setSearch('needle', i, true), index);
+  // The jump settles over ~600ms (mounting, then correcting as real heights
+  // arrive); the alignment is only final after that.
+  await page.waitForTimeout(1100);
+};
+
+test('the first hit of a long chat is scrolled to, not merely highlighted', async ({
+  page,
+}) => {
+  await boot(page);
+  await openChat(page, 90);
+
+  // Hit 0 lives in m3, ~87 messages above where the chat opens. Nothing about
+  // that message has ever been measured.
+  await search(page, 0);
+
+  const box = await activeMatchBox(page);
+  expect(box).not.toBeNull();
+  expect(box.text).toContain('needle');
+  expect(box.top).toBeGreaterThan(0);
+  expect(box.bottom).toBeLessThan(box.viewHeight);
+  expect(await onScreenCount(page)).toBeGreaterThan(0);
+});
+
+test('every arrow press lands on its own hit', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 90);
+
+  const seen = [];
+  for (const index of [0, 1, 2, 3, 4]) {
+    await search(page, index);
+    const box = await activeMatchBox(page);
+    expect(box, `hit ${index} is off screen`).not.toBeNull();
+    expect(box.top).toBeGreaterThan(0);
+    expect(box.bottom).toBeLessThan(box.viewHeight);
+    seen.push(box.messageId);
+  }
+  // The corpus puts one needle in every seventh message, so consecutive hits
+  // are in different messages: each press moved on rather than re-landing on
+  // the one before it.
+  expect(new Set(seen).size).toBe(seen.length);
+});
+
+test('walking backwards lands just as precisely', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 90);
+
+  await search(page, 6);
+  for (const index of [5, 4, 3]) {
+    await search(page, index);
+    const box = await activeMatchBox(page);
+    expect(box, `hit ${index} is off screen`).not.toBeNull();
+    expect(box.top).toBeGreaterThan(0);
+    expect(box.bottom).toBeLessThan(box.viewHeight);
+  }
+});
+
+test('the hit stays put while the row settles', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 90);
+
+  await search(page, 2);
+  const landed = await activeMatchBox(page);
+  // Long after the jump: nothing — a late height correction, the observers
+  // rewriting the spacers — may drag the match back out of view.
+  await page.waitForTimeout(1200);
+  const later = await activeMatchBox(page);
+  expect(later).not.toBeNull();
+  expect(Math.abs(later.top - landed.top)).toBeLessThan(24);
+});
+
+test('moving the active hit does not re-render the whole chat', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 90);
+  await search(page, 0);
+
+  // The full pass re-formats and rewrites the shadow body of every message in
+  // the chat. Doing that per arrow press is what made the arrows feel dead on
+  // a long chat: the presses arrive faster than the passes finish.
+  const formatCalls = await page.evaluate(async () => {
+    const renderer = window.bridge.renderer;
+    const formatter = renderer.formatter;
+    const real = formatter.format.bind(formatter);
+    let calls = 0;
+    formatter.format = (...args) => { calls++; return real(...args); };
+    window.bridge.setSearch('needle', 1, true);
+    formatter.format = real;
+    return calls;
+  });
+  expect(formatCalls).toBe(0);
+
+  await page.waitForTimeout(1100);
+  const box = await activeMatchBox(page);
+  expect(box).not.toBeNull();
+  expect(box.top).toBeGreaterThan(0);
+  expect(box.bottom).toBeLessThan(box.viewHeight);
+});
+
+test('the reader can scroll away from a jump that is still settling', async ({
+  page,
+}) => {
+  await boot(page);
+  await openChat(page, 90);
+
+  await page.evaluate(() => window.bridge.setSearch('needle', 4, true));
+  await page.waitForTimeout(120);
+  // A wheel notch mid-settle: the corrections must stand down rather than
+  // dragging the view back under the reader.
+  await page.evaluate(() => {
+    const container = window.bridge.virtualList.container;
+    container.dispatchEvent(new WheelEvent('wheel', { deltaY: 240, bubbles: true }));
+    container.scrollTop += 600;
+  });
+  const afterUser = await page.evaluate(() => window.bridge.virtualList.container.scrollTop);
+  await page.waitForTimeout(900);
+  const settled = await page.evaluate(() => window.bridge.virtualList.container.scrollTop);
+  expect(Math.abs(settled - afterUser)).toBeLessThan(200);
+  expect(await onScreenCount(page)).toBeGreaterThan(0);
+});
+
+test('hits inside one long message are reached one by one', async ({ page }) => {
+  await boot(page);
+  // One message tall enough to be several screens, carrying three hits pages
+  // apart. Centring the *message* would leave all three off screen: the jump
+  // has to aim at the hit itself.
+  await page.evaluate(() => {
+    const filler = 'lorem ipsum dolor sit amet consectetur adipiscing elit. '.repeat(120);
+    const body = `${filler} needle one ${filler} needle two ${filler} needle three ${filler}`;
+    window.bridge.setMessages(
+      JSON.stringify([
+        {
+          id: 'tall',
+          role: 'assistant',
+          text: body,
+          timestamp: 1767225600000,
+          isUser: false,
+          isAssistant: true,
+          isSystem: false,
+          displayName: 'Alice',
+          isError: false,
+          isHidden: false,
+          isGenerating: false,
+          isPostGenRunning: false,
+        },
+      ]),
+    );
+  });
+  await page.waitForTimeout(600);
+
+  const tops = [];
+  for (const index of [0, 1, 2]) {
+    await search(page, index);
+    const box = await activeMatchBox(page);
+    expect(box, `hit ${index} is off screen`).not.toBeNull();
+    expect(box.top).toBeGreaterThan(0);
+    expect(box.bottom).toBeLessThan(box.viewHeight);
+    tops.push(await page.evaluate(() => window.bridge.virtualList.container.scrollTop));
+  }
+  // Each hit is further down the same message than the one before it.
+  expect(tops[1]).toBeGreaterThan(tops[0]);
+  expect(tops[2]).toBeGreaterThan(tops[1]);
+});
+
+test('a jump to a hit never leaves the chat blank', async ({ page }) => {
+  await boot(page);
+  await openChat(page, 120);
+
+  for (const index of [8, 0, 11, 3]) {
+    await search(page, index);
+    expect(await onScreenCount(page), `blank after hit ${index}`).toBeGreaterThan(0);
+  }
+});

--- a/test/webview_js/specs/selection_window.spec.js
+++ b/test/webview_js/specs/selection_window.spec.js
@@ -1,0 +1,100 @@
+// Selecting messages in a virtualised list.
+//
+// Selection is held by id and reaches the whole chat — "select everything
+// above" walks the list's own item order, not the DOM. What the reader *sees*
+// used to be written to the document only, which in a virtualised list is the
+// twenty-odd rows currently mounted. And the list re-mounts the element it
+// built once rather than re-rendering it, so a row outside the window at the
+// moment of the click never learned it had been selected: scrolling back to it
+// showed an unselected message in a chat that did not even look like it was in
+// selection mode.
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/assets/chat_webview/index.html';
+
+async function boot(page) {
+  await page.setViewportSize({ width: 420, height: 720 });
+  await page.goto(PAGE);
+  await page.waitForFunction(() => !!window.bridge);
+  await page.evaluate(() => {
+    window.__chat = (count) =>
+      JSON.stringify(
+        Array.from({ length: count }, (_, i) => ({
+          id: 'm' + i,
+          role: i % 2 ? 'user' : 'assistant',
+          text: `Message ${i}. ` + 'lorem ipsum dolor sit amet '.repeat(3 + (i % 7)),
+          timestamp: 1767225600000,
+          isUser: i % 2 === 1,
+          isAssistant: i % 2 === 0,
+          isSystem: false,
+          displayName: i % 2 ? 'You' : 'Alice',
+          isError: false,
+          isHidden: false,
+          isGenerating: false,
+          isPostGenRunning: false,
+        })),
+      );
+  });
+  await page.evaluate(() => window.bridge.setMessages(window.__chat(80)));
+  await page.waitForTimeout(600);
+}
+
+/** The classes one message carries, whether or not it is mounted right now. */
+const classesOf = (page, id) =>
+  page.evaluate((messageId) => {
+    const item = window.bridge.virtualList.itemMap.get(messageId);
+    return item ? [...item.el.classList] : null;
+  }, id);
+
+test('selection mode reaches messages outside the render window', async ({ page }) => {
+  await boot(page);
+  await page.evaluate(() => window.bridge.setSelectionMode(true));
+
+  // m2 is near the top of an 80-message chat that opened at the bottom: far
+  // outside the mounted window.
+  expect(await classesOf(page, 'm2')).toContain('selection-mode');
+  expect(await classesOf(page, 'm79')).toContain('selection-mode');
+});
+
+test('selecting a run marks the messages the reader cannot see yet', async ({
+  page,
+}) => {
+  await boot(page);
+  await page.evaluate(() => {
+    window.bridge.setSelectionMode(true);
+    window.bridge.renderer.selectionManager.selectOnly('m75');
+    window.bridge.selectMessagesAbove();
+  });
+
+  // Everything above m75 is selected, including the rows the window never held.
+  expect(await classesOf(page, 'm1')).toContain('selected');
+  expect(await classesOf(page, 'm40')).toContain('selected');
+  expect(await classesOf(page, 'm74')).toContain('selected');
+  expect(await classesOf(page, 'm76')).not.toContain('selected');
+
+  // And they still read as selected once the reader scrolls up to them.
+  await page.evaluate(() => window.bridge.virtualList.scrollToMessage('m40'));
+  await page.waitForTimeout(900);
+  const shown = await page.evaluate(() => {
+    const el = document.querySelector('#chat-container [data-message-id="m40"]');
+    return el ? [...el.classList] : null;
+  });
+  expect(shown).toContain('selected');
+  expect(shown).toContain('selection-mode');
+});
+
+test('leaving selection mode clears the whole chat, not just the window', async ({
+  page,
+}) => {
+  await boot(page);
+  await page.evaluate(() => {
+    window.bridge.setSelectionMode(true);
+    window.bridge.renderer.selectionManager.selectOnly('m75');
+    window.bridge.selectMessagesAbove();
+    window.bridge.setSelectionMode(false);
+  });
+
+  expect(await classesOf(page, 'm1')).not.toContain('selected');
+  expect(await classesOf(page, 'm1')).not.toContain('selection-mode');
+  expect(await classesOf(page, 'm40')).not.toContain('selected');
+});


### PR DESCRIPTION
The search prev/next arrows moved the counter but not the reader: the hit stayed off screen, the list landed a screen away from it, or the chat went blank around it. Selecting a run of messages had the matching failure — the toolbar counted messages that still looked unselected once the reader scrolled back to them.

Three separate causes, all of them the virtualised list.

## The jump (`useVirtualScroll.js`)

- `scrollToIndex` now mounts a window around the target and lands on it by reading its real rect, scrolling by the *delta*. The old jump summed an absolute offset out of the height cache, which for a row that has never been mounted holds nothing but `estimateHeight` / `_estimateHeight` guesses — wrong by screens, not pixels, in a chat of long messages.
- A jump is a **settle**, not a scroll (`_settleOn`): it re-measures and re-corrects across the window in which the row's height actually settles. Without that, the observers replacing estimates with measurements (which rewrites the top spacer under a scroll position that does not move with it) and late reflow from images and fonts slid the target away right after the landing.
- The active search hit is handed to the jump as a `fineTarget`, so every correction pass aims at the word rather than at the middle of the message — and one thing writes `scrollTop` per landing. The second, independent `scrollIntoView` on the highlight raced the jump's own corrections and is gone.
- The reader outranks a settle: a wheel notch or a touch retires it, as does every other scroll entry point (`scrollToBottom`, `scrollToTop`, `refresh`, `restoreAnchor`, `clear`).
- `_recoverIfViewportIsBlank` stands down while a settle runs — it maps a scroll position through a cache that has not caught up yet and would unmount the row being landed on. The settle re-mounts its target on every pass and runs the blank check itself the moment it finishes, so the "never leave the list rendering nothing" invariant still holds.
- `scrollToMessage` returns the settle promise and flashes the message after it, instead of on a fixed 400 ms timer.

## The arrows (`renderer/message_renderer.js`)

- Moving the active hit no longer re-formats and rewrites the shadow body of every message in the chat. That full pass costs hundreds of milliseconds on a long chat, once per press, while the presses arrive faster than the passes finish — which is what made the arrows feel dead. `Renderer._moveActiveMatch` re-collects the highlight nodes in the numbering the last pass gave them (message order, reasoning before body) and moves the `active-search-match` class; a count mismatch still falls back to the full pass, so a class never lands on the wrong word.
- `Renderer._revealMatch` reveals through the list with the node attached, replacing the `scrollToMessage` + 250 ms `_scrollToActiveMatch` pair.

## Opening a chat with a search still open (`chat_webview_initializer.dart`)

- The pre-paint `setSearch` push passes `scroll: false`: there is nothing to scroll to yet, and the highlights still in the page belong to the chat being replaced.
- The reveal now runs *after* the opening `scrollToBottom()` instead of before it, so re-entering a chat leaves the reader on the match rather than at the end.

## Selection (`bridge/selection_manager.js`, `bridge/chat_bridge_controller.js`)

- Selection classes are written to `virtualList.items` (`Bridge._allMessageSections()`), not to `document.querySelectorAll('.message-section')`. Selection is held by id and `selectAbove` / `selectBelow` already walked the full item order, but the list re-mounts the element it already built rather than re-rendering it — so a row outside the render window at the time of the click never learned it had been selected, and never looked like it was in selection mode either.

## Docs

- `docs/rules/message-rendering.md`: three new sections — a jump lands by measuring, state that spans the chat is written to `items` rather than the document, and walking the search hits moves a class rather than the chat.

## Verification

- **New**: `test/webview_js/specs/search_navigation.spec.js` (8 cases). Reverting only the two changed asset files makes **5 of them fail**; the other 3 are regression guards for this change (the reader can scroll away mid-settle; a jump never blanks the chat).
- **New**: `test/webview_js/specs/selection_window.spec.js` (3 cases). Reverting only the two changed bridge files makes **2 of them fail**.
- Full WebView render suite: **97 passed**, re-run after rebasing onto current `nightly`. The two new specs were also run with `--repeat-each=3` (33 passed) to check for timing flakes.
- Static assertions added to `test/webview_assets_test.dart` for the measured landing, the settle's ownership of `scrollTop`, the class-only arrow move and the whole-chat selection write.
- **Not run: `flutter analyze` and `flutter test`** — no Flutter SDK in the agent's environment. The Dart changes are the initializer reorder and the new static assertions; every new assertion was verified by re-implementing `_extractBlockBody` and running it against the edited assets, but CI is the gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JsfgND5BpE4jnwgu7TS3X

---
_Generated by [Claude Code](https://claude.ai/code/session_018JsfgND5BpE4jnwgu7TS3X)_