### PR TITLE
fix(personas): refresh replaced avatars in chat

### DIFF
--- a/lib/features/personas/persona_list_screen.dart
+++ b/lib/features/personas/persona_list_screen.dart
@@ -332,8 +332,10 @@ class _PersonaEditorScreenState extends ConsumerState<_PersonaEditorScreen> {
 
     final imageStorage = await ref.read(imageStorageProvider.future);
     final bytes = await File(filePath).readAsBytes();
+    // Reusing persona_<id>.png leaves the WebView on its cached image and the
+    // persona roster cannot observe a change because avatarPath stays equal.
     final savedPath = await imageStorage.saveAvatar(
-      'persona_$_personaId',
+      'persona_${_personaId}_${DateTime.now().microsecondsSinceEpoch}',
       bytes,
     );
     await FileImage(File(savedPath)).evict();


### PR DESCRIPTION
## Summary

- save replacement persona avatars under a unique path
- make persona roster changes observable by the chat WebView
- prevent stale cached avatars from remaining on user messages

## Testing

- dart format --output=none --set-exit-if-changed lib/features/personas/persona_list_screen.dart
- flutter analyze lib/features/personas/persona_list_screen.dart
- flutter test test/chat_message_persona_test.dart