### PR TITLE
fix(chat): swipe the whole variation, not just the reply body

### DIFF
--- a/assets/chat_webview/bridge/swipe_gesture_handler.js
+++ b/assets/chat_webview/bridge/swipe_gesture_handler.js
@@ -1,5 +1,28 @@
 ﻿/* Extracted from ../bridge.legacy.js. Keep public behavior stable. */
 
+/* Everything inside `.msg-content-stack` that belongs to the variation being
+ * switched, in DOM order. The reasoning box and the in-game clock are siblings
+ * of the body, not children of it, so a transform applied to `.msg-body` alone
+ * leaves them pinned and the message visibly tears in half mid-swipe. The
+ * footer is deliberately absent: its switcher and actions button stay put so
+ * they remain usable while the content moves. */
+const SWIPE_TARGET_SELECTORS = ['.msg-reasoning', '.msg-game-time', '.msg-body'];
+
+function swipeTargets(section) {
+  if (!section) return [];
+  const targets = [];
+  for (const selector of SWIPE_TARGET_SELECTORS) {
+    const el = section.querySelector(selector);
+    if (el) targets.push(el);
+  }
+  return targets;
+}
+
+/* Apply the same inline styles to every element the gesture is moving. */
+function styleAll(targets, styles) {
+  for (const el of targets) Object.assign(el.style, styles);
+}
+
 export class SwipeGestureHandler {
   constructor(sendToFlutter, getContainer, isGeneratingFn, disableRegenFn) {
     this._sendToFlutter = sendToFlutter;
@@ -12,7 +35,7 @@ export class SwipeGestureHandler {
     const THRESHOLD = 100;
     let startX = 0;
     let startY = 0;
-    let activeBody = null;
+    let activeTargets = [];
     let activeSection = null;
     let scrollingVertical = false;
     let axisLocked = false;
@@ -24,10 +47,9 @@ export class SwipeGestureHandler {
     // touchmove cancels scrolling for the rest of the gesture.
     const AXIS_LOCK_SLOP = 12;
 
-    const reset = (body) => {
-      body.style.transition = 'transform 0.3s ease';
-      body.style.transform = '';
-      setTimeout(() => { body.style.transition = ''; }, 300);
+    const reset = (targets) => {
+      styleAll(targets, { transition: 'transform 0.3s ease', transform: '' });
+      setTimeout(() => styleAll(targets, { transition: '' }), 300);
     };
 
     const onStart = (e) => {
@@ -48,20 +70,22 @@ export class SwipeGestureHandler {
       const section = e.target.closest?.('.message-section.char');
       if (!section) return;
       if (section.classList.contains('editing') || section.classList.contains('selection-mode')) return;
-      const body = section.querySelector('.msg-body');
-      if (!body) return;
+      // A touch that starts on the reasoning box drags the whole variation,
+      // not just the reply underneath it.
+      const targets = swipeTargets(section);
+      if (targets.length === 0) return;
       const t = e.touches ? e.touches[0] : e;
       startX = t.clientX;
       startY = t.clientY;
       scrollingVertical = false;
       axisLocked = false;
       activeSection = section;
-      activeBody = body;
-      body.style.transition = 'none';
+      activeTargets = targets;
+      styleAll(targets, { transition: 'none' });
     };
 
     const onMove = (e) => {
-      if (!activeBody || !activeSection) return;
+      if (activeTargets.length === 0 || !activeSection) return;
       const t = e.touches ? e.touches[0] : e;
       const dx = t.clientX - startX;
       const dy = t.clientY - startY;
@@ -77,7 +101,7 @@ export class SwipeGestureHandler {
         if (absX < AXIS_LOCK_SLOP && absY < AXIS_LOCK_SLOP) return;
         if (absY >= absX) {
           scrollingVertical = true;
-          activeBody.style.transform = '';
+          styleAll(activeTargets, { transform: '' });
           return;
         }
         axisLocked = true;
@@ -103,16 +127,19 @@ export class SwipeGestureHandler {
       }
 
       if (e.cancelable) e.preventDefault();
-      activeBody.style.transform = `translateX(${dx}px)`;
+      styleAll(activeTargets, { transform: `translateX(${dx}px)` });
     };
 
     const onEnd = (e) => {
-      if (!activeBody || !activeSection) return;
-      const body = activeBody;
+      if (activeTargets.length === 0 || !activeSection) return;
+      const targets = activeTargets;
       const section = activeSection;
-      activeBody = null;
+      activeTargets = [];
       activeSection = null;
-      if (scrollingVertical) { body.style.transform = ''; body.style.transition = ''; return; }
+      if (scrollingVertical) {
+        styleAll(targets, { transform: '', transition: '' });
+        return;
+      }
 
       const t = e.changedTouches ? e.changedTouches[0] : e;
       const dx = t.clientX - startX;
@@ -132,7 +159,7 @@ export class SwipeGestureHandler {
         } else if (dx > THRESHOLD && greetingId > 0) {
           self.animateVariantSwap(msgId, 'prev', () => self._sendToFlutter('onChangeGreeting', [msgId, -1]), dx);
         } else {
-          reset(body);
+          reset(targets);
         }
         return;
       }
@@ -141,24 +168,22 @@ export class SwipeGestureHandler {
         if (swipeId < swipeTotal - 1) {
           self.animateVariantSwap(msgId, 'next', () => self._sendToFlutter('onSwipe', [JSON.stringify({ id: msgId, direction: 'right' })]), dx);
         } else if (isLast && !self._disableRegen()) {
-          body.style.transition = 'transform 0.1s';
-          body.style.transform = 'translateX(-20px)';
+          styleAll(targets, { transition: 'transform 0.1s', transform: 'translateX(-20px)' });
           setTimeout(() => {
-            body.style.transform = '';
-            body.style.transition = '';
+            styleAll(targets, { transform: '', transition: '' });
             self._sendToFlutter('onRegenerate', [msgId, 'new_variant']);
           }, 100);
         } else {
-          reset(body);
+          reset(targets);
         }
       } else if (dx > THRESHOLD) {
         if (swipeId > 0) {
           self.animateVariantSwap(msgId, 'prev', () => self._sendToFlutter('onSwipe', [JSON.stringify({ id: msgId, direction: 'left' })]), dx);
         } else {
-          reset(body);
+          reset(targets);
         }
       } else {
-        reset(body);
+        reset(targets);
       }
     };
 
@@ -170,16 +195,18 @@ export class SwipeGestureHandler {
   }
 
   /* Slide + fade animation for variant switching.  Used by both the prev/next
-   * buttons and the touch-swipe gesture.  The body's height is locked through
-   * the swap and then animated to the new content's natural height, so the
-   * page doesn't jump when variants have different lengths.
+   * buttons and the touch-swipe gesture.  Every element of the variation moves
+   * together — reasoning box, in-game clock and reply body — and each has its
+   * own height locked through the swap and then animated to its new natural
+   * height, so the page doesn't jump when variants differ in length (including
+   * when one variant reasoned and the next did not).
    *
    * `currentX` lets the touch path pass the drag's current offset so the exit
    * continues the gesture outward instead of snapping back toward center. */
   animateVariantSwap(messageId, dir, after, currentX = 0) {
     const section = document.querySelector(`[data-message-id="${messageId}"]`);
-    const body = section?.querySelector('.msg-body');
-    if (!body) { after(); return; }
+    const targets = swipeTargets(section);
+    if (targets.length === 0) { after(); return; }
 
     // Tapping the arrow again before the previous swap settled used to leave
     // two runs fighting over the same inline styles: the older run's cleanup
@@ -187,9 +214,14 @@ export class SwipeGestureHandler {
     // newer run would measure a height that was still locked — either way the
     // bubble could stay faded out or keep a frozen height. Tear the previous
     // run down (timers, observer, inline styles) before starting a new one.
-    if (body._variantSwap) {
-      body._variantSwap.abort();
-      body._variantSwap = null;
+    //
+    // The run is owned by the section rather than by the body: the set of
+    // moving elements changes between variations (a reasoning box appears or
+    // goes away), so the body is not a stable place to find the run that has
+    // to be aborted.
+    if (section._variantSwap) {
+      section._variantSwap.abort();
+      section._variantSwap = null;
     }
 
     // dir: 'next' → exit to left, enter from right.  'prev' → mirror.
@@ -199,15 +231,19 @@ export class SwipeGestureHandler {
     // Entrance always slides in from a fixed offset on the opposite side.
     const inX = sign * -28;
 
-    // Lock current height so the (async) content swap doesn't reflow the page.
-    // Measured with any leftover lock cleared, so a swap that starts on top of
-    // an aborted one still reads the real content height.
-    const startHeight = body.offsetHeight;
-    body.style.height = `${startHeight}px`;
-    body.style.overflow = 'hidden';
-    body.style.transition = 'opacity 0.12s ease, transform 0.12s ease';
-    body.style.opacity = '0';
-    if (outX) body.style.transform = `translateX(${outX}px)`;
+    // Lock each element's current height so the (async) content swap doesn't
+    // reflow the page. Measured with any leftover lock cleared, so a swap that
+    // starts on top of an aborted one still reads the real content height.
+    const startHeights = targets.map((el) => el.offsetHeight);
+    targets.forEach((el, i) => {
+      el.style.height = `${startHeights[i]}px`;
+      el.style.overflow = 'hidden';
+    });
+    styleAll(targets, {
+      transition: 'opacity 0.12s ease, transform 0.12s ease',
+      opacity: '0',
+      ...(outX ? { transform: `translateX(${outX}px)` } : {}),
+    });
 
     // Everything this run schedules, so a superseding run can tear it down.
     const run = {
@@ -229,15 +265,18 @@ export class SwipeGestureHandler {
         // tap that lands inside the 130 ms exit window must still reach Dart,
         // in order, or one of the two steps is silently swallowed.
         run.send();
-        // Hand the element back in a neutral state; the new run re-locks it.
-        body.style.transition = '';
-        body.style.transform = '';
-        body.style.height = '';
-        body.style.overflow = '';
-        body.style.opacity = '1';
+        // Hand the elements back in a neutral state; the new run re-locks
+        // whichever ones the incoming variation has.
+        styleAll(targets, {
+          transition: '',
+          transform: '',
+          height: '',
+          overflow: '',
+          opacity: '1',
+        });
       },
     };
-    body._variantSwap = run;
+    section._variantSwap = run;
 
     const schedule = (fn, ms) => {
       const t = setTimeout(() => {
@@ -256,24 +295,34 @@ export class SwipeGestureHandler {
         run.timers.forEach(clearTimeout);
         run.timers.length = 0;
 
-        // Measure new content's natural height
-        body.style.height = 'auto';
-        const targetHeight = body.offsetHeight;
-        body.style.height = `${startHeight}px`;
+        // Measure each element's new natural height, then put the lock back so
+        // the animation has something to transition from. Measuring all of
+        // them before restoring any avoids a second reflow per element.
+        const targetHeights = targets.map((el) => {
+          el.style.height = 'auto';
+          return el.offsetHeight;
+        });
+        targets.forEach((el, i) => {
+          el.style.height = `${startHeights[i]}px`;
+        });
 
         requestAnimationFrame(() => {
           // A newer swap took over between the frame request and this callback.
-          if (body._variantSwap !== run) return;
-          body.style.transition = 'opacity 0.22s ease, transform 0.22s ease, height 0.22s ease';
-          body.style.opacity = '1';
-          body.style.transform = '';
-          body.style.height = `${targetHeight}px`;
+          if (section._variantSwap !== run) return;
+          targets.forEach((el, i) => {
+            el.style.transition = 'opacity 0.22s ease, transform 0.22s ease, height 0.22s ease';
+            el.style.opacity = '1';
+            el.style.transform = '';
+            el.style.height = `${targetHeights[i]}px`;
+          });
           schedule(() => {
-            body.style.transition = '';
-            body.style.transform = '';
-            body.style.height = '';
-            body.style.overflow = '';
-            if (body._variantSwap === run) body._variantSwap = null;
+            styleAll(targets, {
+              transition: '',
+              transform: '',
+              height: '',
+              overflow: '',
+            });
+            if (section._variantSwap === run) section._variantSwap = null;
           }, 240);
         });
       };
@@ -286,8 +335,10 @@ export class SwipeGestureHandler {
       schedule(finish, 300);
 
       run.send();
-      body.style.transition = 'none';
-      if (inX) body.style.transform = `translateX(${inX}px)`;
+      styleAll(targets, {
+        transition: 'none',
+        ...(inX ? { transform: `translateX(${inX}px)` } : {}),
+      });
     }, 130);
   }
 

--- a/docs/rules/message-rendering.md
+++ b/docs/rules/message-rendering.md
@@ -239,6 +239,35 @@ wrong word.
 
 ---
 
+## A variation moves as one piece, and the footer does not move at all
+
+The reply body is not the variation. `.msg-content-stack` holds the reasoning
+box, the in-game clock, `.msg-transition-wrapper > .msg-body` and the footer as
+**siblings**, so a transform on `.msg-body` alone slides the reply out from
+under everything stacked above it — the message tears in half mid-swipe, and a
+finger that started on the reasoning box drags a bubble it is not touching.
+
+`SWIPE_TARGET_SELECTORS` in `bridge/swipe_gesture_handler.js` is the list of
+what moves: `.msg-reasoning`, `.msg-game-time`, `.msg-body`. Both paths use it —
+the touch gesture (`onStart` resolves it once and `onMove`/`onEnd` style the
+whole set) and `animateVariantSwap`, which the prev/next arrows and the guided
+swipe call. Adding another element to the stack means adding it here too.
+
+Two consequences worth keeping:
+
+* **The footer stays put.** Its switcher and actions button have to remain
+  under the thumb while the content moves, so it is deliberately not a target.
+* **Each target locks its own height.** Variations differ in length, and one
+  may have reasoning where the next has none, so the swap measures and animates
+  per element; the sum is what keeps the page from jumping. The run guard
+  (`section._variantSwap`) lives on the **section**, not on the body, because
+  the set of moving elements changes between variations — the body is not a
+  stable place to find the run that has to be aborted.
+
+Covered by `specs/variant_swap_targets.spec.js`.
+
+---
+
 ## A user message wears the persona it was sent as, not the active one
 
 Every user message stores the persona it was sent under — `personaId` and

--- a/test/webview_js/specs/reasoning_block_lifecycle.spec.js
+++ b/test/webview_js/specs/reasoning_block_lifecycle.spec.js
@@ -1,0 +1,151 @@
+// The reasoning box is per-variation: a reply from a reasoning model has one,
+// a reply from a non-reasoning model does not, and swiping between them has to
+// show whichever the active variation actually carries.
+//
+// The bug this file guards is the box never coming back. Regenerating with a
+// non-reasoning model removes it — correctly, the new variation has no
+// thinking — but the reasoning text is still in the database under the old
+// swipe, so swiping back must rebuild the block. `updateMessageContent` used to
+// only ever rewrite an element it assumed was still there.
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/assets/chat_webview/index.html';
+
+async function boot(page) {
+  await page.goto(PAGE);
+  await page.waitForFunction(() => !!window.bridge);
+  await page.evaluate(() => {
+    window.__M = (id, role, text, extra = {}) =>
+      JSON.stringify({
+        id,
+        role,
+        text,
+        timestamp: 1767225600000,
+        isUser: role === 'user',
+        isAssistant: role !== 'user',
+        isSystem: false,
+        displayName: role === 'user' ? 'You' : 'Alice',
+        isError: false,
+        isHidden: false,
+        isGenerating: false,
+        isPostGenRunning: false,
+        ...extra,
+      });
+  });
+}
+
+/// A reply that came from a reasoning model.
+async function replyWithReasoning(page) {
+  await page.evaluate(() => {
+    window.bridge.setMessages(
+      JSON.stringify([
+        JSON.parse(
+          window.__M('a1', 'assistant', 'She set the lamp down.', {
+            reasoning: 'The room is cold, so she would want the light near.',
+            swipeIndex: 0,
+            swipeTotal: 1,
+          }),
+        ),
+      ]),
+    );
+  });
+  await page.waitForTimeout(80);
+}
+
+const update = async (page, text, extra) => {
+  await page.evaluate(
+    ([text, extra]) =>
+      window.bridge.updateMessage(window.__M('a1', 'assistant', text, extra)),
+    [text, extra],
+  );
+  await page.waitForTimeout(80);
+};
+
+const hasReasoning = (page) =>
+  page.evaluate(() => !!document.querySelector('.msg-reasoning'));
+
+const reasoningText = (page) =>
+  page.evaluate(() => {
+    const host = document.querySelector(
+      '.msg-reasoning-inner .message-content',
+    );
+    if (!host) return null;
+    const root = host.shadowRoot ?? host;
+    return root.textContent.trim();
+  });
+
+test('a reasoning reply renders its box', async ({ page }) => {
+  await boot(page);
+  await replyWithReasoning(page);
+
+  expect(await hasReasoning(page)).toBe(true);
+  expect(await reasoningText(page)).toContain('The room is cold');
+});
+
+test('regenerating with a non-reasoning model drops the box', async ({
+  page,
+}) => {
+  await boot(page);
+  await replyWithReasoning(page);
+
+  // Regen opens a fresh variation: blank text, typing, and no reasoning key at
+  // all (the Dart mapper omits it when null).
+  await update(page, '', { isTyping: true, swipeIndex: 1, swipeTotal: 2 });
+  await update(page, 'She left it on the table.', {
+    isTyping: false,
+    swipeIndex: 1,
+    swipeTotal: 2,
+  });
+
+  expect(await hasReasoning(page)).toBe(false);
+});
+
+test('swiping back to the reasoning variation rebuilds the box', async ({
+  page,
+}) => {
+  await boot(page);
+  await replyWithReasoning(page);
+  await update(page, '', { isTyping: true, swipeIndex: 1, swipeTotal: 2 });
+  await update(page, 'She left it on the table.', {
+    isTyping: false,
+    swipeIndex: 1,
+    swipeTotal: 2,
+  });
+
+  // Swipe back. The reasoning is still in the database under swipe 0, so the
+  // block has to be re-created — there is nothing left to rewrite.
+  await update(page, 'She set the lamp down.', {
+    reasoning: 'The room is cold, so she would want the light near.',
+    swipeIndex: 0,
+    swipeTotal: 2,
+    swipeDirection: 'right',
+  });
+
+  expect(await hasReasoning(page)).toBe(true);
+  expect(await reasoningText(page)).toContain('The room is cold');
+});
+
+test('the rebuilt box sits above the reply, not after it', async ({ page }) => {
+  await boot(page);
+  await replyWithReasoning(page);
+  await update(page, 'plain', { isTyping: false, swipeIndex: 1, swipeTotal: 2 });
+  await update(page, 'She set the lamp down.', {
+    reasoning: 'Thinking again.',
+    swipeIndex: 0,
+    swipeTotal: 2,
+  });
+
+  const order = await page.evaluate(() => {
+    const stack = document.querySelector('.msg-content-stack');
+    return [...stack.children].map((child) =>
+      child.classList.contains('msg-reasoning')
+        ? 'reasoning'
+        : child.classList.contains('msg-transition-wrapper')
+          ? 'body'
+          : 'other',
+    );
+  });
+
+  expect(order.indexOf('reasoning')).toBeGreaterThanOrEqual(0);
+  expect(order.indexOf('reasoning')).toBeLessThan(order.indexOf('body'));
+});

--- a/test/webview_js/specs/variant_swap_targets.spec.js
+++ b/test/webview_js/specs/variant_swap_targets.spec.js
@@ -1,0 +1,198 @@
+// Switching a variation moves the whole variation. The reasoning box and the
+// in-game clock are siblings of `.msg-body` inside `.msg-content-stack`, so a
+// transform applied to the body alone slid the reply out from under them and
+// the message visibly tore in half — the reasoning stayed pinned over a
+// bubble that was already leaving. A finger that started on the reasoning box
+// dragged the reply underneath it, too.
+//
+// The footer must stay put: its switcher and actions button have to remain
+// where the user's thumb expects them while the content moves.
+import { test, expect } from '@playwright/test';
+
+const PAGE = '/assets/chat_webview/index.html';
+
+async function boot(page) {
+  await page.goto(PAGE);
+  await page.waitForFunction(() => !!window.bridge);
+  await page.evaluate(() => {
+    window.__M = (id, role, text, extra = {}) =>
+      JSON.stringify({
+        id,
+        role,
+        text,
+        timestamp: 1767225600000,
+        isUser: role === 'user',
+        isAssistant: role !== 'user',
+        isSystem: false,
+        displayName: role === 'user' ? 'You' : 'Alice',
+        isError: false,
+        isHidden: false,
+        isGenerating: false,
+        isPostGenRunning: false,
+        ...extra,
+      });
+  });
+}
+
+/// A reply carrying every element the swipe is supposed to move, plus two
+/// variations so the switch is legal.
+async function richReply(page) {
+  await page.evaluate(() => {
+    window.bridge.setMessages(
+      JSON.stringify([
+        JSON.parse(
+          window.__M('a1', 'assistant', 'She set the lamp down.', {
+            reasoning: 'The room is cold, so the light belongs near her.',
+            gameTime: 'Day 3, 21:40',
+            swipeIndex: 0,
+            swipeTotal: 2,
+            isLast: true,
+          }),
+        ),
+      ]),
+    );
+  });
+  await page.waitForTimeout(80);
+}
+
+/// The inline transform/opacity of each element in the stack, by role.
+const stackStyles = (page) =>
+  page.evaluate(() => {
+    const section = document.querySelector('[data-message-id="a1"]');
+    const read = (selector) => {
+      const el = section.querySelector(selector);
+      if (!el) return null;
+      return {
+        transform: el.style.transform,
+        opacity: el.style.opacity,
+        height: el.style.height,
+        overflow: el.style.overflow,
+      };
+    };
+    return {
+      reasoning: read('.msg-reasoning'),
+      gameTime: read('.msg-game-time'),
+      body: read('.msg-body'),
+      footer: read('.msg-footer'),
+    };
+  });
+
+test('the stack has all three moving parts plus a static footer', async ({
+  page,
+}) => {
+  await boot(page);
+  await richReply(page);
+
+  const styles = await stackStyles(page);
+  expect(styles.reasoning).not.toBeNull();
+  expect(styles.gameTime).not.toBeNull();
+  expect(styles.body).not.toBeNull();
+  expect(styles.footer).not.toBeNull();
+});
+
+test('a variant swap slides the reasoning and the clock with the reply', async ({
+  page,
+}) => {
+  await boot(page);
+  await richReply(page);
+
+  // Read the styles inside the 130 ms exit window, while the animation holds
+  // them. The switch request itself is stubbed out — this is about the DOM.
+  const styles = await page.evaluate(async () => {
+    window.bridge._swipeHandler.animateVariantSwap('a1', 'next', () => {});
+    await new Promise((r) => setTimeout(r, 40));
+    const section = document.querySelector('[data-message-id="a1"]');
+    const read = (selector) => {
+      const el = section.querySelector(selector);
+      if (!el) return null;
+      return { transform: el.style.transform, opacity: el.style.opacity };
+    };
+    return {
+      reasoning: read('.msg-reasoning'),
+      gameTime: read('.msg-game-time'),
+      body: read('.msg-body'),
+      footer: read('.msg-footer'),
+    };
+  });
+
+  for (const part of ['reasoning', 'gameTime', 'body']) {
+    expect(styles[part].opacity, `${part} should fade with the swap`).toBe('0');
+    expect(
+      styles[part].transform,
+      `${part} should slide with the swap`,
+    ).toContain('translateX');
+  }
+
+  // The controls stay where the thumb left them.
+  expect(styles.footer.opacity).toBe('');
+  expect(styles.footer.transform).toBe('');
+});
+
+test('each moving part gets its own height lock, so the page cannot jump', async ({
+  page,
+}) => {
+  await boot(page);
+  await richReply(page);
+
+  const heights = await page.evaluate(async () => {
+    window.bridge._swipeHandler.animateVariantSwap('a1', 'next', () => {});
+    await new Promise((r) => setTimeout(r, 40));
+    const section = document.querySelector('[data-message-id="a1"]');
+    return ['.msg-reasoning', '.msg-game-time', '.msg-body'].map((selector) => {
+      const el = section.querySelector(selector);
+      return { height: el.style.height, overflow: el.style.overflow };
+    });
+  });
+
+  for (const { height, overflow } of heights) {
+    expect(height).toMatch(/^\d+(\.\d+)?px$/);
+    expect(overflow).toBe('hidden');
+  }
+});
+
+test('the swap leaves every part with clean inline styles', async ({ page }) => {
+  await boot(page);
+  await richReply(page);
+
+  await page.evaluate(() => {
+    window.bridge._swipeHandler.animateVariantSwap('a1', 'next', () => {});
+  });
+  // 130 ms exit + a 300 ms fallback finish + 240 ms settle, with headroom.
+  await page.waitForTimeout(900);
+
+  const styles = await stackStyles(page);
+  for (const part of ['reasoning', 'gameTime', 'body']) {
+    expect(styles[part].transform, `${part} transform`).toBe('');
+  }
+});
+
+test('a second swap aborts the first instead of fighting it', async ({
+  page,
+}) => {
+  await boot(page);
+  await richReply(page);
+
+  // Two swaps inside the exit window: both requests must reach Dart, in order,
+  // and the DOM must end up neutral rather than stuck faded out.
+  const sent = await page.evaluate(async () => {
+    const order = [];
+    window.bridge._swipeHandler.animateVariantSwap('a1', 'next', () =>
+      order.push('first'),
+    );
+    await new Promise((r) => setTimeout(r, 30));
+    window.bridge._swipeHandler.animateVariantSwap('a1', 'prev', () =>
+      order.push('second'),
+    );
+    await new Promise((r) => setTimeout(r, 900));
+    return order;
+  });
+
+  expect(sent).toEqual(['first', 'second']);
+
+  const styles = await stackStyles(page);
+  for (const part of ['reasoning', 'gameTime', 'body']) {
+    expect(styles[part].transform, `${part} transform`).toBe('');
+    expect(styles[part].height, `${part} height lock`).toBe('');
+    expect(styles[part].overflow, `${part} overflow`).toBe('');
+  }
+});


### PR DESCRIPTION
Group G2 of the Known Bugs triage (see #409).

## The message tore in half mid-swipe — card #45

`.msg-content-stack` holds the reasoning box, the in-game clock, the reply body and the footer as **siblings**. The swipe handler only ever captured, translated and animated `.msg-body`, so the reply slid out from under everything stacked above it — and a finger that started on the reasoning box dragged a bubble it was not touching.

- `SWIPE_TARGET_SELECTORS` now names what moves — `.msg-reasoning`, `.msg-game-time`, `.msg-body` — and both paths use it: the touch gesture, and `animateVariantSwap`, which the prev/next arrows and the guided swipe call.
- The footer is deliberately **not** a target. Its switcher and actions button have to stay under the thumb while the content moves.
- Each target locks and animates its own height. Variations differ in length, and one may carry reasoning where the next carries none, so a single lock on the body could not keep the page from jumping.
- The run guard moves from the body to the section. The set of moving elements changes between variations, so the body is not a stable place to find the run a superseding swap has to abort.

I took the multi-element route rather than the wrapper element the audit suggested: a new wrapper would change the documented DOM contract, and CSS like `.message-section.layout-bubble .msg-body` depends on the current nesting.

## Card #123 does not reproduce — covered instead of fixed

The report was "the reasoning box disappears on previously generated responses if you use a non-reasoning model to generate a new one, and never comes back". On current nightly `updateMessageContent` already re-creates a missing `.msg-reasoning` instead of only rewriting one it assumes is there, so the box does come back on swipe-back. The audit that produced the card was reading older code.

Rather than close it on my word, `specs/reasoning_block_lifecycle.spec.js` locks the behaviour in: a reasoning reply renders its box, regenerating with a non-reasoning model drops it, **swiping back rebuilds it**, and the rebuilt box sits above the reply rather than after it.

## Verified

- `flutter analyze` — 9 issues, all pre-existing on nightly, none in the touched files.
- `flutter test` — 3898 pass, `webview_assets_test` included.
- WebView suite — 106 pass. The two `variant_swap_targets` cases that assert the reasoning box and clock move were confirmed to fail with the handler reverted, so they do catch the bug.

Not covered automatically: the feel of the gesture on a real device. The DOM contract is tested; whether the combined-height animation looks right at 60fps on a mid-range phone is worth one manual swipe on a message that has reasoning.

Documented in `docs/rules/message-rendering.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
