### PR TITLE
fix(lorebooks): stop an imported character's lorebook from firing in every chat

### DIFF
--- a/lib/core/llm/lorebook_activation.dart
+++ b/lib/core/llm/lorebook_activation.dart
@@ -25,6 +25,19 @@ List<Lorebook> activeLorebooksFor({
     if (charGroupId?.isNotEmpty == true) charGroupId!,
   };
   return lorebooks.where((lb) {
+    // `enabled` is the Global switch and it stands on its own, deliberately —
+    // it is not gated on the scope fields below. Those are a *denormalised
+    // mirror* of the activation maps (`_applyActivations` in
+    // `lorebook_connections_sheet.dart` writes the first linked id into them),
+    // so a global book that is also pinned to a character carries
+    // `enabled: true` *and* `activationScope: 'character'`. Gating one on the
+    // other would silently un-globalize every one of those.
+    //
+    // Which means an imported book must never be written with `enabled: true`
+    // in the first place: the read side cannot tell that apart from a book the
+    // user made global on purpose. See `convertJanitorScript` and
+    // `convertCharacterBook`, which both stamp `enabled: false` and let the
+    // character scope do the activating.
     if (lb.enabled) return true;
     if (characterTargets.any(
       (id) => activations?.character[id]?.contains(lb.id) == true,

--- a/lib/core/services/backup/js_lorebook_importer.dart
+++ b/lib/core/services/backup/js_lorebook_importer.dart
@@ -158,7 +158,13 @@ class JsLorebookImporter extends BackupHelpers {
               lorebookId: cbId,
               name: cbRaw['name'] as String? ??
                   '${char['name'] ?? 'Char'} Lorebook',
-              enabled: Value(cbRaw['enabled'] as bool? ?? false),
+              // Never carried over from the card. `enabled` here is Glaze's
+              // Global switch, while `character_book.enabled` on a card means
+              // "this card's own book is on" — copying one into the other is
+              // what made an imported character's lorebook fire in every chat.
+              // The character scope below is what activates it where it
+              // belongs.
+              enabled: const Value(false),
               activationScope: Value('character'),
               activationTargetId: Value(charId),
               entriesJson: jsonEncode(mappedEntries),

--- a/lib/features/catalog/services/janitor_public_lorebook.dart
+++ b/lib/features/catalog/services/janitor_public_lorebook.dart
@@ -454,7 +454,13 @@ Lorebook convertJanitorScript(
   return Lorebook(
     id: generateId(),
     name: name,
-    enabled: true,
+    // `enabled` is the Global switch — the book fires in every chat, whatever
+    // else it is bound to. A book that came attached to one character has no
+    // business there, and `LorebooksNotifier.put` registers a character-scoped
+    // book in the activation map anyway, so it is already active where it
+    // belongs. Mirrors `convertCharacterBook`, which the file-card import path
+    // has done since it was fixed.
+    enabled: characterId == null,
     activationScope: characterId != null ? 'character' : 'global',
     activationTargetId: characterId,
     entries: out,

--- a/test/backup_importer_test.dart
+++ b/test/backup_importer_test.dart
@@ -827,6 +827,39 @@ void main() {
       expect(rows.first.activationTargetId, equals('char1'));
     });
 
+    test("a card's own book is never imported as globally enabled", () async {
+      // `character_book.enabled` on a card means "this card's book is on for
+      // this card". Glaze's `enabled` is the Global switch, and
+      // `activeLorebooksFor` honours it on its own — so copying one into the
+      // other put an imported character's lorebook in every other chat.
+      final importer = JsLorebookImporter(db, imageStorage);
+
+      await importer.importCharacterBooks([
+        {
+          'id': 'char1',
+          'name': 'Test Character',
+          'character_book': {
+            'name': 'Char1 Book',
+            'enabled': true,
+            'entries': [
+              {
+                'keys': ['sword'],
+                'content': 'A legendary sword.',
+                'enabled': true,
+                'position': 0,
+              },
+            ],
+          },
+        },
+      ]);
+
+      final rows = await db.select(db.lorebooks).get();
+      expect(rows.single.enabled, isFalse);
+      // Still active where it belongs — through the character scope.
+      expect(rows.single.activationScope, equals('character'));
+      expect(rows.single.activationTargetId, equals('char1'));
+    });
+
     test('does not duplicate character books on re-import', () async {
       final importer = JsLorebookImporter(db, imageStorage);
 

--- a/test/janitor_public_lorebook_test.dart
+++ b/test/janitor_public_lorebook_test.dart
@@ -93,6 +93,26 @@ void main() {
       expect(book.activationScope, 'character');
       expect(book.activationTargetId, 'char-1');
     });
+
+    test('a book attached to a character is not globally enabled', () {
+      // `enabled` is the Global switch: the book fires in every chat whatever
+      // else it is bound to, and `activeLorebooksFor` honours it on its own
+      // (it has to — a global book pinned to a character carries both flags).
+      // So importing a character *with* its lorebooks used to put that book in
+      // every other character's prompt too.
+      final book = convertJanitorScript(_entries(),
+          name: 'World Lore', characterId: 'char-1');
+      expect(book.enabled, isFalse);
+    });
+
+    test('a book imported on its own is globally enabled', () {
+      // The Lorebooks tab's own import has nothing to scope to, so the Global
+      // switch is the only thing that can make it fire at all.
+      final book = convertJanitorScript(_entries(), name: 'World Lore');
+      expect(book.enabled, isTrue);
+      expect(book.activationScope, 'global');
+      expect(book.activationTargetId, isNull);
+    });
   });
 
   group('book partitioning', () {

--- a/test/lorebook_activation_test.dart
+++ b/test/lorebook_activation_test.dart
@@ -3,7 +3,11 @@ import 'package:glaze_flutter/core/llm/lorebook_activation.dart';
 import 'package:glaze_flutter/core/models/lorebook.dart';
 
 void main() {
-  const book = Lorebook(id: 'book', name: 'Book');
+  // `enabled: false` on purpose. It is the Global switch, and
+  // `activeLorebooksFor` honours it on its own — left at its default (`true`)
+  // every case below would pass through that branch and prove nothing about
+  // the scope it claims to be testing.
+  const book = Lorebook(id: 'book', name: 'Book', enabled: false);
 
   test('character activation applies to every variation in its group', () {
     final active = activeLorebooksFor(
@@ -45,6 +49,7 @@ void main() {
         Lorebook(
           id: 'book',
           name: 'Book',
+          enabled: false,
           activationScope: 'character',
           activationTargetId: 'group',
         ),
@@ -57,5 +62,70 @@ void main() {
     );
 
     expect(active, hasLength(1));
+  });
+
+  test('a book bound to one character stays out of every other chat', () {
+    // What importing a character *with* its lorebooks produces: the book is
+    // scoped to that character and activated for it, and nothing else.
+    const attached = Lorebook(
+      id: 'attached',
+      name: 'World Lore',
+      enabled: false,
+      activationScope: 'character',
+      activationTargetId: 'imported-char',
+    );
+
+    final own = activeLorebooksFor(
+      lorebooks: const [attached],
+      charId: 'imported-char',
+      charWorld: null,
+      chatId: 'session-1',
+      activations: const LorebookActivations(
+        character: {
+          'imported-char': ['attached'],
+        },
+      ),
+    );
+    expect(own, [attached]);
+
+    final somebodyElse = activeLorebooksFor(
+      lorebooks: const [attached],
+      charId: 'other-char',
+      charWorld: null,
+      chatId: 'session-2',
+      activations: const LorebookActivations(
+        character: {
+          'imported-char': ['attached'],
+        },
+      ),
+    );
+    expect(somebodyElse, isEmpty);
+  });
+
+  test('the Global switch reaches every chat even while pinned', () {
+    // The reason the `enabled` branch is not gated on the scope fields: those
+    // are a denormalised mirror of the activation map, so a book the user made
+    // global *and* pinned to a character carries a character scope too.
+    // Requiring the scope to match would take the global half away.
+    const pinned = Lorebook(
+      id: 'pinned',
+      name: 'House Rules',
+      activationScope: 'character',
+      activationTargetId: 'favourite-char',
+    );
+
+    final elsewhere = activeLorebooksFor(
+      lorebooks: const [pinned],
+      charId: 'other-char',
+      charWorld: null,
+      chatId: 'session-2',
+      activations: const LorebookActivations(
+        character: {
+          'favourite-char': ['pinned'],
+        },
+      ),
+    );
+
+    expect(elsewhere, [pinned]);
   });
 }


### PR DESCRIPTION
Card **#99** *Importing cards with lorebooks attached enable them globally* (severity high).

## The bug

Importing a character *with* its lorebooks wrote those books with `enabled: true`. `enabled` is the **Global** switch — the book fires in every chat whatever else it is bound to — so the character's own lore leaked into every other character's prompt, exactly as the reporter described ("like the enable for all chats option is true by default").

The file-card path (PNG/JSON/CharX) was already fixed: `convertCharacterBook` stamps `enabled: false` and lets the character scope do the activating. Two other write paths still had it.

## Changes

- **`convertJanitorScript`** stamped `enabled: true` unconditionally, even when handed a `characterId` to scope the book to. Now `enabled: characterId == null`, which is the contract the capture sheet already documents — *"[characterId] is the Glaze character the saved books are scoped to; null saves them as standalone (global) lorebooks."* This is the path behind catalog import with "Import with lorebooks" and the Lorebooks tab's JanitorAI capture sheet.
- **`JsLorebookImporter.importCharacterBooks`** copied the card's own `character_book.enabled` into it. That flag means "this card's book is on for this card"; it is not Glaze's Global switch. Now always false.

Neither loses the activation — `LorebooksNotifier.put` registers a character-scoped book in the activation map, so the book is still active for the character it came with. It now shows as a purple character badge in the Lorebooks list instead of a green **Global** one, which is also the first place the old behaviour was visible.

## One audit recommendation deliberately not taken

The audit also proposed gating `enabled` on the scope fields inside `activeLorebooksFor`. I did not do that, and left a comment where the branch lives so the next reader does not try it either.

`activationScope` / `activationTargetId` are a **denormalised mirror** of the activation maps — `_applyActivations` in `lorebook_connections_sheet.dart` writes the first linked id into them whenever a connection is added. So a book the user made global **and** pinned to a character carries `enabled: true` *and* `activationScope: 'character'`, which is indistinguishable from a bad import. Gating would silently take the global half away from every one of those books. The defect is on the write side, and that is where it is fixed.

## Known limitation

A book already imported before this change keeps `enabled: true` and stays global. A migration cannot fix it: as above, that row is byte-identical to a book somebody made global on purpose. Turning **Global** off in the book's Connections sheet clears it in one tap, and the sheet now tells the truth about what it is. Say the word if you would rather I flip every character-scoped book to `enabled: false` in a migration and accept un-globalizing the deliberate ones.

Separately, the "this character comes with a lorebook" notice from the thread is a feature, so it is on the feature list rather than in here.

## Verification

- `flutter analyze` — 9 issues, every one pre-existing on `nightly`, none in a touched file
- `flutter test` — 3903 pass
- Both new fix-guarding cases fail with the fix reverted (`convertJanitorScript`, `JsLorebookImporter`)
- The three existing cases in `lorebook_activation_test.dart` were passing through the `enabled` branch — their fixture left it at its default `true`, so none of them exercised the scope each was named after. Fixtures now say `enabled: false` (all three still pass, now for the stated reason) and two new cases cover both halves of the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)