### PR TITLE
Stop a summary write from rebuilding the whole Memory sheet

### DIFF
--- a/lib/features/chat/widgets/memory_sheet.dart
+++ b/lib/features/chat/widgets/memory_sheet.dart
@@ -166,16 +166,28 @@ class _MemorySheetState extends ConsumerState<MemorySheet> {
   /// [syncSummaryEnabled], which also flips the `summary` block in every
   /// preset so the toggle is not silently overridden by the active preset.
   SheetViewAction _summaryToggle(String sessionId) {
-    final enabled = ref.watch(summaryEnabledProvider(sessionId)).value ?? true;
     void setEnabled(bool value) =>
         syncSummaryEnabled(ref, charId: widget.charId, enabled: value);
+    bool isEnabled() =>
+        ref.read(summaryEnabledProvider(sessionId)).value ?? true;
     return SheetViewAction(
-      icon: Switch(
-        value: enabled,
-        onChanged: setEnabled,
-        activeThumbColor: Theme.of(context).colorScheme.primary,
+      // The switch watches for itself. Watched from `build`, every write to
+      // the summary rebuilt this whole sheet — the chrome, the header
+      // measurement and both tab bodies — to move one switch. And the summary
+      // is written often: the Summary tab saves on a debounce as the reader
+      // types, and every auto-summary during a chat bumps the same revision.
+      icon: Consumer(
+        builder: (context, ref, _) {
+          final enabled =
+              ref.watch(summaryEnabledProvider(sessionId)).value ?? true;
+          return Switch(
+            value: enabled,
+            onChanged: setEnabled,
+            activeThumbColor: Theme.of(context).colorScheme.primary,
+          );
+        },
       ),
-      onPressed: () => setEnabled(!enabled),
+      onPressed: () => setEnabled(!isEnabled()),
     );
   }
 }

--- a/lib/shared/widgets/generic_editor.dart
+++ b/lib/shared/widgets/generic_editor.dart
@@ -304,8 +304,12 @@ class _GenericEditorState extends State<GenericEditor> {
       hintText: field.placeholder,
       onChanged: (value) {
         if (!mounted) return;
+        // No setState: the field below the overlay is driven by this
+        // controller and repaints from it on its own. The rebuild this used to
+        // force ran the whole form again on every character typed in the
+        // expanded editor, on top of the parent rebuild the change already
+        // causes.
         ctrl.text = value;
-        setState(() {});
       },
     );
   }


### PR DESCRIPTION
Partial fix for #148 — "editing the summary makes the whole sheet flash white".

## What I could prove

Two real sources of churn on exactly that path:

- **The Memory sheet rebuilt itself on every summary write.** `_summaryToggle` watched `summaryEnabledProvider` from `MemorySheet.build`, and that provider is keyed to `summaryRevisionProvider`, which every summary write bumps — the debounced save while the reader types in the Summary tab, and every auto-summary during a chat. So each write rebuilt the chrome, re-measured the header and rebuilt both tab bodies in order to move one switch. The switch is a `Consumer` now and watches for itself.
- **The expanded field editor rebuilt the form under it per character.** `_openFieldEditor`'s `onChanged` pushed the text into the underlying field's controller *and* called `setState` on the form. The field paints from that controller, so the rebuild bought nothing while running the whole form again on every keystroke, on top of the parent rebuild the controller write already triggers.

## What I could not prove, and where the next person should start

I could not reproduce a **white** flash from the code, and I am not going to guess at a fix for a colour I cannot see. The most likely mechanism I found, written down so nobody has to find it twice:

The expanded editor is a `MaterialPageRoute(fullscreenDialog: true)` pushed on the **root** navigator, i.e. over the sheet. Flutter's Android page transitions (`ZoomPageTransitionsBuilder`, `FadeForwardsPageTransitionsBuilder`) paint a full-screen `ColoredBox` of `ColorScheme.surface` behind the transition — `page_transitions_theme.dart:115` and `:547`. In Glaze's **light** theme `surface` is near-white, so opening or closing that editor would paint the whole screen near-white for the length of the transition, over a sheet the reader sees as a panel. In the dark theme `surface` is `bgColor` and the same flash would be dark and unremarkable.

If that is it, the fix is a `PageTransitionsTheme` decision, not a sheet fix — and it changes every route transition in the app, which is not something to change on a guess.

**To confirm, the reporter needs to say:** platform, light or dark theme, and whether the flash happens when the *expand* button opens the fullscreen editor (and again when it closes) or while typing in the small field. A screen recording settles it outright.

## Verification

- `flutter analyze` — clean on both touched files (8 issues repo-wide, all pre-existing).
- `flutter test` — full suite passes.
- No new test: the only harness that mounts this sheet is `memory_screens_golden_test.dart`, which is opt-in (`GLAZE_GOLDENS=1`) because it rasterises frames. A widget test around it hung on the sheet's post-layout header measurement, and a rebuild-scope assertion is not worth an unstable test. The behaviour change here is scope-of-rebuild only — nothing on screen changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)