### PR TITLE
fix(chat): retire a typing bubble whose run ended while the chat was closed

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -561,6 +561,28 @@ export class Bridge {
     this.virtualList.append(STREAMING_ID, el);
   }
 
+  /* Retires the typing bubble for good, without an exit animation, so a
+   * `setMessages` issued right after this call has nothing left to carry
+   * across. Flutter makes the call when it opens a chat with no run in
+   * flight: the page is a keep-alive singleton, so a run that ended while
+   * the chat was closed left its bubble here with no falling edge to take it
+   * away, and the carry below would read that leftover as proof a reply is
+   * still on its way.
+   *
+   * Level-triggered on the page's own belief: `removeMessage` clears
+   * `_placeholderActive` the moment Flutter stops believing in the bubble, so
+   * a node still on screen under that flag is playing its exit animation and
+   * is left alone to finish it. */
+  retireTypingPlaceholder() {
+    if (!this._placeholderActive && !this._parkedPlaceholder) return;
+    this.flush();
+    this._placeholderActive = false;
+    this._parkedPlaceholder = null;
+    this.virtualList.remove(STREAMING_ID);
+    this._pruneOrphanSeparators();
+    this._ensureHeaderReachable();
+  }
+
   /* Runs [fn] with the placeholder lifted out, then puts it back at the tail.
    * Every batch append goes through here: `virtualList.append` lands after
    * whatever is currently last, so a persisted message arriving mid-generation
@@ -587,8 +609,11 @@ export class Bridge {
     this._parkedPlaceholder = null;
     // Carrying one across says it is still live. Not carrying one says
     // nothing: the node may simply have been lost, which is the case the
-    // re-create branch in _executeUpdateMessage exists for. Only removeMessage
-    // and a chat-replacing clearAll retire the placeholder.
+    // re-create branch in _executeUpdateMessage exists for. Only removeMessage,
+    // retireTypingPlaceholder and a chat-replacing clearAll retire the
+    // placeholder — and the first inference only holds because Flutter retires
+    // a leftover before the setMessages that reopens a chat, so what is
+    // carried here is always a bubble some run is still streaming into.
     if (carriedPlaceholder) this._placeholderActive = true;
     this._suppressLoadMore = true;
     // When re-rendering in place (e.g. a preset switch changes display regexes),

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -69,6 +69,47 @@ Guard: `AbortHandler.isCurrentGen(genId)` — exposed to the stream as
 → `StreamGenerationService.run()`. `AbortHandler.nextGenId()` increments `_activeGenId`
 on abort and on each new generation start.
 
+### INV-C8: The typing bubble lives exactly as long as a reply is on its way
+
+The "Generating…" bubble is not a message. It is a virtual one — a single
+constant id (`__streaming__`) that Flutter puts up, streams text into and takes
+away, while the page draws it. Nothing persists it, so the *only* record that
+it exists is `ChatWebViewSyncState.streamingSent` in the widget that put it up,
+and on mobile the page outlives that widget: `chatWebViewKeepAlive` makes it a
+singleton, so a bubble stays in its DOM across a chat being closed and
+reopened. Two halves follow, and neither is sufficient alone.
+
+**The presence of the bubble is level-triggered, not edge-triggered.** The
+rising and falling edges in `ChatWebViewSyncDispatcher.dispatch` are an
+optimisation, not the authority: an edge is consumed by the `!ready` early
+return during init, by a session switch, and by the widget being disposed
+mid-run. So `reconcileActiveGenerationBridge`
+(`chat_streaming_bridge_sync.dart`) re-derives the whole presentation from the
+current state — a run in flight gets its bubble appended or updated, an idle
+chat gets any bubble retired — and it runs after init, after a session switch,
+and after every message-list sync. Clearing the flags without retiring the node
+is what let a bubble outlive its run: the flags are the widget's, the node is
+the page's.
+
+**A bubble is carried across a re-render only while some run is streaming into
+it.** `setMessages` deliberately carries it (`_detachStreamingPlaceholder` →
+`_reattachStreamingPlaceholder`), because dropping it mid-run leaves every
+following delta updating a node that is gone. The page cannot tell a live
+bubble from a leftover, so Flutter decides: `ChatWebViewInitializer.run()` calls
+`bridge.retireTypingPlaceholder()` before its `setMessages` whenever
+`isGenerating` and `isSendPending` are both false. That call is itself
+level-triggered on the page's own belief (`_placeholderActive`), which is what
+keeps it from cutting short the exit animation `removeMessage` started.
+
+Without both halves, leaving a chat mid-run and returning after the reply
+landed reopened it with the finished reply *and* a typing bubble standing under
+itself — the "duplicate message" that did not go away on a reload, because
+every re-render of that session carried it forward again.
+
+Covered by `specs/placeholder_lifecycle.spec.js` (page side),
+`chat_webview_sync_dispatcher_test.dart` (the reconcile) and
+`chat_webview_initializer_placeholder_test.dart` (the call order at init).
+
 ---
 
 ## 2. Image Generation Invariants
@@ -1516,6 +1557,10 @@ Before merging any structural PR:
 - [ ] Stop generation (abort) preserves partial text when available
 - [ ] Regenerate while generating aborts the current generation first
 - [ ] Switching characters during generation continues background generation
+- [ ] Leaving a chat mid-generation and returning shows the typing bubble again,
+      still with its elapsed clock running (INV-C8)
+- [ ] Leaving a chat mid-generation and returning *after* the reply landed shows
+      the reply once, with no typing bubble under it (INV-C8)
 - [ ] Prompt block order matches preset definition
 - [ ] Vector scan runs before keyword scan; results deduplicated
 - [x] Memory injection respects token budget (PR-B C13 / INV-PS4)

--- a/lib/features/chat/bridge/bridge_message_commands.dart
+++ b/lib/features/chat/bridge/bridge_message_commands.dart
@@ -207,6 +207,28 @@ class MessageBridgeCommands {
     return _host.callJs('removeMessage', messageId);
   }
 
+  /// Retires a typing bubble the page is still holding for a run that is over,
+  /// without the exit animation [removeMessage] plays.
+  ///
+  /// The page is kept alive across chats, and its `setMessages` carries a
+  /// typing bubble across a re-render on purpose — a live run streams into
+  /// that node. A run that ended while its chat was closed never got the
+  /// falling edge that would have removed it, so the bubble is still there and
+  /// the carry hands it to the reopened chat: the reply, standing a second
+  /// time under itself, in a chat where nothing is running.
+  ///
+  /// The page no-ops unless it still believes the bubble is live, so this is
+  /// safe to call whenever nothing is in flight and never cuts short an exit
+  /// animation Flutter has already started.
+  Future<void> retireTypingPlaceholder() {
+    return _host.evalJs(
+      // Guarded: a page from before this method existed (a cached asset, the
+      // legacy bridge snapshot) must not throw here.
+      'if (window.bridge?.retireTypingPlaceholder) '
+      'window.bridge.retireTypingPlaceholder();',
+    );
+  }
+
   void _resolveMappedFileUrls(Map<String, dynamic> map) {
     final paths = map['imagePaths'];
     if (paths is List) {

--- a/lib/features/chat/bridge/chat_bridge_controller.dart
+++ b/lib/features/chat/bridge/chat_bridge_controller.dart
@@ -705,6 +705,8 @@ class ChatBridgeController {
   Future<void> updateMessageContent(String id, String text, bool isUser) =>
       messages.updateMessageContent(id, text, isUser);
   Future<void> removeMessage(String id) => messages.removeMessage(id);
+  Future<void> retireTypingPlaceholder() =>
+      messages.retireTypingPlaceholder();
   Future<void> setLastMessage(String? id) => messages.setLastMessage(id);
   Future<void> setContextWindowStart(String? id) =>
       messages.setContextWindowStart(id);

--- a/lib/features/chat/widgets/chat_streaming_bridge_sync.dart
+++ b/lib/features/chat/widgets/chat_streaming_bridge_sync.dart
@@ -30,6 +30,15 @@ Future<void> reconcileActiveGenerationBridge({
   if (!isBusy || isImpersonating || !isCurrent()) {
     syncState.streamingSent = false;
     syncState.regenStreamingSent = false;
+    // Idle means the page holds no typing bubble — a level-triggered
+    // guarantee, not just the falling edge's word. Clearing the flags without
+    // it is what let a bubble outlive its run: the flags belong to this widget
+    // and a fresh one starts with them false, while the node lives in a page
+    // that is kept alive across chats. `isCurrent()` re-reads the busy state,
+    // so this only fires when the chat is still idle now; the page ignores the
+    // call unless it also still believes the bubble is live, which is what
+    // keeps it from cutting short the exit animation the falling edge started.
+    if (!isBusy && isCurrent()) await bridge.retireTypingPlaceholder();
     return;
   }
 

--- a/lib/features/chat/widgets/chat_webview_initializer.dart
+++ b/lib/features/chat/widgets/chat_webview_initializer.dart
@@ -233,6 +233,33 @@ class ChatWebViewInitializer {
     await bridge.setGenerationPhase(
       generationPhaseLabel(ref.read(generationPhaseProvider(input.charId))),
     );
+    // Before the first paint, and before the retire below can read them: the
+    // page starts the elapsed clock off these two, and a chat reopened mid-run
+    // should find it already running rather than a bubble with no clock until
+    // the next dispatch. `setSendPending` also has to be mirrored into
+    // `isSendPendingInPage`, which is what the dispatcher level-reconciles
+    // against — left at its default it would push the same value again.
+    bridge.isSendPendingInPage = input.isSendPending;
+    await bridge.evalJs(
+      'if (window.bridge) { '
+      'window.bridge.setGenerating(${input.isGenerating}); '
+      // Guarded and last: a page from before this flag existed (a cached
+      // asset, the legacy bridge snapshot) would throw here.
+      'if (window.bridge.setSendPending) '
+      'window.bridge.setSendPending(${input.isSendPending}); '
+      '}',
+    );
+    // The page is kept alive across chats, so it may still hold the typing
+    // bubble of a run that finished while this chat was closed — nothing
+    // dispatched that run's falling edge, because the widget that would have
+    // was disposed. `setMessages` carries a bubble across on purpose, so left
+    // here it reopens the chat with a reply on its way that landed minutes
+    // ago, and no later re-render of the same session takes it back down.
+    // Retire it unless a run really is in flight; the page ignores the call
+    // when it has already stopped believing in the bubble itself.
+    if (!input.isGenerating && !input.isSendPending) {
+      await bridge.retireTypingPlaceholder();
+    }
     await bridge.setMessages(
       input.messages,
       visibleStartIndex: input.visibleStartIndex,
@@ -261,10 +288,11 @@ class ChatWebViewInitializer {
         activeIndex: input.searchCurrentIndex,
       );
     }
+    // The two flags that decorate already-painted nodes, so they run after the
+    // paint. The run flags are pushed before `setMessages` above instead.
     unawaited(
       bridge.evalJs(
         'if (window.bridge) { '
-        'window.bridge.setGenerating(${input.isGenerating}); '
         'window.bridge.setPostGenRunning(${input.isPostGenRunning}); '
         'window.bridge.setImageGenerating(${input.isGeneratingImage}); '
         '}',

--- a/test/chat_webview_initializer_placeholder_test.dart
+++ b/test/chat_webview_initializer_placeholder_test.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The initializer runs against a live WebView, so these assert on the order
+/// its source issues bridge calls in — the same approach as
+/// `chat_webview_memory_initialization_test.dart`. What matters here is
+/// *when* each call happens relative to the first paint, and that is not
+/// observable from anything the initializer returns.
+void main() {
+  late final String source = File(
+    'lib/features/chat/widgets/chat_webview_initializer.dart',
+  ).readAsStringSync();
+  late final int runStart = source.indexOf('Future<void> run() async');
+  int after(String needle) {
+    final index = source.indexOf(needle, runStart);
+    expect(index, isNonNegative, reason: 'not found in run(): $needle');
+    return index;
+  }
+
+  test('a bubble left over from a finished run is retired before the paint', () {
+    // The page is kept alive across chats and `setMessages` carries a typing
+    // bubble across on purpose. A run that ended while its chat was closed
+    // never got its falling edge, so the bubble is still in the page — carried
+    // into the reopened chat it is a reply on its way that landed minutes ago,
+    // and nothing later in the same session takes it back down.
+    final retire = after('bridge.retireTypingPlaceholder()');
+    final paint = after('await bridge.setMessages(');
+    expect(retire, lessThan(paint));
+  });
+
+  test('the retire is guarded on nothing being in flight', () {
+    // Reopening a chat whose run is *still* going must carry the bubble: it is
+    // the node the reply is streaming into. The page cannot tell that bubble
+    // from a leftover, so the guard is the whole of what keeps them apart.
+    final guard = after('if (!input.isGenerating && !input.isSendPending) {');
+    final retire = after('bridge.retireTypingPlaceholder()');
+    expect(guard, lessThan(retire));
+    expect(retire - guard, lessThan(120), reason: 'guard is not the retire\'s');
+  });
+
+  test('the run flags reach the page before the first paint', () {
+    // The elapsed clock runs off these two, so a chat reopened mid-run should
+    // find it already going instead of a bubble with no clock until whatever
+    // rebuild comes next. The send window is the half that was missing: only
+    // the Dart-side mirror was set here, never the page's own flag.
+    final generating = after('window.bridge.setGenerating(');
+    final sendPending = after('window.bridge.setSendPending(');
+    final paint = after('await bridge.setMessages(');
+    expect(generating, lessThan(paint));
+    expect(sendPending, lessThan(paint));
+    // The dispatcher level-reconciles against this field rather than
+    // `isSendPending`, which it has already overwritten by then.
+    expect(after('bridge.isSendPendingInPage ='), lessThan(paint));
+  });
+}

--- a/test/chat_webview_sync_dispatcher_test.dart
+++ b/test/chat_webview_sync_dispatcher_test.dart
@@ -260,6 +260,101 @@ void main() {
       expect(state.streamingSent, isFalse);
     });
 
+    test('an idle reconcile retires a bubble left over from a run', () async {
+      // The page is kept alive across chats, so leaving one mid-run and coming
+      // back after the reply landed finds the bubble still in its DOM: the
+      // widget that would have dispatched the falling edge was disposed before
+      // the run ended. These flags belong to the widget and a fresh one starts
+      // with them false, so clearing them is not enough — the node outlives
+      // them, and `setMessages` carries it into the reopened chat.
+      final bridge = _FakeBridge();
+      final state = ChatWebViewSyncState()
+        ..wasBusy = true
+        ..streamingSent = true;
+
+      await reconcileActiveGenerationBridge(
+        bridge: bridge,
+        syncState: state,
+        isBusy: false,
+        isImpersonating: false,
+        regenTargetId: null,
+        continuationTargetId: null,
+        streaming: const StreamingState(),
+        messages: [_user('u1'), _assistant('a1')],
+        streamingId: '__streaming__',
+        isCurrent: () => true,
+      );
+
+      expect(bridge.retireTypingPlaceholderCalls, 1);
+      expect(state.streamingSent, isFalse);
+      expect(state.wasBusy, isFalse);
+    });
+
+    test('a live run keeps its bubble through a reconcile', () async {
+      final bridge = _FakeBridge();
+      final state = ChatWebViewSyncState()..wasBusy = true;
+
+      await reconcileActiveGenerationBridge(
+        bridge: bridge,
+        syncState: state,
+        isBusy: true,
+        isImpersonating: false,
+        regenTargetId: null,
+        continuationTargetId: null,
+        streaming: const StreamingState(text: 'partial reply'),
+        messages: [_user('u1')],
+        streamingId: '__streaming__',
+        isCurrent: () => true,
+      );
+
+      expect(bridge.retireTypingPlaceholderCalls, 0);
+    });
+
+    test('a reconcile overtaken by a new run retires nothing', () async {
+      // Captured idle, ran after a send started. Retiring here would take away
+      // the bubble the newer dispatch has just put up, which is why the busy
+      // state is re-read through `isCurrent` instead of trusted as captured.
+      final bridge = _FakeBridge();
+      final state = ChatWebViewSyncState();
+
+      await reconcileActiveGenerationBridge(
+        bridge: bridge,
+        syncState: state,
+        isBusy: false,
+        isImpersonating: false,
+        regenTargetId: null,
+        continuationTargetId: null,
+        streaming: const StreamingState(),
+        messages: [_user('u1')],
+        streamingId: '__streaming__',
+        isCurrent: () => false,
+      );
+
+      expect(bridge.retireTypingPlaceholderCalls, 0);
+    });
+
+    test('impersonation streams into the composer and retires nothing', () async {
+      // Impersonation reuses the generating flag, so it reaches the reconcile
+      // as busy — and it never had a chat bubble to retire.
+      final bridge = _FakeBridge();
+      final state = ChatWebViewSyncState()..wasBusy = true;
+
+      await reconcileActiveGenerationBridge(
+        bridge: bridge,
+        syncState: state,
+        isBusy: true,
+        isImpersonating: true,
+        regenTargetId: null,
+        continuationTargetId: null,
+        streaming: const StreamingState(text: 'composer text'),
+        messages: const [],
+        streamingId: '__streaming__',
+        isCurrent: () => true,
+      );
+
+      expect(bridge.retireTypingPlaceholderCalls, 0);
+    });
+
     test('serializes persisted and streaming message mutations', () async {
       final state = ChatWebViewSyncState();
       final firstMutation = Completer<void>();
@@ -990,6 +1085,7 @@ class _FakeBridge implements ChatBridgeController {
   final List<bool> updatedIsLast = [];
   final List<String?> lastMessageIds = [];
   final List<String> removedMessages = [];
+  int retireTypingPlaceholderCalls = 0;
   int scrollToBottomOnAppendCalls = 0;
   final List<(List<Map<String, dynamic>>, List<Map<String, dynamic>>, bool)>
   memoryUpdates = [];
@@ -1059,6 +1155,11 @@ class _FakeBridge implements ChatBridgeController {
   @override
   Future<void> removeMessage(String id) async {
     removedMessages.add(id);
+  }
+
+  @override
+  Future<void> retireTypingPlaceholder() async {
+    retireTypingPlaceholderCalls++;
   }
 
   @override

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -2794,6 +2794,26 @@ void main() {
       expect(setBody, contains('_reattachStreamingPlaceholder(carriedPlaceholder)'));
     });
 
+    test('a leftover bubble can be retired without an exit animation', () {
+      // The carry above is only sound because Flutter retires a leftover
+      // before the setMessages that reopens a chat. `removeMessage` cannot do
+      // that job: it hands the node to a ~340ms exit animation, and the
+      // setMessages that follows would still find it at the tail and carry it.
+      final idx = bridgeControllerJs.indexOf('retireTypingPlaceholder() {');
+      expect(idx, isNot(-1));
+      final body = _extractBlockBody(bridgeControllerJs, idx);
+      // Level-triggered on the page's own belief: a node still on screen with
+      // the flag already cleared is playing the animation Flutter started.
+      expect(
+        body,
+        contains('!this._placeholderActive && !this._parkedPlaceholder'),
+      );
+      expect(body, contains('this._placeholderActive = false'));
+      expect(body, contains('this._parkedPlaceholder = null'));
+      expect(body, contains('this.virtualList.remove(STREAMING_ID)'));
+      expect(body, isNot(contains('animateRemoveSection')));
+    });
+
     test('replacing the chat drops the placeholder instead of parking it', () {
       // The bubble belongs to the session being left. Carried into the chat
       // being opened it claims a reply is on its way there, and it then rides

--- a/test/webview_js/specs/placeholder_lifecycle.spec.js
+++ b/test/webview_js/specs/placeholder_lifecycle.spec.js
@@ -193,3 +193,77 @@ test('a placeholder the list lost mid-run is still re-created', async ({
 
   expect(await renderedIds(page)).toEqual(['a1', 'u1', STREAMING_ID]);
 });
+
+test('a chat reopened after its run ended does not reopen with the bubble', async ({
+  page,
+}) => {
+  await boot(page);
+  await generating(page);
+
+  // The reader leaves the chat mid-run. On mobile the page is a keep-alive
+  // singleton, so this bubble stays in its DOM while the Flutter widget that
+  // owned it is disposed — and the run then finishes with nobody left to
+  // dispatch the falling edge that would have taken it away.
+  //
+  // Re-opening the chat is a plain `setMessages` (no `clearAll`), and the
+  // carry-across exists for exactly that call. Carried here it is a reply on
+  // its way that landed minutes ago, standing under itself, in a chat where
+  // nothing is running — and no later re-render takes it back down.
+  await page.evaluate(async () => {
+    await window.bridge.retireTypingPlaceholder();
+    await window.bridge.setMessages(
+      JSON.stringify([
+        JSON.parse(window.__M('a1', 'assistant', 'greeting')),
+        JSON.parse(window.__M('u1', 'user', 'hi')),
+        JSON.parse(window.__M('a2', 'assistant', 'the reply')),
+      ]),
+    );
+  });
+  await page.waitForTimeout(200);
+
+  expect(await renderedIds(page)).toEqual(['a1', 'u1', 'a2']);
+});
+
+test('a retired bubble cannot be brought back by a leftover delta', async ({
+  page,
+}) => {
+  await boot(page);
+  await generating(page);
+
+  // Retiring is what makes the orphan stay gone. The re-create branch in
+  // `_executeUpdateMessage` exists for a node the list lost mid-run, and it
+  // reads the same belief this call clears — so once retired, the last delta
+  // of the run that left the bubble behind cannot stand it back up.
+  await page.evaluate(() => window.bridge.retireTypingPlaceholder());
+  await page.waitForTimeout(60);
+  expect(await renderedIds(page)).toEqual(['a1', 'u1']);
+
+  await page.evaluate(() =>
+    window.bridge.updateMessage(
+      window.__M('__streaming__', 'assistant', 'the reply', { isTyping: true }),
+    ),
+  );
+  await page.waitForTimeout(300);
+  expect(await renderedIds(page)).toEqual(['a1', 'u1']);
+});
+
+test('retiring does not cut short an exit animation already running', async ({
+  page,
+}) => {
+  await boot(page);
+  await generating(page);
+
+  // The falling edge and the message sync land in the same frame: the
+  // dispatcher removes the bubble (a ~340ms exit animation) and the reconcile
+  // that follows retires it. The page has already stopped believing in it, so
+  // there is nothing to retire and the animation is left to finish.
+  await page.evaluate(() => {
+    window.bridge.removeMessage('__streaming__');
+    window.bridge.retireTypingPlaceholder();
+  });
+  await page.waitForTimeout(80);
+  expect(await renderedIds(page)).toContain(STREAMING_ID);
+
+  await page.waitForTimeout(500);
+  expect(await renderedIds(page)).toEqual(['a1', 'u1']);
+});


### PR DESCRIPTION
Closes the typing-bubble half of two Known Bugs cards.

## The bug

Leaving a chat mid-generation and coming back **after** the reply landed reopened it with the finished reply *and* a "Generating…" bubble standing under itself. No reload took it away.

The bubble is a virtual message — one constant id (`__streaming__`) Flutter puts up, streams into and removes, while the page draws it. Nothing persists it, so its only record is `ChatWebViewSyncState.streamingSent` in the widget that put it up. On mobile the page outlives that widget: `chatWebViewKeepAlive` makes it a singleton. Close the chat mid-run and the widget is disposed before the run ends, so nothing ever dispatches the falling edge — and `setMessages`, which carries a bubble across a re-render *on purpose* (a live run streams into that node), hands the leftover to the reopened chat and to every re-render after it.

Reproduced in the browser harness before anything was changed: reopening rendered `["a1", "u1", "a2", "__streaming__"]`.

## Changes

- **`retireTypingPlaceholder()`** on the page drops the bubble with no exit animation, so a `setMessages` issued right after it has nothing left to carry. `removeMessage` cannot do that job — it hands the node to a ~340ms animation that the following `setMessages` still finds at the tail. The call is level-triggered on the page's own belief (`_placeholderActive`), which is what keeps it from cutting short an animation Flutter already started.
- **`ChatWebViewInitializer`** calls it before its first `setMessages`, guarded on `isGenerating` and `isSendPending` both being false. The page cannot tell a live bubble from a leftover, so that guard is the whole of what keeps them apart: a chat reopened mid-run must still carry its bubble.
- **`reconcileActiveGenerationBridge`** retires on an idle reconcile instead of only clearing its flags. The flags belong to the widget and a fresh one starts with them false, while the node belongs to the page — so "idle means no bubble" becomes level-triggered and covers any edge missed anywhere else, including the "duplicate that vanishes on reopen" variant of the same report.
- **The run flags reach the page before the first paint**, and `setSendPending` is pushed at init at all. Only its Dart-side mirror was being set, so a chat reopened inside the send window showed a bubble with no elapsed clock until whatever rebuild came next. `isSendPendingInPage` is mirrored too, since that is what the dispatcher level-reconciles against.

Documented as **INV-C8** ("the typing bubble lives exactly as long as a reply is on its way"), with the two manual checks it implies.

## Cards

- **#141** *Previously genned message showing as currently genning message briefly* — the **duplicate** half is fixed here. The **ghost** half (the previous reply re-appearing under a new send) did not reproduce: `ChatNotifier._sendMessage` already clears the streaming state synchronously before the bubble is painted, `closeStreamPublishing` shuts the deferred frame publish, and the reconcile is epoch-keyed. `send_window_streaming_reset_test.dart` already guards it. The persisted-duplicate variant the audit flagged as "worth verifying on the writer/commit path" is not reachable: `commitGenerationResult` rejects a second commit on its tail anchor, and `SavedMessageWriter` rebuilds from the base session rather than appending to its own output.
- **#131** *"Generating" textbox disappears when exiting and reopening the chat mid-generation* — the audit's proposed fix is already in nightly (`_resetStreamingPresentationState()` at the top of `_initWebViewOnce` plus a level-triggered `_reconcileActiveGenerationPresentation` after it). What was left was the clock: the page never received `setSendPending` at init, so reopening inside the send window gave a bubble that did not tick. Fixed here.

## Verification

- `flutter analyze` — 9 issues, every one pre-existing on `nightly`, none in a touched file
- `flutter test` — 3906 pass
- `test/webview_js` (headless Chromium, real bridge) — 100 pass
- New coverage fails without the fix: 3 of the 8 `placeholder_lifecycle` cases, and 4 of the 7 new Dart cases (the other 3 assert the *absence* of a retire, which holds trivially without the code)
- One case I wrote asserted that a stray retire spares a live bubble — the page genuinely cannot know that, and the caller owns it. Replaced with the real page-side contract (a retired bubble cannot be resurrected by a leftover delta) and the guard is tested on the Dart side instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)