### PR TITLE
Recover a refused catalog session instead of dead-ending on it

### DIFF
--- a/lib/features/catalog/catalog_provider.dart
+++ b/lib/features/catalog/catalog_provider.dart
@@ -326,7 +326,9 @@ class CatalogNotifier extends StateNotifier<CatalogState> {
           filters: state.filters,
         );
       case CatalogProvider.datacat:
-        await datacatEnsureSession();
+        // No session probe first: every DataCat call now re-establishes the
+        // session itself when the server rejects the token, so the extra
+        // round-trip this used to make before each page bought nothing.
         if (state.query.isNotEmpty) {
           return datacatSearch(
             query: state.query,

--- a/lib/features/catalog/services/catalog_http.dart
+++ b/lib/features/catalog/services/catalog_http.dart
@@ -24,6 +24,26 @@ final _dio = Dio(BaseOptions(
   validateStatus: (_) => true,
 ));
 
+/// Replaces the transport under the shared catalog client.
+///
+/// The client is a file-private singleton on purpose — every provider must
+/// carry the same browser UA — so this is the seam the provider tests use to
+/// answer a request without a network round-trip.
+@visibleForTesting
+void setCatalogHttpAdapter(HttpClientAdapter adapter) {
+  _dio.httpClientAdapter = adapter;
+}
+
+/// The HTTP status a catalog failure reported, or null when the request never
+/// reached a server that answered.
+///
+/// Providers used to decide whether to re-authenticate by searching
+/// `e.toString()` for `'401'`, which matches a 401 that merely appears
+/// somewhere in the server's *body* just as readily as a real one — and reads
+/// as a 401 for a request whose status was something else entirely.
+int? catalogErrorStatus(Object error) =>
+    error is DioException ? error.response?.statusCode : null;
+
 /// Raises a [DioException] carrying the response, so callers can run it through
 /// the shared `formatError()` (same friendly, localized handling as LLM
 /// requests) instead of showing a raw dump. The full body is logged in debug

--- a/lib/features/catalog/services/datacat_provider.dart
+++ b/lib/features/catalog/services/datacat_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:dio/dio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'catalog_http.dart';
@@ -71,29 +72,43 @@ Future<String> _getToken() async {
   return token;
 }
 
-Future<bool> datacatValidate() async {
-  final token = await _getSessionToken();
-  if (token == null) return false;
+/// Runs an authenticated DataCat call, re-establishing the session once when
+/// the server rejects the token it was made with.
+///
+/// The anonymous session token comes from `/api/liberator/identify` and is kept
+/// in SharedPreferences with no expiry, so it outlives whatever the server is
+/// still willing to honour. A token DataCat has forgotten answers 401/403 to
+/// every call carrying it, and the browse path used to be the only one that
+/// knew how to replace one — it ran a throwaway probe request before each
+/// search purely to find out. Every other endpoint dead-ended: the card detail
+/// showed `HTTP 403: Forbidden` behind a Retry button that re-sent the same
+/// dead token, which is why retrying never helped.
+///
+/// A 403 can also be DataCat's bot protection, which no amount of fresh
+/// sessions will cure. One retry is what tells the two apart — and the wasted
+/// request only happens on a failure that was already fatal.
+Future<T> _datacatAuthed<T>(Future<T> Function(String token) call) async {
+  final token = await _getToken();
   try {
-    await catalogGet(
-      '$_base/api/characters/recent-public?limit=1&summary=1',
-      _authHeaders(token),
-    );
-    return true;
-  } catch (e) {
-    if (e.toString().contains('401') || e.toString().contains('403')) {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_keyToken);
-      return false;
-    }
-    return true;
+    return await call(token);
+  } on DioException catch (e) {
+    final status = catalogErrorStatus(e);
+    if (status != 401 && status != 403) rethrow;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_keyToken);
+    return await call(await datacatInit());
   }
 }
 
-Future<void> datacatEnsureSession() async {
-  final valid = await datacatValidate();
-  if (!valid) await datacatInit();
-}
+Future<Map<String, dynamic>> _datacatGet(String path) =>
+    _datacatAuthed((token) => catalogGet('$_base$path', _authHeaders(token)));
+
+Future<Map<String, dynamic>> _datacatPost(
+  String path,
+  Map<String, dynamic> body,
+) => _datacatAuthed(
+  (token) => catalogPost('$_base$path', body, _authHeaders(token)),
+);
 
 String? _pickAvatarSource(Map<String, dynamic> raw, Map<String, dynamic> meta) {
   return (raw['avatar'] ?? raw['image'] ?? raw['image_url'] ??
@@ -171,7 +186,6 @@ Future<CatalogSearchResult> datacatBrowse({
     return CatalogSearchResult(characters: res, total: res.length, hasMore: false);
   }
 
-  final token = await _getToken();
   final offset = (page - 1) * limit;
   final minTok = filters.minTokens > 0 ? filters.minTokens : _minTokens;
 
@@ -180,10 +194,7 @@ Future<CatalogSearchResult> datacatBrowse({
   if (filters.tagIds.isNotEmpty) params.write('&tagIds=${filters.tagIds.join(',')}');
   if (!filters.nsfw) params.write('&blockedTagIds=2');
 
-  final data = await catalogGet(
-    '$_base/api/characters/recent-public?$params',
-    _authHeaders(token),
-  );
+  final data = await _datacatGet('/api/characters/recent-public?$params');
   final chars = ((data['characters'] as List?) ?? []).cast<Map<String, dynamic>>();
   return CatalogSearchResult(
     characters: chars.map(_normalizeListItem).toList(),
@@ -198,11 +209,10 @@ Future<List<CatalogItem>> _datacatFresh({
   int limitWeek = 40,
   bool nsfw = true,
 }) async {
-  final token = await _getToken();
-  var url = '$_base/api/characters/fresh?summary=1&sortBy=$sortBy&limit24=$limit24&limitWeek=$limitWeek';
-  if (!nsfw) url += '&blockedTagIds=2';
+  var path = '/api/characters/fresh?summary=1&sortBy=$sortBy&limit24=$limit24&limitWeek=$limitWeek';
+  if (!nsfw) path += '&blockedTagIds=2';
 
-  final data = await catalogGet(url, _authHeaders(token));
+  final data = await _datacatGet(path);
   final windows = data['windows'] as Map<String, dynamic>? ?? {};
   final last24h = ((windows['last24h']?['characters'] as List?) ?? []).cast<Map<String, dynamic>>();
   final thisWeek = ((windows['thisWeek']?['characters'] as List?) ?? []).cast<Map<String, dynamic>>();
@@ -228,7 +238,6 @@ Future<CatalogSearchResult> datacatSearch({
   int limit = 24,
   CatalogFilters filters = const CatalogFilters(),
 }) async {
-  final token = await _getToken();
   final offset = (page - 1) * limit;
   final minTok = filters.minTokens > 0 ? filters.minTokens : _minTokens;
 
@@ -238,10 +247,7 @@ Future<CatalogSearchResult> datacatSearch({
   if (filters.tagIds.isNotEmpty) params.write('&tagIds=${filters.tagIds.join(',')}');
   if (query.isNotEmpty) params.write('&search=${Uri.encodeComponent(query)}');
 
-  final data = await catalogGet(
-    '$_base/api/characters/recent-public?$params',
-    _authHeaders(token),
-  );
+  final data = await _datacatGet('/api/characters/recent-public?$params');
   final chars = ((data['characters'] as List?) ?? []).cast<Map<String, dynamic>>();
   return CatalogSearchResult(
     characters: chars.map(_normalizeListItem).toList(),
@@ -351,7 +357,6 @@ CharacterData _datacatCharacterData(Map<String, dynamic> char) {
 }
 
 Future<DownloadedCharacter> datacatGetCharacter(String uuid) async {
-  final token = await _getToken();
   final ts = DateTime.now().millisecondsSinceEpoch;
   // Read the plain character endpoint, NOT `/download`: since DataCat added bot
   // protection, `/download` is gated behind a Cloudflare Turnstile "download
@@ -359,10 +364,7 @@ Future<DownloadedCharacter> datacatGetCharacter(String uuid) async {
   // `lease.leaseValid = false`). `/api/characters/{id}` returns the full
   // definition ungated — the same endpoint the site's card modal and the
   // SillyTavern-CharacterLibrary reference use.
-  final data = await catalogGet(
-    '$_base/api/characters/$uuid?t=$ts&sourceKind=janitor',
-    _authHeaders(token),
-  );
+  final data = await _datacatGet('/api/characters/$uuid?t=$ts&sourceKind=janitor');
   final char = (data['character'] ?? data) as Map<String, dynamic>;
   return DownloadedCharacter(
     charData: _datacatCharacterData(char),
@@ -378,13 +380,12 @@ String _detectExtractionSource(String url) {
 }
 
 Future<Map<String, dynamic>> _datacatExtract(String url, {bool publicFeed = true}) async {
-  final token = await _getToken();
   final idempotencyKey = _uuid();
   final source = _detectExtractionSource(url);
 
   if (source == 'saucepan') {
-    return catalogPost(
-      '$_base/api/saucepan-extract/run',
+    return _datacatPost(
+      '/api/saucepan-extract/run',
       {
         'companion': url,
         'extractHidden': false,
@@ -396,12 +397,11 @@ Future<Map<String, dynamic>> _datacatExtract(String url, {bool publicFeed = true
         'vpnNamespace': 'general_scraper',
         'idempotencyKey': idempotencyKey,
       },
-      _authHeaders(token),
     );
   }
 
-  return catalogPost(
-    '$_base/api/character/smart-extract-v2',
+  return _datacatPost(
+    '/api/character/smart-extract-v2',
     {
       'url': url,
       'appearOnPublicFeed': publicFeed,
@@ -409,25 +409,15 @@ Future<Map<String, dynamic>> _datacatExtract(String url, {bool publicFeed = true
       'inlinePostExtractCreatorProfile': true,
       'idempotencyKey': idempotencyKey,
     },
-    _authHeaders(token),
   );
 }
 
-Future<Map<String, dynamic>> _datacatExtractionStatus() async {
-  final token = await _getToken();
-  return catalogGet(
-    '$_base/api/extraction/status?t=${DateTime.now().millisecondsSinceEpoch}',
-    _authHeaders(token),
-  );
-}
+Future<Map<String, dynamic>> _datacatExtractionStatus() =>
+    _datacatGet('/api/extraction/status?t=${DateTime.now().millisecondsSinceEpoch}');
 
 Future<String?> datacatGetCharacterAvatar(String uuid) async {
-  final token = await _getToken();
   final ts = DateTime.now().millisecondsSinceEpoch;
-  final data = await catalogGet(
-    '$_base/api/characters/$uuid?t=$ts',
-    _authHeaders(token),
-  );
+  final data = await _datacatGet('/api/characters/$uuid?t=$ts');
   final char = (data['character'] ?? data) as Map<String, dynamic>;
   final meta = (data['metadata'] ?? <String, dynamic>{}) as Map<String, dynamic>;
   return _resolveAvatarUrl(_pickAvatarSource(char, meta));
@@ -546,10 +536,8 @@ List<CatalogTag> getCachedDatacatTags() => _cachedDatacatTags;
 Future<List<CatalogTag>> fetchDatacatTags() async {
   if (_datacatTagsFetched) return _cachedDatacatTags;
   try {
-    final token = await _getToken();
-    final data = await catalogGet(
-      '$_base/api/tags/faceted?mode=recent&blockedTagIds=2&limit=250&offset=0&sort=count&includeTagIds=2',
-      _authHeaders(token),
+    final data = await _datacatGet(
+      '/api/tags/faceted?mode=recent&blockedTagIds=2&limit=250&offset=0&sort=count&includeTagIds=2',
     );
     final tags = (data['tags'] as List?) ?? [];
     _cachedDatacatTags = tags

--- a/lib/features/catalog/services/janitor_session.dart
+++ b/lib/features/catalog/services/janitor_session.dart
@@ -80,3 +80,44 @@ bool isJanitorTokenExpired(
   final at = (now ?? DateTime.now().toUtc()).add(skew);
   return !expiry.isAfter(at);
 }
+
+/// Whether a request to [url] may be retried without the account's access
+/// token after janitorai.com refused the one it carried.
+///
+/// Browsing JanitorAI needs no account — the feed, a card's metadata, the tag
+/// list and a card's reviews all answer an anonymous reader. Glaze sends the
+/// bearer token anyway, because one WebView session serves everything, so a
+/// spent JWT that cannot be refreshed took the whole Discover tab down with
+/// it: search and the next page of the feed both ended at "session expired
+/// (401)", which names a fix ("log in again") that does not apply and offers
+/// no way back. Dropping the refused token and asking again is what turns that
+/// into an answer.
+///
+/// The list is an allowlist, not a filter on the account paths, and it covers
+/// GET only. An account-bound call retried anonymously does not fail — it
+/// succeeds and describes somebody else, or nobody: a block list read without
+/// a session is an empty block list, which would then be written back over the
+/// real one. So anything not known to be public is refused here, including the
+/// capture flow's reads of chats, personas, scripts and API settings.
+bool janitorReadIsPublic(String url, {String method = 'GET'}) {
+  if (method.toUpperCase() != 'GET') return false;
+  final Uri uri;
+  try {
+    uri = Uri.parse(url);
+  } on FormatException {
+    return false;
+  }
+  final segments = uri.pathSegments;
+  if (segments.length < 2 || segments.first != 'hampter') return false;
+  final path = segments.skip(1).toList();
+  return switch (path.first) {
+    // The feed and a search (`/characters?...`), one card's metadata
+    // (`/characters/{id}`), and the tag autocomplete.
+    'characters' =>
+      path.length <= 2 ||
+          (path.length == 3 && path[1] == 'tags' && path[2] == 'suggest'),
+    'tags' => path.length == 1,
+    'reviews' => path.length == 2,
+    _ => false,
+  };
+}

--- a/lib/features/catalog/services/janitor_webview_proxy.dart
+++ b/lib/features/catalog/services/janitor_webview_proxy.dart
@@ -1677,6 +1677,17 @@ class JanitorWebViewProxy {
         result = await _rawFetch(url, method: method, body: body);
       }
     }
+    // Refused again, and the session could not be saved — the refresh token
+    // beside the JWT is gone too. Browsing needs no account, so a public read
+    // is asked once more with the dead token left off instead of being
+    // reported as "log in again": that sentence names a fix that does not
+    // apply, and the feed and the search box both stopped there. The stored
+    // session is deliberately left alone; a JWT the server would not take is
+    // not evidence that the login is finished.
+    if (result.status == 401 && janitorReadIsPublic(url, method: method)) {
+      _log('401 persists — retrying the read without the account token');
+      result = await _rawFetch(url, method: method, anonymous: true);
+    }
     if (result.status == 401) {
       throw const JanitorAuthException();
     }
@@ -1807,6 +1818,7 @@ class JanitorWebViewProxy {
     String url, {
     String method = 'GET',
     String? body,
+    bool anonymous = false,
   }) async {
     final controller = _controller;
     if (controller == null) return (status: -1, body: '');
@@ -1819,7 +1831,7 @@ class JanitorWebViewProxy {
           .callAsyncJavaScript(
             functionBody: '''
               $_findTokenJs
-              const token = __glazeFindToken();
+              const token = ${anonymous ? 'null' : '__glazeFindToken()'};
               const headers = { "Accept": "application/json, text/plain, */*" };
               if (token) headers["authorization"] = "Bearer " + token;
               const opts = {

--- a/lib/features/catalog/services/janny_provider.dart
+++ b/lib/features/catalog/services/janny_provider.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'catalog_http.dart';
@@ -137,69 +138,123 @@ CatalogItem _normalizeJannyHit(Map<String, dynamic> hit) {
   );
 }
 
+/// The multi-search body for one attempt.
+///
+/// Only the fields whose answers are actually read are sent. The request used
+/// to also ask for `facets`, `attributesToHighlight`, `attributesToCrop` and a
+/// `cropMarker`; all four land in Meilisearch's `_formatted` block or its facet
+/// distribution, neither of which this file ever looks at — and each one is a
+/// clause the backend can reject with a 400 the moment its index configuration
+/// changes. Asking for nothing we do not read removes four ways for search to
+/// die outright.
+Map<String, dynamic> _jannyBody({
+  required String query,
+  required int page,
+  required List<String> filters,
+  required List<String> sort,
+}) => {
+      'queries': [
+        {
+          'indexUid': 'janny-characters',
+          'q': query,
+          if (filters.isNotEmpty) 'filter': filters.join(' AND '),
+          'hitsPerPage': 40,
+          'page': page,
+          if (sort.isNotEmpty) 'sort': sort,
+        }
+      ],
+    };
+
+CatalogSearchResult _jannyResult(Map<String, dynamic> data) {
+  final result = (data['results'] as List?)?.firstOrNull as Map<String, dynamic>? ?? {};
+  return CatalogSearchResult(
+    characters: ((result['hits'] as List?) ?? [])
+        .cast<Map<String, dynamic>>()
+        .map(_normalizeJannyHit)
+        .toList(),
+    total: (result['totalHits'] as int?) ?? 0,
+  );
+}
+
+/// POSTs one search body, re-fetching the search token once if the current one
+/// is refused.
+///
+/// The token is scraped out of Janny's own page bundle and cached; when the
+/// site rotates it the cached copy starts answering 401/403, and the shipped
+/// fallback is the only thing left to try.
+Future<Map<String, dynamic>> _jannyMultiSearch(Map<String, dynamic> body) async {
+  final token = await _getSearchToken();
+  try {
+    return await catalogPost(_searchUrl, body, _jannyHeaders(token));
+  } on DioException catch (e) {
+    final status = catalogErrorStatus(e);
+    if (status != 401 && status != 403) rethrow;
+    await _clearSearchToken();
+    return catalogPost(_searchUrl, body, _jannyHeaders(_fallbackToken));
+  }
+}
+
 Future<CatalogSearchResult> jannySearch({
   String query = '',
   int page = 1,
   CatalogFilters filters = const CatalogFilters(),
 }) async {
-  var token = await _getSearchToken();
-
-  final meiliFilters = <String>[];
+  // Split in two on purpose. The NSFW clause is the user's own setting about
+  // what they are willing to see, so it is never dropped to make a search
+  // work: a degraded search that answers with what somebody asked to be
+  // spared is worse than no answer. Everything else is a preference.
+  final mandatory = <String>[
+    if (!filters.nsfw) 'isNsfw = false',
+  ];
   final minTok = filters.minTokens > 0 ? filters.minTokens : 29;
-  meiliFilters.add('totalToken >= $minTok');
-  if (filters.maxTokens < 100000) meiliFilters.add('totalToken <= ${filters.maxTokens}');
-  if (!filters.nsfw) meiliFilters.add('isNsfw = false');
-  if (filters.tagIds.isNotEmpty) {
-    meiliFilters.addAll(filters.tagIds.map((id) => 'tagIds = $id'));
-  }
+  final preferred = <String>[
+    'totalToken >= $minTok',
+    if (filters.maxTokens < 100000) 'totalToken <= ${filters.maxTokens}',
+    ...filters.tagIds.map((id) => 'tagIds = $id'),
+  ];
 
-  final activeSort = filters.sort;
-  final sortMap = <String, List<String>>{
+  const sortMap = <String, List<String>>{
     'newest': ['createdAtStamp:desc'],
     'oldest': ['createdAtStamp:asc'],
     'tokens_desc': ['totalToken:desc'],
     'tokens_asc': ['totalToken:asc'],
     'relevant': [],
   };
-  final sortArr = sortMap[activeSort] ?? sortMap['newest']!;
+  final sortArr = sortMap[filters.sort] ?? sortMap['newest']!;
 
-  final body = {
-    'queries': [
-      {
-        'indexUid': 'janny-characters',
-        'q': query,
-        'facets': ['isLowQuality', 'isNsfw', 'tagIds', 'totalToken'],
-        'attributesToCrop': ['description:300'],
-        'cropMarker': '...',
-        if (meiliFilters.isNotEmpty) 'filter': meiliFilters.join(' AND '),
-        'attributesToHighlight': ['name', 'description'],
-        'hitsPerPage': 40,
-        'page': page,
-        if (sortArr.isNotEmpty) 'sort': sortArr,
-      }
-    ],
-  };
+  // Janny's search is a Meilisearch instance whose index configuration is
+  // theirs to change, and it answers a clause it no longer supports with a 400
+  // naming the syntax — which is fatal where a 401 is not, because nothing
+  // retried it. The report is exactly that: search stopped working outright.
+  // So a rejected search is asked again more plainly, sortable and filterable
+  // attributes being the two that stop being either.
+  final attempts = <Map<String, dynamic>>[
+    _jannyBody(
+      query: query,
+      page: page,
+      filters: [...mandatory, ...preferred],
+      sort: sortArr,
+    ),
+    if (sortArr.isNotEmpty)
+      _jannyBody(
+        query: query,
+        page: page,
+        filters: [...mandatory, ...preferred],
+        sort: const [],
+      ),
+    if (preferred.isNotEmpty)
+      _jannyBody(query: query, page: page, filters: mandatory, sort: const []),
+  ];
 
-  try {
-    final data = await catalogPost(_searchUrl, body, _jannyHeaders(token));
-    final result = (data['results'] as List?)?.firstOrNull as Map<String, dynamic>? ?? {};
-    return CatalogSearchResult(
-      characters: ((result['hits'] as List?) ?? []).cast<Map<String, dynamic>>().map(_normalizeJannyHit).toList(),
-      total: (result['totalHits'] as int?) ?? 0,
-    );
-  } catch (e) {
-    if (e.toString().contains('401') || e.toString().contains('403')) {
-      await _clearSearchToken();
-      token = _fallbackToken;
-      final data = await catalogPost(_searchUrl, body, _jannyHeaders(token));
-      final result = (data['results'] as List?)?.firstOrNull as Map<String, dynamic>? ?? {};
-      return CatalogSearchResult(
-        characters: ((result['hits'] as List?) ?? []).cast<Map<String, dynamic>>().map(_normalizeJannyHit).toList(),
-        total: (result['totalHits'] as int?) ?? 0,
-      );
+  for (var i = 0; i < attempts.length; i++) {
+    try {
+      return _jannyResult(await _jannyMultiSearch(attempts[i]));
+    } on DioException catch (e) {
+      final isLast = i == attempts.length - 1;
+      if (isLast || catalogErrorStatus(e) != 400) rethrow;
     }
-    rethrow;
   }
+  throw StateError('unreachable: the last attempt either returns or throws');
 }
 
 Future<DownloadedCharacter> jannyFetchCharacter(String characterId, String? slug) async {

--- a/test/catalog_auth_retry_test.dart
+++ b/test/catalog_auth_retry_test.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/catalog/catalog_models.dart';
+import 'package:glaze_flutter/features/catalog/services/catalog_http.dart';
+import 'package:glaze_flutter/features/catalog/services/datacat_provider.dart';
+import 'package:glaze_flutter/features/catalog/services/janny_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Answers every catalog request from [reply], and keeps what was asked.
+///
+/// [reply] receives the request and how many requests came before it, so a
+/// test can refuse the first attempt and serve the retry.
+class _ScriptedAdapter implements HttpClientAdapter {
+  _ScriptedAdapter(this.reply);
+
+  final ({int status, String body}) Function(RequestOptions options, int index)
+  reply;
+  final requests = <RequestOptions>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final answer = reply(options, requests.length);
+    requests.add(options);
+    return ResponseBody.fromString(
+      answer.body,
+      answer.status,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// The body DataCat answers a request made with a token it has forgotten —
+/// the Cloudflare Turnstile blob from the report.
+const _refused =
+    '{"success":false,"serverInstanceId":"main-4330-v26b",'
+    '"hostname":"datacat.run","turnstile":{"action":"character-card-download"},'
+    '"lease":{"leaseValid":false}}';
+
+const _card =
+    '{"character":{"name":"Yixuan","personality":"a body",'
+    '"first_message":"hello"}}';
+
+String? _header(RequestOptions options, String name) =>
+    options.headers[name]?.toString();
+
+Map<String, dynamic> _query(RequestOptions options) =>
+    ((jsonDecode(options.data as String) as Map<String, dynamic>)['queries']
+            as List)
+        .first
+    as Map<String, dynamic>;
+
+void main() {
+  group('DataCat re-establishes a session the server has forgotten', () {
+    test('the card detail recovers instead of dead-ending on 403', () async {
+      SharedPreferences.setMockInitialValues({'gz_dc_token': 'stale'});
+      final adapter = _ScriptedAdapter((options, index) {
+        if (options.path.contains('/liberator/identify')) {
+          return (status: 200, body: '{"sessionToken":"fresh"}');
+        }
+        return _header(options, 'X-Session-Token') == 'fresh'
+            ? (status: 200, body: _card)
+            : (status: 403, body: _refused);
+      });
+      setCatalogHttpAdapter(adapter);
+
+      final downloaded = await datacatGetCharacter('uuid-1');
+
+      expect(downloaded.charData.name, 'Yixuan');
+      // Refused, re-identified, asked again — and the fresh token is the one
+      // the next call starts from.
+      expect(adapter.requests.map((r) => r.uri.path), [
+        '/api/characters/uuid-1',
+        '/api/liberator/identify',
+        '/api/characters/uuid-1',
+      ]);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('gz_dc_token'), 'fresh');
+    });
+
+    test('browsing recovers on its own, with no probe request first', () async {
+      SharedPreferences.setMockInitialValues({'gz_dc_token': 'stale'});
+      final adapter = _ScriptedAdapter((options, index) {
+        if (options.path.contains('/liberator/identify')) {
+          return (status: 200, body: '{"sessionToken":"fresh"}');
+        }
+        return _header(options, 'X-Session-Token') == 'fresh'
+            ? (status: 200, body: '{"characters":[],"totalCount":0}')
+            : (status: 401, body: 'unauthorized');
+      });
+      setCatalogHttpAdapter(adapter);
+
+      await datacatBrowse(filters: const CatalogFilters(sort: 'recent'));
+
+      expect(adapter.requests, hasLength(3));
+      expect(adapter.requests.first.uri.path, '/api/characters/recent-public');
+    });
+
+    test('bot protection a fresh session cannot cure is asked once', () async {
+      SharedPreferences.setMockInitialValues({'gz_dc_token': 'stale'});
+      final adapter = _ScriptedAdapter((options, index) {
+        if (options.path.contains('/liberator/identify')) {
+          return (status: 200, body: '{"sessionToken":"fresh"}');
+        }
+        return (status: 403, body: _refused);
+      });
+      setCatalogHttpAdapter(adapter);
+
+      await expectLater(
+        datacatGetCharacter('uuid-1'),
+        throwsA(
+          isA<DioException>().having(
+            (e) => e.response?.statusCode,
+            'status',
+            403,
+          ),
+        ),
+      );
+      expect(
+        adapter.requests.where((r) => r.uri.path == '/api/characters/uuid-1'),
+        hasLength(2),
+      );
+    });
+
+    test('a failure that is not about the token is not retried', () async {
+      SharedPreferences.setMockInitialValues({'gz_dc_token': 'stale'});
+      final adapter = _ScriptedAdapter(
+        (options, index) => (status: 500, body: 'boom'),
+      );
+      setCatalogHttpAdapter(adapter);
+
+      await expectLater(datacatGetCharacter('uuid-1'), throwsA(anything));
+      expect(adapter.requests, hasLength(1));
+    });
+  });
+
+  group('Janny asks a rejected search again more plainly', () {
+    test('a 400 drops the sort, then the preferences', () async {
+      SharedPreferences.setMockInitialValues({'gz_janny_token': 'tok'});
+      final adapter = _ScriptedAdapter(
+        (options, index) => index < 2
+            ? (
+                status: 400,
+                body:
+                    '{"message":"Attribute totalToken is not filterable.",'
+                    '"code":"invalid_search_filter"}',
+              )
+            : (
+                status: 200,
+                body:
+                    '{"results":[{"hits":[{"id":"1","name":"Kept"}],'
+                    '"totalHits":1}]}',
+              ),
+      );
+      setCatalogHttpAdapter(adapter);
+
+      final result = await jannySearch(
+        query: 'x',
+        filters: const CatalogFilters(sort: 'newest', minTokens: 500),
+      );
+
+      expect(result.characters.single.name, 'Kept');
+      expect(adapter.requests, hasLength(3));
+      final bodies = adapter.requests.map(_query).toList();
+      expect(bodies[0]['sort'], ['createdAtStamp:desc']);
+      expect(bodies[1].containsKey('sort'), isFalse);
+      expect(bodies[1]['filter'], contains('totalToken >= 500'));
+      expect(bodies[2]['filter'], 'isNsfw = false');
+    });
+
+    test(
+      'a degraded search never drops what the reader asked not to see',
+      () async {
+        SharedPreferences.setMockInitialValues({'gz_janny_token': 'tok'});
+        final adapter = _ScriptedAdapter(
+          (options, index) => (status: 400, body: '{"message":"bad syntax"}'),
+        );
+        setCatalogHttpAdapter(adapter);
+
+        await expectLater(
+          jannySearch(filters: const CatalogFilters(nsfw: false)),
+          throwsA(anything),
+        );
+        expect(adapter.requests, isNotEmpty);
+        for (final body in adapter.requests.map(_query)) {
+          expect(body['filter'], contains('isNsfw = false'));
+        }
+      },
+    );
+
+    test('the request asks for nothing the result is not read for', () async {
+      SharedPreferences.setMockInitialValues({'gz_janny_token': 'tok'});
+      final adapter = _ScriptedAdapter(
+        (options, index) => (status: 200, body: '{"results":[]}'),
+      );
+      setCatalogHttpAdapter(adapter);
+
+      await jannySearch(query: 'x');
+
+      final body = _query(adapter.requests.single);
+      // Every one of these lands in Meilisearch's `_formatted` block or its
+      // facet distribution, neither of which the provider reads — and every
+      // one is a clause the backend can reject with a 400.
+      expect(body.containsKey('facets'), isFalse);
+      expect(body.containsKey('attributesToHighlight'), isFalse);
+      expect(body.containsKey('attributesToCrop'), isFalse);
+      expect(body.containsKey('cropMarker'), isFalse);
+    });
+
+    test('a refused search token is replaced by the shipped one', () async {
+      SharedPreferences.setMockInitialValues({'gz_janny_token': 'stale'});
+      final adapter = _ScriptedAdapter(
+        (options, index) => _header(options, 'Authorization') == 'Bearer stale'
+            ? (status: 401, body: 'unauthorized')
+            : (status: 200, body: '{"results":[{"hits":[],"totalHits":0}]}'),
+      );
+      setCatalogHttpAdapter(adapter);
+
+      await jannySearch(query: 'x');
+
+      expect(adapter.requests, hasLength(2));
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('gz_janny_token'), isNull);
+    });
+
+    test('a server fault is reported, not worked around', () async {
+      SharedPreferences.setMockInitialValues({'gz_janny_token': 'tok'});
+      final adapter = _ScriptedAdapter(
+        (options, index) => (status: 500, body: 'boom'),
+      );
+      setCatalogHttpAdapter(adapter);
+
+      await expectLater(jannySearch(query: 'x'), throwsA(anything));
+      expect(adapter.requests, hasLength(1));
+    });
+  });
+}

--- a/test/janitor_session_test.dart
+++ b/test/janitor_session_test.dart
@@ -124,4 +124,90 @@ void main() {
       expect(isJanitorTokenExpired('not-a-token', now: now), isFalse);
     });
   });
+
+  group('janitorReadIsPublic', () {
+    test('the browse surface a reader needs no account for', () {
+      expect(
+        janitorReadIsPublic(
+          'https://janitorai.com/hampter/characters?page=2&mode=all&sort=latest',
+        ),
+        isTrue,
+      );
+      expect(
+        janitorReadIsPublic('https://janitorai.com/hampter/characters/abc123'),
+        isTrue,
+      );
+      expect(
+        janitorReadIsPublic(
+          'https://janitorai.com/hampter/characters/tags/suggest?prefix=ro',
+        ),
+        isTrue,
+      );
+      expect(
+        janitorReadIsPublic('https://janitorai.com/hampter/tags'),
+        isTrue,
+      );
+      expect(
+        janitorReadIsPublic('https://janitorai.com/hampter/reviews/abc123?page=1'),
+        isTrue,
+      );
+    });
+
+    test('an account-bound read is never retried without the account', () {
+      // Each of these answers an anonymous reader with somebody else's data or
+      // with nothing — and the block list is then written back.
+      expect(
+        janitorReadIsPublic(
+          'https://janitorai.com/hampter/profiles/mine/blocked-content',
+        ),
+        isFalse,
+      );
+      expect(
+        janitorReadIsPublic('https://janitorai.com/hampter/profiles/mine'),
+        isFalse,
+      );
+      expect(
+        janitorReadIsPublic('https://janitorai.com/hampter/chats/c1'),
+        isFalse,
+      );
+      expect(
+        janitorReadIsPublic('https://janitorai.com/hampter/personas'),
+        isFalse,
+      );
+      expect(
+        janitorReadIsPublic('https://janitorai.com/hampter/api-settings'),
+        isFalse,
+      );
+      expect(
+        janitorReadIsPublic('https://janitorai.com/hampter/script/s1'),
+        isFalse,
+      );
+    });
+
+    test('only a read is ever repeated — a write is not', () {
+      expect(
+        janitorReadIsPublic(
+          'https://janitorai.com/hampter/characters',
+          method: 'PATCH',
+        ),
+        isFalse,
+      );
+      expect(
+        janitorReadIsPublic(
+          'https://janitorai.com/hampter/characters',
+          method: 'POST',
+        ),
+        isFalse,
+      );
+    });
+
+    test('anything that is not a hampter path is refused outright', () {
+      expect(janitorReadIsPublic('https://janitorai.com/'), isFalse);
+      expect(janitorReadIsPublic('https://janitorai.com/hampter'), isFalse);
+      expect(
+        janitorReadIsPublic('https://ella.janitorai.com/bot-avatars/x.webp'),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
Each catalog provider holds a credential its server can stop honouring, and in
every case exactly one code path knew how to replace one. Every other path
reported the rejection verbatim behind a Retry button that re-sent the same
dead credential — which is why retrying never helped.

## DataCat — the card detail and every other authenticated call (#104)

`/api/liberator/identify` mints an anonymous session token that is stored in
SharedPreferences with no expiry, so it outlives what the server still accepts.
Only the browse path could replace one, and it did so by running a throwaway
probe request before *every* search. `datacatGetCharacter` — the card detail
from the report — had nothing: it showed `HTTP 403: Forbidden` and stopped.

- Every authenticated DataCat call now goes through one wrapper that, on a
  401/403, drops the stored token, re-identifies and asks again once.
- The probe (`datacatEnsureSession` / `datacatValidate`) is gone with its only
  caller, so browsing costs one request per page instead of two.
- A 403 that a fresh session does not cure is DataCat's bot protection; the
  single retry is what tells the two apart, and it only costs a request on a
  failure that was already fatal.

## Janny — a 400 is no longer fatal (#89, item 1)

The Meilisearch multi-search body was hand-built against an index configuration
that is Janny's to change. A rejected clause comes back as a 400 naming the
syntax, and nothing retried a 400 — so search died outright, which is the
report.

- The request stops asking for `facets`, `attributesToHighlight`,
  `attributesToCrop` and `cropMarker`. All four land in Meilisearch's
  `_formatted` block or its facet distribution, neither of which this provider
  reads — and each one is a clause the backend can reject. Sending only what is
  read removes four ways for search to die.
- A 400 now retries without the `sort`, then without the optional filter
  clauses (token bounds, tags).
- The `isNsfw = false` clause is never dropped. A degraded search that answers
  with what somebody asked to be spared is worse than no answer, so if that
  clause is the rejected one the error stands.
- The pre-existing 401/403 token-refresh retry is folded into the same helper
  instead of duplicating the parse.

## JanitorAI — a public read no longer needs the account (#152)

Browse, search and pagination go through in-page fetches that carry the
account's Supabase bearer token, because one WebView session serves everything.
The proxy already reloads the page to let Supabase mint a fresh JWT and retries
once (this part of the linked audit is stale — it landed already). What it did
not have was an answer for a 401 that survives that: it raised
`JanitorAuthException`, and the feed and the search box both ended at
"session expired (401)" — a sentence naming a fix that does not apply, with no
way back.

- A 401 that survives the refresh now retries the read with the refused token
  left off, when the endpoint is one an anonymous reader can have.
- `janitorReadIsPublic` is an allowlist, default-deny, GET only: the feed, a
  card's metadata, the tag autocomplete and a card's reviews. Everything else —
  chats, personas, API settings, scripts, profiles — is refused, because an
  account-bound read retried anonymously does not fail, it succeeds and
  describes nobody. An empty block list read that way would be written back
  over the real one.
- The stored session is deliberately left alone. A JWT the server would not
  take is not evidence that the login is finished.

## Shared plumbing

- `catalogErrorStatus()` replaces the `e.toString().contains('401')` sniff the
  providers used, which matched a 401 appearing anywhere in the server's *body*
  as readily as a real status.
- `setCatalogHttpAdapter()` is a `@visibleForTesting` seam on the shared Dio
  client, so provider retry logic can be driven without a network round-trip.

## Not in this PR

- **#113** is half here and half in error-surface normalization: the raw
  Turnstile JSON in that screenshot is `_extractApiMessage` returning a whole
  string body, which is the next branch. The DataCat side of it — a card read
  that 403s and cannot recover — is fixed here.
- The catalog grid still renders `state.error` as a bare centered `Text`. With
  a public read no longer dead-ending there is no longer a dead end to act on,
  so a retry/login affordance there is left as UI work rather than smuggled in.
- Janny's `/hampter/script/*` reads are not on the anonymous allowlist. They may
  well be public, but nothing here demonstrates it, and default-deny is the
  safer half of that guess.

## Verification

- `flutter analyze` — 9 issues, all pre-existing on `nightly`, none in a
  touched file.
- `flutter test` — 3911 pass, 4 skipped.
- 9 new tests in `test/catalog_auth_retry_test.dart` and
  `test/janitor_session_test.dart`. With `datacat_provider.dart` and
  `janny_provider.dart` reverted to `nightly`, 5 of them fail; the 4 that pass
  either way are the negative controls (a 500 is not retried, the NSFW clause
  survives, the existing token refresh still works).
- The JanitorAI plumbing cannot be unit-tested — it needs a live WebView — so
  the part that could be got wrong is the policy, and that is the pure function
  with the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)