### PR TITLE
Stop a sent message's text surviving as the chat's draft

### DIFF
--- a/lib/core/db/repositories/chat_repo.dart
+++ b/lib/core/db/repositories/chat_repo.dart
@@ -256,9 +256,24 @@ ORDER BY updated_at DESC
       if (prepared == null) return null;
 
       // A retry after a completed transaction must not append the same user
-      // message or a second acceptance event.
+      // message or a second acceptance event. The draft still has to go: this
+      // branch reports the send as accepted, and the session it returns is
+      // published into `ChatState` and the session cache, so a draft left on
+      // it is the text of the message that was just sent — sitting in the
+      // composer again the next time the chat is opened.
       if (!prepared.didAppend) {
-        return _toModel(snapshot, messages: prepared.messages);
+        if ((snapshot.draft ?? '').isEmpty) {
+          return _toModel(snapshot, messages: prepared.messages);
+        }
+        await (_db.update(
+          _db.chatSessions,
+        )..where((t) => t.sessionId.equals(sessionId))).write(
+          const ChatSessionsCompanion(draft: Value('')),
+        );
+        return _toModel(
+          snapshot.copyWith(draft: const Value('')),
+          messages: prepared.messages,
+        );
       }
 
       final result = await _db.transaction<({bool retry, ChatSession? value})>(

--- a/lib/features/chat/chat_provider.dart
+++ b/lib/features/chat/chat_provider.dart
@@ -294,6 +294,7 @@ class ChatNotifier extends AsyncNotifier<ChatState> {
       state = s;
     },
     getState: () => state,
+    writes: _sessionWrites,
   );
 
   void _invalidateHistory() => ref.invalidate(chatHistoryProvider);

--- a/lib/features/chat/controllers/chat_draft_controller.dart
+++ b/lib/features/chat/controllers/chat_draft_controller.dart
@@ -3,11 +3,21 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/state/db_provider.dart';
 import '../chat_session_service.dart';
 import '../chat_state.dart';
+import '../state/chat_session_write_queue.dart';
 
 class ChatDraftController {
   final Ref _ref;
   final void Function(AsyncValue<ChatState>) _setState;
   final AsyncValue<ChatState> Function() _getState;
+
+  /// The same queue every other durable session write goes through. A draft
+  /// write is a write to the session row, and the row's `draft` column is
+  /// cleared by the send's append — so the two must not be left to race. On
+  /// the queue the ordering is the order the user acted in: a draft saved
+  /// before Send commits first and the append clears it, and a draft typed
+  /// during a slow send commits after the append instead of being dropped by
+  /// the message-count guard below.
+  final ChatSessionWriteQueue _writes;
 
   int _saveEpoch = 0;
 
@@ -15,17 +25,36 @@ class ChatDraftController {
     required this._ref,
     required this._setState,
     required this._getState,
+    required this._writes,
   });
 
