### PR TITLE
Stop counting the keyboard twice under the message list

### DIFF
--- a/assets/chat_webview/bridge/chat_bridge_controller.js
+++ b/assets/chat_webview/bridge/chat_bridge_controller.js
@@ -500,12 +500,27 @@ export class Bridge {
   _viewportShrinkPx() {
     const full = this._viewportFullH || 0;
     if (full <= 0) return 0;
-    const shrink = full - this.virtualList.container.clientHeight;
+    const shrink = full - this._visibleViewportH();
     // CSS px and Flutter logical px agree (initial-scale=1), but rounding on
     // either side can leave a pixel or two of slack — ignore that as noise so a
     // non-shrinking embedder never loses real padding to it.
     if (shrink < 8) return 0;
     return Math.min(shrink, this._bottomInsetPx);
+  }
+
+  // The height the reader can actually see, in CSS px.
+  //
+  // Two different things can shrink when the keyboard comes up and the
+  // element only knows about one of them: the *layout* viewport (which sizes
+  // this element, and which an overlaying keyboard leaves alone - that is what
+  // `100dvh` fixes) and the *visual* viewport (which an overlaying keyboard
+  // always shrinks). Whichever is smaller is what is left on screen. Zooming
+  // would also shrink the visual viewport, but the page is pinned at
+  // `initial-scale=1, user-scalable=no`.
+  _visibleViewportH() {
+    const client = this.virtualList.container.clientHeight;
+    const visual = window.visualViewport ? window.visualViewport.height : 0;
+    return visual > 0 ? Math.min(client, visual) : client;
   }
 
   /* ---------- Interaction dispatch ---------- */

--- a/assets/chat_webview/index.html
+++ b/assets/chat_webview/index.html
@@ -15,7 +15,15 @@
       height: 100%;
     }
     #chat-container {
-      width: 100%; height: 100vh;
+      /* `dvh`, not `vh`: the soft keyboard shrinks the *visual* viewport while
+         `100vh` keeps reporting the full screen by definition. The bridge
+         derives the chat's bottom padding from how much of Flutter's inset the
+         viewport already absorbed, measured as a shrink of this element
+         (_viewportShrinkPx in bridge/chat_bridge_controller.js) - and with
+         `100vh` that shrink is always zero, so the keyboard was counted twice:
+         once as screen the reader can no longer see, once as padding. `vh`
+         stays as the fallback for engines without `dvh`. */
+      width: 100%; height: 100vh; height: 100dvh;
       overflow-y: auto; overflow-x: hidden;
       -webkit-overflow-scrolling: touch;
       padding: 0;

--- a/test/webview_assets_test.dart
+++ b/test/webview_assets_test.dart
@@ -1955,14 +1955,36 @@ void main() {
       );
     });
 
-    test('the shrink is measured against the Flutter-reported box height', () {
+    test('the shrink is measured against what the reader can see', () {
       expect(
         bridgeControllerJs,
-        contains('full - this.virtualList.container.clientHeight'),
+        contains('full - this._visibleViewportH()'),
         reason:
             'The shrink must be measured, not assumed — that is what keeps the '
             'same code correct on embedders that resize the WebView and on '
             'those that do not.',
+      );
+      expect(
+        bridgeControllerJs,
+        contains('Math.min(client, visual)'),
+        reason:
+            'A keyboard that overlays the page shrinks the visual viewport and '
+            'leaves the layout viewport alone, so the element measures full '
+            'height while half of it is behind the keyboard. Whichever of the '
+            'two is smaller is what is on screen.',
+      );
+    });
+
+    test('the chat container is sized by the dynamic viewport', () {
+      expect(
+        indexHtml,
+        contains('height: 100vh; height: 100dvh;'),
+        reason:
+            '`100vh` is the viewport with every retractable UI retracted — by '
+            'definition it does not shrink for a keyboard, so the shrink the '
+            'bridge measures was always zero and the keyboard was counted '
+            'twice: once as screen the reader cannot see, once as padding. '
+            '`vh` stays first as the fallback for engines without `dvh`.',
       );
     });
 


### PR DESCRIPTION
Fixes #7 — "opening the keyboard adds the keyboard's padding into the chat container, so you can scroll that padding and see a block of empty space".

## The premise that was false

The bridge already splits Flutter's bottom inset the right way: padding is `inset - viewport shrink`, and the shrink is *measured* rather than assumed, because whether a soft keyboard shrinks the WebView's viewport or merely overlays it is up to the embedder. The comment in `_setupViewportShrinkListener` states the premise plainly:

> `#chat-container` is `height: 100vh`, and any shrink of the visible viewport shows up in its clientHeight.

It does not. `100vh` is defined as the viewport with every retractable UI element retracted — it never shrinks for a keyboard. So the measured shrink was always zero, the whole inset always became padding, and on an embedder where the keyboard does not resize the layout viewport (iOS WKWebView; Android edge-to-edge) the keyboard was counted **twice**: once as screen the reader can no longer see, once as padding under the last message. Scroll up and there is the keyboard-sized hole.

## Changes

- `#chat-container` is `height: 100vh; height: 100dvh;` — the dynamic viewport unit, which is what the existing reconciliation was written to observe. `vh` stays first as the fallback for engines without `dvh`.
- `_visibleViewportH()` takes the smaller of the element's `clientHeight` and `visualViewport.height`. Two different viewports can shrink and the element only knows about one: an overlaying keyboard shrinks the *visual* viewport and leaves the *layout* viewport alone, so the element can measure full height with half of it behind the keyboard. `visualViewport` was already being listened to for resizes — it just was not being read. Zoom would also shrink it, but the page is pinned at `initial-scale=1, user-scalable=no`.

No change to the reconciliation itself: the glide, the deferred shrink and the resting-offset maths all consume the same two numbers and were already correct given an honest shrink. The resting-offset comment ("at rest the padding is `inset - shrink` and the viewport is `full - shrink`, so the shrink cancels") is exactly why this needed no follow-on changes.

## Verification

- `test/webview_assets_test.dart` — 202 passed. The guard that pinned the old measurement (`full - container.clientHeight`) is updated to the new one and now also states why, plus a new guard on `100dvh` in `index.html`.
- `npx playwright test` — 97 passed.

**Needs a device to confirm end to end**, and I want to be straight about that: a desktop Chromium has `dvh == vh` and no soft keyboard, so nothing here can be exercised in the harness beyond the shape of the code. Please check on Android and iOS that opening the keyboard in a chat leaves the newest message sitting on the input bar with no scrollable gap above it.

**Not fixed, same card:** the iOS half — "editing a message scrolls with no inertia". That is momentum loss inside a `-webkit-overflow-scrolling: touch` scroller while an input inside it holds focus, a different mechanism from the inset, and it needs a device to work on at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)