### PR TITLE
Make the chat's first paint carry the display scripts, and recover a page that died

### DIFF
--- a/lib/core/state/active_regex_provider.dart
+++ b/lib/core/state/active_regex_provider.dart
@@ -7,6 +7,12 @@ import 'global_regex_provider.dart';
 
 final activeRegexesProvider = FutureProvider<List<PresetRegex>>((ref) async {
   final repo = ref.watch(presetRepoProvider);
+  // Awaited, not read. The global scripts load from SharedPreferences, and on a
+  // cold start that has not finished by the time anything asks for this list:
+  // reading `.value` then yielded null and dropped every global script from a
+  // list whose whole promise is that it has resolved. The chat's first paint
+  // asks exactly once, so what it gets here is what the reader sees.
+  final globalScripts = ref.watch(globalRegexProvider.future);
   final presets = await repo.getAll();
   final activeId = ref.watch(activePresetIdProvider);
   final preset = activeId != null
@@ -14,13 +20,9 @@ final activeRegexesProvider = FutureProvider<List<PresetRegex>>((ref) async {
       : (presets.isNotEmpty ? presets.first : null);
   final presetRegexes =
       preset?.regexes.where((r) => !r.disabled).toList() ?? <PresetRegex>[];
-  final globalRegexes =
-      ref
-          .watch(globalRegexProvider)
-          .value
-          ?.where((r) => !r.disabled)
-          .toList() ??
-      <PresetRegex>[];
+  final globalRegexes = (await globalScripts)
+      .where((r) => !r.disabled)
+      .toList();
   return [...presetRegexes, ...globalRegexes];
 });
 

--- a/lib/features/chat/widgets/chat_webview_build_listeners.dart
+++ b/lib/features/chat/widgets/chat_webview_build_listeners.dart
@@ -94,9 +94,18 @@ class ChatWebViewBuildListeners {
       next,
     ) {
       final b = bridge;
-      if (b == null || !ready()) return;
       final oldList = prev?.value ?? const <PresetRegex>[];
       final newList = next.value ?? const <PresetRegex>[];
+      if (b == null || !ready()) {
+        // Not a drop. The initializer has already read the list it paints the
+        // chat with, so a change that lands in this window used to be lost for
+        // the rest of the session: the controller was updated on the next
+        // build, but nothing re-rendered the messages it had already written.
+        if (_regexListChanged(oldList, newList)) {
+          syncState.regexContextStale = true;
+        }
+        return;
+      }
       if (_regexListChanged(oldList, newList)) {
         final character = ref.read(characterByIdProvider(charId));
         final effectivePersona = ref.read(

--- a/lib/features/chat/widgets/chat_webview_initializer.dart
+++ b/lib/features/chat/widgets/chat_webview_initializer.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
-import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/models/chat_message.dart';
+import '../../../core/models/preset.dart';
 import '../../../core/state/active_regex_provider.dart';
 import '../../../core/state/active_selection_provider.dart';
 import '../../../core/state/character_provider.dart';
@@ -149,9 +150,8 @@ class ChatWebViewInitializer {
     // `personaId` against this roster, and one that arrives late would render
     // the whole chat with letter avatars first.
     bridge.setPersonaRoster(ref.read(personaListProvider).value ?? const []);
-    final displayRegexes = ref.read(displayRegexesProvider).value ?? const [];
     bridge.setRegexContext(
-      displayRegexes,
+      await _displayRegexes(),
       character,
       effectivePersona,
       sessionVars:
@@ -274,6 +274,26 @@ class ChatWebViewInitializer {
 
     // Push initial ext-block panels on first load.
     unawaited(onSyncExtBlockPanels());
+  }
+
+  /// The display scripts the first paint has to carry.
+  ///
+  /// Awaited, not read. `displayRegexesProvider` loads the active preset from
+  /// the database and the global scripts from SharedPreferences, and on the
+  /// first open of a chat after launch neither has resolved yet — so reading
+  /// `.value` handed this sequence an empty list, `setMessages` below baked the
+  /// un-rewritten text into every message, and nothing re-rendered it. That is
+  /// the whole of "Alter Display scripts do not work on the first chat open":
+  /// the list arrived a few hundred milliseconds after the only moment anyone
+  /// asked for it.
+  Future<List<PresetRegex>> _displayRegexes() async {
+    try {
+      return await ref.read(displayRegexesProvider.future);
+    } catch (e) {
+      // A script list that cannot load must not stop the chat from opening.
+      debugPrint('[ChatWebView] display regexes failed to load: $e');
+      return const [];
+    }
   }
 
   Future<void> _setIdentity() {

--- a/lib/features/chat/widgets/chat_webview_recovery.dart
+++ b/lib/features/chat/widgets/chat_webview_recovery.dart
@@ -1,0 +1,55 @@
+/// Budget for throwing the chat WebView away and building a new one.
+///
+/// The page behind the chat can die while the app still believes it is there.
+/// On Android the render process is killed under memory pressure — a
+/// keep-alive WebView that sat in the background while another app ran is the
+/// ordinary case — and on iOS the web content process can terminate for the
+/// same reason. Afterwards nothing renders, `window.bridge` is gone, and every
+/// call the app makes into the page returns without doing anything. That is
+/// the reported "the messages are not there and the buttons under a message do
+/// nothing": the bridge was lost and only reopening the chat rebuilt it.
+///
+/// Recovery is to discard the native view and build another one, which is
+/// cheap and usually works. What it must not become is a loop: a page that
+/// dies again the moment it is rebuilt is telling us the device cannot keep it
+/// alive right now, and the reader is better served by being told than by
+/// watching the chat flicker. So rebuilds are rationed, and a chat that
+/// finishes initializing pays nothing — the budget exists to bound a storm,
+/// not to count the lifetime of the app.
+class ChatWebViewRecovery {
+  ChatWebViewRecovery({
+    this.maxAttempts = 3,
+    this.window = const Duration(minutes: 2),
+    DateTime Function()? clock,
+  }) : _clock = clock ?? DateTime.now,
+       assert(maxAttempts > 0);
+
+  /// Rebuilds allowed inside [window].
+  final int maxAttempts;
+  final Duration window;
+  final DateTime Function() _clock;
+  final List<DateTime> _attempts = [];
+
+  /// Rebuilds spent inside the current window.
+  int get attemptsInWindow {
+    _prune(_clock());
+    return _attempts.length;
+  }
+
+  /// Books a rebuild. `false` once [maxAttempts] have been spent inside
+  /// [window]: the caller must tell the reader instead of trying again.
+  bool requestRebuild() {
+    final now = _clock();
+    _prune(now);
+    if (_attempts.length >= maxAttempts) return false;
+    _attempts.add(now);
+    return true;
+  }
+
+  /// Called when the chat finished initializing. The page is alive, so
+  /// whatever it took to get here is no longer evidence of a storm.
+  void noteHealthy() => _attempts.clear();
+
+  void _prune(DateTime now) =>
+      _attempts.removeWhere((at) => now.difference(at) > window);
+}

--- a/lib/features/chat/widgets/chat_webview_surface.dart
+++ b/lib/features/chat/widgets/chat_webview_surface.dart
@@ -54,6 +54,8 @@ class ChatWebViewSurface extends ConsumerStatefulWidget {
     required this.bottomInset,
     required this.onBridgeReady,
     required this.onInitWebView,
+    required this.onPageProcessGone,
+    this.rebuildGeneration = 0,
   });
 
   final ChatWebViewBridgeHost bridgeHost;
@@ -88,6 +90,17 @@ class ChatWebViewSurface extends ConsumerStatefulWidget {
   /// Starts the parent's idempotent WebView initialization.
   final Future<void> Function() onInitWebView;
 
+  /// The page behind this surface died — Android killed the render process,
+  /// or iOS terminated the web content process. The parent owns what happens
+  /// next; the surface only reports it.
+  final VoidCallback onPageProcessGone;
+
+  /// Bumped by the parent to demand a brand new native WebView. The keep-alive
+  /// instance is shared by every chat, so a dead one has to be disposed before
+  /// the replacement is attached — otherwise the new widget re-attaches the
+  /// same corpse.
+  final int rebuildGeneration;
+
   @override
   ConsumerState<ChatWebViewSurface> createState() => _ChatWebViewSurfaceState();
 }
@@ -109,6 +122,39 @@ class _ChatWebViewSurfaceState extends ConsumerState<ChatWebViewSurface> {
         if (mounted) setState(() => _mountNativeView = true);
       });
     }
+  }
+
+  @override
+  void didUpdateWidget(ChatWebViewSurface oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.rebuildGeneration != oldWidget.rebuildGeneration) {
+      unawaited(_rebuildNativeView());
+    }
+  }
+
+  /// Replaces the native WebView after its page died.
+  ///
+  /// The view is unmounted for a frame first, and the keep-alive instance
+  /// disposed while nothing is attached to it: on mobile every chat shares one
+  /// preloaded WebView, so remounting without disposing hands the replacement
+  /// widget the same dead native view and nothing changes. Disposing frees the
+  /// keep-alive id, and the remount below creates a fresh WebView under it.
+  Future<void> _rebuildNativeView() async {
+    if (!mounted) return;
+    setState(() => _mountNativeView = false);
+    final keepAlive = chatWebViewKeepAliveForPlatform();
+    if (keepAlive != null) {
+      try {
+        await InAppWebViewController.disposeKeepAlive(keepAlive);
+      } catch (e) {
+        debugPrint('[ChatWebView] disposing the keep-alive failed: $e');
+      }
+    }
+    // One frame with nothing attached, so the platform view is really gone
+    // before its replacement asks to be created.
+    await Future<void>.delayed(Duration.zero);
+    if (!mounted) return;
+    setState(() => _mountNativeView = true);
   }
 
   Widget _background(BuildContext context) {
@@ -249,6 +295,7 @@ class _ChatWebViewSurfaceState extends ConsumerState<ChatWebViewSurface> {
                 ? ChatWebViewTrackpadScroll(
                     charId: widget.charId,
                     child: InAppWebView(
+                      key: ValueKey<int>(widget.rebuildGeneration),
                       webViewEnvironment: chatWebViewEnvironment,
                       keepAlive: chatWebViewKeepAliveForPlatform(),
                       initialFile: chatWebViewInitialFile(),
@@ -256,6 +303,25 @@ class _ChatWebViewSurfaceState extends ConsumerState<ChatWebViewSurface> {
                       initialSettings: _webViewSettings,
                       onWebViewCreated: _onWebViewCreated,
                       onLoadStop: _onLoadStop,
+                      // Android 26+. Until this was handled, a killed render
+                      // process left a blank page the app kept talking to.
+                      onRenderProcessGone: (controller, detail) {
+                        debugPrint(
+                          '[ChatWebView] render process gone '
+                          '(didCrash: ${detail.didCrash})',
+                        );
+                        if (_callbackIsActive(widget.lifecycleEpoch)) {
+                          widget.onPageProcessGone();
+                        }
+                      },
+                      onWebContentProcessDidTerminate: (controller) {
+                        debugPrint(
+                          '[ChatWebView] web content process terminated',
+                        );
+                        if (_callbackIsActive(widget.lifecycleEpoch)) {
+                          widget.onPageProcessGone();
+                        }
+                      },
                       shouldOverrideUrlLoading: (controller, request) async {
                         return chatWebViewNavigationPolicy(request.request.url);
                       },

--- a/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
+++ b/lib/features/chat/widgets/chat_webview_sync_dispatcher.dart
@@ -50,6 +50,13 @@ class ChatWebViewSyncState {
     return operation;
   }
 
+  /// Set when the display-regex list changed while the bridge was still
+  /// initializing, i.e. after the initializer read the list it painted with.
+  /// The messages on screen were rewritten with the older list, and only a
+  /// re-render fixes that — pushing the new list to the controller does not
+  /// touch what is already in the DOM.
+  bool regexContextStale = false;
+
   /// Invalidates async streaming work when generation or session ownership
   /// changes. Callers capture the value and re-check it after every await.
   int streamEpoch = 0;

--- a/lib/features/chat/widgets/chat_webview_widget.dart
+++ b/lib/features/chat/widgets/chat_webview_widget.dart
@@ -29,6 +29,7 @@ import 'chat_webview_callbacks.dart';
 import 'chat_webview_ext_block_callbacks.dart';
 import 'chat_webview_initializer.dart';
 import 'chat_webview_panel_refresher.dart';
+import 'chat_webview_recovery.dart';
 import 'chat_webview_surface.dart';
 import 'chat_webview_sync_dispatcher.dart';
 import 'message_scripts_prompt_sheet.dart';
@@ -220,6 +221,12 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
   Future<void>? _initFuture;
   ChatWebViewWidget? _deferredSwitchFrom;
   bool _bridgeFailureNotified = false;
+
+  /// Rations rebuilds of the native view: see [ChatWebViewRecovery].
+  final ChatWebViewRecovery _recovery = ChatWebViewRecovery();
+
+  /// Bumped to hand the surface a brand new WebView after the old page died.
+  int _rebuildGeneration = 0;
   bool _lifecycleActive = true;
   int _lifecycleEpoch = 0;
   VoidCallback? _clearBridgeRegistry;
@@ -274,17 +281,19 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     // Bridge never appeared after 5 seconds of polling. This can be an actual
     // platform failure, but can also be a native-view lifecycle race during a
     // rapid route change, so do not claim a missing runtime without evidence.
-    if (!mounted || _bridgeFailureNotified) return;
-    _bridgeFailureNotified = true;
+    if (!mounted) return;
     debugPrint(
       '[ChatWebView] bridge was not created after 5s — '
       'native WebView did not finish initializing',
     );
-    GlazeErrorDialog.show(
-      context,
+    if (_recovery.requestRebuild()) {
+      setState(() => _rebuildGeneration++);
+      WidgetsBinding.instance.addPostFrameCallback((_) => _kickInitWhenReady());
+      return;
+    }
+    _notifyWebViewFailure(
       'Chat view is still initializing. Please return to the chat once more. '
       'If this keeps happening, restart Glaze and check the diagnostic log.',
-      prefix: 'Chat view failed to load',
     );
   }
 
@@ -472,6 +481,9 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
         onReady: () {
           if (!mounted || !identical(_bridge, bridge)) return;
           _ready = true;
+          // The page is alive and painted: whatever it took to get here is no
+          // longer evidence of a rebuild storm.
+          _recovery.noteHealthy();
           // Do not expose the controller to background services or the Windows
           // trackpad sink until the page bridge and its DOM are initialized.
           ref.read(chatBridgeRegistryProvider(widget.charId).notifier).state =
@@ -482,10 +494,10 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       ).run().timeout(_kWebViewInitTimeout);
       PerfDebug.chatWebViewInitCompleted();
     } on TimeoutException catch (e, st) {
-      _handleWebViewFailure(e, st, phase: 'init');
+      _handleWebViewFailure(e, st, phase: 'init', rebuildable: true);
       return;
     } catch (e, st) {
-      _handleWebViewFailure(e, st, phase: 'init');
+      _handleWebViewFailure(e, st, phase: 'init', rebuildable: true);
       return;
     } finally {
       if (!_ready) _initFuture = null;
@@ -508,6 +520,10 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
     await _bridgeOp(_syncExtBlockPanels(), label: 'syncExtBlockPanels');
     final deferred = _deferredSwitchFrom;
     _deferredSwitchFrom = null;
+    // Consumed here whichever branch runs below: the other two re-push every
+    // message anyway, so the re-render this flag asks for happens regardless.
+    final regexContextStale = _syncState.regexContextStale;
+    _syncState.regexContextStale = false;
     if (deferred != null) {
       unawaited(_applySessionSwitch(deferred, epoch: _sessionSwitchEpoch));
     } else if (initSessionId != widget.sessionId) {
@@ -518,24 +534,83 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       // dispatcher skips them because _ready is false. Re-sync only when data
       // changed since the initializer captured it; an unconditional second
       // setMessages causes a visible duplicate first-chat render on Windows.
-      if (initVisibleStartIndex != widget.visibleStartIndex ||
+      // `regexContextStale`: the display-script list resolved while init was
+      // running, after the initializer read the list it painted with. The
+      // messages are in the DOM rewritten by the older list, and only a
+      // re-render replaces them.
+      if (regexContextStale ||
+          initVisibleStartIndex != widget.visibleStartIndex ||
           !chatMessageListsIdentical(initMessages, widget.messages)) {
         unawaited(_resyncMessagesAfterInit());
       }
     }
   }
 
+  /// The page behind the chat died. Nothing on screen is real any more: the
+  /// DOM is gone, `window.bridge` with it, and every call the app makes into
+  /// the page from here on returns without doing anything — which is why the
+  /// symptom was a chat with no messages whose edit and regenerate buttons did
+  /// nothing until it was reopened.
+  ///
+  /// So the Dart side stops believing in it (nothing is pushed into a dead
+  /// page, and no background service gets the controller out of the registry),
+  /// and the native view is replaced. [ChatWebViewRecovery] decides when to
+  /// stop trying and tell the reader instead.
+  void _handlePageProcessGone() {
+    if (!mounted) return;
+    _ready = false;
+    _initFuture = null;
+    _resetStreamingPresentationState();
+    _clearBridgeRegistry?.call();
+    _bridge = null;
+    if (!_recovery.requestRebuild()) {
+      debugPrint('[ChatWebView] page died too often; not rebuilding again');
+      _notifyWebViewFailure(
+        'The chat view keeps being closed by the system, usually because the '
+        'device is low on memory. Reopen the chat, and restart Glaze if it '
+        'happens again.',
+      );
+      return;
+    }
+    setState(() => _rebuildGeneration++);
+    // The replacement view normally reports itself through
+    // `onWebViewCreated`; this is the same safety net used at startup for the
+    // case where it does not.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _kickInitWhenReady());
+  }
+
+  /// Tells the reader the chat view could not be brought up, once per widget.
+  void _notifyWebViewFailure(Object message) {
+    if (!mounted || _bridgeFailureNotified) return;
+    _bridgeFailureNotified = true;
+    GlazeErrorDialog.show(context, message, prefix: 'Chat view failed to load');
+  }
+
   void _handleWebViewFailure(
     Object e,
     StackTrace? st, {
     required String phase,
+    bool rebuildable = false,
   }) {
     debugPrint('[ChatWebView] $phase failed: $e\n$st');
     _setSessionSwitching(false);
     if (!mounted) return;
-    if (_bridgeFailureNotified) return;
-    _bridgeFailureNotified = true;
-    GlazeErrorDialog.show(context, e, prefix: 'Chat view failed to load');
+    // An init that could not reach the page is the same situation as a page
+    // that died under it: the JS bridge handshake it waited 30s for will not
+    // answer a second attempt against that same page either. So the view is
+    // replaced and init runs again on a live one, and the reader hears about
+    // it only once the rebuild budget is spent.
+    if (rebuildable && _recovery.requestRebuild()) {
+      debugPrint('[ChatWebView] rebuilding the view after a failed $phase');
+      _ready = false;
+      _initFuture = null;
+      _bridge = null;
+      _clearBridgeRegistry?.call();
+      setState(() => _rebuildGeneration++);
+      WidgetsBinding.instance.addPostFrameCallback((_) => _kickInitWhenReady());
+      return;
+    }
+    _notifyWebViewFailure(e);
   }
 
   /// Re-shows the chat header and re-baselines the JS hide-on-scroll tracker.
@@ -1264,6 +1339,8 @@ class ChatWebViewWidgetState extends ConsumerState<ChatWebViewWidget>
       bottomInset: widget.bottomInset,
       onBridgeReady: (ChatBridgeController b) => _bridge = b,
       onInitWebView: _initWebView,
+      onPageProcessGone: _handlePageProcessGone,
+      rebuildGeneration: _rebuildGeneration,
     );
   }
 

--- a/test/chat_webview_recovery_test.dart
+++ b/test/chat_webview_recovery_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:glaze_flutter/features/chat/widgets/chat_webview_recovery.dart';
+
+void main() {
+  late DateTime now;
+  ChatWebViewRecovery recovery({int maxAttempts = 3}) => ChatWebViewRecovery(
+    maxAttempts: maxAttempts,
+    window: const Duration(minutes: 2),
+    clock: () => now,
+  );
+
+  setUp(() => now = DateTime(2026, 1, 1, 12));
+
+  test('a page that dies is rebuilt, up to the budget', () {
+    final r = recovery();
+
+    expect(r.requestRebuild(), isTrue);
+    expect(r.requestRebuild(), isTrue);
+    expect(r.requestRebuild(), isTrue);
+    // The fourth death inside two minutes is a storm, not an accident: the
+    // reader is told instead of watching the chat rebuild itself again.
+    expect(r.requestRebuild(), isFalse);
+    expect(r.attemptsInWindow, 3);
+  });
+
+  test('a death long after the last one is an accident again', () {
+    final r = recovery();
+    for (var i = 0; i < 3; i++) {
+      expect(r.requestRebuild(), isTrue);
+    }
+    expect(r.requestRebuild(), isFalse);
+
+    now = now.add(const Duration(minutes: 3));
+
+    expect(r.attemptsInWindow, 0);
+    expect(r.requestRebuild(), isTrue);
+  });
+
+  test('the window slides instead of resetting on the hour', () {
+    final r = recovery(maxAttempts: 2);
+    expect(r.requestRebuild(), isTrue);
+    now = now.add(const Duration(minutes: 1));
+    expect(r.requestRebuild(), isTrue);
+    expect(r.requestRebuild(), isFalse);
+
+    // The first attempt has aged out of the window; the second has not.
+    now = now.add(const Duration(minutes: 1, seconds: 1));
+    expect(r.attemptsInWindow, 1);
+    expect(r.requestRebuild(), isTrue);
+  });
+
+  test('a chat that finished initializing owes nothing', () {
+    final r = recovery();
+    expect(r.requestRebuild(), isTrue);
+    expect(r.requestRebuild(), isTrue);
+
+    r.noteHealthy();
+
+    expect(r.attemptsInWindow, 0);
+    for (var i = 0; i < 3; i++) {
+      expect(r.requestRebuild(), isTrue, reason: 'attempt $i');
+    }
+  });
+}

--- a/test/display_regexes_resolution_test.dart
+++ b/test/display_regexes_resolution_test.dart
@@ -1,0 +1,98 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:glaze_flutter/core/db/app_db.dart';
+import 'package:glaze_flutter/core/db/repositories/preset_repo.dart';
+import 'package:glaze_flutter/core/models/preset.dart';
+import 'package:glaze_flutter/core/state/active_regex_provider.dart';
+import 'package:glaze_flutter/core/state/db_provider.dart';
+import 'package:glaze_flutter/core/state/global_regex_provider.dart';
+
+/// The global scripts behind a load that has not finished yet — which is every
+/// cold start, where they come out of SharedPreferences while the chat is
+/// already opening. Reading the provider's `.value` in that window is what
+/// dropped them from the list the chat's first paint asked for.
+class _SlowGlobalRegexNotifier extends GlobalRegexNotifier {
+  @override
+  Future<List<PresetRegex>> build() async {
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    return const [
+      PresetRegex(
+        id: 'global-display',
+        name: 'Global card',
+        regex: '/CARD/g',
+        ephemerality: [1],
+      ),
+      PresetRegex(
+        id: 'global-off',
+        name: 'Disabled',
+        regex: '/OFF/g',
+        ephemerality: [1],
+        disabled: true,
+      ),
+    ];
+  }
+}
+
+const _presetDisplay = PresetRegex(
+  id: 'preset-display',
+  name: 'Preset card',
+  regex: '/TRK/g',
+  ephemerality: [1],
+);
+
+const _presetPromptOnly = PresetRegex(
+  id: 'preset-prompt-only',
+  name: 'Prompt only',
+  regex: '/PROMPT/g',
+  ephemerality: [2],
+);
+
+void main() {
+  late AppDatabase db;
+  late ProviderContainer container;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    await PresetRepo(db).put(
+      const Preset(
+        id: 'p1',
+        name: 'Preset',
+        regexes: [_presetDisplay, _presetPromptOnly],
+      ),
+    );
+    container = ProviderContainer(
+      overrides: [
+        appDbProvider.overrideWithValue(db),
+        globalRegexProvider.overrideWith(_SlowGlobalRegexNotifier.new),
+      ],
+    );
+  });
+
+  tearDown(() {
+    container.dispose();
+    return db.close();
+  });
+
+  test('the resolved list waits for the global scripts', () async {
+    final active = await container.read(activeRegexesProvider.future);
+
+    expect(
+      active.map((r) => r.id),
+      containsAll(<String>['preset-display', 'global-display']),
+      reason: 'a global script must not be dropped because it loaded late',
+    );
+    expect(active.map((r) => r.id), isNot(contains('global-off')));
+  });
+
+  test('the display list is what the first paint can rely on', () async {
+    final display = await container.read(displayRegexesProvider.future);
+
+    expect(display.map((r) => r.id), ['preset-display', 'global-display']);
+    expect(
+      display.map((r) => r.id),
+      isNot(contains('preset-prompt-only')),
+      reason: 'a prompt-only script has no business in the display pass',
+    );
+  });
+}


### PR DESCRIPTION
Two cards on the same path: what the chat's first paint gets, and what happens when the page behind it is gone. #154 (display regexes on first open) and #87 (chat blank on Android, bridge lost, buttons under a message dead).

## #154 — the display scripts missed the only moment anyone asked for them

`ChatWebViewInitializer` read `displayRegexesProvider.value` synchronously. On the first open after launch neither half of that list has resolved — the active preset comes from the database, the global scripts from SharedPreferences — so the sequence got an empty list, `setMessages` baked the un-rewritten text into every message, and nothing re-rendered it. Later opens worked because by then the provider had a value. That is exactly the report: "not always".

Three fixes, all on that path:

- The initializer **awaits** `displayRegexesProvider.future`. A list that cannot load falls back to empty rather than blocking the chat from opening.
- `activeRegexesProvider` awaited the preset repository but read `globalRegexProvider.value`, so even a resolved list could come back without a single global script. It awaits that future now.
- The `displayRegexesProvider` listener returned early while the bridge was not ready — which is precisely the window the list resolves in. Pushing the new list to the controller does not re-render what is already in the DOM, so that change was lost for the whole session. It is now recorded (`regexContextStale`) and the post-init pass re-renders.

## #87 — the page can die while the app still believes in it

Android kills a WebView's render process under memory pressure, and the keep-alive WebView every chat shares — backgrounded while another app runs — is the ordinary case. iOS can terminate the web content process for the same reason. Neither event was handled: afterwards nothing renders, `window.bridge` is gone, and every call the app makes into the page returns having done nothing. Both halves of the report follow from that one state, including why reopening the chat was the cure.

- `onRenderProcessGone` (Android 26+) and `onWebContentProcessDidTerminate` (iOS) now report it.
- The Dart side stops believing in the page: not ready, controller out of the registry, streaming presentation state reset — nothing is pushed into a corpse.
- The native view is replaced. The shared keep-alive instance is disposed first (`InAppWebViewController.disposeKeepAlive`), because otherwise the replacement widget re-attaches the same dead WebView and nothing changes.
- The two failure paths that used to end at a dialog — an init that could not reach the page, and a bridge that never appeared within 5s — now take the same recovery first. Waiting out the 30s handshake again against the same page buys nothing; a new page is cheap.
- `ChatWebViewRecovery` rations it: three rebuilds in two minutes, then the reader is told instead of watching the chat flicker, and a chat that finishes initializing clears the budget.

## Verification

- `test/display_regexes_resolution_test.dart` (new, 2 tests) — a global script behind a 30 ms load, the shape of a cold start. Both tests fail on `nightly` (the script is dropped) and pass with the fix.
- `test/chat_webview_recovery_test.dart` (new, 4 tests) — the rebuild budget on a fake clock: the cap, the sliding window, and a healthy init clearing it.
- `flutter test` — 3904 passed, 4 skipped. `flutter analyze` — 8 issues, all pre-existing on `nightly`.

**Not covered by a test, and worth saying plainly:** the renderer-death path itself. `ChatBridgeController` wraps a real `InAppWebViewController`, so there is no seam to construct one in a widget test; the decision logic was extracted into `ChatWebViewRecovery` precisely so the part that *can* be tested is. The wiring needs a device — a chat left in the background under memory pressure on Android, or `adb shell am send-trim-memory <pid> COMPLETE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)