### PR TITLE
fix(chat): keep the token badge and the previews honest after Continue

### DIFF
--- a/assets/chat_webview/renderer/message_renderer.js
+++ b/assets/chat_webview/renderer/message_renderer.js
@@ -458,34 +458,73 @@ if (messageData.isEditing) classes.push('editing');
     stat.className = 'gen-stat';
     const hasGen = genTime && genTime !== '0s';
     const hasTokens = tokenCount && tokenCount > 0;
-    if (hasGen) {
-      const clock = document.createElement('span');
-      clock.innerHTML = ICON.clock;
-      clock.firstChild.style.cssText = `width:12px;height:12px;fill:currentColor;margin-right:${clockMargin};`;
-      stat.appendChild(clock.firstChild);
-      const gw = document.createElement('span');
-      gw.className = 'gen-time-wrapper';
-      const rn = new RollingNumber(genTime);
-      rn.el.classList.add('gen-time');
-      rn.el.classList.add('gen-time-badge');
-      gw.rollingNumber = rn;
-      gw.appendChild(rn.el);
-      stat.appendChild(gw);
-    }
-    if (hasTokens) {
-      const tc = document.createElement('div');
-      tc.className = 'token-count-inline';
-      if (hasGen) tc.style.marginLeft = '6px';
-      const doc = document.createElement('span');
-      doc.innerHTML = ICON.doc;
-      doc.firstChild.style.cssText = 'width:12px;height:12px;fill:currentColor;margin-right:2px;';
-      tc.appendChild(doc.firstChild);
-      const t = document.createElement('span');
-      t.textContent = `${tokenCount}t`;
-      tc.appendChild(t);
-      stat.appendChild(tc);
-    }
+    if (hasGen) stat.appendChild(this._buildGenTime(genTime, clockMargin));
+    if (hasTokens) stat.appendChild(this._createTokenCount(tokenCount, hasGen));
     return stat;
+  }
+
+  /* Clock icon + rolling elapsed-time badge as one fragment. The clock leads
+     the gen-stat, so callers insert this at the front rather than append. */
+  _buildGenTime(genTime, clockMargin = '2px') {
+    const frag = document.createDocumentFragment();
+    const clock = document.createElement('span');
+    clock.innerHTML = ICON.clock;
+    clock.firstChild.style.cssText = `width:12px;height:12px;fill:currentColor;margin-right:${clockMargin};`;
+    frag.appendChild(clock.firstChild);
+    const gw = document.createElement('span');
+    gw.className = 'gen-time-wrapper';
+    const rn = new RollingNumber(genTime);
+    rn.el.classList.add('gen-time');
+    rn.el.classList.add('gen-time-badge');
+    gw.rollingNumber = rn;
+    gw.appendChild(rn.el);
+    frag.appendChild(gw);
+    return frag;
+  }
+
+  /* Doc icon + `Nt` token count. Built standalone so `updateMessageMeta` can
+     put it back into a gen-stat the streaming window stripped it out of. */
+  _createTokenCount(tokenCount, hasGen) {
+    const tc = document.createElement('div');
+    tc.className = 'token-count-inline';
+    if (hasGen) tc.style.marginLeft = '6px';
+    const doc = document.createElement('span');
+    doc.innerHTML = ICON.doc;
+    doc.firstChild.style.cssText = 'width:12px;height:12px;fill:currentColor;margin-right:2px;';
+    tc.appendChild(doc.firstChild);
+    const t = document.createElement('span');
+    t.textContent = `${tokenCount}t`;
+    tc.appendChild(t);
+    return tc;
+  }
+
+  /* Make `stat` show `tokenCount`, whether or not it still has the element:
+     retext when present, re-create when the streaming window removed it. */
+  _reconcileTokenCount(stat, tokenCount, hasGen) {
+    if (!stat) return;
+    const existing = stat.querySelector('.token-count-inline span:last-child');
+    if (existing) {
+      existing.textContent = `${tokenCount}t`;
+      return;
+    }
+    stat.appendChild(this._createTokenCount(tokenCount, hasGen));
+  }
+
+  /* Same contract for the elapsed-time badge: a gen-stat that was built from
+     a token count alone has no clock to retext, so build one. */
+  _reconcileGenTime(stat, genTime, clockMargin) {
+    if (!stat) return;
+    const wrapper = stat.querySelector('.gen-time-wrapper');
+    if (wrapper && wrapper.rollingNumber) {
+      wrapper.rollingNumber.setValue(genTime);
+      return;
+    }
+    const badge = stat.querySelector('.gen-time-badge');
+    if (badge) {
+      badge.textContent = genTime;
+      return;
+    }
+    stat.insertBefore(this._buildGenTime(genTime, clockMargin), stat.firstChild);
   }
 
   /* ----- Bubble meta (inside body) ----- */
