### PR TITLE
Bump the app version to 0.8.0

### DIFF
--- a/lib/core/constants/app_version.dart
+++ b/lib/core/constants/app_version.dart
@@ -1,4 +1,4 @@
-const appVersion = String.fromEnvironment('APP_VERSION', defaultValue: '0.7.0');
+const appVersion = String.fromEnvironment('APP_VERSION', defaultValue: '0.8.0');
 const buildDate = String.fromEnvironment('BUILD_DATE');
 const buildBranch = String.fromEnvironment('BUILD_BRANCH');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: glaze_flutter
 description: "Glaze — AI chat client (Flutter)"
 publish_to: 'none'
-version: 0.7.0-a
+version: 0.8.0
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Changes

- `pubspec.yaml`: `0.7.0-a` → `0.8.0`. This is what `build-branch.yml` and `build-release.yml` read the version from (`grep '^version:' pubspec.yaml`, `+build` stripped), so it is what every CI build reports and what the update checker compares against.
- `lib/core/constants/app_version.dart`: the `APP_VERSION` default `0.7.0` → `0.8.0`. That default is what a local build without the dart-define falls back to; left behind, a dev build reports a version no release ever had.

The `-a` suffix is dropped — the workflows strip it before it reaches a build anyway.

## Verification

- `flutter test test/update_check_service_test.dart` — 15 passed. Its version strings are literals for the parser, so they are unaffected by the bump.
- `flutter analyze lib/core/constants/app_version.dart` — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)