### PR TITLE
Keep an audio embed inside the message bubble

### DIFF
--- a/assets/chat_webview/renderer/shadow_style.js
+++ b/assets/chat_webview/renderer/shadow_style.js
@@ -44,6 +44,21 @@ export const SHADOW_STYLE = `
   }
   .glaze-message a { color: var(--primary-color, #7996CE); text-decoration: underline; }
   .glaze-message img { max-width: 100%; height: auto; border-radius: 8px; margin: 8px 0; }
+  /* Media Chromium lays out at a fixed intrinsic width. An audio element is
+     300px wide by default, which is wider than a bubble gets on a phone (88%
+     of the screen, less its padding) - so the player painted straight through
+     the bubble's rounded border. Constraining the element is the fix rather
+     than clipping the bubble: a card is allowed to paint outside it, which is
+     what the CSS-only overlay cards are built on. */
+  .glaze-message audio,
+  .glaze-message video,
+  .glaze-message iframe,
+  .glaze-message canvas,
+  .glaze-message embed,
+  .glaze-message object {
+    max-width: 100%;
+    min-width: 0;
+  }
   .glaze-message .chat-quote-unclosed {
     color: var(--current-quote-color, var(--quote-color, #7996CE));
     opacity: 0.7;

--- a/test/webview_js/corpus/cards.js
+++ b/test/webview_js/corpus/cards.js
@@ -113,6 +113,13 @@ function jscToggle() {
     text: `0. test`,
   },
   {
+    id: 'audio-embed',
+    title: 'An audio embed inside a message',
+    origin: 'Discord #1531795415253385277 - the player overhung the bubble',
+    text: `Listen to this:
+<audio controls src="https://cdn.discordapp.com/attachments/1/2/voice-message.ogg"></audio>`,
+  },
+  {
     id: 'prose-angle-brackets',
     title: 'Prose that contains angle brackets',
     origin: 'the orphan heuristic existed for this case',

--- a/test/webview_js/specs/cards.spec.js
+++ b/test/webview_js/specs/cards.spec.js
@@ -507,3 +507,26 @@ test('an image tag inside a reasoning panel stays text', async ({ page }) => {
   expect(shape.placeholders).toBe(0);
   expect(shape.text).toContain('[IMG:GEN:лес]');
 });
+
+test('an audio embed shrinks to the message instead of overhanging it', async ({ page }) => {
+  await render(page, card('audio-embed').text);
+  const shape = await page.evaluate(() => {
+    const host = document.querySelector('#chat-container .message-content');
+    // What a bubble gives a message on a phone: 88% of a 360px screen, less
+    // the bubble's own padding. Narrower than the 300px Chromium gives an
+    // `<audio>` element by default, which is the whole bug.
+    host.style.width = '260px';
+    const audio = host.shadowRoot.querySelector('audio');
+    const box = host.getBoundingClientRect();
+    const player = audio ? audio.getBoundingClientRect() : null;
+    return {
+      rendered: !!audio,
+      width: player ? player.width : -1,
+      overhang: player ? player.right - box.right : -1,
+      host: box.width,
+    };
+  });
+  expect(shape.rendered, 'the embed itself still renders').toBe(true);
+  expect(shape.overhang, 'the player paints outside the message').toBeLessThanOrEqual(0);
+  expect(shape.width).toBeLessThanOrEqual(shape.host);
+});


### PR DESCRIPTION
Closes the audio-embed overflow reported on Discord (#1531795415253385277).

## What was wrong

The player in the screenshot is Chromium's own `<audio>` control, which it lays out at a fixed 300px. A bubble on a phone gets 88% of the screen less its padding — about 260px on a 360px-wide device — so the control kept its intrinsic width and painted straight through the bubble's rounded border.

## Changes

- Cap browser-sized media at the width of the message it sits in, in `SHADOW_STYLE`, next to the `img` rule that has always done this. `<video>`, `<iframe>`, `<canvas>`, `<embed>` and `<object>` get the same cap — all six default to a fixed intrinsic width, and the bug is the width, not the tag.
- Corpus entry `audio-embed`, verbatim in the shape a card author writes it, per `docs/rules/message-rendering.md`.
- Spec: squeeze a message to a phone-bubble width and assert the player's right edge does not cross the message's.

Deliberately **not** `overflow: hidden` on `.msg-body`, which the audit suggested as a belt-and-suspenders measure. That clips the symptom and breaks a documented feature: a card is allowed to paint outside its bubble, and every CSS-only overlay card (`#toggle:checked ~ .overlay`) depends on it.

## Verification

- The new spec fails on `nightly` with a 40px overhang and passes with the rule.
- `npx playwright test` — 98 passed.
- `flutter test test/webview_assets_test.dart` — 201 passed.
- `flutter analyze assets` — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)