@@ -877,37 +916,18 @@ if (messageData.isEditing) classes.push('editing');
       let genStatFooter = footerMeta?.querySelector('.gen-stat');
 
       if (hasGen) {
-        const timeStr = msg.genTime;
-        if (genStatBubble) {
-          const wrapper = genStatBubble.querySelector('.gen-time-wrapper');
-          if (wrapper && wrapper.rollingNumber) {
-            wrapper.rollingNumber.setValue(timeStr);
-          } else {
-            const badge = genStatBubble.querySelector('.gen-time-badge');
-            if (badge) badge.textContent = timeStr;
-          }
-        }
-        if (genStatFooter) {
-          const wrapper = genStatFooter.querySelector('.gen-time-wrapper');
-          if (wrapper && wrapper.rollingNumber) {
-            wrapper.rollingNumber.setValue(timeStr);
-          } else {
-            const badge = genStatFooter.querySelector('.gen-time-badge');
-            if (badge) badge.textContent = timeStr;
-          }
-        }
+        this._reconcileGenTime(genStatBubble, msg.genTime, '2px');
+        this._reconcileGenTime(genStatFooter, msg.genTime, '4px');
       }
 
       if (hasTokens) {
-        const tokenStr = `${msg.tokens}t`;
-        if (genStatBubble) {
-          const tc = genStatBubble.querySelector('.token-count-inline span:last-child');
-          if (tc) tc.textContent = tokenStr;
-        }
-        if (genStatFooter) {
-          const tc = genStatFooter.querySelector('.token-count-inline span:last-child');
-          if (tc) tc.textContent = tokenStr;
-        }
+        // Level-reconcile, don't just retext: the streaming window strips
+        // `.token-count-inline` out of a gen-stat that survives (the clock
+        // keeps `hasGen` true), so after a Continue or Regenerate the element
+        // is gone while its parent is not. Updating text in place would then
+        // find nothing and the badge would never come back.
+        this._reconcileTokenCount(genStatBubble, msg.tokens, hasGen);
+        this._reconcileTokenCount(genStatFooter, msg.tokens, hasGen);
       }
 
       if (!genStatBubble && bubbleMeta && (hasGen || hasTokens)) {

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1132,6 +1132,44 @@ content updates) carry no `role` and leave it alone. When the run settles the
 dispatcher pushes one update with the flag cleared — the only thing that drops
 the badge on the failure path, where no message changed.
 
+### INV-CM7: A continued message keeps its stats and knows where it grew
+
+A continuation folds into the message it extends, so everything derived from
+that message has to account for two runs instead of one.
+
+**Generation stats accumulate.** `mergeContinuationMessage` writes
+`sumContinuationTokens(original, generated)` and
+`sumContinuationGenTime(original, generated)` — the badge reports what was spent
+on that one message, not just on the last run. A stat missing on either side
+falls through to the other, and a `genTime` that does not parse counts as
+absent, so a malformed value can never wipe out a good one. The sums are
+written to the message, to `swipesMeta[swipeId]` and to the active nested swipe,
+because a swipe round-trip restores from the meta
+(`ChatMessageService.setSwipe`).
+
+**The WebView reconciles the stat row, it never assumes it.** During the
+streaming window `updateMessageMeta` removes `.token-count-inline` (the count
+belongs to the finished text) while the surrounding `.gen-stat` survives on the
+clock. The update that brings the merged message back therefore finds the parent
+but not the child: `_reconcileTokenCount` / `_reconcileGenTime` retext when the
+element is there and rebuild it when it is not. The clock is inserted at the
+front of the row, so a rebuilt badge keeps the clock-then-count order.
+
+**The boundary is recorded.** `ChatMessage.continuationOffset` is the index in
+`content` where the newest segment starts (`continuationOffsetFor` — past the
+blank line `joinContinuation` inserts). Preview surfaces truncate from the
+front, so without it they keep quoting the opening the user has already read:
+`previewSource(content, continuationOffset)` is what the notification body
+(`buildMessagePreview`) and both of `ChatRepo`'s session-metadata projections
+slice with. An offset that does not address the current text is ignored, so a
+stale value degrades to the whole message rather than an empty preview.
+
+The boundary is per-green-swipe and dies with the text it described: it is
+stored in `swipesMeta[swipeId]`, restored on swipe navigation, cleared when the
+user hand-edits the message (`ChatMessageService.editMessage`), and left alone
+by nested (blue) swipe switching, which does not change the green swipe's text.
+A continuation that produced no text keeps the previous boundary.
+
 ---
 
 ## 9. Extension Post-Generation Invariants
@@ -1527,6 +1565,8 @@ Before merging any structural PR:
   - [ ] Continue injects one system turn after the extended reply (INV-CM3)
   - [ ] A failed continue leaves the message untouched and toasts (INV-CM4)
   - [ ] Continue reasoning lands in the reasoning block, not the reply (INV-CM5)
