### PR TITLE
Apply a message deletion to the row as it is, not as it was

### DIFF
--- a/lib/features/chat/chat_message_service.dart
+++ b/lib/features/chat/chat_message_service.dart
@@ -275,12 +275,12 @@ class ChatMessageService {
         }
       }
       await trackerRepo.replaceLedgerState(session.id, committedBase);
-      await chatRepo.put(updated);
+      final survivors = await _writeDeletion(session, plan);
       final canonRollback = await _ref
           .read(sessionCanonRollbackRepoProvider)
           .reconcileInTransaction(
             sessionId: session.id,
-            survivingMessages: updated.messages,
+            survivingMessages: survivors,
           );
       wakeLoreEmbeddingWorker = canonRollback.shouldWakeLoreEmbeddingWorker;
     });
@@ -302,6 +302,53 @@ class ChatMessageService {
     final durable = await chatRepo.getById(session.id) ?? updated;
     ChatSessionService.updateCache(durable);
     return durable;
+  }
+
+  /// Applies [plan] to the durable row and returns the surviving messages.
+  ///
+  /// The deletion is re-applied by message id against the row as it is *now*,
+  /// rather than writing the shortened list the plan carries. The plan was
+  /// computed on the frame of the tap, and the transaction around this can run
+  /// for a while on a long chat — long enough for a reply to finish streaming
+  /// into the row, or for a variation switch to commit. Writing the plan
+  /// wholesale wrote those back out again: the delete undid work it had nothing
+  /// to do with, and the row disagreed with the screen until the chat was
+  /// reopened.
+  ///
+  /// The deleted count is read from the durable row for the same reason — two
+  /// deletions in flight each add their own, instead of the later one
+  /// overwriting the earlier one's total.
+  ///
+  /// Messages written before ids existed carry an empty one and cannot be
+  /// addressed this way. When the plan holds any of those, the shortened list
+  /// is written as before: an index-based delete is only correct against the
+  /// snapshot it was computed from, so nothing is gained by being clever here.
+  Future<List<ChatMessage>> _writeDeletion(
+    ChatSession session,
+    MessageDeletionPlan plan,
+  ) async {
+    final chatRepo = _ref.read(chatRepoProvider);
+    if (plan.deletedMessageIds.length != plan.deletedIndices.length) {
+      await chatRepo.put(plan.session);
+      return plan.session.messages;
+    }
+    final durable = await chatRepo.mutateSession(
+      sessionId: session.id,
+      updatedAt: plan.session.updatedAt,
+      mutate: (current) {
+        final remaining = current.messages
+            .where((message) => !plan.deletedMessageIds.contains(message.id))
+            .toList();
+        final vars = Map<String, String>.from(current.sessionVars)
+          ..[ChatSessionX.deletedMessagesVarKey] =
+              (current.deletedMessageCount + plan.deletedIndices.length)
+                  .toString();
+        return current.copyWith(messages: remaining, sessionVars: vars);
+      },
+    );
+    // No row: the session was deleted from under the delete. Nothing survives,
+    // and the rollback below has nothing to reconcile against.
+    return durable?.messages ?? const [];
   }
 
   ChatSession toggleMessageHidden(ChatSession session, int index) {

--- a/test/chat_delete_plan_test.dart
+++ b/test/chat_delete_plan_test.dart
@@ -113,6 +113,79 @@ void main() {
     expect(persisted?.deletedMessageCount, 2);
   });
 
