### PR TITLE
feat(linux): add AppImage and .tar.zst release artifacts

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -26,7 +26,7 @@ on:
         default: true
         type: boolean
       build_linux:
-        description: 'Linux (DEB + pacman)'
+        description: 'Linux (DEB + pacman + AppImage + tar.zst)'
         required: false
         default: true
         type: boolean
@@ -86,11 +86,10 @@ jobs:
           SAFE_BRANCH=$(echo "$BUILD_BRANCH" | sed 's#[/ ]#-#g')
           FILE_SLUG="G-$(date -u '+%d%m%Y-%H%M')-$SAFE_BRANCH"
 
-          # Release channel drives the app identity, data folder, cloud root,
-          # update source and the build-watermark default via
-          # --dart-define=BUILD_CHANNEL. Developer mode is off on every channel
-          # and only unlocks via the About easter egg. Only the two release
-          # branches get a non-nightly channel; every other branch is nightly.
+          # Release channel drives the in-app dev-tooling defaults (developer
+          # mode + build watermark) via --dart-define=BUILD_CHANNEL. Only the
+          # two release branches get a non-nightly channel; every other branch
+          # builds as nightly, i.e. with dev tooling on.
           case "$BUILD_BRANCH" in
             stable)  BUILD_CHANNEL=stable  ;;
             staging) BUILD_CHANNEL=staging ;;