+  - [ ] After Continue the token/time badge is back and counts both runs (INV-CM7)
+  - [ ] The notification and chat-list row quote the continuation (INV-CM7)
   - [ ] Block chain does not start on aborted or errored generation (INV-EG4)
   - [ ] Extension cancel token is separate from chat cancel token (INV-EG5)
   - [ ] `dependsOnPrevious` blocks await the preceding block; output is chained (INV-EG6)

--- a/lib/core/db/repositories/chat_repo.dart
+++ b/lib/core/db/repositories/chat_repo.dart
@@ -1201,6 +1201,12 @@ ORDER BY updated_at DESC
               }
               lastContent = parts.join(' ');
             }
+            // A continued message grew at its tail, so the row must preview
+            // from the continuation boundary rather than the head (INV-CM7).
+            lastContent = previewSource(
+              lastContent,
+              lastMsg['continuationOffset'] as int?,
+            );
             if (lastContent.length > 250) {
               lastContent = lastContent.substring(0, 250);
             }
@@ -1268,6 +1274,10 @@ ORDER BY updated_at DESC
               .map((part) => part['text'] as String)
               .join(' ');
         }
+        lastContent = previewSource(
+          lastContent,
+          lastMessage['continuationOffset'] as int?,
+        );
         if (lastContent.length > 250) {
           lastContent = lastContent.substring(0, 250);
         }

--- a/lib/core/models/chat_message.dart
+++ b/lib/core/models/chat_message.dart
@@ -156,6 +156,13 @@ abstract class ChatMessage with _$ChatMessage {
     @Default(false) bool isError,
     String? genTime,
     int? tokens,
+
+    /// Index in [content] where the newest continuation segment begins, set
+    /// when a Continue run folds its output into this message. Preview
+    /// surfaces slice from here so a notification or a chat-list row shows the
+    /// text that was just generated rather than the head the user has already
+    /// read (INV-CM7). Null on a message that was never continued.
+    int? continuationOffset,
     int? greetingIndex,
     @Default([]) List<String> contextRefs,
     @Default('none') String swipeDirection,
@@ -189,6 +196,26 @@ extension ChatMessageAttachments on ChatMessage {
   ];
 
   bool get hasAttachments => attachments.isNotEmpty;
+}
+
+/// The slice of a message's text a preview should show.
+///
+/// Continuations append to the end of the message they extend
+/// ([ChatMessage.continuationOffset] records where the newest segment starts),
+/// so every surface that truncates from the *front* — the OS notification
+/// body, the chat-list row — would otherwise keep showing the opening the user
+/// has already read. Slicing from the boundary makes those previews follow the
+/// text that was just generated (INV-CM7).
+///
+/// Lives here rather than in the chat feature because both the notification
+/// path and `ChatRepo`'s session metadata projection need it. An offset that
+/// does not address the current text is ignored, so a stale or corrupt value
+/// degrades to the whole message instead of an empty preview.
+String previewSource(String content, int? continuationOffset) {
+  final offset = continuationOffset ?? 0;
+  if (offset <= 0 || offset >= content.length) return content;
+  final tail = content.substring(offset).trim();
+  return tail.isEmpty ? content : tail;
 }
 
 /// Splits [paths] across the two storage fields of [ChatMessage].

--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -89,6 +89,10 @@ class ChatMessageService {
         ...updatedSwipesMeta[swipeIdx],
         'reasoning': newReasoning,
         'tokens': updatedTokens,
+        // A hand-edit rewrites the text, so an index into the pre-edit string
+        // no longer points at the continuation. Drop it rather than slice the
+        // new text at a stale offset (INV-CM7).
+        'continuationOffset': null,
         if (updatedAgentSwipes.isNotEmpty) ...{
           'agentSwipes': updatedAgentSwipes
               .map((swipe) => swipe.toJson())
@@ -105,6 +109,7 @@ class ChatMessageService {
       swipesMeta: updatedSwipesMeta,
       agentSwipes: updatedAgentSwipes,
       tokens: updatedTokens,
+      continuationOffset: null,
     );
     return _persist(session, newMessages);
   }
@@ -454,6 +459,10 @@ class ChatMessageService {
                 )]
                 .tokens
           : meta?['tokens'] as int?,
+      // Per-swipe, like the counts above: only the variation a Continue run
+      // extended carries a boundary, so swiping to a sibling must clear it
+      // rather than slice that sibling at a stale offset (INV-CM7).
+      continuationOffset: meta?['continuationOffset'] as int?,
       time: activeAgentSwipe?.time,
       triggeredLorebooks: _triggeredFromMeta(meta, 'triggeredLorebooks'),
       triggeredMemories: _triggeredFromMeta(meta, 'triggeredMemories'),