-  Future<void> saveDraft(String draftText) async {
+  /// Persists the composer's contents as this session's draft.
+  ///
+  /// The epoch is claimed synchronously, before the queue wait, so the newest
+  /// debounce is the one that lands however long the queue takes to reach it.
+  Future<void> saveDraft(String draftText) {
+    final epoch = ++_saveEpoch;
+    return _writes.run(() => _commitDraft(draftText, epoch));
+  }
+
+  Future<void> _commitDraft(String draftText, int epoch) async {
     if (!_ref.mounted) return;
+    if (epoch != _saveEpoch) return;
     final current = _getState().value;
     if (current == null || current.session == null) return;
-    if (current.session!.draft == draftText) return;
 
     final sessionId = current.session!.id;
+    // Read inside the operation, not before the queue wait: the count has to
+    // describe the row this write is about to land on. A draft typed while a
+    // send was still encoding used to carry the pre-append count and be
+    // rejected outright, which lost the user's next message.
     final expectedMessageCount = current.session!.messages.length;
-    final epoch = ++_saveEpoch;
+    // Deliberately not skipped when the in-memory draft already equals
+    // [draftText]. `ChatState`'s copy is not evidence about the column: the
+    // guard below abandons the publish when the message list moved under the
+    // write, so state can believe the draft is empty while the row still
+    // holds text. Skipping on that comparison is what let a sent message's
+    // text survive in the column with nothing left to clear it.
     final updatedSession = await _ref
         .read(chatRepoProvider)
         .updateDraftIfMessageCount(

--- a/lib/features/chat/widgets/chat_input_bar.dart
+++ b/lib/features/chat/widgets/chat_input_bar.dart
@@ -553,6 +553,15 @@ class _ChatInputBarState extends ConsumerState<ChatInputBar> {
     // reading as a send that never registered. The payload is captured above,
     // so the rare rejection puts it straight back.
     _clearComposedPayload();
+    // The stored draft is spent the moment its text becomes a message, so
+    // clear it on the tap instead of leaving it to the debounce the clear
+    // above just re-armed. That timer is 500ms in which nothing has cleared
+    // the row yet and `dispose` cancels it outright — leave the chat right
+    // after sending and it never fires. It is also the only writer that can
+    // clear a row which is *already* holding a sent message's text, so
+    // pushing the empty draft through here is what cleans one up.
+    _debounce?.cancel();
+    widget.onDraftChanged?.call('');
     bool accepted;
     try {
       if (attachments.isNotEmpty) {

--- a/test/chat_draft_controller_test.dart
+++ b/test/chat_draft_controller_test.dart
@@ -10,6 +10,7 @@ import 'package:glaze_flutter/core/models/chat_message.dart';
 import 'package:glaze_flutter/core/state/db_provider.dart';
 import 'package:glaze_flutter/features/chat/chat_state.dart';
 import 'package:glaze_flutter/features/chat/controllers/chat_draft_controller.dart';
+import 'package:glaze_flutter/features/chat/state/chat_session_write_queue.dart';
 
 class _DelayedDraftRepo extends ChatRepo {
   final Completer<void> started = Completer<void>();
@@ -75,6 +76,7 @@ void main() {
         ref: container.read(Provider((ref) => ref)),
         setState: (next) => state = next,
         getState: () => state,
+        writes: ChatSessionWriteQueue(),
       );
 
       final pending = controller.saveDraft('draft A');
@@ -93,6 +95,7 @@ void main() {
       ref: container.read(Provider((ref) => ref)),
       setState: (next) => state = next,
       getState: () => state,
+      writes: ChatSessionWriteQueue(),
     );
 
     final pending = controller.saveDraft('draft A');
@@ -116,5 +119,96 @@ void main() {
     await pending;
 
     expect(state.value!.messages.map((item) => item.id), ['m1', 'u1']);
+  });
+
+  group('the durable row, not the in-memory copy', () {
+    late AppDatabase liveDb;
+    late ChatRepo liveRepo;
+    late ProviderContainer liveContainer;
+    late ChatSessionWriteQueue writes;
+
+    setUp(() {
+      liveDb = AppDatabase.forTesting(NativeDatabase.memory());
+      liveRepo = ChatRepo(liveDb);
+      writes = ChatSessionWriteQueue();
+      liveContainer = ProviderContainer(
+        overrides: [chatRepoProvider.overrideWithValue(liveRepo)],
+      );
+    });
+
+    tearDown(() async {
+      liveContainer.dispose();
+      await liveDb.close();
+    });
+
+    ChatDraftController controllerFor(
+      AsyncValue<ChatState> Function() getState, {
+      void Function(AsyncValue<ChatState>)? setState,
+    }) => ChatDraftController(
+      ref: liveContainer.read(Provider((ref) => ref)),
+      setState: setState ?? (_) {},
+      getState: getState,
+      writes: writes,
+    );
+
+    test('an empty draft clears a row the send left holding text', () async {
+      await liveRepo.put(sessionA.copyWith(id: 'live', draft: 'hello'));
+      // What a send publishes: the state copy says the draft is gone, while
+      // the column still holds the text. `ChatState` is not evidence about
+      // the row, so the clear has to go through anyway.
+      AsyncValue<ChatState> state = AsyncData(
+        ChatState(session: sessionA.copyWith(id: 'live', draft: '')),
+      );
+
+      await controllerFor(() => state).saveDraft('');
+
+      expect((await liveRepo.getById('live'))?.draft, '');
+    });
+
+    test('a draft typed during a send commits against the appended row', () async {
+      await liveRepo.put(sessionA.copyWith(id: 'live'));
+      final appendStarted = Completer<void>();
+      final releaseAppend = Completer<void>();
+      AsyncValue<ChatState> state = AsyncData(
+        ChatState(session: sessionA.copyWith(id: 'live')),
+      );
+
+      // Stands in for the send's durable append: already on the queue, and
+      // slow, the way encoding a long chat is slow.
+      final append = writes.run(() async {
+        appendStarted.complete();
+        await releaseAppend.future;
+        await liveRepo.mutateMessages(
+          sessionId: 'live',
+          mutate: (messages) => [
+            ...messages,
+            const ChatMessage(id: 'u1', role: 'user', content: 'sent'),
+          ],
+          updatedAt: 2,
+        );
+      });
+      await appendStarted.future;
+
+      // The composer is empty again, so the user starts the next message while
+      // the send is still being written. The optimistic paint already counts
+      // the sent message.
+      state = AsyncData(
+        ChatState(
+          session: sessionA.copyWith(
+            id: 'live',
+            messages: [
+              message,
+              const ChatMessage(id: 'u1', role: 'user', content: 'sent'),
+            ],
+          ),
+        ),
+      );
+      final saved = controllerFor(() => state).saveDraft('the next one');
+      releaseAppend.complete();
+      await append;
+      await saved;
+
+      expect((await liveRepo.getById('live'))?.draft, 'the next one');
+    });
   });
 }

--- a/test/chat_input_bar_test.dart
+++ b/test/chat_input_bar_test.dart
@@ -23,6 +23,7 @@ void main() {
   group('ChatInputBar', () {
     late List<String> sentMessages;
     late List<List<String>> sentAttachments;
+    late List<String> draftWrites;
 
     Widget buildChatInputBar({
       FocusNode? focusNode,
@@ -39,6 +40,7 @@ void main() {
     }) {
       sentMessages = [];
       sentAttachments = [];
+      draftWrites = [];
       return ProviderScope(
         child: MaterialApp(
           home: Scaffold(
@@ -61,6 +63,7 @@ void main() {
               enterToSend: enterToSend,
               isEditingMessage: isEditingMessage,
               initialDraft: initialDraft,
+              onDraftChanged: draftWrites.add,
               onImpersonate: onImpersonate,
               onStop: onStop,
             ),
@@ -401,6 +404,31 @@ void main() {
 
         expect(find.byType(Image), findsOneWidget);
       });
+    });
+
+    testWidgets('sending clears the stored draft on the tap', (tester) async {
+      await tester.pumpWidget(buildChatInputBar(initialDraft: 'sent text'));
+
+      await tester.tap(find.byIcon(Icons.send_rounded));
+      await tester.pump();
+
+      // No debounce wait: the row must not be left holding the text of a
+      // message that is already on its way, because leaving the chat inside
+      // that window cancels the timer that would have cleared it.
+      expect(draftWrites, ['']);
+      expect(sentMessages, ['sent text']);
+    });
+
+    testWidgets('a rejected send puts its draft back', (tester) async {
+      await tester.pumpWidget(
+        buildChatInputBar(initialDraft: 'keep me', acceptSend: false),
+      );
+
+      await tester.tap(find.byIcon(Icons.send_rounded));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(draftWrites, ['', 'keep me']);
     });
 
     testWidgets('rejected send keeps the composed text', (tester) async {

--- a/test/chat_repo_generation_manifest_commit_test.dart
+++ b/test/chat_repo_generation_manifest_commit_test.dart
@@ -263,6 +263,38 @@ void main() {
     expect(await manifestRepo.getVariationAcceptances('session'), hasLength(1));
   });
 
+  test('an idempotent retry still clears the draft', () async {
+    final base = _session();
+    final generated = base.copyWith(messages: [_assistant('assistant', 'reply')]);
+    await chatRepo.put(base);
+    await chatRepo.commitGenerationResult(
+      baseSession: base, generatedSession: generated, regenTargetId: null, manifest: _manifest(),
+    );
+    final message = _user('user', 'next');
+    await chatRepo.appendUserMessageAndAcceptCurrentVariation(
+      sessionId: 'session', message: message,
+      expectedPrecedingAssistant: _identity('assistant', 0, 0), updatedAt: 11,
+    );
+    // A draft debounce that landed after the append: the row is holding the
+    // text of a message that has already been sent.
+    await chatRepo.updateDraftIfMessageCount(
+      sessionId: 'session', draft: 'next', expectedMessageCount: 2,
+    );
+
+    // This branch reports the send as accepted and its session is published
+    // into `ChatState` and the session cache, so it owes the same draft clear
+    // the appending branch does — otherwise the sent text is back in the
+    // composer the next time the chat opens.
+    final retry = await chatRepo.appendUserMessageAndAcceptCurrentVariation(
+      sessionId: 'session', message: message,
+      expectedPrecedingAssistant: _identity('assistant', 0, 0), updatedAt: 11,
+    );
+
+    expect(retry?.messages, hasLength(2));
+    expect(retry?.draft, '');
+    expect((await chatRepo.getById('session'))?.draft, '');
+  });
+
 }
 
 Future<List<LorebookUseManifestRow>> _manifestRows(AppDatabase db) =>


### PR DESCRIPTION
Trello: [Last sent message reappearing on input box](https://trello.com/c/DK3UFke7) (#121)

The composer's draft lives in `chat_sessions.draft`, is re-seeded into the input from `state.session.draft` on every chat open (the notifier is `keepAlive`, so that value outlives the screen), and is cleared as a *side effect* of whichever append variant the send happened to take. Three holes in that arrangement can leave the row holding the text of a message that has already been sent and answered — which is what puts it back in the input box on the next open.

## Changes

- `ChatRepo.appendUserMessageAndAcceptCurrentVariation` clears the draft on its idempotent (`didAppend == false`) branch too. That branch reports the send as accepted and its session is published into `ChatState` and the session cache, so a draft left on it is the sent message's own text.
- `ChatDraftController.saveDraft` no longer skips a write whose text matches the in-memory draft. `ChatState`'s copy is not evidence about the column: the controller's message-count guard abandons the publish when the message list moves under the write, so state can believe the draft is empty while the row still holds text — and the empty write that would have cleared it was exactly the one being skipped.
- Draft writes go through the existing `ChatSessionWriteQueue`, the queue every other durable session write already uses. A draft write and the send's append are now ordered instead of racing, and `expectedMessageCount` is read when the write's turn comes up rather than before the wait — a draft typed *during* a slow send used to carry the pre-append count and be rejected outright, losing the user's next message.
- `ChatInputBar._handleSend` clears the stored draft on the tap instead of leaving it to the 500ms debounce the composer clear re-arms. `dispose` cancels that timer, so leaving the chat right after sending meant nothing ever cleared the row. This is also the writer that cleans up a row which is *already* holding a sent message's text, so no migration is needed for sessions affected by an older build — the next send in that chat clears it.

## Verification

- `flutter analyze` — 9 issues, all pre-existing on `nightly`, none in a touched file.
- `flutter test` — 3903 pass, 4 skipped.
- Each fix is guarded by a test that fails without it, checked by stashing the change:
  - `an idempotent retry still clears the draft` → `Expected: '' / Actual: 'next'`
  - `an empty draft clears a row the send left holding text` → `Expected: '' / Actual: 'hello'`
  - `a draft typed during a send commits against the appended row` → `Expected: 'the next one' / Actual: <null>`
  - `sending clears the stored draft on the tap` → `Expected: [''] / Actual: []`
  - `a rejected send puts its draft back` → `Expected: ['', 'keep me'] / Actual: ['keep me']`

## Note on the audit

The automated audit's proposed interleaving no longer exists: it describes `_handleSend` clearing the composer only after the durable append, while `nightly` clears it on the tap, which cancels and re-arms the debounce with an empty controller. I could not construct the reporter's exact repro from the current code, and the card has no repro steps. What is fixed here are the holes that are demonstrable — the third one (the uncancelled debounce that `dispose` kills) is the one that leaves a row uncleared in normal use, and the first leaks the sent text specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)