@@ -179,7 +178,6 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -319,7 +317,6 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -399,7 +396,6 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -539,7 +535,6 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -576,6 +571,8 @@ jobs:
           shopt -s nullglob
           DEB=(build/linux/deb/*.deb)
           PKG=(build/linux/arch/*.pkg.tar.zst)
+          APPIMG=(build/linux/appimage/*.AppImage)
+          TARZST=(build/linux/tarzst/*.tar.zst)
 
           if [ ${#DEB[@]} -gt 0 ]; then
             mv "${DEB[0]}" "build/linux/deb/${SLUG}-linux.deb"
@@ -589,7 +586,19 @@ jobs:
             echo "::warning::No pacman package was produced — makepkg missing or the build failed."
           fi
 
-          if [ ${#DEB[@]} -eq 0 ] && [ ${#PKG[@]} -eq 0 ]; then
+          if [ ${#APPIMG[@]} -gt 0 ]; then
+            mv "${APPIMG[0]}" "build/linux/appimage/${SLUG}-linux.AppImage"
+          else
+            echo "::warning::No AppImage was produced — linuxdeploy missing or the build failed."
+          fi
+
+          if [ ${#TARZST[@]} -gt 0 ]; then
+            mv "${TARZST[0]}" "build/linux/tarzst/${SLUG}-linux.tar.zst"
+          else
+            echo "::warning::No .tar.zst was produced — zstd missing or the build failed."
+          fi
+
+          if [ ${#DEB[@]} -eq 0 ] && [ ${#PKG[@]} -eq 0 ] && [ ${#APPIMG[@]} -eq 0 ] && [ ${#TARZST[@]} -eq 0 ]; then
             echo "::error::build_linux_packages.sh produced no package at all."
             exit 1
           fi
@@ -605,6 +614,18 @@ jobs:
         with:
           name: Glaze-release-Pacman
           path: "build/linux/arch/${{ needs.metadata.outputs.file_slug }}-linux.pkg.tar.zst"
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-release-AppImage
+          path: "build/linux/appimage/${{ needs.metadata.outputs.file_slug }}-linux.AppImage"
+
+      - name: Upload tar.zst artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-release-TarZst
+          path: "build/linux/tarzst/${{ needs.metadata.outputs.file_slug }}-linux.tar.zst"
 
   # ── telegram notify ────────────────────────────────────────────────────────
   notify:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -32,7 +32,7 @@ on:
         default: true
         type: boolean
       build_linux:
-        description: 'Linux (DEB + pacman)'
+        description: 'Linux (DEB + pacman + AppImage + tar.zst)'
         required: false
         default: true
         type: boolean
@@ -177,7 +177,6 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -317,7 +316,6 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -397,7 +395,6 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -522,7 +519,6 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.44.9'
           channel: 'stable'
           cache: true
 
@@ -559,6 +555,8 @@ jobs:
           shopt -s nullglob
           DEB=(build/linux/deb/*.deb)
           PKG=(build/linux/arch/*.pkg.tar.zst)
+          APPIMG=(build/linux/appimage/*.AppImage)
+          TARZST=(build/linux/tarzst/*.tar.zst)
 
           if [ ${#DEB[@]} -gt 0 ]; then
             mv "${DEB[0]}" "build/linux/deb/${SLUG}-linux.deb"
@@ -572,7 +570,19 @@ jobs:
             echo "::warning::No pacman package was produced — makepkg missing or the build failed."
           fi
 
-          if [ ${#DEB[@]} -eq 0 ] && [ ${#PKG[@]} -eq 0 ]; then
+          if [ ${#APPIMG[@]} -gt 0 ]; then
+            mv "${APPIMG[0]}" "build/linux/appimage/${SLUG}-linux.AppImage"
+          else
+            echo "::warning::No AppImage was produced — linuxdeploy missing or the build failed."
+          fi
+
+          if [ ${#TARZST[@]} -gt 0 ]; then
+            mv "${TARZST[0]}" "build/linux/tarzst/${SLUG}-linux.tar.zst"
+          else
+            echo "::warning::No .tar.zst was produced — zstd missing or the build failed."
+          fi
+
+          if [ ${#DEB[@]} -eq 0 ] && [ ${#PKG[@]} -eq 0 ] && [ ${#APPIMG[@]} -eq 0 ] && [ ${#TARZST[@]} -eq 0 ]; then
             echo "::error::build_linux_packages.sh produced no package at all."
             exit 1
           fi
@@ -588,6 +598,18 @@ jobs:
         with:
           name: Glaze-release-Pacman
           path: "build/linux/arch/${{ needs.metadata.outputs.tag_name }}-linux.pkg.tar.zst"
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-release-AppImage
+          path: "build/linux/appimage/${{ needs.metadata.outputs.tag_name }}-linux.AppImage"
+
+      - name: Upload tar.zst artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Glaze-release-TarZst
+          path: "build/linux/tarzst/${{ needs.metadata.outputs.tag_name }}-linux.tar.zst"
 
   # ── github release ─────────────────────────────────────────────────────────
   release:

--- a/scripts/build_linux_packages.sh
+++ b/scripts/build_linux_packages.sh
@@ -164,4 +164,101 @@ else
     echo "makepkg not found. Skipping pacman package creation."
 fi
 
+# 3. Build AppImage (Arch Linux compatible, distro-agnostic)
+# Uses linuxdeploy with the appimage plugin to turn the Flutter bundle into a
+# portable AppImage. Guarded the same way as the formats above, so a failure
+# here doesn't abort the script and lose packages that already built.
+APPIMAGE_DIR="build/linux/appimage"
+mkdir -p "$APPIMAGE_DIR"
+
+# The desktop file and icon are needed by linuxdeploy; reuse the same content
+# the other packages ship so all formats stay in sync.
+cat <<DESKTOP > "$APPIMAGE_DIR/$APP_NAME.desktop"
+[Desktop Entry]
+Name=Glaze
+Comment=Native LLM frontend for AI roleplay
+Exec=$APP_NAME
+Icon=$APP_NAME
+Terminal=false
+Type=Application
+Categories=Utility;Chat;Network;
+DESKTOP
+cp assets/logos/glaze.png "$APPIMAGE_DIR/$APP_NAME.png"
+
+APPIMAGE_TOOL=""
+if [ -n "${APPIMAGE_LINUXDEPLOY:-}" ]; then
+    APPIMAGE_TOOL="$APPIMAGE_LINUXDEPLOY"
+elif command -v linuxdeploy &> /dev/null; then
+    APPIMAGE_TOOL="linuxdeploy"
+else
+    # linuxdeploy is a single portable binary; download the official
+    # AppImage-building tool when the runner doesn't provide one.
+    case "$ARCH" in
+        x86_64)  LINUXDEPLOY_ARCH="x86_64" ;;
+        aarch64) LINUXDEPLOY_ARCH="aarch64" ;;
+        *)       LINUXDEPLOY_ARCH="" ;;
+    esac
+    if [ -n "$LINUXDEPLOY_ARCH" ]; then
+        curl -fsSL -o "$APPIMAGE_DIR/linuxdeploy.AppImage" \
+            "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-$LINUXDEPLOY_ARCH.AppImage" \
+        && chmod +x "$APPIMAGE_DIR/linuxdeploy.AppImage" \
+        && APPIMAGE_TOOL="$APPIMAGE_DIR/linuxdeploy.AppImage"
+    fi
+fi
+
+if [ -n "$APPIMAGE_TOOL" ]; then
+    echo "Building AppImage..."
+    # linuxdeploy wants an AppDir with usr/ layout. The bundle binary is
+    # renamed to match the Exec= name in the desktop file.
+    APPDIR="$APPIMAGE_DIR/AppDir"
+    rm -rf "$APPDIR"
+    mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/share/applications" "$APPDIR/usr/share/icons/hicolor/512x512/apps"
+    cp -r "$BUNDLE_DIR"/* "$APPDIR/usr/bin/"
+    if [ -f "$APPDIR/usr/bin/glaze_flutter" ]; then
+        mv "$APPDIR/usr/bin/glaze_flutter" "$APPDIR/usr/bin/$APP_NAME"
+    elif [ -f "$APPDIR/usr/bin/Glaze" ]; then
+        mv "$APPDIR/usr/bin/Glaze" "$APPDIR/usr/bin/$APP_NAME"
+    fi
+    cp "$APPIMAGE_DIR/$APP_NAME.desktop" "$APPDIR/usr/share/applications/"
+    cp "$APPIMAGE_DIR/$APP_NAME.png" "$APPDIR/usr/share/icons/hicolor/512x512/apps/"
+
+    # GitHub runners set ARCH to something linuxdeploy does not know, and it
+    # needs to be a documented self-hosted value for the AppImage runtime too.
+    export ARCH=${LINUXDEPLOY_ARCH:-x86_64}
+    export APPIMAGE_EXTRACT_AND_RUN=1
+    if "$APPIMAGE_TOOL" --appdir "$APPDIR" --desktop-file "$APPDIR/usr/share/applications/$APP_NAME.desktop" \
+        --icon-file "$APPDIR/usr/share/icons/hicolor/512x512/apps/$APP_NAME.png" \
+        --output appimage; then
+        # linuxdeploy writes Glaze-<ARCH>.AppImage next to the AppDir; normalise
+        # the name to match the other package artifacts.
+        APPIMAGE_OUT=$(ls "$APPIMAGE_DIR"/Glaze-*.AppImage 2>/dev/null | head -1)
+        if [ -n "$APPIMAGE_OUT" ]; then
+            mv "$APPIMAGE_OUT" "$APPIMAGE_DIR/Glaze-${VERSION}-${ARCH}.AppImage"
+            echo "AppImage created at $APPIMAGE_DIR/Glaze-${VERSION}-${ARCH}.AppImage"
+        else
+            echo "::warning::linuxdeploy reported success but no AppImage was found in $APPIMAGE_DIR."
+        fi
+    else
+        echo "::warning::linuxdeploy failed — no AppImage was produced."
+    fi
+else
+    echo "::warning::linuxdeploy unavailable — no AppImage was produced."
+fi
+
+# 4. Build portable .tar.zst (Arch Linux native compression)
+# A plain tarball of the bundle for users who want no package manager at all.
+# zstd is in the CI dependency list; guarded anyway so a missing tool doesn't
+# abort the script and lose packages that already built.
+if command -v tar &> /dev/null && tar --help | grep -q zstd 2>/dev/null; then
+    echo "Building .tar.zst archive..."
+    TARZST_DIR="build/linux/tarzst"
+    mkdir -p "$TARZST_DIR/glaze-${VERSION}"
+    cp -r "$BUNDLE_DIR"/* "$TARZST_DIR/glaze-${VERSION}/"
+    tar --zstd -cf "$TARZST_DIR/glaze-${VERSION}-linux-${ARCH}.tar.zst" -C "$TARZST_DIR" "glaze-${VERSION}"
+    rm -rf "$TARZST_DIR/glaze-${VERSION}"
+    echo "Tar.zst created at $TARZST_DIR/glaze-${VERSION}-linux-${ARCH}.tar.zst"
+else
+    echo "::warning::tar with zstd support not found — no .tar.zst archive was produced."
+fi
+
 echo "Packaging complete!"


### PR DESCRIPTION
## Summary

Extends the Linux release packaging (`scripts/build_linux_packages.sh`) with two additional formats so releases are directly usable on **Arch Linux** and its derivatives:

- **AppImage** — built with [linuxdeploy](https://github.com/linuxdeploy/linuxdeploy) (auto-downloaded on the runner when not present), from the same Flutter bundle, desktop file and icon the .deb/pacman packages use. Portable, no package manager needed.
- **`.tar.zst`** — plain tarball of the bundle using zstd (native compression on Arch), extract-anywhere-and-run.

## Changes

- `scripts/build_linux_packages.sh`: two new best-effort packaging sections (AppImage via linuxdeploy, `.tar.zst` via `tar --zstd`). Both warn instead of failing when their tooling is missing, matching the existing .deb/makepkg pattern.
- `.github/workflows/build-release.yml` and `build-branch.yml`:
  - Linux input description updated to reflect the new formats.
  - Rename step handles the two new artifacts (`${SLUG}-linux.AppImage`, `${SLUG}-linux.tar.zst`) and only errors when **no** Linux artifact was produced at all.
  - New `Glaze-release-AppImage` and `Glaze-release-TarZst` artifact uploads, which flow into the GitHub Release assets via the existing `Glaze-release-*` download pattern.

## Notes for maintainers

- No new runner dependencies are required: linuxdeploy is fetched automatically; zstd tar support ships with Ubuntu runners.
- The AppImage step honours an optional `APPIMAGE_LINUXDEPLOY` env var to point at a preinstalled linuxdeploy binary.

(Supersedes #405 — retargeted to `nightly` and rebased onto it; the old PR was based on `stable`.)