@@ -862,6 +871,8 @@ class ChatMessageService {
           active.content.isEmpty && (active.reasoning?.isNotEmpty ?? false),
       genTime: active.genTime,
       tokens: active.tokens,
+      // The surviving swipe owns its own boundary — or none (INV-CM7).
+      continuationOffset: nextMeta['continuationOffset'] as int?,
       time: active.time,
       studioOutputs: active.studioOutputs,
       isError: nextMeta['isError'] == true,

--- a/lib/features/chat/services/continuation_message_merger.dart
+++ b/lib/features/chat/services/continuation_message_merger.dart
@@ -26,6 +26,15 @@ ChatMessage mergeContinuationMessage(
     original.reasoning,
     generated.reasoning,
   );
+  // The badge counts everything generated for this one message, so the
+  // continuation's cost is added to the original turn's rather than replacing
+  // it (INV-CM7). A run that produced no text adds nothing and leaves the
+  // previous boundary alone.
+  final tokens = sumContinuationTokens(original.tokens, generated.tokens);
+  final genTime = sumContinuationGenTime(original.genTime, generated.genTime);
+  final continuationOffset = generated.content.isEmpty
+      ? original.continuationOffset
+      : continuationOffsetFor(original.content, generated.content);
 
   final swipes = original.swipes.isEmpty
       ? [content]
@@ -41,8 +50,8 @@ ChatMessage mergeContinuationMessage(
             content: content,
             kind: 'final',
             reasoning: reasoning,
-            genTime: generated.genTime,
-            tokens: generated.tokens,
+            genTime: genTime,
+            tokens: tokens,
             time: original.time,
             studioOutputs: generated.studioOutputs,
             parentSwipeId: swipeId,
@@ -55,6 +64,8 @@ ChatMessage mergeContinuationMessage(
   agentSwipes[agentSwipeId] = agentSwipes[agentSwipeId].copyWith(
     content: content,
     reasoning: reasoning,
+    genTime: genTime,
+    tokens: tokens,
   );
 
   final swipesMeta = List<Map<String, dynamic>>.from(original.swipesMeta);
@@ -64,6 +75,9 @@ ChatMessage mergeContinuationMessage(
   swipesMeta[swipeId] = {
     ...swipesMeta[swipeId],
     'reasoning': reasoning,
+    'genTime': genTime,
+    'tokens': tokens,
+    'continuationOffset': continuationOffset,
     'agentSwipes': agentSwipes.map((swipe) => swipe.toJson()).toList(),
     'agentSwipeId': agentSwipeId,
   };
@@ -71,6 +85,9 @@ ChatMessage mergeContinuationMessage(
   return original.copyWith(
     content: content,
     reasoning: reasoning,
+    genTime: genTime,
+    tokens: tokens,
+    continuationOffset: continuationOffset,
     swipes: swipes,
     swipeId: swipeId,
     swipesMeta: swipesMeta,
@@ -86,6 +103,47 @@ String joinContinuation(String original, String continuation) {
   if (original.isEmpty) return continuation;
   if (continuation.isEmpty) return original;
   return '$original\n\n$continuation';
+}
+
+/// Index in the merged content where the continuation's text begins — that is,
+/// how much of [joinContinuation]'s output belongs to the original turn. Used
+/// by preview surfaces that would otherwise show the head of a message the
+/// user has already read (INV-CM7). Zero when the whole message *is* the
+/// continuation.
+int continuationOffsetFor(String original, String continuation) {
+  if (original.isEmpty || continuation.isEmpty) return 0;
+  // joinContinuation glues the two halves with a blank line.
+  return original.length + 2;
+}
+
+/// Sums the token counts of a message and the continuation that extended it,
+/// so the badge reflects everything generated for that one message rather
+/// than only the last run. A missing count on either side falls through to the
+/// other instead of zeroing the total.
+int? sumContinuationTokens(int? original, int? continuation) {
+  if (original == null) return continuation;
+  if (continuation == null) return original;
+  return original + continuation;
+}
+
+/// Sums two `"12.3s"` generation times the same way, keeping one decimal. A
+/// value that does not parse counts as absent, so a malformed string can never
+/// wipe out a good one.
+String? sumContinuationGenTime(String? original, String? continuation) {
+  final first = _parseGenSeconds(original);
+  final second = _parseGenSeconds(continuation);
+  if (first == null && second == null) return original ?? continuation;
+  final total = (first ?? 0) + (second ?? 0);
+  return '${total.toStringAsFixed(1)}s';
+}
+
+double? _parseGenSeconds(String? value) {
+  final trimmed = value?.trim() ?? '';
+  if (trimmed.isEmpty) return null;
+  final digits = trimmed.endsWith('s')
+      ? trimmed.substring(0, trimmed.length - 1)
+      : trimmed;
+  return double.tryParse(digits);
 }
 
 /// Header the continuation's reasoning is filed under inside the message's

--- a/lib/features/chat/utils/message_preview.dart
+++ b/lib/features/chat/utils/message_preview.dart
@@ -4,10 +4,14 @@ import '../../../core/models/chat_message.dart';
 /// system notifications (Android foreground/background).
 /// Strips common markdown markers so the preview is readable in the
 /// notification body. Pure function — no Riverpod, no state.
+///
+/// A message a Continue run extended is previewed from its continuation
+/// boundary, so the notification announces the text that was just generated
+/// instead of the opening the user has already read (INV-CM7).
 String? buildMessagePreview(List<ChatMessage> messages) {
   try {
     for (final m in messages.reversed) {
-      final content = m.content;
+      final content = previewSource(m.content, m.continuationOffset);
       if (content.isNotEmpty) {
         final text = content
             .replaceAll(RegExp(r'\*\*[^*]+\*\*'), '')

--- a/test/chat_repo_metadata_test.dart
+++ b/test/chat_repo_metadata_test.dart
@@ -56,4 +56,66 @@ void main() {
       expect(metadata.originKind, 'branched');
     },
   );
+
+  // The chat-list row truncates from the front, so a message a Continue run
+  // extended would keep previewing the opening the user already read
+  // (INV-CM7). Both projections have to slice at the boundary — the
+  // json_extract one behind getAllSessionMetadata and the string-scanning one
+  // behind getMetadataByCharacterId — or the list goes stale on exactly the
+  // messages that just changed.
+  group('a continued message previews its continuation', () {
+    const continued = ChatSession(
+      id: 'session',
+      characterId: 'character',
+      sessionIndex: 0,
+      updatedAt: 42,
+      messages: [
+        ChatMessage(id: 'u', role: 'user', content: 'Go on', timestamp: 1000),
+        ChatMessage(
+          id: 'a',
+          role: 'assistant',
+          content: 'The opening line.\n\nThe continuation.',
+          continuationOffset: 19,
+          timestamp: 2000,
+        ),
+      ],
+    );
+
+    test('in the json_extract projection', () async {
+      await repo.put(continued);
+      final metadata = (await repo.getAllSessionMetadata()).single;
+      expect(metadata.lastMessageContent, 'The continuation.');
+    });
+
+    test('in the string-scanning projection', () async {
+      await repo.put(continued);
+      final metadata = await repo.getMetadataByCharacterId('character');
+      expect(metadata.single.lastMessageContent, 'The continuation.');
+    });
+
+    test('a message that was never continued is previewed whole', () async {
+      await repo.put(
+        const ChatSession(
+          id: 'plain',
+          characterId: 'character',
+          sessionIndex: 1,
+          updatedAt: 42,
+          messages: [
+            ChatMessage(
+              id: 'a',
+              role: 'assistant',
+              content: 'The opening line.\n\nThe continuation.',
+              timestamp: 2000,
+            ),
+          ],
+        ),
+      );
+
+      final metadata = (await repo.getAllSessionMetadata()).single;
+      expect(
+        metadata.lastMessageContent,
+        'The opening line.\n\nThe continuation.',
+      );
+    });
+  });
 }

--- a/test/continuation_message_merger_test.dart
+++ b/test/continuation_message_merger_test.dart
@@ -87,6 +87,127 @@ void main() {
     expect(merged.agentSwipes.single.tokens, 2);
   });
 
+  group('generation stats survive the merge (INV-CM7)', () {
+    test('the badge counts both runs, not just the continuation', () {
+      const original = ChatMessage(
+        id: 'original',
+        role: 'assistant',
+        content: 'First',
+        genTime: '4.0s',
+        tokens: 120,
+        swipes: ['First'],
+        swipesMeta: [<String, dynamic>{'genTime': '4.0s', 'tokens': 120}],
+      );
+      const generated = ChatMessage(
+        id: 'temporary',
+        role: 'assistant',
+        content: 'Second',
+        genTime: '2.5s',
+        tokens: 30,
+      );
+
+      final merged = mergeContinuationMessage(original, generated);
+
+      expect(merged.tokens, 150);
+      expect(merged.genTime, '6.5s');
+      // The swipe's meta is what a swipe round-trip restores from, so it has
+      // to agree with the message or the badge dies on the way back.
+      expect(merged.swipesMeta[0]['tokens'], 150);
+      expect(merged.swipesMeta[0]['genTime'], '6.5s');
+      expect(merged.agentSwipes.single.tokens, 150);
+      expect(merged.agentSwipes.single.genTime, '6.5s');
+    });
+
+    test('a missing stat on either side does not zero the total', () {
+      const original = ChatMessage(
+        id: 'original',
+        role: 'assistant',
+        content: 'First',
+        tokens: 120,
+      );
+      const generated = ChatMessage(
+        id: 'temporary',
+        role: 'assistant',
+        content: 'Second',
+      );
+
+      final merged = mergeContinuationMessage(original, generated);
+
+      expect(merged.tokens, 120);
+      expect(merged.genTime, isNull);
+    });
+
+    test('an unparseable time is treated as absent, never as a wipe', () {
+      expect(sumContinuationGenTime('4.0s', 'not a time'), '4.0s');
+      expect(sumContinuationGenTime('not a time', '2.0s'), '2.0s');
+      expect(sumContinuationGenTime('junk', 'junk'), 'junk');
+      expect(sumContinuationGenTime(null, null), isNull);
+    });
+
+    test('tokens add up, or fall through to whichever side has a count', () {
+      expect(sumContinuationTokens(10, 5), 15);
+      expect(sumContinuationTokens(null, 5), 5);
+      expect(sumContinuationTokens(10, null), 10);
+      expect(sumContinuationTokens(null, null), isNull);
+    });
+  });
+
+  group('continuation boundary (INV-CM7)', () {
+    test('records where the continuation starts in the merged text', () {
+      const original = ChatMessage(
+        id: 'original',
+        role: 'assistant',
+        content: 'The opening line.',
+      );
+      const generated = ChatMessage(
+        id: 'temporary',
+        role: 'assistant',
+        content: 'The continuation.',
+      );
+
+      final merged = mergeContinuationMessage(original, generated);
+
+      expect(merged.continuationOffset, 'The opening line.'.length + 2);
+      expect(
+        merged.content.substring(merged.continuationOffset!),
+        'The continuation.',
+      );
+      expect(merged.swipesMeta[0]['continuationOffset'], merged.continuationOffset);
+    });
+
+    test('a continuation that produced nothing keeps the old boundary', () {
+      const original = ChatMessage(
+        id: 'original',
+        role: 'assistant',
+        content: 'One\n\nTwo',
+        continuationOffset: 5,
+      );
+      const generated = ChatMessage(
+        id: 'temporary',
+        role: 'assistant',
+        content: '',
+      );
+
+      expect(mergeContinuationMessage(original, generated).continuationOffset, 5);
+    });
+
+    test('a message that is entirely the continuation has no boundary', () {
+      expect(continuationOffsetFor('', 'everything'), 0);
+      expect(continuationOffsetFor('something', ''), 0);
+    });
+
+    test('previewSource slices from the boundary and tolerates a bad one', () {
+      expect(previewSource('One\n\nTwo', 5), 'Two');
+      expect(previewSource('One\n\nTwo', null), 'One\n\nTwo');
+      expect(previewSource('One\n\nTwo', 0), 'One\n\nTwo');
+      // Past the end, negative, or slicing to nothing: show the whole message
+      // rather than an empty preview.
+      expect(previewSource('One\n\nTwo', 999), 'One\n\nTwo');
+      expect(previewSource('One\n\nTwo', -3), 'One\n\nTwo');
+      expect(previewSource('One\n\n   ', 5), 'One\n\n   ');
+    });
+  });
+
   group('joinContinuationReasoning', () {
     test('files the continuation under an accent Continue header', () {
       expect(

--- a/test/message_preview_continuation_test.dart
+++ b/test/message_preview_continuation_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/core/models/chat_message.dart';
+import 'package:glaze_flutter/features/chat/utils/message_preview.dart';
+
+/// The notification body is built from the last message's text, truncated from
+/// the front. A Continue run appends, so without the boundary the push that
+/// announces a continuation quotes the half the user has already read
+/// (INV-CM7).
+void main() {
+  test('the notification quotes the continuation, not the opening', () {
+    const messages = [
+      ChatMessage(id: 'u', role: 'user', content: 'go on'),
+      ChatMessage(
+        id: 'a',
+        role: 'assistant',
+        content: 'She set the lamp down.\n\nThen the door opened.',
+        continuationOffset: 24,
+      ),
+    ];
+
+    expect(buildMessagePreview(messages), 'Then the door opened.');
+  });
+
+  test('a message that was never continued is quoted from the start', () {
+    const messages = [
+      ChatMessage(
+        id: 'a',
+        role: 'assistant',
+        content: 'She set the lamp down.',
+      ),
+    ];
+
+    expect(buildMessagePreview(messages), 'She set the lamp down.');
+  });
+
+  test('markdown markers are still stripped out of a continuation', () {
+    const messages = [
+      ChatMessage(
+        id: 'a',
+        role: 'assistant',
+        content: 'Opening.\n\n**Bold** and *soft* and ==red== text.',
+        continuationOffset: 10,
+      ),
+    ];
+
+    expect(buildMessagePreview(messages), 'and and text.');
+  });
+
+  test('the 80-character cap applies to the continuation slice', () {
+    final tail = 'x' * 200;
+    final messages = [
+      ChatMessage(
+        id: 'a',
+        role: 'assistant',
+        content: 'Opening.\n\n$tail',
+        continuationOffset: 10,
+      ),
+    ];
+
+    final preview = buildMessagePreview(messages)!;
+    expect(preview, '${'x' * 80}...');
+  });
+
+  test('an empty continuation slice falls back to the whole message', () {
+    const messages = [
+      ChatMessage(
+        id: 'a',
+        role: 'assistant',
+        content: 'Only an opening.\n\n',
+        continuationOffset: 18,
+      ),
+    ];
+
+    expect(buildMessagePreview(messages), 'Only an opening.');
+  });
+}

--- a/test/webview_js/specs/gen_stat_badges.spec.js
+++ b/test/webview_js/specs/gen_stat_badges.spec.js
@@ -1,0 +1,182 @@
+// The gen-stat row — elapsed clock and `Nt` token count — is level-reconciled
+// out of whatever Flutter last pushed. The bug this file guards is an
+// asymmetry: the streaming window strips `.token-count-inline` out of a
+// gen-stat that *survives* (the clock keeps the row alive), and the update
+// that brought the finished message back only ever retexted an element it
+// assumed was still there. So after a Continue or a Regenerate the badge was
+// gone for good — until the chat was re-rendered from scratch.
+//
+// These run in a real browser against the real renderer because the failure is
+// a DOM-identity one: nothing about the message map is wrong, only what is
+// left of the row that should display it.
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/assets/chat_webview/index.html';
+
+async function boot(page) {
+  await page.goto(PAGE);
+  await page.waitForFunction(() => !!window.bridge);
+  await page.evaluate(() => {
+    window.__M = (id, role, text, extra = {}) =>
+      JSON.stringify({
+        id,
+        role,
+        text,
+        timestamp: 1767225600000,
+        isUser: role === 'user',
+        isAssistant: role !== 'user',
+        isSystem: false,
+        displayName: role === 'user' ? 'You' : 'Alice',
+        isError: false,
+        isHidden: false,
+        isGenerating: false,
+        isPostGenRunning: false,
+        ...extra,
+      });
+  });
+}
+
+/// A finished reply carrying both stats — the state a bubble sits in before
+/// the user asks for more of it.
+async function finishedReply(page, { genTime = '4.0s', tokens = 120 } = {}) {
+  await page.evaluate(
+    ([genTime, tokens]) => {
+      window.bridge.setMessages(
+        JSON.stringify([
+          JSON.parse(window.__M('a1', 'assistant', 'She set the lamp down.', {
+            genTime,
+            tokens,
+          })),
+        ]),
+      );
+    },
+    [genTime, tokens],
+  );
+  await page.waitForTimeout(60);
+}
+
+const update = async (page, extra) => {
+  await page.evaluate(
+    (extra) =>
+      window.bridge.updateMessage(
+        window.__M('a1', 'assistant', extra.text ?? 'She set the lamp down.', extra),
+      ),
+    extra,
+  );
+  await page.waitForTimeout(80);
+};
+
+/// Every token count the page is actually showing, one entry per meta row.
+const tokenBadges = (page) =>
+  page.evaluate(() =>
+    [...document.querySelectorAll('.token-count-inline')].map((el) =>
+      el.textContent.trim(),
+    ),
+  );
+
+/// Waits for every elapsed-time badge to settle on `expected`, then returns
+/// how many there were.
+///
+/// The badge is a RollingNumber, so its `textContent` is not the value: each
+/// character is a column carrying a hidden `.digit-measure` ("0") next to the
+/// visible `.digit`, and a column being animated out lingers in the DOM. The
+/// value has to be composed from the visible glyphs instead.
+async function settledTimeBadges(page, expected) {
+  await page.waitForFunction((expected) => {
+    const read = (badge) => {
+      const columns = [...badge.querySelectorAll('.rolling-column')];
+      if (columns.length === 0) return badge.textContent.trim();
+      return columns
+        .map((col) => {
+          const glyph =
+            col.querySelector('.symbol') ?? col.querySelector('.digit');
+          return glyph ? glyph.textContent : '';
+        })
+        .join('');
+    };
+    const badges = [...document.querySelectorAll('.gen-time-badge')];
+    return badges.length > 0 && badges.every((el) => read(el) === expected);
+  }, expected);
+  return page.evaluate(
+    () => document.querySelectorAll('.gen-time-badge').length,
+  );
+}
+
+test('a finished reply shows its token count', async ({ page }) => {
+  await boot(page);
+  await finishedReply(page);
+
+  const badges = await tokenBadges(page);
+  expect(badges.length).toBeGreaterThan(0);
+  for (const badge of badges) expect(badge).toBe('120t');
+});
+
+test('the token count is dropped while the reply streams', async ({ page }) => {
+  await boot(page);
+  await finishedReply(page);
+
+  // A Continue or Regenerate flags the target bubble as typing for the whole
+  // streaming window; a stale count from the previous run must not sit there.
+  await update(page, { isTyping: true, genTime: '4.0s', tokens: 120 });
+
+  expect(await tokenBadges(page)).toEqual([]);
+});
+
+test('the token count comes back when the continuation lands', async ({
+  page,
+}) => {
+  await boot(page);
+  await finishedReply(page);
+  await update(page, { isTyping: true, genTime: '4.0s', tokens: 120 });
+
+  // The merged message: both runs' stats, and no longer typing.
+  await update(page, {
+    text: 'She set the lamp down.\n\nThen the door opened.',
+    isTyping: false,
+    genTime: '6.5s',
+    tokens: 150,
+  });
+
+  const badges = await tokenBadges(page);
+  expect(badges.length).toBeGreaterThan(0);
+  for (const badge of badges) expect(badge).toBe('150t');
+});
+
+test('the elapsed time keeps updating across the same window', async ({
+  page,
+}) => {
+  await boot(page);
+  await finishedReply(page);
+  await update(page, { isTyping: true, genTime: '4.0s', tokens: 120 });
+  await update(page, { isTyping: false, genTime: '6.5s', tokens: 150 });
+
+  expect(await settledTimeBadges(page, '6.5s')).toBeGreaterThan(0);
+});
+
+test('the clock leads the row it is rebuilt into', async ({ page }) => {
+  await boot(page);
+  // A reply with a count but no measurable time: the row exists without a
+  // clock, so a later time has to be inserted ahead of the count rather than
+  // appended after it.
+  await finishedReply(page, { genTime: '0s', tokens: 120 });
+  await update(page, { isTyping: false, genTime: '3.0s', tokens: 120 });
+
+  const order = await page.evaluate(() =>
+    [...document.querySelectorAll('.gen-stat')]
+      .filter((stat) => stat.querySelector('.gen-time-badge'))
+      .map((stat) =>
+        [...stat.children].map((child) =>
+          child.classList.contains('token-count-inline')
+            ? 'tokens'
+            : child.classList.contains('gen-time-wrapper')
+              ? 'time'
+              : 'icon',
+        ),
+      ),
+  );
+
+  expect(order.length).toBeGreaterThan(0);
+  for (const row of order) {
+    expect(row.indexOf('time')).toBeLessThan(row.indexOf('tokens'));
+  }
+});


### PR DESCRIPTION
First branch of the Known Bugs triage (group G1, see #409). A continuation folds into the message it extends, and two things downstream never learned to account for two runs instead of one.

## The token/time badge disappeared for good — card #118

During the streaming window `updateMessageMeta` strips `.token-count-inline` out of the message (the count belongs to finished text), but the surrounding `.gen-stat` survives, because the clock keeps `hasGen` true. The update that brought the merged message back then looked for the count *inside* that row and found nothing — and the re-create branch was gated on the row itself being absent. So after a Continue, and after a Regenerate since it uses the same window, the badge was gone until the chat was re-rendered from scratch.

- `_reconcileTokenCount` / `_reconcileGenTime` now level-reconcile the row: retext the element when it is there, rebuild it when it is not. The elapsed clock is inserted at the front, so a rebuilt row keeps clock-then-count order.
- `mergeContinuationMessage` sums the two runs' `tokens` and `genTime` instead of dropping them, so the badge reports what the message cost rather than what its last run cost. The sums go to the message, to `swipesMeta[swipeId]` and to the active nested swipe, because a swipe round-trip restores from the meta. An unparseable `genTime` counts as absent, so a malformed value cannot wipe out a good one.

## The notification and the chat-list row quoted the wrong half — card #150

Both previews truncate from the front and a continuation appends, so the push that announced new text — and the row meant to show it — kept quoting the opening the user had already read.

- New `ChatMessage.continuationOffset` records where the newest segment starts.
- `previewSource()` slices there and is shared by `buildMessagePreview` and both of `ChatRepo`'s session-metadata projections. An offset that does not address the current text is ignored, so a stale value degrades to the whole message instead of an empty preview.
- The boundary is per-green-swipe: restored on swipe navigation, cleared on a hand-edit (the edited text makes the index meaningless), untouched by nested swipe switching.

Documented as **INV-CM7**, with two entries added to the manual checklist.

## Two cards in this group needed no change

They were fixed on nightly after the audit that produced them:

- **#110** (Continue re-generates the same reply, reasoning leaks into the body) — now INV-CM3 (`kContinueInstruction` injected as a system turn) and INV-CM5 (reasoning filed under its own header).
- **#119** (a timeout error replaced the whole message, severity high) — now INV-CM4 (`_continueFailure` never writes to the message; the failure surfaces as a toast).

Both were verified present in the code, not just in the docs.

## Verified

- `flutter analyze` — 9 issues, all pre-existing on nightly, none in the touched files.
- `flutter test` — 3914 pass. (`agent_ops_localization_contract_test` needs `dart run easy_localization:generate` to have run first, exactly as CI does it; without that step it fails on clean nightly too.)
- WebView suite — 102 pass, including a new `specs/gen_stat_badges.spec.js`. Its two badge-lifecycle cases were confirmed to fail with the renderer change reverted, so they do catch the bug.

Not covered by an automated test: the badge and preview on a real device. Worth a manual pass against the INV-CM7 checklist entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