+  test('a reply that lands while the delete commits survives it', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+
+    final session = _session(3);
+    final chatRepo = container.read(chatRepoProvider);
+    await chatRepo.put(session);
+
+    final service = container.read(_messageServiceProvider);
+    final plan = service.planDeleteMessages(session, {1})!;
+
+    // What the delete's own transaction is slow enough to race with on a long
+    // chat: a reply finishing its stream, landing on the durable row through
+    // the atomic append path while the plan is already in flight.
+    await chatRepo.mutateMessages(
+      sessionId: 's1',
+      updatedAt: 2,
+      mutate: (messages) => [
+        ...messages,
+        const ChatMessage(id: 'm-new', role: 'assistant', content: 'landed'),
+      ],
+    );
+
+    final committed = await service.commitDeleteMessages(session, plan);
+
+    final persisted = await chatRepo.getById('s1');
+    expect(
+      persisted?.messages.map((m) => m.id),
+      ['m0', 'm2', 'm-new'],
+      reason: 'the delete wrote its pre-computed list over the new message',
+    );
+    expect(committed.messages.map((m) => m.id), ['m0', 'm2', 'm-new']);
+    expect(persisted?.deletedMessageCount, 1);
+  });
+
+  test('a message with no id is still deleted', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final container = ProviderContainer(
+      overrides: [appDbProvider.overrideWithValue(db)],
+    );
+    addTearDown(() async {
+      container.dispose();
+      await db.close();
+    });
+
+    // Written before messages carried ids. Deleting by id cannot address it,
+    // so the commit falls back to writing the planned list.
+    const session = ChatSession(
+      id: 's1',
+      characterId: 'c1',
+      sessionIndex: 0,
+      messages: [
+        ChatMessage(id: 'm0', role: 'user', content: 'first'),
+        ChatMessage(id: '', role: 'assistant', content: 'legacy'),
+        ChatMessage(id: 'm2', role: 'user', content: 'third'),
+      ],
+    );
+    await container.read(chatRepoProvider).put(session);
+
+    final service = container.read(_messageServiceProvider);
+    final plan = service.planDeleteMessages(session, {1})!;
+    await service.commitDeleteMessages(session, plan);
+
+    final persisted = await container.read(chatRepoProvider).getById('s1');
+    expect(persisted?.messages.map((m) => m.content), ['first', 'third']);
+  });
+
   test(
     'tail deletion preserves completed reconciliation range and checkpoint',
     () async {


### PR DESCRIPTION
#78 — "deleted messages sometimes come back after certain actions".

## What was already fixed, and what was left

The reported symptom's main cause is fixed on `nightly` and its own documentation says so: `ChatSessionWriteQueue` exists because a variation switch used to commit against the pre-delete row and write the deleted messages back — "deleted messages come back the moment you flip a variation". One queue for every durable session write, plus publication tokens so an older commit still writes but no longer repaints, closed that.

What was left is the same race from the other side, and it is in the delete itself.

## The remaining hole

`commitDeleteMessages` wrote the shortened list **the plan carried**, wholesale (`chatRepo.put`). The plan is computed on the frame of the tap — that is the point, the bubbles have to disappear immediately — and the transaction behind it is long on a big chat: knowledge rollback, memory, snapshots, ledger, checkpoints, embeddings, plus a full session re-encode. Anything that reached the row in that window was written straight back out by the delete:

- a reply that finished streaming (it lands through the atomic append path, so the queue does not order it) was **erased**;
- a variation switch that had committed in that window was **undone**.

Either way the row and the screen disagreed until the chat was reopened, which is the shape of the report.

## Changes

- The deletion is re-applied **by message id inside the transaction**, against the row as it is at that moment, via `ChatRepo.mutateSession`.
- The deleted-message counter is read from the durable row rather than the snapshot, so two deletions in flight each add their own count instead of the later one overwriting the earlier one's total.
- Messages written before ids existed carry an empty one and cannot be addressed by id. When a plan holds any of those, the planned list is written as before — an index-based delete is only correct against the snapshot it was computed from, so there is nothing to gain by being clever there.

## Verification

- `test/chat_delete_plan_test.dart` — two new tests. "A reply that lands while the delete commits survives it" fails on `nightly` (the new message is wiped) and passes with the fix. "A message with no id is still deleted" is a deliberate negative control: it passes either way and pins the fallback.
- `flutter test` — 3900 passed, 4 skipped. `flutter analyze` — 9 issues, all pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)